### PR TITLE
Clean up inheritance hierarchy for CSharpAttributeData/VisualBasicAttributeData.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // prevent cascading diagnostics
                 Debug.Assert(hasErrors);
-                return new SourceAttributeData(boundAttribute.Syntax.GetReference(), attributeType, attributeConstructor, hasErrors);
+                return new SourceAttributeData(Compilation, (AttributeSyntax)boundAttribute.Syntax, attributeType, attributeConstructor, hasErrors);
             }
 
             // Validate attribute constructor parameters have valid attribute parameter type
@@ -323,7 +323,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagnostics.Add(boundAttribute.Syntax, useSiteInfo);
 
             return new SourceAttributeData(
-                boundAttribute.Syntax.GetReference(),
+                Compilation,
+                (AttributeSyntax)boundAttribute.Syntax,
                 attributeType,
                 attributeConstructor,
                 rewrittenArguments,

--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var peModule = (Symbols.Metadata.PE.PEModuleSymbol)module;
                     foreach (CSharpAttributeData assemblyLevelAttribute in peModule.GetAssemblyAttributes())
                     {
-                        if (assemblyLevelAttribute.IsTargetAttribute(peModule, AttributeDescription.CLSCompliantAttribute))
+                        if (assemblyLevelAttribute.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute))
                         {
                             sawClsCompliantAttribute = true;
                             break;
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (CSharpAttributeData attribute in symbol.GetAttributes())
             {
-                if (attribute.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute))
+                if (attribute.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute))
                 {
                     Location attributeLocation;
                     if (TryGetAttributeWarningLocation(attribute, out attributeLocation))
@@ -692,7 +692,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = startPos; i < parameters.Length; i++)
             {
                 Location attributeLocation;
-                if (TryGetClsComplianceAttributeLocation(parameters[i].GetAttributes(), parameters[i], out attributeLocation))
+                if (TryGetClsComplianceAttributeLocation(parameters[i].GetAttributes(), out attributeLocation))
                 {
                     this.AddDiagnostic(ErrorCode.WRN_CLS_MeaninglessOnParam, attributeLocation);
                 }
@@ -702,7 +702,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void CheckForMeaninglessOnReturn(MethodSymbol method)
         {
             Location attributeLocation;
-            if (TryGetClsComplianceAttributeLocation(method.GetReturnTypeAttributes(), method, out attributeLocation))
+            if (TryGetClsComplianceAttributeLocation(method.GetReturnTypeAttributes(), out attributeLocation))
             {
                 this.AddDiagnostic(ErrorCode.WRN_CLS_MeaninglessOnReturn, attributeLocation);
             }
@@ -763,11 +763,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool TryGetClsComplianceAttributeLocation(ImmutableArray<CSharpAttributeData> attributes, Symbol targetSymbol, out Location attributeLocation)
+        private bool TryGetClsComplianceAttributeLocation(ImmutableArray<CSharpAttributeData> attributes, out Location attributeLocation)
         {
             foreach (CSharpAttributeData data in attributes)
             {
-                if (data.IsTargetAttribute(targetSymbol, AttributeDescription.CLSCompliantAttribute))
+                if (data.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute))
                 {
                     if (TryGetAttributeWarningLocation(data, out attributeLocation))
                     {
@@ -1187,7 +1187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (CSharpAttributeData data in symbol.GetAttributes())
             {
                 // Check signature before HasErrors to avoid realizing symbols for other attributes.
-                if (data.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute))
+                if (data.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute))
                 {
                     NamedTypeSymbol attributeClass = data.AttributeClass;
                     if ((object)attributeClass != null)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -195,7 +195,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal override SynthesizedAttributeData SynthesizeEmbeddedAttribute()
         {
             // _lazyEmbeddedAttribute should have been created before calling this method.
-            return new SynthesizedAttributeData(
+            return SynthesizedAttributeData.Create(
+                Compilation,
                 _lazyEmbeddedAttribute.Constructors[0],
                 ImmutableArray<TypedConstant>.Empty,
                 ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -206,7 +207,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if ((object)_lazyNullableAttribute != null)
             {
                 var constructorIndex = (member == WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags) ? 1 : 0;
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyNullableAttribute.Constructors[constructorIndex],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -219,7 +221,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyNullableContextAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyNullableContextAttribute.Constructors[0],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -232,7 +235,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyNullablePublicOnlyAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyNullablePublicOnlyAttribute.Constructors[0],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -246,7 +250,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if ((object)_lazyNativeIntegerAttribute != null)
             {
                 var constructorIndex = (member == WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags) ? 1 : 0;
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyNativeIntegerAttribute.Constructors[constructorIndex],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -259,7 +264,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyScopedRefAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyScopedRefAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -272,7 +278,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyRefSafetyRulesAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyRefSafetyRulesAttribute.Constructors[0],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -285,7 +292,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyIsReadOnlyAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyIsReadOnlyAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -298,7 +306,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyRequiresLocationAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyRequiresLocationAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -311,7 +320,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyIsUnmanagedAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyIsUnmanagedAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -324,7 +334,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyIsByRefLikeAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyIsByRefLikeAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedEvent.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedEvent.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
 
             foreach (var attrData in underlyingContainingType.GetAttributes())
             {
-                if (attrData.IsTargetAttribute(underlyingContainingType, AttributeDescription.ComEventInterfaceAttribute))
+                if (attrData.IsTargetAttribute(AttributeDescription.ComEventInterfaceAttribute))
                 {
                     bool foundMatch = false;
                     NamedTypeSymbol sourceInterface = null;

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             if (hasGuid)
             {
                 // This is an interface with a GuidAttribute, so we will generate the no-parameter TypeIdentifier.
-                return new SynthesizedAttributeData(ctor, ImmutableArray<TypedConstant>.Empty, ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
+                return SynthesizedAttributeData.Create(TypeManager.ModuleBeingBuilt.Compilation, ctor, ImmutableArray<TypedConstant>.Empty, ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
             }
             else
             {
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                 if ((object)stringType != null)
                 {
                     string guidString = TypeManager.GetAssemblyGuidString(UnderlyingNamedType.AdaptedNamedTypeSymbol.ContainingAssembly);
-                    return new SynthesizedAttributeData(ctor,
+                    return SynthesizedAttributeData.Create(TypeManager.ModuleBeingBuilt.Compilation, ctor,
                                     ImmutableArray.Create(new TypedConstant(stringType, TypedConstantKind.Primitive, guidString),
                                                     new TypedConstant(stringType, TypedConstantKind.Primitive,
                                                                             UnderlyingNamedType.AdaptedNamedTypeSymbol.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))),

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypesManager.cs
@@ -116,9 +116,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             return lazyMethod;
         }
 
-        internal override int GetTargetAttributeSignatureIndex(SymbolAdapter underlyingSymbol, CSharpAttributeData attrData, AttributeDescription description)
+        internal override int GetTargetAttributeSignatureIndex(CSharpAttributeData attrData, AttributeDescription description)
         {
-            return attrData.GetTargetAttributeSignatureIndex(underlyingSymbol.AdaptedSymbol, description);
+            return attrData.GetTargetAttributeSignatureIndex(description);
         }
 
         internal override CSharpAttributeData CreateSynthesizedAttribute(WellKnownMember constructor, CSharpAttributeData attrData, SyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                     // When emitting a com event interface, we have to tweak the parameters: the spec requires that we use
                     // the original source interface as both source interface and event provider. Otherwise, we'd have to embed
                     // the event provider class too.
-                    return new SynthesizedAttributeData(ctor,
+                    return SynthesizedAttributeData.Create(ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create<TypedConstant>(attrData.CommonConstructorArguments[0], attrData.CommonConstructorArguments[0]),
                         ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
 
@@ -144,12 +144,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                     // instantiatable. The attribute cannot refer directly to the coclass, however, because we can't embed
                     // classes, and we can't emit a reference to the PIA. We don't actually need
                     // the class name at runtime: we will instead emit a reference to System.Object, as a placeholder.
-                    return new SynthesizedAttributeData(ctor,
+                    return SynthesizedAttributeData.Create(ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create(new TypedConstant(ctor.Parameters[0].Type, TypedConstantKind.Type, ctor.ContainingAssembly.GetSpecialType(SpecialType.System_Object))),
                         ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
 
                 default:
-                    return new SynthesizedAttributeData(ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments);
+                    return SynthesizedAttributeData.Create(ModuleBeingBuilt.Compilation, ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -269,8 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
         {
             var node = (AttributeSyntax)attributeSyntax;
-            CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
-            diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+            diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, ((CSharpAttributeData)attribute).GetAttributeArgumentLocation(parameterIndex), node.GetErrorDisplayName());
         }
 
         protected override void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName)
@@ -287,16 +286,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
-            var node = (AttributeSyntax)attributeSyntax;
-            CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
-            diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeNotValidForFields, attributeArgumentSyntax.Location, unmanagedTypeName);
+            diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeNotValidForFields, ((CSharpAttributeData)attribute).GetAttributeArgumentLocation(parameterIndex), unmanagedTypeName);
         }
 
         protected override void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
-            var node = (AttributeSyntax)attributeSyntax;
-            CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
-            diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeOnlyValidForFields, attributeArgumentSyntax.Location, unmanagedTypeName);
+            diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeOnlyValidForFields, ((CSharpAttributeData)attribute).GetAttributeArgumentLocation(parameterIndex), unmanagedTypeName);
         }
 
         protected override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 foreach (var attrData in @interface.GetAttributes())
                 {
-                    if (attrData.IsTargetAttribute(@interface, AttributeDescription.ComEventInterfaceAttribute) &&
+                    if (attrData.IsTargetAttribute(AttributeDescription.ComEventInterfaceAttribute) &&
                         attrData.CommonConstructorArguments.Length == 2)
                     {
                         return RewriteNoPiaEventAssignmentOperator(node, rewrittenReceiverOpt, rewrittenArgument);

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var kickoffType = KickoffMethod.ContainingType;
                 foreach (var attribute in kickoffType.GetAttributes())
                 {
-                    if (attribute.IsTargetAttribute(kickoffType, AttributeDescription.DebuggerNonUserCodeAttribute) ||
-                        attribute.IsTargetAttribute(kickoffType, AttributeDescription.DebuggerStepThroughAttribute))
+                    if (attribute.IsTargetAttribute(AttributeDescription.DebuggerNonUserCodeAttribute) ||
+                        attribute.IsTargetAttribute(AttributeDescription.DebuggerStepThroughAttribute))
                     {
                         if (builder == null)
                         {

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.cs
@@ -79,10 +79,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var kickoffMethod = StateMachineType.KickoffMethod;
                 foreach (var attribute in kickoffMethod.GetAttributes())
                 {
-                    if (attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerHiddenAttribute) ||
-                        attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerNonUserCodeAttribute) ||
-                        attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerStepperBoundaryAttribute) ||
-                        attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerStepThroughAttribute))
+                    if (attribute.IsTargetAttribute(AttributeDescription.DebuggerHiddenAttribute) ||
+                        attribute.IsTargetAttribute(AttributeDescription.DebuggerNonUserCodeAttribute) ||
+                        attribute.IsTargetAttribute(AttributeDescription.DebuggerStepperBoundaryAttribute) ||
+                        attribute.IsTargetAttribute(AttributeDescription.DebuggerStepThroughAttribute))
                     {
                         if (builder == null)
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -43,20 +43,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // Overridden to be able to apply MemberNotNull to the new members
         [MemberNotNullWhen(true, nameof(AttributeClass), nameof(AttributeConstructor))]
-        internal override bool HasErrors
-        {
-            get
-            {
-                var hasErrors = base.HasErrors;
-                if (!hasErrors)
-                {
-                    Debug.Assert(AttributeClass is not null);
-                    Debug.Assert(AttributeConstructor is not null);
-                }
+        internal abstract override bool HasErrors { get; }
 
-                return hasErrors;
-            }
-        }
+        internal abstract override bool IsConditionallyOmitted { get; }
 
         /// <summary>
         /// Gets the list of constructor arguments specified by this application of the attribute.  This list contains both positional arguments
@@ -79,30 +68,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Compares the namespace and type name with the attribute's namespace and type name.
         /// Returns true if they are the same.
         /// </summary>
-        internal virtual bool IsTargetAttribute(string namespaceName, string typeName)
+        internal abstract bool IsTargetAttribute(string namespaceName, string typeName);
+
+        internal bool IsTargetAttribute(AttributeDescription description)
         {
-            Debug.Assert(this.AttributeClass is object);
-
-            if (!this.AttributeClass.Name.Equals(typeName))
-            {
-                return false;
-            }
-
-            if (this.AttributeClass.IsErrorType() && !(this.AttributeClass is MissingMetadataTypeSymbol))
-            {
-                // Can't guarantee complete name information.
-                return false;
-            }
-
-            return this.AttributeClass.HasNameQualifier(namespaceName);
+            return GetTargetAttributeSignatureIndex(description) != -1;
         }
 
-        internal bool IsTargetAttribute(Symbol targetSymbol, AttributeDescription description)
-        {
-            return GetTargetAttributeSignatureIndex(targetSymbol, description) != -1;
-        }
+        internal abstract int GetTargetAttributeSignatureIndex(AttributeDescription description);
 
-        internal abstract int GetTargetAttributeSignatureIndex(Symbol targetSymbol, AttributeDescription description);
+        internal abstract Location GetAttributeArgumentLocation(int parameterIndex);
 
         /// <summary>
         /// Checks if an applied attribute with the given attributeType matches the namespace name and type name of the given early attribute's description
@@ -247,7 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SecurityWellKnownAttributeData securityData = data.GetOrCreateData();
                 securityData.SetSecurityAttribute(arguments.Index, action, arguments.AttributesCount);
 
-                if (this.IsTargetAttribute(targetSymbol, AttributeDescription.PermissionSetAttribute))
+                if (this.IsTargetAttribute(AttributeDescription.PermissionSetAttribute))
                 {
                     string? resolvedPathForFixup = DecodePermissionSetAttribute(compilation, arguments.AttributeSyntaxOpt, (BindingDiagnosticBag)arguments.Diagnostics);
                     if (resolvedPathForFixup != null)
@@ -377,7 +352,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // attribute argument to have the above mentioned behavior, even though the comment clearly mentions that this behavior was intended only for the HostProtectionAttribute.
                 // We currently allow this case only for the HostProtectionAttribute. In future if need arises, we can exactly match native compiler's behavior.
 
-                if (this.IsTargetAttribute(targetSymbol, AttributeDescription.HostProtectionAttribute))
+                if (this.IsTargetAttribute(AttributeDescription.HostProtectionAttribute))
                 {
                     hasErrors = false;
                     return DeclarativeSecurityAction.LinkDemand;
@@ -412,7 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case (int)DeclarativeSecurityAction.InheritanceDemand:
                 case (int)DeclarativeSecurityAction.LinkDemand:
-                    if (this.IsTargetAttribute(targetSymbol, AttributeDescription.PrincipalPermissionAttribute))
+                    if (this.IsTargetAttribute(AttributeDescription.PrincipalPermissionAttribute))
                     {
                         // CS7052: SecurityAction value '{0}' is invalid for PrincipalPermission attribute
                         object displayString;
@@ -609,8 +584,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 default:
                     // CS0591: Invalid value for argument to '{0}' attribute
-                    Location attributeArgumentSyntaxLocation = this.GetAttributeArgumentSyntaxLocation(0, nodeOpt);
-                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntaxLocation, nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
+                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, this.GetAttributeArgumentLocation(0), nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
                     break;
             }
         }
@@ -636,8 +610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 default:
                     // CS0591: Invalid value for argument to '{0}' attribute
-                    CSharpSyntaxNode attributeArgumentSyntax = this.GetAttributeArgumentSyntax(0, node);
-                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, this.GetAttributeArgumentLocation(0), node.GetErrorDisplayName());
                     break;
             }
         }
@@ -653,7 +626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!Guid.TryParseExact(guidString, "D", out guid))
             {
                 // CS0591: Invalid value for argument to '{0}' attribute
-                Location attributeArgumentSyntaxLocation = this.GetAttributeArgumentSyntaxLocation(0, nodeOpt);
+                Location attributeArgumentSyntaxLocation = this.GetAttributeArgumentLocation(0);
                 diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntaxLocation, nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
                 guidString = String.Empty;
             }
@@ -712,11 +685,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case SymbolKind.Assembly:
                     if ((!emittingAssemblyAttributesInNetModule &&
-                            (IsTargetAttribute(target, AttributeDescription.AssemblyCultureAttribute) ||
-                             IsTargetAttribute(target, AttributeDescription.AssemblyVersionAttribute) ||
-                             IsTargetAttribute(target, AttributeDescription.AssemblyFlagsAttribute) ||
-                             IsTargetAttribute(target, AttributeDescription.AssemblyAlgorithmIdAttribute))) ||
-                        IsTargetAttribute(target, AttributeDescription.TypeForwardedToAttribute) ||
+                            (IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) ||
+                             IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) ||
+                             IsTargetAttribute(AttributeDescription.AssemblyFlagsAttribute) ||
+                             IsTargetAttribute(AttributeDescription.AssemblyAlgorithmIdAttribute))) ||
+                        IsTargetAttribute(AttributeDescription.TypeForwardedToAttribute) ||
                         IsSecurityAttribute(target.DeclaringCompilation))
                     {
                         return false;
@@ -725,7 +698,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.Event:
-                    if (IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute))
+                    if (IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
                     {
                         return false;
                     }
@@ -733,10 +706,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.Field:
-                    if (IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.NonSerializedAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.FieldOffsetAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute))
+                    if (IsTargetAttribute(AttributeDescription.SpecialNameAttribute) ||
+                        IsTargetAttribute(AttributeDescription.NonSerializedAttribute) ||
+                        IsTargetAttribute(AttributeDescription.FieldOffsetAttribute) ||
+                        IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
                     {
                         return false;
                     }
@@ -746,18 +719,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.Method:
                     if (isReturnType)
                     {
-                        if (IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute))
+                        if (IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
                         {
                             return false;
                         }
                     }
                     else
                     {
-                        if (IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) ||
-                            IsTargetAttribute(target, AttributeDescription.MethodImplAttribute) ||
-                            IsTargetAttribute(target, AttributeDescription.DllImportAttribute) ||
-                            IsTargetAttribute(target, AttributeDescription.PreserveSigAttribute) ||
-                            IsTargetAttribute(target, AttributeDescription.DynamicSecurityMethodAttribute) ||
+                        if (IsTargetAttribute(AttributeDescription.SpecialNameAttribute) ||
+                            IsTargetAttribute(AttributeDescription.MethodImplAttribute) ||
+                            IsTargetAttribute(AttributeDescription.DllImportAttribute) ||
+                            IsTargetAttribute(AttributeDescription.PreserveSigAttribute) ||
+                            IsTargetAttribute(AttributeDescription.DynamicSecurityMethodAttribute) ||
                             IsSecurityAttribute(target.DeclaringCompilation))
                         {
                             return false;
@@ -771,11 +744,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.NamedType:
-                    if (IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.ComImportAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.SerializableAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.StructLayoutAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.WindowsRuntimeImportAttribute) ||
+                    if (IsTargetAttribute(AttributeDescription.SpecialNameAttribute) ||
+                        IsTargetAttribute(AttributeDescription.ComImportAttribute) ||
+                        IsTargetAttribute(AttributeDescription.SerializableAttribute) ||
+                        IsTargetAttribute(AttributeDescription.StructLayoutAttribute) ||
+                        IsTargetAttribute(AttributeDescription.WindowsRuntimeImportAttribute) ||
                         IsSecurityAttribute(target.DeclaringCompilation))
                     {
                         return false;
@@ -784,11 +757,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.Parameter:
-                    if (IsTargetAttribute(target, AttributeDescription.OptionalAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.DefaultParameterValueAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.InAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.OutAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute))
+                    if (IsTargetAttribute(AttributeDescription.OptionalAttribute) ||
+                        IsTargetAttribute(AttributeDescription.DefaultParameterValueAttribute) ||
+                        IsTargetAttribute(AttributeDescription.InAttribute) ||
+                        IsTargetAttribute(AttributeDescription.OutAttribute) ||
+                        IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
                     {
                         return false;
                     }
@@ -796,12 +769,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.Property:
-                    if (IsTargetAttribute(target, AttributeDescription.IndexerNameAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.DisallowNullAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.AllowNullAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.MaybeNullAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.NotNullAttribute))
+                    if (IsTargetAttribute(AttributeDescription.IndexerNameAttribute) ||
+                        IsTargetAttribute(AttributeDescription.SpecialNameAttribute) ||
+                        IsTargetAttribute(AttributeDescription.DisallowNullAttribute) ||
+                        IsTargetAttribute(AttributeDescription.AllowNullAttribute) ||
+                        IsTargetAttribute(AttributeDescription.MaybeNullAttribute) ||
+                        IsTargetAttribute(AttributeDescription.NotNullAttribute))
                     {
                         return false;
                     }
@@ -816,11 +789,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
     internal static class AttributeDataExtensions
     {
-        internal static int IndexOfAttribute(this ImmutableArray<CSharpAttributeData> attributes, Symbol targetSymbol, AttributeDescription description)
+        internal static int IndexOfAttribute(this ImmutableArray<CSharpAttributeData> attributes, AttributeDescription description)
         {
             for (int i = 0; i < attributes.Length; i++)
             {
-                if (attributes[i].IsTargetAttribute(targetSymbol, description))
+                if (attributes[i].IsTargetAttribute(description))
                 {
                     return i;
                 }
@@ -829,27 +802,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return -1;
         }
 
-        internal static CSharpSyntaxNode GetAttributeArgumentSyntax(this AttributeData attribute, int parameterIndex, AttributeSyntax attributeSyntax)
-        {
-            Debug.Assert(attribute is SourceAttributeData);
-            return ((SourceAttributeData)attribute).GetAttributeArgumentSyntax(parameterIndex, attributeSyntax);
-        }
-
         internal static string? DecodeNotNullIfNotNullAttribute(this CSharpAttributeData attribute)
         {
             var arguments = attribute.CommonConstructorArguments;
             return arguments.Length == 1 && arguments[0].TryDecodeValue(SpecialType.System_String, out string? value) ? value : null;
-        }
-
-        internal static Location GetAttributeArgumentSyntaxLocation(this AttributeData attribute, int parameterIndex, AttributeSyntax? attributeSyntaxOpt)
-        {
-            if (attributeSyntaxOpt == null)
-            {
-                return NoLocation.Singleton;
-            }
-
-            Debug.Assert(attribute is SourceAttributeData);
-            return ((SourceAttributeData)attribute).GetAttributeArgumentSyntax(parameterIndex, attributeSyntaxOpt).Location;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/PEAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/PEAttributeData.cs
@@ -134,17 +134,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         /// Matches an attribute by metadata namespace, metadata type name and metadata signature. Does not load the
         /// type symbol for the attribute.
         /// </summary>
-        /// <param name="targetSymbol">Target symbol.</param>
         /// <param name="description">Attribute to match.</param>
         /// <returns>
         /// An index of the target constructor signature in
         /// signatures array, -1 if
         /// this is not the target attribute.
         /// </returns>
-        internal override int GetTargetAttributeSignatureIndex(Symbol targetSymbol, AttributeDescription description)
+        internal override int GetTargetAttributeSignatureIndex(AttributeDescription description)
         {
             // Matching an attribute by name should not load the attribute class.
             return _decoder.GetTargetAttributeSignatureIndex(_handle, description);
+        }
+
+        internal override Location GetAttributeArgumentLocation(int parameterIndex)
+        {
+            return new MetadataLocation(_decoder.ModuleSymbol);
         }
 
         [MemberNotNullWhen(true, nameof(AttributeClass), nameof(AttributeConstructor))]
@@ -166,5 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return _lazyHasErrors.Value();
             }
         }
+
+        internal override bool IsConditionallyOmitted => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/RetargetingAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/RetargetingAttributeData.cs
@@ -4,43 +4,52 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 {
     /// <summary>
     /// Represents a retargeting custom attribute
     /// </summary>
-    internal sealed class RetargetingAttributeData : SourceAttributeData
+    internal sealed class RetargetingAttributeData : CSharpAttributeData
     {
+        private readonly CSharpAttributeData _underlying;
+        private readonly NamedTypeSymbol _attributeClass;
+        private readonly MethodSymbol? _attributeConstructor;
+        private readonly ImmutableArray<TypedConstant> _constructorArguments;
+        private readonly ImmutableArray<KeyValuePair<string, TypedConstant>> _namedArguments;
+
         internal RetargetingAttributeData(
-            SyntaxReference applicationNode,
+            CSharpAttributeData underlying,
             NamedTypeSymbol attributeClass,
-            MethodSymbol attributeConstructor,
+            MethodSymbol? attributeConstructor,
             ImmutableArray<TypedConstant> constructorArguments,
-            ImmutableArray<int> constructorArgumentsSourceIndices,
-            ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments,
-            bool hasErrors,
-            bool isConditionallyOmitted)
-            : base(applicationNode, attributeClass, attributeConstructor, constructorArguments, constructorArgumentsSourceIndices, namedArguments, hasErrors, isConditionallyOmitted)
+            ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
         {
+            Debug.Assert(underlying is SourceAttributeData or SynthesizedAttributeData);
+
+            _underlying = underlying;
+            _attributeClass = attributeClass;
+            _attributeConstructor = attributeConstructor;
+            _constructorArguments = constructorArguments;
+            _namedArguments = namedArguments;
         }
 
-        /// <summary>
-        /// Gets the retargeted System.Type type symbol.
-        /// </summary>
-        /// <param name="targetSymbol">Target symbol on which this attribute is applied.</param>
-        /// <returns>Retargeted System.Type type symbol.</returns>
-        internal override TypeSymbol GetSystemType(Symbol targetSymbol)
-        {
-            var retargetingAssembly = (RetargetingAssemblySymbol)(targetSymbol.Kind == SymbolKind.Assembly ? targetSymbol : targetSymbol.ContainingAssembly);
-            var underlyingAssembly = (SourceAssemblySymbol)retargetingAssembly.UnderlyingAssembly;
+        public override NamedTypeSymbol AttributeClass => _attributeClass;
+        public override MethodSymbol? AttributeConstructor => _attributeConstructor;
+        protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _constructorArguments;
+        protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _namedArguments;
 
-            // Get the System.Type from the underlying assembly's Compilation
-            TypeSymbol systemType = underlyingAssembly.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Type);
+        public override SyntaxReference? ApplicationSyntaxReference => null;
 
-            // Retarget the type
-            var retargetingModule = (RetargetingModuleSymbol)retargetingAssembly.Modules[0];
-            return retargetingModule.RetargetingTranslator.Retarget(systemType, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
-        }
+        [MemberNotNullWhen(true, nameof(AttributeClass), nameof(AttributeConstructor))]
+        internal override bool HasErrors => _underlying.HasErrors || _attributeConstructor is null;
+
+        internal override bool IsConditionallyOmitted => _underlying.IsConditionallyOmitted;
+
+        internal override Location GetAttributeArgumentLocation(int parameterIndex) => _underlying.GetAttributeArgumentLocation(parameterIndex);
+        internal override int GetTargetAttributeSignatureIndex(AttributeDescription description) => _underlying.GetTargetAttributeSignatureIndex(description);
+        internal override bool IsTargetAttribute(string namespaceName, string typeName) => _underlying.IsTargetAttribute(namespaceName, typeName);
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/SourceAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/SourceAttributeData.cs
@@ -15,8 +15,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// Represents a Source custom attribute specification
     /// </summary>
-    internal class SourceAttributeData : CSharpAttributeData
+    internal sealed class SourceAttributeData : CSharpAttributeData
     {
+        private readonly CSharpCompilation _compilation;
         private readonly NamedTypeSymbol _attributeClass;
         private readonly MethodSymbol? _attributeConstructor;
         private readonly ImmutableArray<TypedConstant> _constructorArguments;
@@ -24,10 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly ImmutableArray<KeyValuePair<string, TypedConstant>> _namedArguments;
         private readonly bool _isConditionallyOmitted;
         private readonly bool _hasErrors;
-        private readonly SyntaxReference? _applicationNode;
+        private readonly SyntaxReference _applicationNode;
 
-        internal SourceAttributeData(
-            SyntaxReference? applicationNode,
+        private SourceAttributeData(
+            CSharpCompilation compilation,
+            SyntaxReference applicationNode,
             NamedTypeSymbol attributeClass,
             MethodSymbol? attributeConstructor,
             ImmutableArray<TypedConstant> constructorArguments,
@@ -43,6 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 constructorArgumentsSourceIndices.Any() && constructorArgumentsSourceIndices.Length == constructorArguments.Length);
             Debug.Assert(attributeConstructor is object || hasErrors);
 
+            _compilation = compilation;
             _attributeClass = attributeClass;
             _attributeConstructor = attributeConstructor;
             _constructorArguments = constructorArguments;
@@ -53,9 +56,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _applicationNode = applicationNode;
         }
 
-        internal SourceAttributeData(SyntaxReference applicationNode, NamedTypeSymbol attributeClass, MethodSymbol? attributeConstructor, bool hasErrors)
+        internal SourceAttributeData(CSharpCompilation compilation, AttributeSyntax attributeSyntax, NamedTypeSymbol attributeClass, MethodSymbol? attributeConstructor, bool hasErrors)
             : this(
-            applicationNode,
+            compilation,
+            attributeSyntax,
             attributeClass,
             attributeConstructor,
             constructorArguments: ImmutableArray<TypedConstant>.Empty,
@@ -63,6 +67,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             namedArguments: ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty,
             hasErrors: hasErrors,
             isConditionallyOmitted: false)
+        {
+        }
+
+        internal SourceAttributeData(
+            CSharpCompilation compilation,
+            AttributeSyntax attributeSyntax,
+            NamedTypeSymbol attributeClass,
+            MethodSymbol? attributeConstructor,
+            ImmutableArray<TypedConstant> constructorArguments,
+            ImmutableArray<int> constructorArgumentsSourceIndices,
+            ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments,
+            bool hasErrors,
+            bool isConditionallyOmitted)
+            : this(compilation, attributeSyntax.GetReference(), attributeClass, attributeConstructor, constructorArguments, constructorArgumentsSourceIndices, namedArguments, hasErrors, isConditionallyOmitted)
         {
         }
 
@@ -82,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override SyntaxReference? ApplicationSyntaxReference
+        public override SyntaxReference ApplicationSyntaxReference
         {
             get
             {
@@ -103,14 +121,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal CSharpSyntaxNode GetAttributeArgumentSyntax(int parameterIndex, AttributeSyntax attributeSyntax)
+        internal CSharpSyntaxNode GetAttributeArgumentSyntax(int parameterIndex)
         {
             // This method is only called when decoding (non-erroneous) well-known attributes.
             Debug.Assert(!this.HasErrors);
             Debug.Assert(this.AttributeConstructor is object);
             Debug.Assert(parameterIndex >= 0);
             Debug.Assert(parameterIndex < this.AttributeConstructor.ParameterCount);
-            Debug.Assert(attributeSyntax != null);
+
+            var attributeSyntax = (AttributeSyntax)_applicationNode.GetSyntax();
 
             if (_constructorArgumentsSourceIndices.IsDefault)
             {
@@ -139,6 +158,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override Location GetAttributeArgumentLocation(int parameterIndex)
+        {
+            return GetAttributeArgumentSyntax(parameterIndex).Location;
+        }
+
         internal override bool IsConditionallyOmitted
         {
             get
@@ -155,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                return new SourceAttributeData(this.ApplicationSyntaxReference, this.AttributeClass, this.AttributeConstructor, this.CommonConstructorArguments,
+                return new SourceAttributeData(this._compilation, this.ApplicationSyntaxReference, this.AttributeClass, this.AttributeConstructor, this.CommonConstructorArguments,
                     this.ConstructorArgumentsSourceIndices, this.CommonNamedArguments, this.HasErrors, isConditionallyOmitted);
             }
         }
@@ -185,16 +209,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// and System.Type.  It will not match an arbitrary signature but it is sufficient to match the signatures of the current set of
         /// well known attributes.
         /// </summary>
-        /// <param name="targetSymbol">The symbol which is the target of the attribute</param>
         /// <param name="description">The attribute to match.</param>
-        internal override int GetTargetAttributeSignatureIndex(Symbol targetSymbol, AttributeDescription description)
+        internal override int GetTargetAttributeSignatureIndex(AttributeDescription description)
         {
-            if (!IsTargetAttribute(description.Namespace, description.Name))
+            return GetTargetAttributeSignatureIndex(_compilation, AttributeClass, AttributeConstructor, description);
+        }
+
+        internal static int GetTargetAttributeSignatureIndex(CSharpCompilation compilation, NamedTypeSymbol attributeClass, MethodSymbol? attributeConstructor, AttributeDescription description)
+        {
+            if (!IsTargetAttribute(attributeClass, description.Namespace, description.Name))
             {
                 return -1;
             }
 
-            var ctor = this.AttributeConstructor;
+            var ctor = attributeConstructor;
 
             // Ensure that the attribute data really has a constructor before comparing the signature.
             if (ctor is null)
@@ -401,7 +429,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             break;
 
                         case (byte)SerializationTypeCode.Type:
-                            lazySystemType ??= GetSystemType(targetSymbol);
+                            lazySystemType ??= compilation.GetWellKnownType(WellKnownType.System_Type);
 
                             if (!TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything))
                             {
@@ -427,14 +455,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        /// <summary>
-        /// Gets the System.Type type symbol from targetSymbol's containing assembly.
-        /// </summary>
-        /// <param name="targetSymbol">Target symbol on which this attribute is applied.</param>
-        /// <returns>System.Type type symbol.</returns>
-        internal virtual TypeSymbol GetSystemType(Symbol targetSymbol)
+        internal override bool IsTargetAttribute(string namespaceName, string typeName)
         {
-            return targetSymbol.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Type);
+            return IsTargetAttribute(AttributeClass, namespaceName, typeName);
+        }
+
+        /// <summary>
+        /// Compares the namespace and type name with the attribute's namespace and type name.
+        /// Returns true if they are the same.
+        /// </summary>
+        internal static bool IsTargetAttribute(NamedTypeSymbol attributeClass, string namespaceName, string typeName)
+        {
+            Debug.Assert(attributeClass is object);
+
+            if (!attributeClass.Name.Equals(typeName))
+            {
+                return false;
+            }
+
+            if (attributeClass.IsErrorType() && !(attributeClass is MissingMetadataTypeSymbol))
+            {
+                // Can't guarantee complete name information.
+                return false;
+            }
+
+            return attributeClass.HasNameQualifier(namespaceName);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 namedStringArguments = builder.ToImmutableAndFree();
             }
 
-            return new SynthesizedAttributeData(ctorSymbol, arguments, namedStringArguments);
+            return SynthesizedAttributeData.Create(this, ctorSymbol, arguments, namedStringArguments);
         }
 
         internal SynthesizedAttributeData? TrySynthesizeAttribute(
@@ -443,7 +443,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            return new SynthesizedAttributeData(
+            return SynthesizedAttributeData.Create(
+                this,
                 ctorSymbol,
                 arguments: ImmutableArray<TypedConstant>.Empty,
                 namedArguments: ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get
             {
                 var assemblyAttributes = GetAssemblyAttributes();
-                return assemblyAttributes.IndexOfAttribute(this, AttributeDescription.CompilationRelaxationsAttribute) >= 0;
+                return assemblyAttributes.IndexOfAttribute(AttributeDescription.CompilationRelaxationsAttribute) >= 0;
             }
         }
 
@@ -670,7 +670,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get
             {
                 var assemblyAttributes = GetAssemblyAttributes();
-                return assemblyAttributes.IndexOfAttribute(this, AttributeDescription.RuntimeCompatibilityAttribute) >= 0;
+                return assemblyAttributes.IndexOfAttribute(AttributeDescription.RuntimeCompatibilityAttribute) >= 0;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                         // This is a local type explicitly declared in source. Get information from TypeIdentifier attribute.
                         foreach (var attrData in type.GetAttributes())
                         {
-                            int signatureIndex = attrData.GetTargetAttributeSignatureIndex(type, AttributeDescription.TypeIdentifierAttribute);
+                            int signatureIndex = attrData.GetTargetAttributeSignatureIndex(AttributeDescription.TypeIdentifierAttribute);
 
                             if (signatureIndex != -1)
                             {
@@ -1145,11 +1145,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
             internal IEnumerable<CSharpAttributeData> RetargetAttributes(IEnumerable<CSharpAttributeData> attributes)
             {
-#if DEBUG
-                SynthesizedAttributeData x = null;
-                SourceAttributeData y = x; // Code below relies on the fact that SynthesizedAttributeData derives from SourceAttributeData.
-                x = (SynthesizedAttributeData)y;
-#endif
                 foreach (var attributeData in attributes)
                 {
                     yield return this.RetargetAttributeData(attributeData);
@@ -1158,14 +1153,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
             private CSharpAttributeData RetargetAttributeData(CSharpAttributeData oldAttributeData)
             {
-                SourceAttributeData oldAttribute = (SourceAttributeData)oldAttributeData;
-
-                MethodSymbol oldAttributeCtor = oldAttribute.AttributeConstructor;
+                MethodSymbol oldAttributeCtor = oldAttributeData.AttributeConstructor;
                 MethodSymbol newAttributeCtor = (object)oldAttributeCtor == null ?
                     null :
                     Retarget(oldAttributeCtor, MemberSignatureComparer.RetargetedExplicitImplementationComparer);
 
-                NamedTypeSymbol oldAttributeType = oldAttribute.AttributeClass;
+                NamedTypeSymbol oldAttributeType = oldAttributeData.AttributeClass;
                 NamedTypeSymbol newAttributeType;
                 if ((object)newAttributeCtor != null)
                 {
@@ -1180,24 +1173,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                     newAttributeType = null;
                 }
 
-                ImmutableArray<TypedConstant> oldAttributeCtorArguments = oldAttribute.CommonConstructorArguments;
+                ImmutableArray<TypedConstant> oldAttributeCtorArguments = oldAttributeData.CommonConstructorArguments;
                 ImmutableArray<TypedConstant> newAttributeCtorArguments = RetargetAttributeConstructorArguments(oldAttributeCtorArguments);
 
-                ImmutableArray<KeyValuePair<string, TypedConstant>> oldAttributeNamedArguments = oldAttribute.CommonNamedArguments;
+                ImmutableArray<KeyValuePair<string, TypedConstant>> oldAttributeNamedArguments = oldAttributeData.CommonNamedArguments;
                 ImmutableArray<KeyValuePair<string, TypedConstant>> newAttributeNamedArguments = RetargetAttributeNamedArguments(oldAttributeNamedArguments);
 
                 // Must create a RetargetingAttributeData even if the types and
                 // arguments are unchanged since the AttributeData instance is
                 // used to resolve System.Type which may require retargeting.
                 return new RetargetingAttributeData(
-                    oldAttribute.ApplicationSyntaxReference,
+                    oldAttributeData,
                     newAttributeType,
                     newAttributeCtor,
                     newAttributeCtorArguments,
-                    oldAttribute.ConstructorArgumentsSourceIndices,
-                    newAttributeNamedArguments,
-                    hasErrors: oldAttribute.HasErrors || newAttributeCtor is null,
-                    oldAttribute.IsConditionallyOmitted);
+                    newAttributeNamedArguments);
             }
 
             private ImmutableArray<TypedConstant> RetargetAttributeConstructorArguments(ImmutableArray<TypedConstant> constructorArguments)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -168,15 +168,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NonSerializedAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NonSerializedAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasNonSerializedAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.FieldOffsetAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.FieldOffsetAttribute))
             {
                 if (this.IsStatic || this.IsConst)
                 {
@@ -189,8 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (offset < 0)
                     {
                         // Dev10 reports CS0647: "Error emitting attribute ..."
-                        CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, arguments.AttributeSyntaxOpt);
-                        diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
+                        diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(0), arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                         offset = 0;
                     }
 
@@ -199,7 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     arguments.GetOrCreateData<FieldWellKnownAttributeData>().SetFieldOffset(offset);
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
             {
                 MarshalAsAttributeDecoder<FieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
             }
@@ -215,27 +214,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 | ReservedAttributes.RequiredMemberAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DateTimeConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DateTimeConstantAttribute))
             {
                 VerifyConstantValueMatches(attribute.DecodeDateTimeConstantValue(), ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DecimalConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DecimalConstantAttribute))
             {
                 VerifyConstantValueMatches(attribute.DecodeDecimalConstantValue(), ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AllowNullAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasAllowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DisallowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DisallowNullAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasDisallowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasMaybeNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasNotNullAttribute = true;
             }
@@ -329,7 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     Debug.Assert(boundAttributes.Any());
 
                     // error CS0636: The FieldOffset attribute can only be placed on members of types marked with the StructLayout(LayoutKind.Explicit)
-                    int i = boundAttributes.IndexOfAttribute(this, AttributeDescription.FieldOffsetAttribute);
+                    int i = boundAttributes.IndexOfAttribute(AttributeDescription.FieldOffsetAttribute);
                     diagnostics.Add(ErrorCode.ERR_StructOffsetOnBadStruct, allAttributeSyntaxNodes[i].Name.Location);
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -1138,24 +1138,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // TODO: This list used to include AssemblyOperatingSystemAttribute and AssemblyProcessorAttribute,
             //       but it doesn't look like they are defined, cannot find them on MSDN.
-            if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyTitleAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyDescriptionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyConfigurationAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCultureAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyVersionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCompanyAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyProductAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyInformationalVersionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCopyrightAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyTrademarkAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyFileAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyNameAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyAlgorithmIdAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyFlagsAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyDelaySignAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyFileVersionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.SatelliteContractVersionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblySignatureKeyAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.AssemblyTitleAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyConfigurationAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyCompanyAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyProductAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyCopyrightAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyTrademarkAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyAlgorithmIdAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyFlagsAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyDelaySignAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.SatelliteContractVersionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute))
             {
                 return true;
             }
@@ -1500,19 +1500,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             void limitedDecodeWellKnownAttribute(CSharpAttributeData attribute, QuickAttributes attributeMatches, ref CommonAssemblyWellKnownAttributeData result)
             {
                 if (attributeMatches is QuickAttributes.AssemblySignatureKey &&
-                    attribute.IsTargetAttribute(this, AttributeDescription.AssemblySignatureKeyAttribute))
+                    attribute.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute))
                 {
                     result ??= new CommonAssemblyWellKnownAttributeData();
                     result.AssemblySignatureKeyAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 }
                 else if (attributeMatches is QuickAttributes.AssemblyKeyFile &&
-                    attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyFileAttribute))
+                    attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute))
                 {
                     result ??= new CommonAssemblyWellKnownAttributeData();
                     result.AssemblyKeyFileAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 }
                 else if (attributeMatches is QuickAttributes.AssemblyKeyName &&
-                    attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyNameAttribute))
+                    attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute))
                 {
                     result ??= new CommonAssemblyWellKnownAttributeData();
                     result.AssemblyKeyContainerAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
@@ -2350,96 +2350,96 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int signature;
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.InternalsVisibleToAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.InternalsVisibleToAttribute))
             {
                 DecodeOneInternalsVisibleToAttribute(arguments.AttributeSyntaxOpt, attribute, diagnostics, index, ref _lazyInternalsVisibleToMap);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblySignatureKeyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute))
             {
                 var signatureKey = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblySignatureKeyAttributeSetting = signatureKey;
 
                 if (!StrongNameKeys.IsValidPublicKeyString(signatureKey))
                 {
-                    diagnostics.Add(ErrorCode.ERR_InvalidSignaturePublicKey, attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt));
+                    diagnostics.Add(ErrorCode.ERR_InvalidSignaturePublicKey, attribute.GetAttributeArgumentLocation(0));
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyFileAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyKeyFileAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyKeyContainerAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyDelaySignAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyDelaySignAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyDelaySignAttributeSetting = (bool)attribute.CommonConstructorArguments[0].ValueInternal ? ThreeState.True : ThreeState.False;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute))
             {
                 string verString = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 Version version;
                 if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: !_compilation.IsEmitDeterministic, version: out version))
                 {
-                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
+                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentLocation(0);
                     bool foundBadWildcard = _compilation.IsEmitDeterministic && verString?.Contains('*') == true;
                     diagnostics.Add(foundBadWildcard ? ErrorCode.ERR_InvalidVersionFormatDeterministic : ErrorCode.ERR_InvalidVersionFormat, attributeArgumentSyntaxLocation, verString ?? "<null>");
                 }
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyVersionAttributeSetting = version;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyFileVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute))
             {
                 Version dummy;
                 string verString = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 if (!VersionHelper.TryParse(verString, version: out dummy))
                 {
-                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
+                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentLocation(0);
                     diagnostics.Add(ErrorCode.WRN_InvalidVersionFormat, attributeArgumentSyntaxLocation, verString ?? "<null>");
                 }
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyFileVersionAttributeSetting = verString;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyTitleAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyTitleAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyTitleAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyDescriptionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyDescriptionAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCultureAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute))
             {
                 var cultureString = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 if (!string.IsNullOrEmpty(cultureString))
                 {
                     if (_compilation.Options.OutputKind.IsApplication())
                     {
-                        diagnostics.Add(ErrorCode.ERR_InvalidAssemblyCultureForExe, attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt));
+                        diagnostics.Add(ErrorCode.ERR_InvalidAssemblyCultureForExe, attribute.GetAttributeArgumentLocation(0));
                     }
                     else if (!AssemblyIdentity.IsValidCultureName(cultureString))
                     {
-                        diagnostics.Add(ErrorCode.ERR_InvalidAssemblyCulture, attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt));
+                        diagnostics.Add(ErrorCode.ERR_InvalidAssemblyCulture, attribute.GetAttributeArgumentLocation(0));
                         cultureString = null;
                     }
                 }
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyCultureAttributeSetting = cultureString;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCompanyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyCompanyAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyCompanyAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyProductAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyProductAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyProductAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyInformationalVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyInformationalVersionAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SatelliteContractVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SatelliteContractVersionAttribute))
             {
                 //just check the format of this one, don't do anything else with it.
                 Version dummy;
@@ -2447,19 +2447,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: false, version: out dummy))
                 {
-                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
-                    diagnostics.Add(ErrorCode.ERR_InvalidVersionFormat2, attributeArgumentSyntaxLocation, verString ?? "<null>");
+                    diagnostics.Add(ErrorCode.ERR_InvalidVersionFormat2, attribute.GetAttributeArgumentLocation(0), verString ?? "<null>");
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCopyrightAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyCopyrightAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyCopyrightAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyTrademarkAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyTrademarkAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyTrademarkAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if ((signature = attribute.GetTargetAttributeSignatureIndex(this, AttributeDescription.AssemblyFlagsAttribute)) != -1)
+            else if ((signature = attribute.GetTargetAttributeSignatureIndex(AttributeDescription.AssemblyFlagsAttribute)) != -1)
             {
                 object value = attribute.CommonConstructorArguments[0].ValueInternal;
                 AssemblyFlags nameFlags;
@@ -2479,31 +2478,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 attribute.DecodeSecurityAttribute<CommonAssemblyWellKnownAttributeData>(this, _compilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ClassInterfaceAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ClassInterfaceAttribute))
             {
                 attribute.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.TypeLibVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.TypeLibVersionAttribute))
             {
                 ValidateIntegralAttributeNonNegativeArguments(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ComCompatibleVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ComCompatibleVersionAttribute))
             {
                 ValidateIntegralAttributeNonNegativeArguments(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.GuidAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.GuidAttribute))
             {
                 attribute.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CompilationRelaxationsAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CompilationRelaxationsAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().HasCompilationRelaxationsAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ReferenceAssemblyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ReferenceAssemblyAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().HasReferenceAssemblyAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.RuntimeCompatibilityAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.RuntimeCompatibilityAttribute))
             {
                 bool wrapNonExceptionThrows = true;
 
@@ -2519,15 +2518,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().RuntimeCompatibilityWrapNonExceptionThrows = wrapNonExceptionThrows;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DebuggableAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DebuggableAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().HasDebuggableAttribute = true;
             }
-            else if (!isFromNetModule && attribute.IsTargetAttribute(this, AttributeDescription.TypeForwardedToAttribute))
+            else if (!isFromNetModule && attribute.IsTargetAttribute(AttributeDescription.TypeForwardedToAttribute))
             {
                 DecodeTypeForwardedToAttribute(ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CaseSensitiveExtensionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CaseSensitiveExtensionAttribute))
             {
                 if ((object)arguments.AttributeSyntaxOpt != null)
                 {
@@ -2535,7 +2534,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_ExplicitExtension, arguments.AttributeSyntaxOpt.Location);
                 }
             }
-            else if ((signature = attribute.GetTargetAttributeSignatureIndex(this, AttributeDescription.AssemblyAlgorithmIdAttribute)) != -1)
+            else if ((signature = attribute.GetTargetAttributeSignatureIndex(AttributeDescription.AssemblyAlgorithmIdAttribute)) != -1)
             {
                 object value = attribute.CommonConstructorArguments[0].ValueInternal;
                 AssemblyHashAlgorithm algorithmId;
@@ -2551,7 +2550,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyAlgorithmIdAttributeSetting = algorithmId;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExperimentalAttribute))
             {
                 var obsoleteData = attribute.DecodeExperimentalAttribute();
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().ExperimentalAttributeData = obsoleteData;
@@ -2570,8 +2569,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (arg < 0)
                 {
                     // CS0591: Invalid value for argument to '{0}' attribute
-                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(i, nodeOpt);
-                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntaxLocation, (object)nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
+                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(i), (object)nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -733,22 +733,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(AttributeDescription.InterpolatedStringHandlerArgumentAttribute.Signatures.Length == 2);
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.DefaultParameterValueAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.DefaultParameterValueAttribute))
             {
                 // Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DefaultParameterValueAttribute, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DecimalConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DecimalConstantAttribute))
             {
                 // Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DecimalConstantAttribute, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DateTimeConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DateTimeConstantAttribute))
             {
                 // Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DateTimeConstantAttribute, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.OptionalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.OptionalAttribute))
             {
                 Debug.Assert(_lazyHasOptionalAttribute == ThreeState.True);
 
@@ -758,44 +758,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_DefaultValueUsedWithAttributes, arguments.AttributeSyntaxOpt.Name.Location);
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ParamArrayAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ParamArrayAttribute))
             {
                 // error CS0674: Do not use 'System.ParamArrayAttribute'. Use the 'params' keyword instead.
                 diagnostics.Add(ErrorCode.ERR_ExplicitParamArray, arguments.AttributeSyntaxOpt.Name.Location);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.InAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.InAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasInAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.OutAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.OutAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasOutAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
             {
                 MarshalAsAttributeDecoder<ParameterWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Parameter, MessageProvider.Instance);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IDispatchConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.IDispatchConstantAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasIDispatchConstantAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IUnknownConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.IUnknownConstantAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasIUnknownConstantAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CallerLineNumberAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CallerLineNumberAttribute))
             {
                 ValidateCallerLineNumberAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CallerFilePathAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CallerFilePathAttribute))
             {
                 ValidateCallerFilePathAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CallerMemberNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CallerMemberNameAttribute))
             {
                 ValidateCallerMemberNameAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CallerArgumentExpressionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CallerArgumentExpressionAttribute))
             {
                 ValidateCallerArgumentExpressionAttribute(arguments.AttributeSyntaxOpt, attribute, diagnostics);
             }
@@ -811,48 +811,48 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ReservedAttributes.ScopedRefAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AllowNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasAllowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DisallowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DisallowNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasDisallowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasMaybeNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullWhenAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullWhenAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().MaybeNullWhenAttribute = DecodeMaybeNullWhenOrNotNullWhenOrDoesNotReturnIfAttribute(attribute);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasNotNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullWhenAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullWhenAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().NotNullWhenAttribute = DecodeMaybeNullWhenOrNotNullWhenOrDoesNotReturnIfAttribute(attribute);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DoesNotReturnIfAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DoesNotReturnIfAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().DoesNotReturnIfAttribute = DecodeMaybeNullWhenOrNotNullWhenOrDoesNotReturnIfAttribute(attribute);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullIfNotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullIfNotNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().AddNotNullIfParameterNotNull(attribute.DecodeNotNullIfNotNullAttribute());
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.EnumeratorCancellationAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.EnumeratorCancellationAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasEnumeratorCancellationAttribute = true;
                 ValidateCancellationTokenAttribute(arguments.AttributeSyntaxOpt, (BindingDiagnosticBag)arguments.Diagnostics);
             }
-            else if (attribute.GetTargetAttributeSignatureIndex(this, AttributeDescription.InterpolatedStringHandlerArgumentAttribute) is (0 or 1) and var index)
+            else if (attribute.GetTargetAttributeSignatureIndex(AttributeDescription.InterpolatedStringHandlerArgumentAttribute) is (0 or 1) and var index)
             {
                 DecodeInterpolatedStringHandlerArgumentAttribute(ref arguments, diagnostics, index);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnscopedRefAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnscopedRefAttribute))
             {
                 if (!this.IsValidUnscopedRefAttributeTarget())
                 {
@@ -1237,7 +1237,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private void DecodeInterpolatedStringHandlerArgumentAttribute(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, BindingDiagnosticBag diagnostics, int attributeIndex)
         {
             Debug.Assert(attributeIndex is 0 or 1);
-            Debug.Assert(arguments.Attribute.IsTargetAttribute(this, AttributeDescription.InterpolatedStringHandlerArgumentAttribute) && arguments.Attribute.CommonConstructorArguments.Length == 1);
+            Debug.Assert(arguments.Attribute.IsTargetAttribute(AttributeDescription.InterpolatedStringHandlerArgumentAttribute) && arguments.Attribute.CommonConstructorArguments.Length == 1);
             Debug.Assert(arguments.AttributeSyntaxOpt is not null);
 
             if (Type is not NamedTypeSymbol { IsInterpolatedStringHandlerType: true } handlerType)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -298,22 +298,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
             else if (ReportExplicitUseOfReservedAttributes(in arguments, ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute | ReservedAttributes.TupleElementNamesAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<CommonEventWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnscopedRefAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnscopedRefAttribute))
             {
                 diagnostics.Add(ErrorCode.ERR_UnscopedRefAttributeUnsupportedMemberTarget, arguments.AttributeSyntaxOpt!.Location);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.FixedBufferAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.FixedBufferAttribute))
             {
                 // error CS1716: Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute. Use the 'fixed' field modifier instead.
                 ((BindingDiagnosticBag)arguments.Diagnostics).Add(ErrorCode.ERR_DoNotUseFixedBufferAttr, arguments.AttributeSyntaxOpt.Name.Location);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -506,35 +506,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
             Debug.Assert(!attribute.HasErrors);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.PreserveSigAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.PreserveSigAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().SetPreserveSignature(arguments.Index);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MethodImplAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MethodImplAttribute))
             {
                 AttributeData.DecodeMethodImplAttribute<MethodWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>(ref arguments, MessageProvider.Instance);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DllImportAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DllImportAttribute))
             {
                 DecodeDllImportAttribute(ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ConditionalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ConditionalAttribute))
             {
                 ValidateConditionalAttribute(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSuppressUnmanagedCodeSecurityAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicSecurityMethodAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DynamicSecurityMethodAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasDynamicSecurityMethodAttribute = true;
             }
@@ -553,42 +553,42 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ReservedAttributes.CaseSensitiveExtensionAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SecurityCriticalAttribute)
-                || attribute.IsTargetAttribute(this, AttributeDescription.SecuritySafeCriticalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SecurityCriticalAttribute)
+                || attribute.IsTargetAttribute(AttributeDescription.SecuritySafeCriticalAttribute))
             {
                 if (IsAsync)
                 {
                     diagnostics.Add(ErrorCode.ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync, arguments.AttributeSyntaxOpt.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<MethodWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DoesNotReturnAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DoesNotReturnAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasDoesNotReturnAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MemberNotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MemberNotNullAttribute))
             {
                 MessageID.IDS_FeatureMemberNotNull.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 CSharpAttributeData.DecodeMemberNotNullAttribute<MethodWellKnownAttributeData>(ContainingType, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MemberNotNullWhenAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MemberNotNullWhenAttribute))
             {
                 MessageID.IDS_FeatureMemberNotNull.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 CSharpAttributeData.DecodeMemberNotNullWhenAttribute<MethodWellKnownAttributeData>(ContainingType, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ModuleInitializerAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ModuleInitializerAttribute))
             {
                 MessageID.IDS_FeatureModuleInitializers.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 DecodeModuleInitializerAttribute(arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnmanagedCallersOnlyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnmanagedCallersOnlyAttribute))
             {
                 DecodeUnmanagedCallersOnlyAttribute(ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnscopedRefAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnscopedRefAttribute))
             {
                 if (this.IsValidUnscopedRefAttributeTarget())
                 {
@@ -599,7 +599,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_UnscopedRefAttributeUnsupportedMemberTarget, arguments.AttributeSyntaxOpt.Location);
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.InterceptsLocationAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.InterceptsLocationAttribute))
             {
                 DecodeInterceptsLocationAttribute(arguments);
             }
@@ -639,7 +639,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments,
             AttributeDescription description)
         {
-            if (arguments.Attribute.IsTargetAttribute(this, description))
+            if (arguments.Attribute.IsTargetAttribute(description))
             {
                 if (this.IsAccessor())
                 {
@@ -709,8 +709,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (name == null || !SyntaxFacts.IsValidIdentifier(name))
                 {
                     // CS0633: The argument to the '{0}' attribute must be a valid identifier
-                    CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, node);
-                    diagnostics.Add(ErrorCode.ERR_BadArgumentToAttribute, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+                    diagnostics.Add(ErrorCode.ERR_BadArgumentToAttribute, attribute.GetAttributeArgumentLocation(0), node.GetErrorDisplayName());
                 }
             }
         }
@@ -736,7 +735,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
             Debug.Assert(!attribute.HasErrors);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
             {
                 // MarshalAs applied to the return value:
                 MarshalAsAttributeDecoder<ReturnTypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.ReturnValue, MessageProvider.Instance);
@@ -752,15 +751,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ReservedAttributes.NativeIntegerAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
             {
                 arguments.GetOrCreateData<ReturnTypeWellKnownAttributeData>().HasMaybeNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullAttribute))
             {
                 arguments.GetOrCreateData<ReturnTypeWellKnownAttributeData>().HasNotNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullIfNotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullIfNotNullAttribute))
             {
                 arguments.GetOrCreateData<ReturnTypeWellKnownAttributeData>().AddNotNullIfParameterNotNull(attribute.DecodeNotNullIfNotNullAttribute());
             }
@@ -803,8 +802,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!MetadataHelpers.IsValidMetadataIdentifier(moduleName))
             {
                 // Dev10 reports CS0647: "Error emitting attribute ..."
-                CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, arguments.AttributeSyntaxOpt);
-                diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
+                diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(0), arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                 hasErrors = true;
                 moduleName = null;
             }
@@ -978,7 +976,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var attributeFilePath = (string?)attributeArguments[0].Value;
             if (attributeFilePath is null)
             {
-                diagnostics.Add(ErrorCode.ERR_InterceptorFilePathCannotBeNull, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax));
+                diagnostics.Add(ErrorCode.ERR_InterceptorFilePathCannotBeNull, attributeData.GetAttributeArgumentLocation(filePathParameterIndex));
                 return;
             }
 
@@ -1015,7 +1013,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     diagnostics.Add(
                         ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate,
-                        attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax),
+                        attributeData.GetAttributeArgumentLocation(filePathParameterIndex),
                         attributeFilePath,
                         mapPath(referenceResolver, unmappedMatch));
                     return;
@@ -1034,19 +1032,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     diagnostics.Add(
                         ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate,
-                        attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax),
+                        attributeData.GetAttributeArgumentLocation(filePathParameterIndex),
                         attributeFilePath,
                         mapPath(referenceResolver, suffixMatch));
                     return;
                 }
 
-                diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilation, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath);
+                diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilation, attributeData.GetAttributeArgumentLocation(filePathParameterIndex), attributeFilePath);
 
                 return;
             }
             else if (matchingTrees.Count > 1)
             {
-                diagnostics.Add(ErrorCode.ERR_InterceptorNonUniquePath, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath);
+                diagnostics.Add(ErrorCode.ERR_InterceptorNonUniquePath, attributeData.GetAttributeArgumentLocation(filePathParameterIndex), attributeFilePath);
                 return;
             }
 
@@ -1057,7 +1055,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (lineNumberZeroBased < 0 || characterNumberZeroBased < 0)
             {
-                var location = attributeData.GetAttributeArgumentSyntaxLocation(lineNumberZeroBased < 0 ? lineNumberParameterIndex : characterNumberParameterIndex, attributeSyntax);
+                var location = attributeData.GetAttributeArgumentLocation(lineNumberZeroBased < 0 ? lineNumberParameterIndex : characterNumberParameterIndex);
                 diagnostics.Add(ErrorCode.ERR_InterceptorLineCharacterMustBePositive, location);
                 return;
             }
@@ -1067,7 +1065,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (lineNumberZeroBased >= referencedLineCount)
             {
-                diagnostics.Add(ErrorCode.ERR_InterceptorLineOutOfRange, attributeData.GetAttributeArgumentSyntaxLocation(lineNumberParameterIndex, attributeSyntax), referencedLineCount, lineNumberOneBased);
+                diagnostics.Add(ErrorCode.ERR_InterceptorLineOutOfRange, attributeData.GetAttributeArgumentLocation(lineNumberParameterIndex), referencedLineCount, lineNumberOneBased);
                 return;
             }
 
@@ -1075,7 +1073,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var lineLength = line.End - line.Start;
             if (characterNumberZeroBased >= lineLength)
             {
-                diagnostics.Add(ErrorCode.ERR_InterceptorCharacterOutOfRange, attributeData.GetAttributeArgumentSyntaxLocation(characterNumberParameterIndex, attributeSyntax), lineLength, characterNumberOneBased);
+                diagnostics.Add(ErrorCode.ERR_InterceptorCharacterOutOfRange, attributeData.GetAttributeArgumentLocation(characterNumberParameterIndex), lineLength, characterNumberOneBased);
                 return;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -308,7 +308,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     foreach (var attrData in a.GetAttributes())
                     {
-                        if (attrData.IsTargetAttribute(a, AttributeDescription.GuidAttribute))
+                        if (attrData.IsTargetAttribute(AttributeDescription.GuidAttribute))
                         {
                             string guidString;
                             if (attrData.TryGetGuidAttributeValue(out guidString))
@@ -316,14 +316,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 hasGuidAttribute = true;
                             }
                         }
-                        else if (attrData.IsTargetAttribute(a, AttributeDescription.ImportedFromTypeLibAttribute))
+                        else if (attrData.IsTargetAttribute(AttributeDescription.ImportedFromTypeLibAttribute))
                         {
                             if (attrData.CommonConstructorArguments.Length == 1)
                             {
                                 hasImportedFromTypeLibOrPrimaryInteropAssemblyAttribute = true;
                             }
                         }
-                        else if (attrData.IsTargetAttribute(a, AttributeDescription.PrimaryInteropAssemblyAttribute))
+                        else if (attrData.IsTargetAttribute(AttributeDescription.PrimaryInteropAssemblyAttribute))
                         {
                             if (attrData.CommonConstructorArguments.Length == 2)
                             {
@@ -510,13 +510,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.DefaultCharSetAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.DefaultCharSetAttribute))
             {
                 CharSet charSet = attribute.GetConstructorArgument<CharSet>(0, SpecialType.System_Enum);
                 if (!ModuleWellKnownAttributeData.IsValidCharSet(charSet))
                 {
-                    CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, arguments.AttributeSyntaxOpt);
-                    ((BindingDiagnosticBag)arguments.Diagnostics).Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
+                    ((BindingDiagnosticBag)arguments.Diagnostics).Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(0), arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                 }
                 else
                 {
@@ -527,11 +526,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ReservedAttributes.NullableContextAttribute | ReservedAttributes.NullablePublicOnlyAttribute | ReservedAttributes.RefSafetyRulesAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<ModuleWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExperimentalAttribute))
             {
                 arguments.GetOrCreateData<ModuleWellKnownAttributeData>().ExperimentalAttributeData = attribute.DecodeExperimentalAttribute();
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1096,60 +1096,60 @@ next:;
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.AttributeUsageAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.AttributeUsageAttribute))
             {
                 DecodeAttributeUsageAttribute(attribute, arguments.AttributeSyntaxOpt, diagnose: true, diagnosticsOpt: diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DefaultMemberAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DefaultMemberAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasDefaultMemberAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CoClassAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CoClassAttribute))
             {
                 DecodeCoClassAttribute(ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ConditionalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ConditionalAttribute))
             {
                 ValidateConditionalAttribute(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.GuidAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.GuidAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().GuidString = attribute.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SerializableAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SerializableAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSerializableAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.StructLayoutAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.StructLayoutAttribute))
             {
                 AttributeData.DecodeStructLayoutAttribute<TypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>(
                     ref arguments, this.DefaultMarshallingCharSet, defaultAutoLayoutSize: 0, messageProvider: MessageProvider.Instance);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSuppressUnmanagedCodeSecurityAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ClassInterfaceAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ClassInterfaceAttribute))
             {
                 attribute.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.InterfaceTypeAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.InterfaceTypeAttribute))
             {
                 attribute.DecodeInterfaceTypeAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.WindowsRuntimeImportAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.WindowsRuntimeImportAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasWindowsRuntimeImportAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.RequiredAttributeAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.RequiredAttributeAttribute))
             {
                 // CS1608: The Required attribute is not permitted on C# types
                 diagnostics.Add(ErrorCode.ERR_CantUseRequiredAttribute, arguments.AttributeSyntaxOpt.Name.Location);
@@ -1168,16 +1168,16 @@ next:;
                 | ReservedAttributes.RequiredMemberAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SecurityCriticalAttribute)
-                || attribute.IsTargetAttribute(this, AttributeDescription.SecuritySafeCriticalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SecurityCriticalAttribute)
+                || attribute.IsTargetAttribute(AttributeDescription.SecuritySafeCriticalAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSecurityCriticalAttributes = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<TypeWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CollectionBuilderAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CollectionBuilderAttribute))
             {
                 var builderType = attribute.CommonConstructorArguments[0].ValueInternal as TypeSymbol;
                 if (!IsValidCollectionBuilderType(builderType))
@@ -1195,17 +1195,17 @@ next:;
                     diagnostics.Add(ErrorCode.ERR_CollectionBuilderAttributeInvalidMethodName, arguments.AttributeSyntaxOpt.Name.Location);
                 }
             }
-            else if (_lazyIsExplicitDefinitionOfNoPiaLocalType == ThreeState.Unknown && attribute.IsTargetAttribute(this, AttributeDescription.TypeIdentifierAttribute))
+            else if (_lazyIsExplicitDefinitionOfNoPiaLocalType == ThreeState.Unknown && attribute.IsTargetAttribute(AttributeDescription.TypeIdentifierAttribute))
             {
                 _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.True;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.InlineArrayAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.InlineArrayAttribute))
             {
                 int length = attribute.CommonConstructorArguments[0].DecodeValue<int>(SpecialType.System_Int32);
 
                 if (length <= 0)
                 {
-                    diagnostics.Add(ErrorCode.ERR_InvalidInlineArrayLength, attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt));
+                    diagnostics.Add(ErrorCode.ERR_InvalidInlineArrayLength, attribute.GetAttributeArgumentLocation(0));
                 }
 
                 if (TypeKind != TypeKind.Struct)
@@ -1311,8 +1311,7 @@ next:;
                     if (diagnose)
                     {
                         // invalid attribute target
-                        CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, node);
-                        diagnosticsOpt.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+                        diagnosticsOpt.Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(0), node.GetErrorDisplayName());
                     }
 
                     return AttributeUsageInfo.Null;
@@ -1392,8 +1391,7 @@ next:;
                 if (name == null || !SyntaxFacts.IsValidIdentifier(name))
                 {
                     // CS0633: The argument to the '{0}' attribute must be a valid identifier
-                    CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, node);
-                    diagnostics.Add(ErrorCode.ERR_BadArgumentToAttribute, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+                    diagnostics.Add(ErrorCode.ERR_BadArgumentToAttribute, attribute.GetAttributeArgumentLocation(0), node.GetErrorDisplayName());
                 }
             }
         }
@@ -1570,7 +1568,7 @@ next:;
                 // Symbol with ComImportAttribute must have a GuidAttribute
                 if (data == null || data.GuidString == null)
                 {
-                    int index = boundAttributes.IndexOfAttribute(this, AttributeDescription.ComImportAttribute);
+                    int index = boundAttributes.IndexOfAttribute(AttributeDescription.ComImportAttribute);
                     diagnostics.Add(ErrorCode.ERR_ComImportWithoutUuidAttribute, allAttributeSyntaxNodes[index].Name.Location);
                 }
 
@@ -1618,7 +1616,7 @@ next:;
                 Debug.Assert(boundAttributes.Any());
 
                 // Symbol with CoClassAttribute must have a ComImportAttribute
-                int index = boundAttributes.IndexOfAttribute(this, AttributeDescription.CoClassAttribute);
+                int index = boundAttributes.IndexOfAttribute(AttributeDescription.CoClassAttribute);
                 diagnostics.Add(ErrorCode.WRN_CoClassWithoutComImport, allAttributeSyntaxNodes[index].Location, this.Name);
             }
 
@@ -1627,7 +1625,7 @@ next:;
             {
                 Debug.Assert(boundAttributes.Any());
 
-                int index = boundAttributes.IndexOfAttribute(this, AttributeDescription.DefaultMemberAttribute);
+                int index = boundAttributes.IndexOfAttribute(AttributeDescription.DefaultMemberAttribute);
                 diagnostics.Add(ErrorCode.ERR_DefaultMemberOnIndexedType, allAttributeSyntaxNodes[index].Name.Location);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -773,11 +773,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var annotations = ReturnTypeFlowAnalysisAnnotations;
             if ((annotations & FlowAnalysisAnnotations.MaybeNull) != 0)
             {
-                AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(_property.MaybeNullAttributeIfExists));
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(_property.MaybeNullAttributeIfExists));
             }
             if ((annotations & FlowAnalysisAnnotations.NotNull) != 0)
             {
-                AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(_property.NotNullAttributeIfExists));
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(_property.NotNullAttributeIfExists));
             }
         }
 
@@ -795,7 +795,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 foreach (var attributeData in _property.MemberNotNullAttributeIfExists)
                 {
-                    AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(attributeData));
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(attributeData));
                 }
             }
 
@@ -803,7 +803,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 foreach (var attributeData in _property.MemberNotNullWhenAttributeIfExists)
                 {
-                    AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(attributeData));
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(attributeData));
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -1246,24 +1246,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.IndexerNameAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.IndexerNameAttribute))
             {
                 //NOTE: decoding was done by EarlyDecodeWellKnownAttribute.
                 ValidateIndexerNameAttribute(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<PropertyWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DynamicAttribute))
             {
                 // DynamicAttribute should not be set explicitly.
                 diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
@@ -1280,33 +1280,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 | ReservedAttributes.RequiredMemberAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DisallowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DisallowNullAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasDisallowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AllowNullAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasAllowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasMaybeNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasNotNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MemberNotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MemberNotNullAttribute))
             {
                 MessageID.IDS_FeatureMemberNotNull.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 CSharpAttributeData.DecodeMemberNotNullAttribute<PropertyWellKnownAttributeData>(ContainingType, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MemberNotNullWhenAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MemberNotNullWhenAttribute))
             {
                 MessageID.IDS_FeatureMemberNotNull.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 CSharpAttributeData.DecodeMemberNotNullWhenAttribute<PropertyWellKnownAttributeData>(ContainingType, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnscopedRefAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnscopedRefAttribute))
             {
                 if (this.IsValidUnscopedRefAttributeTarget())
                 {
@@ -1389,10 +1389,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool HasUnscopedRefAttribute => GetDecodedWellKnownAttributeData()?.HasUnscopedRefAttribute == true;
 
         private SourceAttributeData FindAttribute(AttributeDescription attributeDescription)
-            => (SourceAttributeData)GetAttributes().First(a => a.IsTargetAttribute(this, attributeDescription));
+            => (SourceAttributeData)GetAttributes().First(a => a.IsTargetAttribute(attributeDescription));
 
         private ImmutableArray<SourceAttributeData> FindAttributes(AttributeDescription attributeDescription)
-            => GetAttributes().Where(a => a.IsTargetAttribute(this, attributeDescription)).Cast<SourceAttributeData>().ToImmutableArray();
+            => GetAttributes().Where(a => a.IsTargetAttribute(attributeDescription)).Cast<SourceAttributeData>().ToImmutableArray();
 
         internal override void PostDecodeWellKnownAttributes(ImmutableArray<CSharpAttributeData> boundAttributes, ImmutableArray<AttributeSyntax> allAttributeSyntaxNodes, BindingDiagnosticBag diagnostics, AttributeLocation symbolPart, WellKnownAttributeData decodedData)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SynthesizedAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SynthesizedAttributeData.cs
@@ -11,35 +11,77 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// Class to represent a synthesized attribute
     /// </summary>
-    internal sealed class SynthesizedAttributeData : SourceAttributeData
+    internal abstract class SynthesizedAttributeData : CSharpAttributeData
     {
-        internal SynthesizedAttributeData(MethodSymbol wellKnownMember, ImmutableArray<TypedConstant> arguments, ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
-            : base(
-            applicationNode: null,
-            attributeClass: wellKnownMember.ContainingType,
-            attributeConstructor: wellKnownMember,
-            constructorArguments: arguments,
-            constructorArgumentsSourceIndices: default,
-            namedArguments: namedArguments,
-            hasErrors: false,
-            isConditionallyOmitted: false)
+        public static SynthesizedAttributeData Create(CSharpCompilation compilation, MethodSymbol wellKnownMember, ImmutableArray<TypedConstant> arguments, ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
         {
-            Debug.Assert((object)wellKnownMember != null);
-            Debug.Assert(!arguments.IsDefault);
-            Debug.Assert(!namedArguments.IsDefault); // Frequently empty though.
+            return new FromMethodAndArguments(compilation, wellKnownMember, arguments, namedArguments);
         }
 
-        internal SynthesizedAttributeData(SourceAttributeData original)
-            : base(
-            applicationNode: original.ApplicationSyntaxReference,
-            attributeClass: original.AttributeClass,
-            attributeConstructor: original.AttributeConstructor,
-            constructorArguments: original.CommonConstructorArguments,
-            constructorArgumentsSourceIndices: original.ConstructorArgumentsSourceIndices,
-            namedArguments: original.CommonNamedArguments,
-            hasErrors: original.HasErrors,
-            isConditionallyOmitted: original.IsConditionallyOmitted)
+        public static SynthesizedAttributeData Create(SourceAttributeData original)
         {
+            return new FromSourceAttributeData(original);
+        }
+
+        private sealed class FromMethodAndArguments : SynthesizedAttributeData
+        {
+            private readonly CSharpCompilation _compilation;
+            private readonly MethodSymbol _wellKnownMember;
+            private readonly ImmutableArray<TypedConstant> _arguments;
+            private readonly ImmutableArray<KeyValuePair<string, TypedConstant>> _namedArguments;
+
+            internal FromMethodAndArguments(CSharpCompilation compilation, MethodSymbol wellKnownMember, ImmutableArray<TypedConstant> arguments, ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
+            {
+                Debug.Assert((object)wellKnownMember != null);
+                Debug.Assert(!arguments.IsDefault);
+                Debug.Assert(!namedArguments.IsDefault); // Frequently empty though.
+
+                _compilation = compilation;
+                _wellKnownMember = wellKnownMember;
+                _arguments = arguments;
+                _namedArguments = namedArguments;
+            }
+
+            public override SyntaxReference? ApplicationSyntaxReference => null;
+            public override NamedTypeSymbol AttributeClass => _wellKnownMember.ContainingType;
+            public override MethodSymbol AttributeConstructor => _wellKnownMember;
+            protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _arguments;
+            protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _namedArguments;
+            internal override bool HasErrors => false;
+            internal override bool IsConditionallyOmitted => false;
+            internal override Location GetAttributeArgumentLocation(int parameterIndex) => NoLocation.Singleton;
+
+            internal override int GetTargetAttributeSignatureIndex(AttributeDescription description)
+            {
+                return SourceAttributeData.GetTargetAttributeSignatureIndex(_compilation, AttributeClass, AttributeConstructor, description);
+            }
+
+            internal override bool IsTargetAttribute(string namespaceName, string typeName)
+            {
+                return SourceAttributeData.IsTargetAttribute(AttributeClass, namespaceName, typeName);
+            }
+        }
+
+        private sealed class FromSourceAttributeData : SynthesizedAttributeData
+        {
+            private readonly SourceAttributeData _original;
+
+            internal FromSourceAttributeData(SourceAttributeData original)
+            {
+                _original = original;
+            }
+
+            public override SyntaxReference? ApplicationSyntaxReference => _original.ApplicationSyntaxReference;
+            public override NamedTypeSymbol AttributeClass => _original.AttributeClass;
+            public override MethodSymbol? AttributeConstructor => _original.AttributeConstructor;
+            protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _original.CommonConstructorArguments;
+            protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _original.CommonNamedArguments;
+            internal override bool HasErrors => _original.HasErrors;
+            internal override bool IsConditionallyOmitted => _original.IsConditionallyOmitted;
+
+            internal override Location GetAttributeArgumentLocation(int parameterIndex) => _original.GetAttributeArgumentLocation(parameterIndex);
+            internal override int GetTargetAttributeSignatureIndex(AttributeDescription description) => _original.GetTargetAttributeSignatureIndex(description);
+            internal override bool IsTargetAttribute(string namespaceName, string typeName) => _original.IsTargetAttribute(namespaceName, typeName);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1377,7 +1377,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var attrData in this.GetAttributes())
             {
-                if (attrData.IsTargetAttribute(this, AttributeDescription.GuidAttribute))
+                if (attrData.IsTargetAttribute(AttributeDescription.GuidAttribute))
                 {
                     if (attrData.TryGetGuidAttributeValue(out guidString))
                     {
@@ -1464,7 +1464,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
             if ((reserved & ReservedAttributes.DynamicAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.DynamicAttribute))
             {
                 // DynamicAttribute should not be set explicitly.
                 diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
@@ -1486,12 +1486,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
             }
             else if ((reserved & ReservedAttributes.TupleElementNamesAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute))
             {
                 diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if ((reserved & ReservedAttributes.NullableAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.NullableAttribute))
             {
                 // NullableAttribute should not be set explicitly.
                 diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
@@ -1509,19 +1509,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
             }
             else if ((reserved & ReservedAttributes.CaseSensitiveExtensionAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.CaseSensitiveExtensionAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.CaseSensitiveExtensionAttribute))
             {
                 // ExtensionAttribute should not be set explicitly.
                 diagnostics.Add(ErrorCode.ERR_ExplicitExtension, arguments.AttributeSyntaxOpt.Location);
             }
             else if ((reserved & ReservedAttributes.RequiredMemberAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.RequiredMemberAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.RequiredMemberAttribute))
             {
                 // Do not use 'System.Runtime.CompilerServices.RequiredMemberAttribute'. Use the 'required' keyword on required fields and properties instead.
                 diagnostics.Add(ErrorCode.ERR_ExplicitRequiredMember, arguments.AttributeSyntaxOpt.Location);
             }
             else if ((reserved & ReservedAttributes.ScopedRefAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.ScopedRefAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.ScopedRefAttribute))
             {
                 // Do not use 'System.Runtime.CompilerServices.ScopedRefAttribute'. Use the 'scoped' keyword instead.
                 diagnostics.Add(ErrorCode.ERR_ExplicitScopedRef, arguments.AttributeSyntaxOpt.Location);
@@ -1538,7 +1538,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool reportExplicitUseOfReservedAttribute(CSharpAttributeData attribute, in DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, in AttributeDescription attributeDescription)
             {
-                if (attribute.IsTargetAttribute(this, attributeDescription))
+                if (attribute.IsTargetAttribute(attributeDescription))
                 {
                     // Do not use '{FullName}'. This is reserved for compiler usage.
                     diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, attributeDescription.FullName);

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -832,7 +832,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Find the AsyncMethodBuilder attribute.
             foreach (var attr in symbol.GetAttributes())
             {
-                if (attr.IsTargetAttribute(symbol, AttributeDescription.AsyncMethodBuilderAttribute)
+                if (attr.IsTargetAttribute(AttributeDescription.AsyncMethodBuilderAttribute)
                     && attr.CommonConstructorArguments.Length == 1
                     && attr.CommonConstructorArguments[0].Kind == TypedConstantKind.Type)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
@@ -219,16 +219,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(arguments.Diagnostics.DiagnosticBag is not null);
             Debug.Assert(arguments.AttributeSyntaxOpt is not null);
-            if (arguments.Attribute.IsTargetAttribute(this, AttributeDescription.CompilerFeatureRequiredAttribute))
+            if (arguments.Attribute.IsTargetAttribute(AttributeDescription.CompilerFeatureRequiredAttribute))
             {
                 // Do not use '{FullName}'. This is reserved for compiler usage.
                 arguments.Diagnostics.DiagnosticBag.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.CompilerFeatureRequiredAttribute.FullName);
             }
-            else if (arguments.Attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+            else if (arguments.Attribute.IsTargetAttribute(AttributeDescription.ExperimentalAttribute))
             {
                 if (!SyntaxFacts.IsValidIdentifier((string?)arguments.Attribute.CommonConstructorArguments[0].ValueInternal))
                 {
-                    var attrArgumentLocation = arguments.Attribute.GetAttributeArgumentSyntaxLocation(parameterIndex: 0, arguments.AttributeSyntaxOpt);
+                    var attrArgumentLocation = arguments.Attribute.GetAttributeArgumentLocation(parameterIndex: 0);
                     arguments.Diagnostics.DiagnosticBag.Add(ErrorCode.ERR_InvalidExperimentalDiagID, attrArgumentLocation);
                 }
             }
@@ -469,7 +469,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         CSharpAttributeData boundAttribute = boundAttributes[i];
 
-                        if (!boundAttribute.HasErrors && boundAttribute.IsTargetAttribute(this, AttributeDescription.TypeForwardedToAttribute) &&
+                        if (!boundAttribute.HasErrors && boundAttribute.IsTargetAttribute(AttributeDescription.TypeForwardedToAttribute) &&
                             boundAttribute.CommonConstructorArguments[0].ValueInternal is TypeSymbol &&
                             attributesToBind[i].ArgumentList?.Arguments[0].Expression.Location is { } location)
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
@@ -85,11 +85,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var annotations = FlowAnalysisAnnotations;
                 if ((annotations & FlowAnalysisAnnotations.DisallowNull) != 0)
                 {
-                    AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(property.DisallowNullAttributeIfExists));
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.DisallowNullAttributeIfExists));
                 }
                 if ((annotations & FlowAnalysisAnnotations.AllowNull) != 0)
                 {
-                    AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(property.AllowNullAttributeIfExists));
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.AllowNullAttributeIfExists));
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.FixedBufferAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.FixedBufferAttribute))
             {
                 // error CS8362: Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute on property
                 ((BindingDiagnosticBag)arguments.Diagnostics).Add(ErrorCode.ERR_DoNotUseFixedBufferAttrOnProperty, arguments.AttributeSyntaxOpt.Name.Location);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
@@ -182,7 +182,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             AddSynthesizedAttribute(
                 ref attributes,
-                new SynthesizedAttributeData(
+                SynthesizedAttributeData.Create(
+                    moduleBuilder.Compilation,
                     _inlineArrayAttributeConstructor,
                     arguments: ImmutableArray.Create(new TypedConstant(compilation.GetSpecialType(SpecialType.System_Int32), TypedConstantKind.Primitive, _arrayLength)),
                     namedArguments: ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty));

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -2984,7 +2984,7 @@ class UsePia5 : ITest30
         }
 
         [Fact]
-        public void DispIdAttribute()
+        public void DispIdAttribute_01()
         {
             string pia = @"
 using System;
@@ -3047,6 +3047,88 @@ class UsePia5 : ITest30
             CompileAndVerify(compilation1, symbolValidator: metadataValidator);
 
             CompileAndVerify(compilation2, symbolValidator: metadataValidator);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70338")]
+        public void DispIdAttribute_02()
+        {
+            string dispId = @"
+namespace System.Runtime.InteropServices
+{
+    public class DispIdAttribute : System.Attribute
+    {
+        public DispIdAttribute (int dispId){}
+    }
+}
+";
+            var dispIdDefinition = CreateCompilation(dispId, options: TestOptions.ReleaseDll, assemblyName: "DispId").EmitToImageReference(aliases: ImmutableArray.Create("dispId"));
+
+            string pia = @"
+extern alias dispId;
+
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: ImportedFromTypeLib(""GeneralPIA.dll"")]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest30
+{
+    [dispId::System.Runtime.InteropServices.DispIdAttribute(124)]
+    void M1();
+}
+";
+
+            var piaCompilation = CreateCompilation(pia, references: new[] { dispIdDefinition }, options: TestOptions.ReleaseDll, assemblyName: "Pia");
+
+            CompileAndVerify(piaCompilation).VerifyDiagnostics();
+
+            string consumer = @"
+class UsePia
+{
+    public static void Main()
+    {
+    }
+}
+
+class UsePia5 : ITest30
+{
+    public void M1()
+    {
+    }
+} 
+";
+
+            var compilation1 = CreateCompilation(consumer, options: TestOptions.ReleaseExe,
+                references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation, embedInteropTypes: true) });
+
+            var compilation2 = CreateCompilation(consumer, options: TestOptions.ReleaseExe,
+                references: new MetadataReference[] { piaCompilation.EmitToImageReference(embedInteropTypes: true) });
+
+            System.Action<ModuleSymbol> metadataValidator =
+                delegate (ModuleSymbol module)
+                {
+                    ((PEModuleSymbol)module).Module.PretendThereArentNoPiaLocalTypes();
+
+                    var itest30 = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMembers("ITest30").Single();
+
+                    var m1 = (PEMethodSymbol)itest30.GetMembers("M1").Single();
+
+                    var attr = m1.GetAttributes("System.Runtime.InteropServices", "DispIdAttribute").Single();
+                    Assert.Equal("System.Runtime.InteropServices.DispIdAttribute(124)", attr.ToString());
+                };
+
+            CompileAndVerify(compilation1.AddReferences(dispIdDefinition), symbolValidator: metadataValidator).VerifyDiagnostics();
+
+            CompileAndVerify(compilation1, symbolValidator: metadataValidator).VerifyDiagnostics();
+
+            CompileAndVerify(compilation2.AddReferences(dispIdDefinition), symbolValidator: metadataValidator).VerifyDiagnostics();
+
+            // https://github.com/dotnet/roslyn/issues/70338: Going to start failing after https://github.com/dotnet/roslyn/pull/70151 is merged
+            //CompileAndVerify(compilation2, symbolValidator: metadataValidator).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -588,9 +588,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.True(attributeData.ConstructorArgumentsSourceIndices.IsDefault);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal("a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"b: new object[] { ""Hello"", ""World"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal("a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"b: new object[] { ""Hello"", ""World"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -620,10 +619,9 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 2, 0, 1 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal("a: 2", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal("b: 0", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
-            Assert.Equal("c: 1", attributeData.GetAttributeArgumentSyntax(parameterIndex: 2, attributeSyntax).ToString());
+            Assert.Equal("a: 2", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal("b: 0", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
+            Assert.Equal("c: 1", attributeData.GetAttributeArgumentSyntax(parameterIndex: 2).ToString());
         }
 
         [Fact]
@@ -1103,9 +1101,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 1, 0 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"b: new object[] { ""Hello"", ""World"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"b: new object[] { ""Hello"", ""World"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -1144,9 +1141,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 1, 0 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = comp.SyntaxTrees[0].GetRoot().DescendantNodes().OfType<AttributeSyntax>().First();
-            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"b: ""Hello""", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"b: ""Hello""", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -1184,9 +1180,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 0, 1 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal(@"true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"new object[] { ""Hello"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"new object[] { ""Hello"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -1224,9 +1219,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 0, 1 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"new object[] { ""Hello"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"new object[] { ""Hello"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -1263,9 +1257,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 1, 0 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"b: null", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"b: null", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Assembly.cs
@@ -2127,7 +2127,7 @@ public class C { }
 
         private static IEnumerable<CSharpAttributeData> GetAssemblyDescriptionAttributes(AssemblySymbol assembly)
         {
-            return assembly.GetAttributes().Where(data => data.IsTargetAttribute(assembly, AttributeDescription.AssemblyDescriptionAttribute));
+            return assembly.GetAttributes().Where(data => data.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute));
         }
 
         [Fact, WorkItem(530579, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530579")]
@@ -2237,10 +2237,8 @@ public class C { }
 
             CompileAndVerify(appCompilation, symbolValidator: (ModuleSymbol m) =>
             {
-                // var list = new ArrayBuilder<AttributeData>();
-                var asm = m.ContainingAssembly;
                 var attrs = m.ContainingAssembly.GetAttributes();
-                var attrlist = attrs.Where(a => a.IsTargetAttribute(asm, AttributeDescription.AssemblyFileVersionAttribute));
+                var attrlist = attrs.Where(a => a.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute));
 
                 Assert.Equal(1, attrlist.Count());
                 Assert.Equal("System.Reflection.AssemblyFileVersionAttribute(\"4.3.2.1\")", attrlist.First().ToString());
@@ -2267,6 +2265,127 @@ static class Logo
 
             var compilation = CreateCompilation(s, options: TestOptions.ReleaseDll);
             compilation.GetDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70338")]
+        public void ErrorsWithAssemblyAttributesInModules_01()
+        {
+            string attribute1 = @"
+public class A1 : System.Attribute
+{
+    public A1(int a){}
+}
+";
+            var attributeDefinition1 = CreateCompilation(attribute1, options: TestOptions.ReleaseDll, assemblyName: "A1").EmitToImageReference();
+
+            string module = @"
+[assembly:A1(1)]
+";
+            var moduleWithAttribute = CreateCompilation(module, references: new[] { attributeDefinition1 }, options: TestOptions.ReleaseModule, assemblyName: "M1").EmitToImageReference();
+
+            var comp = CreateCompilation("", references: new[] { moduleWithAttribute, attributeDefinition1 }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp, symbolValidator: (m) =>
+                                                    {
+                                                        var attrs = m.ContainingAssembly.GetAttributes();
+                                                        Assert.Equal(4, attrs.Length);
+                                                        AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                        AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                        AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                        AssertEx.Equal("A1(1)", attrs[3].ToString());
+                                                    }).VerifyDiagnostics();
+
+            var comp2 = CreateCompilation("", references: new[] { moduleWithAttribute }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp2, symbolValidator: (m) =>
+                                                     {
+                                                         var attrs = m.ContainingAssembly.GetAttributes();
+                                                         Assert.Equal(3, attrs.Length);
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                         AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                     }).VerifyDiagnostics();
+
+            string attribute2 = @"
+public class A1 : System.Attribute
+{
+    public A1(){}
+}
+";
+            var attributeDefinition2 = CreateCompilation(attribute2, options: TestOptions.ReleaseDll, assemblyName: "A1").EmitToImageReference();
+
+            var comp3 = CreateCompilation("", references: new[] { moduleWithAttribute, attributeDefinition2 }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp3, symbolValidator: (m) =>
+                                                     {
+                                                         var attrs = m.ContainingAssembly.GetAttributes();
+                                                         Assert.Equal(3, attrs.Length);
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                         AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                     }).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70338")]
+        public void ErrorsWithAssemblyAttributesInModules_02()
+        {
+            string c1 = @"
+public class C1
+{
+}
+";
+            var c1Definition = CreateCompilation(c1, options: TestOptions.ReleaseDll, assemblyName: "A1").EmitToImageReference();
+
+            string module1 = @"
+[assembly:A1(typeof(C1))]
+
+public class A1 : System.Attribute
+{
+    public A1(System.Type t){}
+}
+";
+            var module1WithAttribute = CreateCompilation(module1, references: new[] { c1Definition }, options: TestOptions.ReleaseModule, assemblyName: "M1").EmitToImageReference();
+
+            var comp = CreateCompilation("", references: new[] { module1WithAttribute, c1Definition }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp, symbolValidator: (m) =>
+                                                    {
+                                                        var attrs = m.ContainingAssembly.GetAttributes();
+                                                        Assert.Equal(4, attrs.Length);
+                                                        AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                        AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                        AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                        AssertEx.Equal("A1(typeof(C1))", attrs[3].ToString());
+                                                    }).VerifyDiagnostics();
+
+            var comp2 = CreateCompilation("", references: new[] { module1WithAttribute }, options: TestOptions.ReleaseDll);
+
+            comp2.VerifyEmitDiagnostics(
+                // error CS0012: The type 'C1' is defined in an assembly that is not referenced. You must add a reference to assembly 'A1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("C1", "A1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+                );
+
+            string module2 = @"
+[module:A1(typeof(C1))]
+
+public class A1 : System.Attribute
+{
+    public A1(System.Type t){}
+}
+";
+            var module2WithAttribute = CreateCompilation(module2, references: new[] { c1Definition }, options: TestOptions.ReleaseModule, assemblyName: "M1").EmitToImageReference();
+            var comp3 = CreateCompilation("", references: new[] { module2WithAttribute, c1Definition }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp3, symbolValidator: (m) =>
+                                                     {
+                                                         var attrs = m.ContainingAssembly.GetAttributes();
+                                                         Assert.Equal(3, attrs.Length);
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                         AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                     }).VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -115,7 +115,7 @@ public class Test
 
                 foreach (var attrData in m.ContainingAssembly.GetAttributes())
                 {
-                    if (attrData.IsTargetAttribute(m.ContainingAssembly, AttributeDescription.AssemblyKeyFileAttribute))
+                    if (attrData.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute))
                     {
                         haveAttribute = true;
                         break;
@@ -258,7 +258,7 @@ public class Test
 
                 foreach (var attrData in m.ContainingAssembly.GetAttributes())
                 {
-                    if (attrData.IsTargetAttribute(m.ContainingAssembly, AttributeDescription.AssemblyKeyNameAttribute))
+                    if (attrData.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute))
                     {
                         haveAttribute = true;
                         break;
@@ -2795,7 +2795,7 @@ class B
             {
                 var assembly = module.ContainingAssembly;
                 Assert.NotNull(assembly);
-                Assert.False(assembly.GetAttributes().Any(attr => attr.IsTargetAttribute(assembly, AttributeDescription.InternalsVisibleToAttribute)));
+                Assert.False(assembly.GetAttributes().Any(attr => attr.IsTargetAttribute(AttributeDescription.InternalsVisibleToAttribute)));
             });
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -11562,7 +11562,7 @@ public class A
             Assert.Equal(expectedScope, parameter.EffectiveScope);
             Assert.Equal(expectedHasUnscopedRefAttribute, parameter.HasUnscopedRefAttribute);
 
-            var attribute = parameter.GetAttributes().FirstOrDefault(a => a.GetTargetAttributeSignatureIndex(parameter, AttributeDescription.ScopedRefAttribute) != -1);
+            var attribute = parameter.GetAttributes().FirstOrDefault(a => a.GetTargetAttributeSignatureIndex(AttributeDescription.ScopedRefAttribute) != -1);
             Assert.Null(attribute);
 
             VerifyParameterSymbol(parameter.GetPublicSymbol(), expectedDisplayString, expectedRefKind, expectedScope);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -2127,7 +2127,7 @@ class Program
             var indexer = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Program").Indexers.Single();
             Assert.True(indexer.IsIndexer);
             Assert.Equal("A", indexer.MetadataName);
-            Assert.True(indexer.GetAttributes().Single().IsTargetAttribute(indexer, AttributeDescription.IndexerNameAttribute));
+            Assert.True(indexer.GetAttributes().Single().IsTargetAttribute(AttributeDescription.IndexerNameAttribute));
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMember.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMember.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
                 foreach (var attrData in GetCustomAttributesToEmit(moduleBuilder))
                 {
-                    if (TypeManager.IsTargetAttribute(UnderlyingSymbol, attrData, AttributeDescription.DispIdAttribute))
+                    if (TypeManager.IsTargetAttribute(attrData, AttributeDescription.DispIdAttribute))
                     {
                         if (attrData.CommonConstructorArguments.Length == 1)
                         {

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 // The constructors might be missing (for example, in metadata case) and doing lookup
                 // will ensure that we report appropriate errors.
 
-                if (TypeManager.IsTargetAttribute(UnderlyingMethod, attrData, AttributeDescription.LCIDConversionAttribute))
+                if (TypeManager.IsTargetAttribute(attrData, AttributeDescription.LCIDConversionAttribute))
                 {
                     if (attrData.CommonConstructorArguments.Length == 1)
                     {

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedParameter.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedParameter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
             private bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
             {
-                return TypeManager.IsTargetAttribute(UnderlyingParameter, attrData, description);
+                return TypeManager.IsTargetAttribute(attrData, description);
             }
 
             private ImmutableArray<TAttributeData> GetAttributes(TPEModuleBuilder moduleBuilder, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                     }
                     else
                     {
-                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(UnderlyingParameter, attrData, AttributeDescription.DecimalConstantAttribute);
+                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(attrData, AttributeDescription.DecimalConstantAttribute);
                         if (signatureIndex != -1)
                         {
                             Debug.Assert(signatureIndex == 0 || signatureIndex == 1);

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
             private bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
             {
-                return TypeManager.IsTargetAttribute(UnderlyingNamedType, attrData, description);
+                return TypeManager.IsTargetAttribute(attrData, description);
             }
 
             private ImmutableArray<TAttributeData> GetAttributes(TPEModuleBuilder moduleBuilder, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                     }
                     else
                     {
-                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(UnderlyingNamedType, attrData, AttributeDescription.InterfaceTypeAttribute);
+                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(attrData, AttributeDescription.InterfaceTypeAttribute);
                         if (signatureIndex != -1)
                         {
                             Debug.Assert(signatureIndex == 0 || signatureIndex == 1);

--- a/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
@@ -148,11 +148,11 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
             return false;
         }
 
-        internal abstract int GetTargetAttributeSignatureIndex(TSymbol underlyingSymbol, TAttributeData attrData, AttributeDescription description);
+        internal abstract int GetTargetAttributeSignatureIndex(TAttributeData attrData, AttributeDescription description);
 
-        internal bool IsTargetAttribute(TSymbol underlyingSymbol, TAttributeData attrData, AttributeDescription description)
+        internal bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
         {
-            return GetTargetAttributeSignatureIndex(underlyingSymbol, attrData, description) != -1;
+            return GetTargetAttributeSignatureIndex(attrData, description) != -1;
         }
 
         internal abstract TAttributeData CreateSynthesizedAttribute(WellKnownMember constructor, TAttributeData attrData, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         public static IEnumerable<CSharpAttributeData> GetAttributes(this Symbol @this, AttributeDescription description)
         {
-            return @this.GetAttributes().Where(a => a.IsTargetAttribute(@this, description));
+            return @this.GetAttributes().Where(a => a.IsTargetAttribute(description));
         }
 
         public static CSharpAttributeData GetAttribute(this Symbol @this, NamedTypeSymbol c)

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -147,7 +147,7 @@ Friend Module Extensions
 
     <Extension>
     Friend Function GetAttributes(this As Symbol, description As AttributeDescription) As IEnumerable(Of VisualBasicAttributeData)
-        Return this.GetAttributes().Where(Function(a) a.IsTargetAttribute(this, description))
+        Return this.GetAttributes().Where(Function(a) a.IsTargetAttribute(description))
     End Function
 
     <Extension>

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim namedArgs As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)) = visitor.VisitNamedArguments(boundAttribute.NamedArguments, diagnostics)
             Dim isConditionallyOmitted As Boolean = Not visitor.HasErrors AndAlso IsAttributeConditionallyOmitted(boundAttributeType, node, boundAttribute.SyntaxTree)
 
-            Return New SourceAttributeData(node.GetReference(), DirectCast(boundAttribute.Type, NamedTypeSymbol), boundAttribute.Constructor, args, namedArgs, isConditionallyOmitted, hasErrors:=visitor.HasErrors)
+            Return New SourceAttributeData(Compilation, node.GetReference(), DirectCast(boundAttribute.Type, NamedTypeSymbol), boundAttribute.Constructor, args, namedArgs, isConditionallyOmitted, hasErrors:=visitor.HasErrors)
         End Function
 
         Protected Function IsAttributeConditionallyOmitted(attributeType As NamedTypeSymbol, node As AttributeSyntax, syntaxTree As SyntaxTree) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -219,7 +219,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Case MethodKind.PropertyGet, MethodKind.PropertySet
                         ' As in dev11, this warning is not produced for event accessors.
                         For Each attribute In symbol.GetAttributes()
-                            If attribute.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute) Then
+                            If attribute.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute) Then
                                 Dim attributeLocation As Location = Nothing
                                 If TryGetAttributeWarningLocation(attribute, attributeLocation) Then
                                     Dim attributeUsage As AttributeUsageInfo = attribute.AttributeClass.GetAttributeUsageInfo()
@@ -760,7 +760,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             isAttributeInherited = False
             For Each attributeData In symbol.GetAttributes()
                 ' Check signature before HasErrors to avoid realizing symbols for other attributes.
-                If attributeData.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute) Then
+                If attributeData.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute) Then
                     Dim attributeClass = attributeData.AttributeClass
                     If attributeClass IsNot Nothing Then
                         _diagnostics.ReportUseSite(attributeClass, If(symbol.Locations.IsEmpty, NoLocation.Singleton, symbol.Locations(0)))

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -851,7 +851,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Shared Function GetDesignerInitializeComponentMethod(sourceTypeSymbol As SourceMemberContainerTypeSymbol) As MethodSymbol
 
-            If sourceTypeSymbol.TypeKind = TypeKind.Class AndAlso sourceTypeSymbol.GetAttributes().IndexOfAttribute(sourceTypeSymbol, AttributeDescription.DesignerGeneratedAttribute) > -1 Then
+            If sourceTypeSymbol.TypeKind = TypeKind.Class AndAlso sourceTypeSymbol.GetAttributes().IndexOfAttribute(AttributeDescription.DesignerGeneratedAttribute) > -1 Then
                 For Each member As Symbol In sourceTypeSymbol.GetMembers("InitializeComponent")
                     If member.Kind = SymbolKind.Method Then
                         Dim method = DirectCast(member, MethodSymbol)

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedEvent.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedEvent.vb
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Dim underlyingContainingType = ContainingType.UnderlyingNamedType
 
             For Each attrData In underlyingContainingType.AdaptedNamedTypeSymbol.GetAttributes()
-                If attrData.IsTargetAttribute(underlyingContainingType.AdaptedNamedTypeSymbol, AttributeDescription.ComEventInterfaceAttribute) Then
+                If attrData.IsTargetAttribute(AttributeDescription.ComEventInterfaceAttribute) Then
                     Dim foundMatch = False
                     Dim sourceInterface As NamedTypeSymbol = Nothing
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
@@ -202,7 +202,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
             If hasGuid Then
                 ' This is an interface with a GuidAttribute, so we will generate the no-parameter TypeIdentifier.
-                Return New SynthesizedAttributeData(ctor, ImmutableArray(Of TypedConstant).Empty, ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
+                Return New SynthesizedAttributeData(TypeManager.ModuleBeingBuilt.Compilation, ctor, ImmutableArray(Of TypedConstant).Empty, ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
 
             Else
                 ' This is an interface with no GuidAttribute, or some other type, so we will generate the
@@ -216,7 +216,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
                 If stringType IsNot Nothing Then
                     Dim guidString = TypeManager.GetAssemblyGuidString(UnderlyingNamedType.AdaptedNamedTypeSymbol.ContainingAssembly)
-                    Return New SynthesizedAttributeData(ctor,
+                    Return New SynthesizedAttributeData(TypeManager.ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create(New TypedConstant(stringType, TypedConstantKind.Primitive, guidString),
                             New TypedConstant(stringType, TypedConstantKind.Primitive, UnderlyingNamedType.AdaptedNamedTypeSymbol.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))),
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -81,8 +81,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Return lazyMethod
         End Function
 
-        Friend Overrides Function GetTargetAttributeSignatureIndex(underlyingSymbol As SymbolAdapter, attrData As VisualBasicAttributeData, description As AttributeDescription) As Integer
-            Return attrData.GetTargetAttributeSignatureIndex(underlyingSymbol.AdaptedSymbol, description)
+        Friend Overrides Function GetTargetAttributeSignatureIndex(attrData As VisualBasicAttributeData, description As AttributeDescription) As Integer
+            Return attrData.GetTargetAttributeSignatureIndex(description)
         End Function
 
         Friend Overrides Function CreateSynthesizedAttribute(constructor As WellKnownMember, attrData As VisualBasicAttributeData, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As VisualBasicAttributeData
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                     ' When emitting a com event interface, we have to tweak the parameters: the spec requires that we use
                     ' the original source interface as both source interface and event provider. Otherwise, we'd have to embed
                     ' the event provider class too.
-                    Return New SynthesizedAttributeData(ctor,
+                    Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create(attrData.CommonConstructorArguments(0), attrData.CommonConstructorArguments(0)),
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
 
@@ -105,12 +105,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                     ' instantiatable. The attribute cannot refer directly to the coclass, however, because we can't embed
                     ' classes, and we can't emit a reference to the PIA. We don't actually need
                     ' the class name at runtime: we will instead emit a reference to System.Object, as a placeholder.
-                    Return New SynthesizedAttributeData(ctor,
+                    Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create(New TypedConstant(ctor.Parameters(0).Type, TypedConstantKind.Type, ctor.ContainingAssembly.GetSpecialType(SpecialType.System_Object))),
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
 
                 Case Else
-                    Return New SynthesizedAttributeData(ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments)
+                    Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments)
 
             End Select
         End Function

--- a/src/Compilers/VisualBasic/Portable/Emit/ParameterSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/ParameterSymbolAdapter.vb
@@ -184,7 +184,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overridable ReadOnly Property IsMetadataOptional As Boolean
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsOptional OrElse GetAttributes().Any(Function(a) a.IsTargetAttribute(Me, AttributeDescription.OptionalAttribute))
+                Return Me.IsOptional OrElse GetAttributes().Any(Function(a) a.IsTargetAttribute(AttributeDescription.OptionalAttribute))
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AddRemoveHandler.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AddRemoveHandler.vb
@@ -215,7 +215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim [interface] = [event].ContainingType
 
                 For Each attrData In [interface].GetAttributes()
-                    If attrData.IsTargetAttribute([interface], AttributeDescription.ComEventInterfaceAttribute) AndAlso
+                    If attrData.IsTargetAttribute(AttributeDescription.ComEventInterfaceAttribute) AndAlso
                         attrData.CommonConstructorArguments.Length = 2 Then
                         expr = RewriteNoPiaAddRemoveHandler(node, receiver, [event], handler)
                         Exit For

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.vb
@@ -68,8 +68,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Inherit some attributes from the container of the kickoff method
                 Dim kickoffType = KickoffMethod.ContainingType
                 For Each attribute In kickoffType.GetAttributes()
-                    If attribute.IsTargetAttribute(kickoffType, AttributeDescription.DebuggerNonUserCodeAttribute) OrElse
-                       attribute.IsTargetAttribute(kickoffType, AttributeDescription.DebuggerStepThroughAttribute) Then
+                    If attribute.IsTargetAttribute(AttributeDescription.DebuggerNonUserCodeAttribute) OrElse
+                       attribute.IsTargetAttribute(AttributeDescription.DebuggerStepThroughAttribute) Then
                         If builder Is Nothing Then
                             builder = ArrayBuilder(Of VisualBasicAttributeData).GetInstance(2) ' only 2 different attributes are inherited at the moment
                         End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.vb
@@ -208,10 +208,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Inherit some attributes from the kickoff method
                 Dim kickoffMethod = StateMachineType.KickoffMethod
                 For Each attribute In kickoffMethod.GetAttributes()
-                    If attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerHiddenAttribute) OrElse
-                       attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerNonUserCodeAttribute) OrElse
-                       attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerStepperBoundaryAttribute) OrElse
-                       attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerStepThroughAttribute) Then
+                    If attribute.IsTargetAttribute(AttributeDescription.DebuggerHiddenAttribute) OrElse
+                       attribute.IsTargetAttribute(AttributeDescription.DebuggerNonUserCodeAttribute) OrElse
+                       attribute.IsTargetAttribute(AttributeDescription.DebuggerStepperBoundaryAttribute) OrElse
+                       attribute.IsTargetAttribute(AttributeDescription.DebuggerStepThroughAttribute) Then
                         If builder Is Nothing Then
                             builder = ArrayBuilder(Of VisualBasicAttributeData).GetInstance(4) ' only 4 different attributes are inherited at the moment
                         End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
@@ -58,29 +58,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Friend MustOverride Overrides ReadOnly Property HasErrors As Boolean
+
+        Friend MustOverride Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+
         ''' <summary>
         ''' Compares the namespace and type name with the attribute's namespace and type name.  Returns true if they are the same.
         ''' </summary>
-        Friend Overridable Function IsTargetAttribute(
+        Friend MustOverride Function IsTargetAttribute(
             namespaceName As String,
             typeName As String,
             Optional ignoreCase As Boolean = False
         ) As Boolean
-            If AttributeClass.IsErrorType() AndAlso Not TypeOf AttributeClass Is MissingMetadataTypeSymbol Then
-                ' Can't guarantee complete name information.
-                Return False
-            End If
 
-            Dim options As StringComparison = If(ignoreCase, StringComparison.OrdinalIgnoreCase, StringComparison.Ordinal)
-            Return AttributeClass.HasNameQualifier(namespaceName, options) AndAlso
-                AttributeClass.Name.Equals(typeName, options)
+        Friend Function IsTargetAttribute(description As AttributeDescription) As Boolean
+            Return GetTargetAttributeSignatureIndex(description) <> -1
         End Function
 
-        Friend Function IsTargetAttribute(targetSymbol As Symbol, description As AttributeDescription) As Boolean
-            Return GetTargetAttributeSignatureIndex(targetSymbol, description) <> -1
-        End Function
-
-        Friend MustOverride Function GetTargetAttributeSignatureIndex(targetSymbol As Symbol, description As AttributeDescription) As Integer
+        Friend MustOverride Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
 
         ''' <summary>
         ''' Checks if an applied attribute with the given attributeType matches the namespace name and type name of the given early attribute's description
@@ -196,7 +191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim securityData As SecurityWellKnownAttributeData = data.GetOrCreateData()
                 securityData.SetSecurityAttribute(arguments.Index, action, arguments.AttributesCount)
 
-                If Me.IsTargetAttribute(targetSymbol, AttributeDescription.PermissionSetAttribute) Then
+                If Me.IsTargetAttribute(AttributeDescription.PermissionSetAttribute) Then
                     Dim resolvedPathForFixup As String = Me.DecodePermissionSetAttribute(compilation, arguments)
                     If resolvedPathForFixup IsNot Nothing Then
                         securityData.SetPathForPermissionSetAttributeFixup(arguments.Index, resolvedPathForFixup, arguments.AttributesCount)
@@ -229,7 +224,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' attribute argument to have the above mentioned behavior, even though the comment clearly mentions that this behavior was intended only for the HostProtectionAttribute.
                 ' We currently allow this case only for the HostProtectionAttribute. In future if need arises, we can exactly match native compiler's behavior.
 
-                If Me.IsTargetAttribute(targetSymbol, AttributeDescription.HostProtectionAttribute) Then
+                If Me.IsTargetAttribute(AttributeDescription.HostProtectionAttribute) Then
                     Return DeclarativeSecurityAction.LinkDemand
                 End If
             Else
@@ -294,7 +289,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Case DeclarativeSecurityAction.InheritanceDemand,
                      DeclarativeSecurityAction.LinkDemand
 
-                    If Me.IsTargetAttribute(targetSymbol, AttributeDescription.PrincipalPermissionAttribute) Then
+                    If Me.IsTargetAttribute(AttributeDescription.PrincipalPermissionAttribute) Then
                         ' BC31215: SecurityAction value '{0}' is invalid for PrincipalPermission attribute
                         Dim displayAndLocation As (ArgumentDisplay As String, Location As Location) = GetFirstArgumentDisplayAndLocation(nodeOpt, securityAction)
                         diagnostics.Add(ERRID.ERR_PrincipalPermissionInvalidAction, displayAndLocation.Location, displayAndLocation.ArgumentDisplay)
@@ -550,71 +545,71 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Select Case target.Kind
                 Case SymbolKind.Assembly
                     If (Not emittingAssemblyAttributesInNetModule AndAlso
-                            (IsTargetAttribute(target, AttributeDescription.AssemblyCultureAttribute) OrElse
-                             IsTargetAttribute(target, AttributeDescription.AssemblyVersionAttribute) OrElse
-                             IsTargetAttribute(target, AttributeDescription.AssemblyFlagsAttribute) OrElse
-                             IsTargetAttribute(target, AttributeDescription.AssemblyAlgorithmIdAttribute))) OrElse
-                       (IsTargetAttribute(target, AttributeDescription.CLSCompliantAttribute) AndAlso
+                            (IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) OrElse
+                             IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) OrElse
+                             IsTargetAttribute(AttributeDescription.AssemblyFlagsAttribute) OrElse
+                             IsTargetAttribute(AttributeDescription.AssemblyAlgorithmIdAttribute))) OrElse
+                       (IsTargetAttribute(AttributeDescription.CLSCompliantAttribute) AndAlso
                             target.DeclaringCompilation.Options.OutputKind = OutputKind.NetModule) OrElse
-                       IsTargetAttribute(target, AttributeDescription.TypeForwardedToAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.TypeForwardedToAttribute) OrElse
                        Me.IsSecurityAttribute(target.DeclaringCompilation) Then
                         Return False
                     End If
 
                 Case SymbolKind.Event
-                    If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.NonSerializedAttribute) Then
+                    If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.NonSerializedAttribute) Then
                         Return False
                     End If
 
                 Case SymbolKind.Field
-                    If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.NonSerializedAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.FieldOffsetAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute) Then
+                    If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.NonSerializedAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.FieldOffsetAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                         Return False
                     End If
 
                 Case SymbolKind.Method
                     If isReturnType Then
-                        If IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute) Then
+                        If IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                             Return False
                         End If
                     Else
-                        If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) OrElse
-                           IsTargetAttribute(target, AttributeDescription.MethodImplAttribute) OrElse
-                           IsTargetAttribute(target, AttributeDescription.DllImportAttribute) OrElse
-                           IsTargetAttribute(target, AttributeDescription.PreserveSigAttribute) OrElse
+                        If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) OrElse
+                           IsTargetAttribute(AttributeDescription.MethodImplAttribute) OrElse
+                           IsTargetAttribute(AttributeDescription.DllImportAttribute) OrElse
+                           IsTargetAttribute(AttributeDescription.PreserveSigAttribute) OrElse
                            Me.IsSecurityAttribute(target.DeclaringCompilation) Then
                             Return False
                         End If
                     End If
 
                 Case SymbolKind.NetModule
-                    If (IsTargetAttribute(target, AttributeDescription.CLSCompliantAttribute) AndAlso
+                    If (IsTargetAttribute(AttributeDescription.CLSCompliantAttribute) AndAlso
                             target.DeclaringCompilation.Options.OutputKind <> OutputKind.NetModule) Then
                         Return False
                     End If
                 Case SymbolKind.NamedType
-                    If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.ComImportAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.SerializableAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.StructLayoutAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.WindowsRuntimeImportAttribute) OrElse
+                    If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.ComImportAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.SerializableAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.StructLayoutAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.WindowsRuntimeImportAttribute) OrElse
                        Me.IsSecurityAttribute(target.DeclaringCompilation) Then
                         Return False
                     End If
 
                 Case SymbolKind.Parameter
-                    If IsTargetAttribute(target, AttributeDescription.OptionalAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.InAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.OutAttribute) Then
+                    If IsTargetAttribute(AttributeDescription.OptionalAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.MarshalAsAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.InAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.OutAttribute) Then
                         Return False
                     End If
 
                 Case SymbolKind.Property
-                    If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) Then
+                    If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                         Return False
                     End If
             End Select
@@ -625,9 +620,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
     Friend Module AttributeDataExtensions
         <System.Runtime.CompilerServices.Extension()>
-        Public Function IndexOfAttribute(attributes As ImmutableArray(Of VisualBasicAttributeData), targetSymbol As Symbol, description As AttributeDescription) As Integer
+        Public Function IndexOfAttribute(attributes As ImmutableArray(Of VisualBasicAttributeData), description As AttributeDescription) As Integer
             For i As Integer = 0 To attributes.Length - 1
-                If attributes(i).IsTargetAttribute(targetSymbol, description) Then
+                If attributes(i).IsTargetAttribute(description) Then
                     Return i
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/PEAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/PEAttributeData.vb
@@ -114,7 +114,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         ''' -1 if this is not the target attribute.
         ''' </returns>
         ''' <remarks>Matching an attribute by name does not load the attribute class.</remarks>
-        Friend Overrides Function GetTargetAttributeSignatureIndex(targetSymbol As Symbol, description As AttributeDescription) As Integer
+        Friend Overrides Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
             Return _decoder.GetTargetAttributeSignatureIndex(_handle, description)
         End Function
 
@@ -191,6 +191,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 End If
 
                 Return _lazyHasErrors.Value
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+            Get
+                Return False
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/RetargetingAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/RetargetingAttributeData.vb
@@ -13,33 +13,77 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
     ''' <summary>
     ''' Represents a retargeting custom attribute
     ''' </summary>
-    Friend Class RetargetingAttributeData
-        Inherits SourceAttributeData
-        Friend Sub New(ByVal applicationNode As SyntaxReference,
+    Friend NotInheritable Class RetargetingAttributeData
+        Inherits VisualBasicAttributeData
+
+        Private ReadOnly _underlying As VisualBasicAttributeData
+        Private ReadOnly _attributeClass As NamedTypeSymbol
+        Private ReadOnly _attributeConstructor As MethodSymbol
+        Private ReadOnly _constructorArguments As ImmutableArray(Of TypedConstant)
+        Private ReadOnly _namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+
+        Friend Sub New(ByVal underlying As VisualBasicAttributeData,
                        ByVal attributeClass As NamedTypeSymbol,
                        ByVal attributeConstructor As MethodSymbol,
                        ByVal constructorArguments As ImmutableArray(Of TypedConstant),
-                       ByVal namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)),
-                       ByVal isConditionallyOmitted As Boolean,
-                       ByVal hasErrors As Boolean)
-            MyBase.New(applicationNode, attributeClass, attributeConstructor, constructorArguments, namedArguments, isConditionallyOmitted, hasErrors)
+                       ByVal namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)))
+            Debug.Assert(TypeOf underlying Is SourceAttributeData OrElse TypeOf underlying Is SynthesizedAttributeData)
+
+            _underlying = underlying
+            Me._attributeClass = attributeClass
+            Me._attributeConstructor = attributeConstructor
+            Me._constructorArguments = constructorArguments.NullToEmpty()
+            Me._namedArguments = namedArguments.NullToEmpty()
         End Sub
 
-        ''' <summary>
-        ''' Gets the retargeted System.Type type symbol.
-        ''' </summary>
-        ''' <param name="targetSymbol">Target symbol on which this attribute is applied.</param>
-        ''' <returns>Retargeted System.Type type symbol.</returns>
-        Friend Overrides Function GetSystemType(ByVal targetSymbol As Symbol) As TypeSymbol
-            Dim retargetingAssembly = DirectCast(If(targetSymbol.Kind = SymbolKind.Assembly, targetSymbol, targetSymbol.ContainingAssembly), RetargetingAssemblySymbol)
-            Dim underlyingAssembly = DirectCast(retargetingAssembly.UnderlyingAssembly, SourceAssemblySymbol)
+        Public Overrides ReadOnly Property AttributeClass As NamedTypeSymbol
+            Get
+                Return _attributeClass
+            End Get
+        End Property
 
-            ' Get the System.Type from the underlying assembly's Compilation
-            Dim systemType As TypeSymbol = underlyingAssembly.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Type)
+        Public Overrides ReadOnly Property AttributeConstructor As MethodSymbol
+            Get
+                Return _attributeConstructor
+            End Get
+        End Property
 
-            ' Retarget the type
-            Dim retargetingModule = DirectCast(retargetingAssembly.Modules(0), RetargetingModuleSymbol)
-            Return retargetingModule.RetargetingTranslator.Retarget(systemType, RetargetOptions.RetargetPrimitiveTypesByTypeCode)
+        Public Overrides ReadOnly Property ApplicationSyntaxReference As SyntaxReference
+            Get
+                Return Nothing
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property CommonConstructorArguments As ImmutableArray(Of TypedConstant)
+            Get
+                Return _constructorArguments
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property CommonNamedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+            Get
+                Return _namedArguments
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+            Get
+                Return _underlying.IsConditionallyOmitted
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property HasErrors As Boolean
+            Get
+                Return _underlying.HasErrors OrElse _attributeConstructor Is Nothing
+            End Get
+        End Property
+
+        Friend Overrides Function IsTargetAttribute(namespaceName As String, typeName As String, Optional ignoreCase As Boolean = False) As Boolean
+            Return _underlying.IsTargetAttribute(namespaceName, typeName, ignoreCase)
+        End Function
+
+        Friend Overrides Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
+            Return _underlying.GetTargetAttributeSignatureIndex(description)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
@@ -16,9 +16,10 @@ Imports System.Reflection.Metadata
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
-    Friend Class SourceAttributeData
+    Friend NotInheritable Class SourceAttributeData
         Inherits VisualBasicAttributeData
 
+        Private ReadOnly _compilation As VisualBasicCompilation
         Private ReadOnly _attributeClass As NamedTypeSymbol ' TODO - Remove attribute class. It is available from the constructor.
         Private ReadOnly _attributeConstructor As MethodSymbol
         Private ReadOnly _constructorArguments As ImmutableArray(Of TypedConstant)
@@ -27,7 +28,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly _hasErrors As Boolean
         Private ReadOnly _applicationNode As SyntaxReference
 
-        Friend Sub New(ByVal applicationNode As SyntaxReference,
+        Friend Sub New(ByVal compilation As VisualBasicCompilation,
+                       ByVal applicationNode As SyntaxReference,
                        ByVal attrClass As NamedTypeSymbol,
                        ByVal attrMethod As MethodSymbol,
                        ByVal constructorArgs As ImmutableArray(Of TypedConstant),
@@ -36,6 +38,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                        ByVal hasErrors As Boolean)
             Debug.Assert(attrMethod IsNot Nothing OrElse hasErrors)
 
+            Me._compilation = compilation
             Me._applicationNode = applicationNode
             Me._attributeClass = attrClass
             Me._attributeConstructor = attrMethod
@@ -75,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend NotOverridable Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+        Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
             Get
                 Return _isConditionallyOmitted
             End Get
@@ -86,7 +89,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Me
             End If
 
-            Return New SourceAttributeData(Me.ApplicationSyntaxReference,
+            Return New SourceAttributeData(Me._compilation,
+                                           Me.ApplicationSyntaxReference,
                                            Me.AttributeClass,
                                            Me.AttributeConstructor,
                                            Me.CommonConstructorArguments,
@@ -95,7 +99,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                            Me.HasErrors)
         End Function
 
-        Friend NotOverridable Overrides ReadOnly Property HasErrors As Boolean
+        Friend Overrides ReadOnly Property HasErrors As Boolean
             Get
                 Return _hasErrors
             End Get
@@ -108,14 +112,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' well known attributes.
         ''' </summary>
         ''' <param name="description">Attribute to match.</param>
-        Friend Overrides Function GetTargetAttributeSignatureIndex(targetSymbol As Symbol, description As AttributeDescription) As Integer
-            If Not IsTargetAttribute(description.Namespace, description.Name, description.MatchIgnoringCase) Then
+        Friend Overrides Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
+            Return GetTargetAttributeSignatureIndex(_compilation, AttributeClass, AttributeConstructor, description)
+        End Function
+
+        Friend Overloads Shared Function GetTargetAttributeSignatureIndex(compilation As VisualBasicCompilation, attributeClass As NamedTypeSymbol, attributeConstructor As MethodSymbol, description As AttributeDescription) As Integer
+            If Not IsTargetAttribute(attributeClass, description.Namespace, description.Name, description.MatchIgnoringCase) Then
                 Return -1
             End If
 
             Dim lazySystemType As TypeSymbol = Nothing
 
-            Dim ctor = AttributeConstructor
+            Dim ctor = attributeConstructor
             ' Ensure that the attribute data really has a constructor before comparing the signature.
             If ctor Is Nothing Then
                 Return -1
@@ -235,7 +243,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                         Case CByte(SerializationTypeCode.Type)
                             If lazySystemType Is Nothing Then
-                                lazySystemType = GetSystemType(targetSymbol)
+                                lazySystemType = compilation.GetWellKnownType(WellKnownType.System_Type)
                             End If
 
                             foundMatch = TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything)
@@ -264,14 +272,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         ''' <summary>
-        ''' Gets the System.Type type symbol from targetSymbol's containing assembly.
+        ''' Compares the namespace and type name with the attribute's namespace and type name.  Returns true if they are the same.
         ''' </summary>
-        ''' <param name="targetSymbol">Target symbol on which this attribute is applied.</param>
-        ''' <returns>System.Type type symbol.</returns>
-        Friend Overridable Function GetSystemType(targetSymbol As Symbol) As TypeSymbol
-            Return targetSymbol.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Type)
+        Friend Overrides Function IsTargetAttribute(
+            namespaceName As String,
+            typeName As String,
+            Optional ignoreCase As Boolean = False
+        ) As Boolean
+            Return IsTargetAttribute(AttributeClass, namespaceName, typeName, ignoreCase)
         End Function
 
+        Friend Overloads Shared Function IsTargetAttribute(
+            attributeClass As NamedTypeSymbol,
+            namespaceName As String,
+            typeName As String,
+            Optional ignoreCase As Boolean = False
+        ) As Boolean
+            If attributeClass.IsErrorType() AndAlso Not TypeOf attributeClass Is MissingMetadataTypeSymbol Then
+                ' Can't guarantee complete name information.
+                Return False
+            End If
+
+            Dim options As StringComparison = If(ignoreCase, StringComparison.OrdinalIgnoreCase, StringComparison.Ordinal)
+            Return attributeClass.HasNameQualifier(namespaceName, options) AndAlso
+                attributeClass.Name.Equals(typeName, options)
+        End Function
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
@@ -387,14 +387,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Friend Overrides ReadOnly Property HasAssemblyCompilationRelaxationsAttribute As Boolean
             Get
                 Dim assemblyAttributes = GetAssemblyAttributes()
-                Return assemblyAttributes.IndexOfAttribute(Me, AttributeDescription.CompilationRelaxationsAttribute) >= 0
+                Return assemblyAttributes.IndexOfAttribute(AttributeDescription.CompilationRelaxationsAttribute) >= 0
             End Get
         End Property
 
         Friend Overrides ReadOnly Property HasAssemblyRuntimeCompatibilityAttribute As Boolean
             Get
                 Dim assemblyAttributes = GetAssemblyAttributes()
-                Return assemblyAttributes.IndexOfAttribute(Me, AttributeDescription.RuntimeCompatibilityAttribute) >= 0
+                Return assemblyAttributes.IndexOfAttribute(AttributeDescription.RuntimeCompatibilityAttribute) >= 0
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -265,7 +265,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                     If type.ContainingModule Is _retargetingModule.UnderlyingModule Then
                         ' This is a local type explicitly declared in source. Get information from TypeIdentifier attribute.
                         For Each attrData In type.GetAttributes()
-                            Dim signatureIndex = attrData.GetTargetAttributeSignatureIndex(type, AttributeDescription.TypeIdentifierAttribute)
+                            Dim signatureIndex = attrData.GetTargetAttributeSignatureIndex(AttributeDescription.TypeIdentifierAttribute)
 
                             If signatureIndex <> -1 Then
                                 Debug.Assert(signatureIndex = 0 OrElse signatureIndex = 1)
@@ -660,11 +660,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             End Function
 
             Friend Iterator Function RetargetAttributes(attributes As IEnumerable(Of VisualBasicAttributeData)) As IEnumerable(Of VisualBasicAttributeData)
-#If DEBUG Then
-                Dim x As SynthesizedAttributeData = Nothing
-                Dim y As SourceAttributeData = x ' Code below relies on the fact that SynthesizedAttributeData derives from SourceAttributeData.
-                x = DirectCast(y, SynthesizedAttributeData)
-#End If
                 For Each attrData In attributes
                     Yield RetargetAttributeData(attrData)
                 Next
@@ -696,13 +691,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                 ' Must create a RetargetingAttributeData even if the types and
                 ' arguments are unchanged since the AttributeData instance is
                 ' used to resolve System.Type which may require retargeting.
-                Return New RetargetingAttributeData(oldAttribute.ApplicationSyntaxReference,
+                Return New RetargetingAttributeData(oldAttribute,
                                                     newAttributeType,
                                                     newAttributeCtor,
                                                     newCtorArguments,
-                                                    newNamedArguments,
-                                                    oldAttribute.IsConditionallyOmitted,
-                                                    hasErrors:=oldAttribute.HasErrors OrElse newAttributeCtor Is Nothing)
+                                                    newNamedArguments)
             End Function
 
             Private Function RetargetAttributeConstructorArguments(constructorArguments As ImmutableArray(Of TypedConstant)) As ImmutableArray(Of TypedConstant)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -163,24 +163,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ' TODO: This list used to include AssemblyOperatingSystemAttribute and AssemblyProcessorAttribute,
             '       but it doesn't look like they are defined, cannot find them on MSDN.
-            If attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyTitleAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyDescriptionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyConfigurationAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyCultureAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyVersionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyCompanyAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyProductAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyInformationalVersionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyCopyrightAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyTrademarkAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyKeyFileAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyKeyNameAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyAlgorithmIdAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyFlagsAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyDelaySignAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyFileVersionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.SatelliteContractVersionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblySignatureKeyAttribute) Then
+            If attribute.IsTargetAttribute(AttributeDescription.AssemblyTitleAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyConfigurationAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyCompanyAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyProductAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyCopyrightAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyTrademarkAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyAlgorithmIdAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyFlagsAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyDelaySignAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.SatelliteContractVersionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute) Then
 
                 Return True
             End If
@@ -1000,13 +1000,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(arguments.SymbolPart = AttributeLocation.None)
             Dim diagnostics = DirectCast(arguments.Diagnostics, BindingDiagnosticBag)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.CaseInsensitiveExtensionAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.CaseInsensitiveExtensionAttribute) Then
                 ' Already have an attribute, no need to add another one.
                 Debug.Assert(_lazyEmitExtensionAttribute <> ThreeState.True)
                 _lazyEmitExtensionAttribute = ThreeState.False
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.InternalsVisibleToAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.InternalsVisibleToAttribute) Then
                 ProcessOneInternalsVisibleToAttribute(arguments.AttributeSyntaxOpt, attrData, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblySignatureKeyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute) Then
                 Dim signatureKey = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblySignatureKeyAttributeSetting = signatureKey
 
@@ -1014,20 +1014,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     diagnostics.Add(ERRID.ERR_InvalidSignaturePublicKey, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
                 End If
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyKeyFileAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyKeyFileAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyKeyNameAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyKeyContainerAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyDelaySignAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyDelaySignAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyDelaySignAttributeSetting = If(DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, Boolean), ThreeState.True, ThreeState.False)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) Then
                 Dim verString = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 Dim version As Version = Nothing
                 If Not VersionHelper.TryParseAssemblyVersion(verString, allowWildcard:=Not _compilation.IsEmitDeterministic, version:=version) Then
                     diagnostics.Add(ERRID.ERR_InvalidVersionFormat, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
                 End If
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyVersionAttributeSetting = version
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyFileVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute) Then
                 Dim dummy As Version = Nothing
                 Dim verString = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 If Not VersionHelper.TryParse(verString, version:=dummy) Then
@@ -1035,13 +1035,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyFileVersionAttributeSetting = verString
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyInformationalVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyInformationalVersionAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyTitleAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyTitleAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyTitleAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyDescriptionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyDescriptionAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyCultureAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) Then
                 Dim cultureString = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 If Not String.IsNullOrEmpty(cultureString) Then
                     If Me.DeclaringCompilation.Options.OutputKind.IsApplication() Then
@@ -1053,46 +1053,46 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyCultureAttributeSetting = cultureString
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyCompanyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyCompanyAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyCompanyAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyProductAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyProductAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyProductAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyInformationalVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyInformationalVersionAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SatelliteContractVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.SatelliteContractVersionAttribute) Then
                 'just check the format of this one, don't do anything else with it.
                 Dim dummy As Version = Nothing
                 Dim verString = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 If Not VersionHelper.TryParseAssemblyVersion(verString, allowWildcard:=False, version:=dummy) Then
                     diagnostics.Add(ERRID.ERR_InvalidVersionFormat2, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
                 End If
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyCopyrightAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyCopyrightAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyCopyrightAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyTrademarkAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyTrademarkAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyTrademarkAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
             ElseIf attrData.IsSecurityAttribute(Me.DeclaringCompilation) Then
                 attrData.DecodeSecurityAttribute(Of CommonAssemblyWellKnownAttributeData)(Me, Me.DeclaringCompilation, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ClassInterfaceAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ClassInterfaceAttribute) Then
                 attrData.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.TypeLibVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.TypeLibVersionAttribute) Then
                 ValidateIntegralAttributeNonNegativeArguments(attrData, arguments.AttributeSyntaxOpt, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ComCompatibleVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ComCompatibleVersionAttribute) Then
                 ValidateIntegralAttributeNonNegativeArguments(attrData, arguments.AttributeSyntaxOpt, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.GuidAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.GuidAttribute) Then
                 attrData.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.CompilationRelaxationsAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.CompilationRelaxationsAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasCompilationRelaxationsAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ReferenceAssemblyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ReferenceAssemblyAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasReferenceAssemblyAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.RuntimeCompatibilityAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.RuntimeCompatibilityAttribute) Then
                 ' VB doesn't need to decode argument values
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().RuntimeCompatibilityWrapNonExceptionThrows = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DebuggableAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DebuggableAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasDebuggableAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ExperimentalAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().ExperimentalAttributeData = attrData.DecodeExperimentalAttribute()
             Else
-                Dim signature As Integer = attrData.GetTargetAttributeSignatureIndex(Me, AttributeDescription.AssemblyAlgorithmIdAttribute)
+                Dim signature As Integer = attrData.GetTargetAttributeSignatureIndex(AttributeDescription.AssemblyAlgorithmIdAttribute)
 
                 If signature <> -1 Then
                     Dim value As Object = attrData.CommonConstructorArguments(0).ValueInternal
@@ -1106,7 +1106,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyAlgorithmIdAttributeSetting = algorithmId
                 Else
-                    signature = attrData.GetTargetAttributeSignatureIndex(Me, AttributeDescription.AssemblyFlagsAttribute)
+                    signature = attrData.GetTargetAttributeSignatureIndex(AttributeDescription.AssemblyFlagsAttribute)
 
                     If signature <> -1 Then
                         Dim value As Object = attrData.CommonConstructorArguments(0).ValueInternal

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
@@ -652,11 +652,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(arguments.AttributeSyntaxOpt IsNot Nothing)
             Dim attrData = arguments.Attribute
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.NonSerializedAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.NonSerializedAttribute) Then
                 ' Although NonSerialized attribute is only applicable on fields we relax that restriction and allow application on events as well
                 ' to allow making the backing field non-serializable.
 
@@ -666,9 +666,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_InvalidNonSerializedUsage, arguments.AttributeSyntaxOpt.GetLocation())
                 End If
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                 arguments.GetOrCreateData(Of EventWellKnownAttributeData).HasSpecialNameAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
                 arguments.GetOrCreateData(Of EventWellKnownAttributeData).HasExcludeFromCodeCoverageAttribute = True
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
@@ -720,13 +720,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(arguments.SymbolPart = AttributeLocation.None)
             Dim diagnostics = DirectCast(arguments.Diagnostics, BindingDiagnosticBag)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 diagnostics.Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                 arguments.GetOrCreateData(Of CommonFieldWellKnownAttributeData)().HasSpecialNameAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.NonSerializedAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.NonSerializedAttribute) Then
 
                 If Me.ContainingType.IsSerializable Then
                     arguments.GetOrCreateData(Of CommonFieldWellKnownAttributeData)().HasNonSerializedAttribute = True
@@ -734,7 +734,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     diagnostics.Add(ERRID.ERR_InvalidNonSerializedUsage, arguments.AttributeSyntaxOpt.GetLocation())
                 End If
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.FieldOffsetAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.FieldOffsetAttribute) Then
                 Dim offset = attrData.CommonConstructorArguments(0).DecodeValue(Of Integer)(SpecialType.System_Int32)
                 If offset < 0 Then
                     diagnostics.Add(ERRID.ERR_BadAttribute1, VisualBasicAttributeData.GetFirstArgumentLocation(arguments.AttributeSyntaxOpt), attrData.AttributeClass)
@@ -743,11 +743,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 arguments.GetOrCreateData(Of CommonFieldWellKnownAttributeData)().SetFieldOffset(offset)
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MarshalAsAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                 MarshalAsAttributeDecoder(Of CommonFieldWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation).Decode(arguments, AttributeTargets.Field, MessageProvider.Instance)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DateTimeConstantAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DateTimeConstantAttribute) Then
                 VerifyConstantValueMatches(attrData.DecodeDateTimeConstantValue(), arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DecimalConstantAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DecimalConstantAttribute) Then
                 VerifyConstantValueMatches(attrData.DecodeDecimalConstantValue(), arguments)
             Else
                 MyBase.DecodeWellKnownAttribute(arguments)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -1570,9 +1570,9 @@ lReportErrorOnTwoTokens:
             Dim attrData = arguments.Attribute
             Debug.Assert(Not attrData.HasErrors)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.UnmanagedCallersOnlyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.UnmanagedCallersOnlyAttribute) Then
                 ' VB does not support UnmanagedCallersOnly attributes on methods at all
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_UnmanagedCallersOnlyNotSupported, arguments.AttributeSyntaxOpt.Location)
             End If
@@ -1597,7 +1597,7 @@ lReportErrorOnTwoTokens:
             ' Decode well-known attributes applied to method
             Dim attrData = arguments.Attribute
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.CaseInsensitiveExtensionAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.CaseInsensitiveExtensionAttribute) Then
                 ' Just report errors here. The extension attribute is decoded early.
 
                 If Me.MethodKind <> MethodKind.Ordinary AndAlso Me.MethodKind <> MethodKind.DeclareMethod Then
@@ -1626,7 +1626,7 @@ lReportErrorOnTwoTokens:
                     End If
                 End If
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.WebMethodAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.WebMethodAttribute) Then
 
                 ' Check for optional parameters
                 For Each parameter In Me.Parameters
@@ -1635,12 +1635,12 @@ lReportErrorOnTwoTokens:
                     End If
                 Next
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.PreserveSigAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.PreserveSigAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().SetPreserveSignature(arguments.Index)
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MethodImplAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.MethodImplAttribute) Then
                 AttributeData.DecodeMethodImplAttribute(Of MethodWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation)(arguments, MessageProvider.Instance)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DllImportAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DllImportAttribute) Then
                 If Not IsDllImportAttributeAllowed(arguments.AttributeSyntaxOpt, diagnostics) Then
                     Return
                 End If
@@ -1708,35 +1708,35 @@ lReportErrorOnTwoTokens:
                     DllImportData.MakeFlags(exactSpelling, charSet, setLastError, callingConvention, bestFitMapping, throwOnUnmappable),
                     preserveSig)
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasSpecialNameAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasExcludeFromCodeCoverageAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasSuppressUnmanagedCodeSecurityAttribute = True
             ElseIf attrData.IsSecurityAttribute(Me.DeclaringCompilation) Then
                 attrData.DecodeSecurityAttribute(Of MethodWellKnownAttributeData)(Me, Me.DeclaringCompilation, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.STAThreadAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.STAThreadAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasSTAThreadAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MTAThreadAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.MTAThreadAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasMTAThreadAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ConditionalAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ConditionalAttribute) Then
                 If Not Me.IsSub Then
                     ' BC41007: Attribute 'Conditional' is only valid on 'Sub' declarations.
                     diagnostics.Add(ERRID.WRN_ConditionalNotValidOnFunction, Me.Locations(0))
                 End If
             ElseIf VerifyObsoleteAttributeAppliedToMethod(arguments, AttributeDescription.ObsoleteAttribute) Then
             ElseIf VerifyObsoleteAttributeAppliedToMethod(arguments, AttributeDescription.DeprecatedAttribute) Then
-            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ModuleInitializerAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(AttributeDescription.ModuleInitializerAttribute) Then
                 diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.ModuleInitializerAttribute.FullName)
             Else
                 Dim methodImpl As MethodSymbol = If(Me.IsPartial, PartialImplementationPart, Me)
 
                 If methodImpl IsNot Nothing AndAlso (methodImpl.IsAsync OrElse methodImpl.IsIterator) AndAlso Not methodImpl.ContainingType.IsInterfaceType() Then
-                    If attrData.IsTargetAttribute(Me, AttributeDescription.SecurityCriticalAttribute) Then
+                    If attrData.IsTargetAttribute(AttributeDescription.SecurityCriticalAttribute) Then
                         Binder.ReportDiagnostic(diagnostics, arguments.AttributeSyntaxOpt.GetLocation(), ERRID.ERR_SecurityCriticalAsync, "SecurityCritical")
                         Return
-                    ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SecuritySafeCriticalAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.SecuritySafeCriticalAttribute) Then
                         Binder.ReportDiagnostic(diagnostics, arguments.AttributeSyntaxOpt.GetLocation(), ERRID.ERR_SecurityCriticalAsync, "SecuritySafeCritical")
                         Return
                     End If
@@ -1748,7 +1748,7 @@ lReportErrorOnTwoTokens:
             ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation),
             description As AttributeDescription
         ) As Boolean
-            If arguments.Attribute.IsTargetAttribute(Me, description) Then
+            If arguments.Attribute.IsTargetAttribute(description) Then
                 ' Obsolete Attribute is not allowed on event accessors.
                 If Me.IsAccessor() AndAlso Me.AssociatedSymbol.Kind = SymbolKind.Event Then
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ObsoleteInvalidOnEventMember, Me.Locations(0), description.FullName)
@@ -1765,7 +1765,7 @@ lReportErrorOnTwoTokens:
             Dim attrData = arguments.Attribute
             Debug.Assert(Not attrData.HasErrors)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.MarshalAsAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                 MarshalAsAttributeDecoder(Of CommonReturnTypeWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation).Decode(arguments, AttributeTargets.ReturnValue, MessageProvider.Instance)
             End If
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -779,7 +779,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim hasImportedFromTypeLibOrPrimaryInteropAssemblyAttribute = False
 
                 For Each attrData In assembly.GetAttributes()
-                    If attrData.IsTargetAttribute(assembly, AttributeDescription.GuidAttribute) Then
+                    If attrData.IsTargetAttribute(AttributeDescription.GuidAttribute) Then
                         If attrData.CommonConstructorArguments.Length = 1 Then
                             Dim value = attrData.CommonConstructorArguments(0).ValueInternal
                             If value Is Nothing OrElse TypeOf value Is String Then
@@ -787,12 +787,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             End If
                         End If
 
-                    ElseIf attrData.IsTargetAttribute(assembly, AttributeDescription.ImportedFromTypeLibAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.ImportedFromTypeLibAttribute) Then
                         If attrData.CommonConstructorArguments.Length = 1 Then
                             hasImportedFromTypeLibOrPrimaryInteropAssemblyAttribute = True
                         End If
 
-                    ElseIf attrData.IsTargetAttribute(assembly, AttributeDescription.PrimaryInteropAssemblyAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.PrimaryInteropAssemblyAttribute) Then
                         If attrData.CommonConstructorArguments.Length = 2 Then
                             hasImportedFromTypeLibOrPrimaryInteropAssemblyAttribute = True
                         End If
@@ -1103,20 +1103,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(Not attrData.HasErrors)
             Debug.Assert(arguments.SymbolPart = AttributeLocation.None)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.DefaultCharSetAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.DefaultCharSetAttribute) Then
                 Dim charSet As CharSet = attrData.GetConstructorArgument(Of CharSet)(0, SpecialType.System_Enum)
                 If Not CommonModuleWellKnownAttributeData.IsValidCharSet(charSet) Then
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_BadAttribute1, VisualBasicAttributeData.GetFirstArgumentLocation(arguments.AttributeSyntaxOpt), attrData.AttributeClass)
                 Else
                     arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData)().DefaultCharacterSet = charSet
                 End If
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DebuggableAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DebuggableAttribute) Then
                 arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).HasDebuggableAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ExperimentalAttribute) Then
                 arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).ExperimentalAttributeData = attrData.DecodeObsoleteAttribute(ObsoleteAttributeKind.Experimental)
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -1976,7 +1976,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' it is worth to intercept this attribute in DecodeWellKnownAttribute and cache the fact of attribute's
             ' presence and the guid value. If we start caching that information, implementation of this function 
             ' should change to take advantage of the cache.
-            Return GetAttributes().IndexOfAttribute(Me, AttributeDescription.GuidAttribute) > -1
+            Return GetAttributes().IndexOfAttribute(AttributeDescription.GuidAttribute) > -1
         End Function
 
         ''' <summary>
@@ -1987,7 +1987,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' it is worth to intercept this attribute in DecodeWellKnownAttribute and cache the fact of attribute's
             ' presence and its data. If we start caching that information, implementation of this function 
             ' should change to take advantage of the cache.
-            Return GetAttributes().IndexOfAttribute(Me, AttributeDescription.ClassInterfaceAttribute) > -1
+            Return GetAttributes().IndexOfAttribute(AttributeDescription.ClassInterfaceAttribute) > -1
         End Function
 
         ''' <summary>
@@ -1998,7 +1998,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' it is worth to intercept this attribute in DecodeWellKnownAttribute and cache the fact of attribute's
             ' presence and the its data. If we start caching that information, implementation of this function 
             ' should change to take advantage of the cache.
-            Return GetAttributes().IndexOfAttribute(Me, AttributeDescription.ComSourceInterfacesAttribute) > -1
+            Return GetAttributes().IndexOfAttribute(AttributeDescription.ComSourceInterfacesAttribute) > -1
         End Function
 
         Friend Overrides Function EarlyDecodeWellKnownAttribute(ByRef arguments As EarlyDecodeWellKnownAttributeArguments(Of EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation)) As VisualBasicAttributeData
@@ -2173,7 +2173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' If we start caching information about ComSourceInterfacesAttribute here, implementation of HasComSourceInterfacesAttribute function should be changed accordingly.
             ' If we start caching information about ComVisibleAttribute here, implementation of GetComVisibleState function should be changed accordingly.
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 diagnostics.Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
@@ -2181,11 +2181,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Select Case Me.TypeKind
                 Case TypeKind.Class
-                    If attrData.IsTargetAttribute(Me, AttributeDescription.CaseInsensitiveExtensionAttribute) Then
+                    If attrData.IsTargetAttribute(AttributeDescription.CaseInsensitiveExtensionAttribute) Then
                         diagnostics.Add(ErrorFactory.ErrorInfo(ERRID.ERR_ExtensionOnlyAllowedOnModuleSubOrFunction), Me.Locations(0))
                         decoded = True
 
-                    ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.VisualBasicComClassAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.VisualBasicComClassAttribute) Then
                         If Me.IsGenericType Then
                             diagnostics.Add(ERRID.ERR_ComClassOnGeneric, Me.Locations(0))
                         Else
@@ -2194,7 +2194,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                         decoded = True
 
-                    ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DefaultEventAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.DefaultEventAttribute) Then
                         If attrData.CommonConstructorArguments.Length = 1 AndAlso attrData.CommonConstructorArguments(0).Kind = TypedConstantKind.Primitive Then
                             Dim eventName = TryCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
 
@@ -2208,7 +2208,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End If
 
                 Case TypeKind.Interface
-                    If attrData.IsTargetAttribute(Me, AttributeDescription.CoClassAttribute) Then
+                    If attrData.IsTargetAttribute(AttributeDescription.CoClassAttribute) Then
                         Debug.Assert(Not attrData.CommonConstructorArguments.IsDefault AndAlso attrData.CommonConstructorArguments.Length = 1)
                         Dim argument As TypedConstant = attrData.CommonConstructorArguments(0)
 
@@ -2228,12 +2228,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End If
 
                 Case TypeKind.Module
-                    If ContainingSymbol.Kind = SymbolKind.Namespace AndAlso attrData.IsTargetAttribute(Me, AttributeDescription.CaseInsensitiveExtensionAttribute) Then
+                    If ContainingSymbol.Kind = SymbolKind.Namespace AndAlso attrData.IsTargetAttribute(AttributeDescription.CaseInsensitiveExtensionAttribute) Then
                         ' Already have an attribute, no need to add another one.
                         SuppressExtensionAttributeSynthesis()
                         decoded = True
 
-                    ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.VisualBasicComClassAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.VisualBasicComClassAttribute) Then
                         ' Can't apply ComClassAttribute to a Module
                         diagnostics.Add(ErrorFactory.ErrorInfo(ERRID.ERR_InvalidAttributeUsage2, AttributeDescription.VisualBasicComClassAttribute.Name, Me.Name), Me.Locations(0))
                         decoded = True
@@ -2241,7 +2241,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Select
 
             If Not decoded Then
-                If attrData.IsTargetAttribute(Me, AttributeDescription.DefaultMemberAttribute) Then
+                If attrData.IsTargetAttribute(AttributeDescription.DefaultMemberAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasDefaultMemberAttribute = True
 
                     ' Check that the explicit <DefaultMember(...)> argument matches the default property if any.
@@ -2252,14 +2252,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         diagnostics.Add(ERRID.ERR_ConflictDefaultPropertyAttribute, Locations(0), Me)
                     End If
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SerializableAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.SerializableAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSerializableAttribute = True
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasExcludeFromCodeCoverageAttribute = True
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSpecialNameAttribute = True
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.StructLayoutAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.StructLayoutAttribute) Then
                     Debug.Assert(arguments.AttributeSyntaxOpt IsNot Nothing)
 
                     Dim defaultAutoLayoutSize = If(Me.TypeKind = TypeKind.Structure, 1, 0)
@@ -2270,33 +2270,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         diagnostics.Add(ERRID.ERR_StructLayoutAttributeNotAllowed, arguments.AttributeSyntaxOpt.GetLocation(), Me)
                     End If
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSuppressUnmanagedCodeSecurityAttribute = True
 
                 ElseIf attrData.IsSecurityAttribute(Me.DeclaringCompilation) Then
                     attrData.DecodeSecurityAttribute(Of CommonTypeWellKnownAttributeData)(Me, Me.DeclaringCompilation, arguments)
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ClassInterfaceAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.ClassInterfaceAttribute) Then
                     attrData.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, diagnostics)
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.InterfaceTypeAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.InterfaceTypeAttribute) Then
                     attrData.DecodeInterfaceTypeAttribute(arguments.AttributeSyntaxOpt, diagnostics)
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.GuidAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.GuidAttribute) Then
                     attrData.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, diagnostics)
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.WindowsRuntimeImportAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.WindowsRuntimeImportAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasWindowsRuntimeImportAttribute = True
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SecurityCriticalAttribute) OrElse
-                       attrData.IsTargetAttribute(Me, AttributeDescription.SecuritySafeCriticalAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.SecurityCriticalAttribute) OrElse
+                       attrData.IsTargetAttribute(AttributeDescription.SecuritySafeCriticalAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSecurityCriticalAttributes = True
 
                 ElseIf _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.Unknown AndAlso
-                    attrData.IsTargetAttribute(Me, AttributeDescription.TypeIdentifierAttribute) Then
+                    attrData.IsTargetAttribute(AttributeDescription.TypeIdentifierAttribute) Then
                     _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.True
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.RequiredAttributeAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.RequiredAttributeAttribute) Then
                     Debug.Assert(arguments.AttributeSyntaxOpt IsNot Nothing)
                     diagnostics.Add(ERRID.ERR_CantUseRequiredAttribute, arguments.AttributeSyntaxOpt.GetLocation(), Me)
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
@@ -304,7 +304,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' presence and its value. If we start caching that information, implementation of this function 
                 ' should change to take advantage of the cache.
                 Dim attrData As ImmutableArray(Of VisualBasicAttributeData) = target.GetAttributes()
-                Dim comVisible = attrData.IndexOfAttribute(target, AttributeDescription.ComVisibleAttribute)
+                Dim comVisible = attrData.IndexOfAttribute(AttributeDescription.ComVisibleAttribute)
 
                 If comVisible > -1 Then
                     Dim typedValue As TypedConstant = attrData(comVisible).CommonConstructorArguments(0)
@@ -478,7 +478,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' presence and its value. If we start caching that information, implementation of this function 
                 ' should change to take advantage of the cache.
                 Dim attrData As ImmutableArray(Of VisualBasicAttributeData) = target.GetAttributes()
-                Dim dispIdIndex = attrData.IndexOfAttribute(target, AttributeDescription.DispIdAttribute)
+                Dim dispIdIndex = attrData.IndexOfAttribute(AttributeDescription.DispIdAttribute)
 
                 If dispIdIndex > -1 Then
                     Dim typedValue As TypedConstant = attrData(dispIdIndex).CommonConstructorArguments(0)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_GroupClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_GroupClass.vb
@@ -176,7 +176,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                         Dim generatedDiagnostics As Boolean = False
                                         Dim data As VisualBasicAttributeData = (New EarlyWellKnownAttributeBinder(Me, binder)).GetAttribute(attr, attributeType, generatedDiagnostics)
                                         If Not data.HasErrors AndAlso Not generatedDiagnostics AndAlso
-                                           data.IsTargetAttribute(Me, AttributeDescription.MyGroupCollectionAttribute) Then
+                                           data.IsTargetAttribute(AttributeDescription.MyGroupCollectionAttribute) Then
                                             ' Looks like we've found MyGroupCollectionAttribute
                                             If attributeData IsNot Nothing Then
                                                 ' Ambiguity, the attribute cannot be applied multiple times. Let's ignore all of them,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -282,7 +282,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             Continue For
                         End If
                         Dim newArgs = ImmutableArray.Create(New TypedConstant(oldTypedConstant.TypeInternal, oldTypedConstant.Kind, correctedParameterName))
-                        Yield New SourceAttributeData(attribute.ApplicationSyntaxReference, attribute.AttributeClass, attribute.AttributeConstructor, newArgs, attribute.CommonNamedArguments, attribute.IsConditionallyOmitted, attribute.HasErrors)
+                        Yield New SourceAttributeData(DeclaringCompilation, attribute.ApplicationSyntaxReference, attribute.AttributeClass, attribute.AttributeConstructor, newArgs, attribute.CommonNamedArguments, attribute.IsConditionallyOmitted, attribute.HasErrors)
                         Continue For
                     End If
                 End If
@@ -339,26 +339,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             '  InAttribute, OutAttribute
             '     - metadata flag set, no diagnostics reported, don't influence language semantics
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.DefaultParameterValueAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.DefaultParameterValueAttribute) Then
                 ' Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DefaultParameterValueAttribute, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DecimalConstantAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DecimalConstantAttribute) Then
                 ' Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DecimalConstantAttribute, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DateTimeConstantAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DateTimeConstantAttribute) Then
                 ' Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DateTimeConstantAttribute, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.InAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.InAttribute) Then
                 arguments.GetOrCreateData(Of CommonParameterWellKnownAttributeData)().HasInAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.OutAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.OutAttribute) Then
                 arguments.GetOrCreateData(Of CommonParameterWellKnownAttributeData)().HasOutAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MarshalAsAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                 MarshalAsAttributeDecoder(Of CommonParameterWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation).Decode(arguments, AttributeTargets.Parameter, MessageProvider.Instance)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.CallerArgumentExpressionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.CallerArgumentExpressionAttribute) Then
                 Dim index = GetEarlyDecodedWellKnownAttributeData()?.CallerArgumentExpressionParameterIndex
                 If index = Ordinal Then
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.WRN_CallerArgumentExpressionAttributeSelfReferential, arguments.AttributeSyntaxOpt.Location, Me.Name)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
@@ -478,7 +478,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend Overrides Sub DecodeWellKnownAttribute(ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation))
             If arguments.SymbolPart = AttributeLocation.None Then
-                If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.DebuggerHiddenAttribute) Then
+                If arguments.Attribute.IsTargetAttribute(AttributeDescription.DebuggerHiddenAttribute) Then
                     arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().IsPropertyAccessorWithDebuggerHiddenAttribute = True
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
@@ -556,12 +556,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim attrData = arguments.Attribute
             Dim diagnostics = DirectCast(arguments.Diagnostics, BindingDiagnosticBag)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 diagnostics.Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
             If arguments.SymbolPart = AttributeLocation.Return Then
-                Dim isMarshalAs = attrData.IsTargetAttribute(Me, AttributeDescription.MarshalAsAttribute)
+                Dim isMarshalAs = attrData.IsTargetAttribute(AttributeDescription.MarshalAsAttribute)
 
                 ' write-only property doesn't accept any return type attributes other than MarshalAs
                 ' MarshalAs is applied on the "Value" parameter of the setter if the property has no parameters and the containing type is an interface .
@@ -579,13 +579,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return
                 End If
             Else
-                If attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+                If attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                     arguments.GetOrCreateData(Of CommonPropertyWellKnownAttributeData).HasSpecialNameAttribute = True
                     Return
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
                     arguments.GetOrCreateData(Of CommonPropertyWellKnownAttributeData).HasExcludeFromCodeCoverageAttribute = True
                     Return
-                ElseIf Not IsWithEvents AndAlso attrData.IsTargetAttribute(Me, AttributeDescription.DebuggerHiddenAttribute) Then
+                ElseIf Not IsWithEvents AndAlso attrData.IsTargetAttribute(AttributeDescription.DebuggerHiddenAttribute) Then
                     ' if neither getter or setter is marked by DebuggerHidden Dev11 reports a warning
                     If Not (_getMethod IsNot Nothing AndAlso DirectCast(_getMethod, SourcePropertyAccessorSymbol).HasDebuggerHiddenAttribute OrElse
                             _setMethod IsNot Nothing AndAlso DirectCast(_setMethod, SourcePropertyAccessorSymbol).HasDebuggerHiddenAttribute) Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -716,7 +716,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Friend Function GetGuidStringDefaultImplementation(<Out> ByRef guidString As String) As Boolean
             For Each attrData In GetAttributes()
-                If attrData.IsTargetAttribute(Me, AttributeDescription.GuidAttribute) Then
+                If attrData.IsTargetAttribute(AttributeDescription.GuidAttribute) Then
                     If attrData.TryGetGuidAttributeValue(guidString) Then
                         Return True
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
@@ -198,13 +198,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             MarkEmbeddedAttributeTypeReference(arguments.Attribute, arguments.AttributeSyntaxOpt, compilation)
             ReportExtensionAttributeUseSiteInfo(arguments.Attribute, arguments.AttributeSyntaxOpt, compilation, DirectCast(arguments.Diagnostics, BindingDiagnosticBag))
 
-            If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.SkipLocalsInitAttribute) Then
+            If arguments.Attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.SkipLocalsInitAttribute.FullName)
-            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.CompilerFeatureRequiredAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(AttributeDescription.CompilerFeatureRequiredAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_DoNotUseCompilerFeatureRequired, arguments.AttributeSyntaxOpt.Location)
-            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.RequiredMemberAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(AttributeDescription.RequiredMemberAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_DoNotUseRequiredMember, arguments.AttributeSyntaxOpt.Location)
-            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(AttributeDescription.ExperimentalAttribute) Then
                 If Not SyntaxFacts.IsValidIdentifier(DirectCast(arguments.Attribute.CommonConstructorArguments(0).ValueInternal, String)) Then
                     Dim attrArgumentLocation = VisualBasicAttributeData.GetFirstArgumentLocation(arguments.AttributeSyntaxOpt)
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_InvalidExperimentalDiagID, attrArgumentLocation)

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedAttributeData.vb
@@ -14,21 +14,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' Class to represent a synthesized attribute
     ''' </summary>
     Friend NotInheritable Class SynthesizedAttributeData
-        Inherits SourceAttributeData
+        Inherits VisualBasicAttributeData
 
-        Friend Sub New(wellKnownMember As MethodSymbol,
+        Private ReadOnly _compilation As VisualBasicCompilation
+        Private ReadOnly _attributeConstructor As MethodSymbol
+        Private ReadOnly _constructorArguments As ImmutableArray(Of TypedConstant)
+        Private ReadOnly _namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+
+        Friend Sub New(compilation As VisualBasicCompilation,
+                       wellKnownMember As MethodSymbol,
                        arguments As ImmutableArray(Of TypedConstant),
                        namedArgs As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)))
 
-            MyBase.New(Nothing,
-                       wellKnownMember.ContainingType,
-                       wellKnownMember,
-                       arguments,
-                       namedArgs,
-                       isConditionallyOmitted:=False,
-                       hasErrors:=False)
-
             Debug.Assert(wellKnownMember IsNot Nothing AndAlso Not arguments.IsDefault)
+
+            Me._compilation = compilation
+            Me._attributeConstructor = wellKnownMember
+            Me._constructorArguments = arguments.NullToEmpty()
+            Me._namedArguments = namedArgs.NullToEmpty()
         End Sub
 
         ''' <summary>
@@ -36,6 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' If the constructor has UseSiteErrors and the attribute is optional returns Nothing.
         ''' </summary>
         Friend Shared Function Create(
+            compilation As VisualBasicCompilation,
             constructorSymbol As MethodSymbol,
             constructor As WellKnownMember,
             Optional arguments As ImmutableArray(Of TypedConstant) = Nothing,
@@ -58,8 +62,58 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     namedArguments = ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty
                 End If
 
-                Return New SynthesizedAttributeData(constructorSymbol, arguments, namedArguments)
+                Return New SynthesizedAttributeData(compilation, constructorSymbol, arguments, namedArguments)
             End If
+        End Function
+
+        Public Overrides ReadOnly Property AttributeClass As NamedTypeSymbol
+            Get
+                Return _attributeConstructor.ContainingType
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property AttributeConstructor As MethodSymbol
+            Get
+                Return _attributeConstructor
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property ApplicationSyntaxReference As SyntaxReference
+            Get
+                Return Nothing
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property CommonConstructorArguments As ImmutableArray(Of TypedConstant)
+            Get
+                Return _constructorArguments
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property CommonNamedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+            Get
+                Return _namedArguments
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property HasErrors As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        Friend Overrides Function IsTargetAttribute(namespaceName As String, typeName As String, Optional ignoreCase As Boolean = False) As Boolean
+            Return SourceAttributeData.IsTargetAttribute(AttributeClass, namespaceName, typeName, ignoreCase)
+        End Function
+
+        Friend Overrides Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
+            Return SourceAttributeData.GetTargetAttributeSignatureIndex(_compilation, AttributeClass, AttributeConstructor, description)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -184,7 +184,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 namedStringArguments = builder.ToImmutableAndFree()
             End If
 
-            Return New SynthesizedAttributeData(constructorSymbol, arguments, namedStringArguments)
+            Return New SynthesizedAttributeData(Me, constructorSymbol, arguments, namedStringArguments)
         End Function
 
         Private Shared Function ReturnNothingOrThrowIfAttributeNonOptional(constructor As WellKnownMember, Optional isOptionalUse As Boolean = False) As SynthesizedAttributeData
@@ -202,7 +202,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                          constructor.GetUseSiteInfo().DiagnosticInfo Is Nothing AndAlso
                          constructor.ContainingType.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
-            Return SynthesizedAttributeData.Create(constructor, WellKnownMember.System_Runtime_CompilerServices_ExtensionAttribute__ctor)
+            Return SynthesizedAttributeData.Create(Me, constructor, WellKnownMember.System_Runtime_CompilerServices_ExtensionAttribute__ctor)
         End Function
 
         Friend Function SynthesizeStateMachineAttribute(method As MethodSymbol, compilationState As ModuleCompilationState) As SynthesizedAttributeData

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
@@ -2077,7 +2077,7 @@ System.Reflection.AssemblyTrademarkAttribute("Roslyn")
 
     Private Shared Sub GetAssemblyDescriptionAttributes(assembly As AssemblySymbol, list As ArrayBuilder(Of VisualBasicAttributeData))
         For Each attrData In assembly.GetAttributes()
-            If attrData.IsTargetAttribute(assembly, AttributeDescription.AssemblyDescriptionAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute) Then
                 list.Add(attrData)
             End If
         Next
@@ -2225,6 +2225,153 @@ BC42370: Attribute 'AssemblyDescriptionAttribute' from module 'M2.netmodule' wil
                                                               Assert.Equal("System.Reflection.AssemblyDescriptionAttribute(""Module1"")", list(0).ToString())
                                                           End Sub)
 
+    End Sub
+
+    <Fact>
+    <WorkItem("https://github.com/dotnet/roslyn/issues/70338")>
+    Public Sub ErrorsWithAssemblyAttributesInModules_01()
+        Dim attribute1 =
+<compilation name="A1">
+    <file><![CDATA[
+public class A1 
+    Inherits System.Attribute
+
+    public Sub New(a As Integer)
+    End Sub    
+End Class
+    ]]></file>
+</compilation>
+
+        Dim attributeDefinition1 = CreateCompilation(attribute1, options:=TestOptions.ReleaseDll).EmitToImageReference()
+
+        Dim [module] =
+<compilation name="M1">
+    <file><![CDATA[
+<assembly:A1(1)>
+    ]]></file>
+</compilation>
+
+        Dim moduleWithAttribute = CreateCompilation([module], references:={attributeDefinition1}, options:=TestOptions.ReleaseModule).EmitToImageReference()
+
+        Dim comp = CreateCompilation("", references:={moduleWithAttribute, attributeDefinition1}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp, symbolValidator:=Sub(m)
+                                                    Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                    Assert.Equal(4, attrs.Length)
+                                                    AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                    AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                    AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                    AssertEx.Equal("A1(1)", attrs(3).ToString())
+                                                End Sub).VerifyDiagnostics()
+
+        Dim comp2 = CreateCompilation("", references:={moduleWithAttribute}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp2, symbolValidator:=Sub(m)
+                                                     Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                     Assert.Equal(3, attrs.Length)
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                     AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                 End Sub).VerifyDiagnostics()
+
+        Dim attribute2 =
+<compilation name="A1">
+    <file><![CDATA[
+public class A1 
+    Inherits System.Attribute
+
+    public Sub New()
+    End Sub    
+End Class
+    ]]></file>
+</compilation>
+
+        Dim attributeDefinition2 = CreateCompilation(attribute2, options:=TestOptions.ReleaseDll).EmitToImageReference()
+
+        Dim comp3 = CreateCompilation("", references:={moduleWithAttribute, attributeDefinition2}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp3, symbolValidator:=Sub(m)
+                                                     Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                     Assert.Equal(3, attrs.Length)
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                     AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                 End Sub).VerifyDiagnostics()
+    End Sub
+
+    <Fact>
+    <WorkItem("https://github.com/dotnet/roslyn/issues/70338")>
+    Public Sub ErrorsWithAssemblyAttributesInModules_02()
+        Dim c1 =
+<compilation name="A1">
+    <file><![CDATA[
+public class C1 
+End Class
+    ]]></file>
+</compilation>
+
+        Dim c1Definition = CreateCompilation(c1, options:=TestOptions.ReleaseDll).EmitToImageReference()
+
+        Dim module1 =
+<compilation name="M1">
+    <file><![CDATA[
+<assembly:A1(GetType(C1))>
+
+public class A1 
+    Inherits System.Attribute
+
+    public Sub New(a As System.Type)
+    End Sub    
+End Class
+    ]]></file>
+</compilation>
+
+        Dim module1WithAttribute = CreateCompilation(module1, references:={c1Definition}, options:=TestOptions.ReleaseModule).EmitToImageReference()
+
+        Dim comp = CreateCompilation("", references:={module1WithAttribute, c1Definition}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp, symbolValidator:=Sub(m)
+                                                    Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                    Assert.Equal(4, attrs.Length)
+                                                    AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                    AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                    AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                    AssertEx.Equal("A1(GetType(C1))", attrs(3).ToString())
+                                                End Sub).VerifyDiagnostics()
+
+        Dim comp2 = CreateCompilation("", references:={module1WithAttribute}, options:=TestOptions.ReleaseDll)
+
+        comp2.AssertTheseEmitDiagnostics(
+<expected>
+BC30652: Reference required to assembly 'A1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'C1'. Add one to your project.
+</expected>
+        )
+
+        Dim module2 =
+<compilation name="M1">
+    <file><![CDATA[
+<module:A1(GetType(C1))>
+
+public class A1 
+    Inherits System.Attribute
+
+    public Sub New(a As System.Type)
+    End Sub    
+End Class
+    ]]></file>
+</compilation>
+
+        Dim module2WithAttribute = CreateCompilation(module2, references:={c1Definition}, options:=TestOptions.ReleaseModule).EmitToImageReference()
+
+        Dim comp3 = CreateCompilation("", references:={module2WithAttribute}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp3, symbolValidator:=Sub(m)
+                                                     Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                     Assert.Equal(3, attrs.Length)
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                     AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                 End Sub).VerifyDiagnostics()
     End Sub
 
 End Class


### PR DESCRIPTION
This is a refactoring in preparation for more changes related to #70338.
- Break inheritance between SynthesizedAttributeData/RetargetingAttributeData and SourceAttributeData.
- Strengthen detection of well-known attributes for RetargetingAttributeData
- Remove redundant inputs for some APIs