### PR TITLE
Modify BKTree.Lookup to pass the threshold to GetEditDistance when there will not be a need for the actual edit distance

### DIFF
--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -8,6 +8,8 @@ T:Microsoft.CodeAnalysis.Formatting.FormattingOptions; Use FormattingOptions2 in
 T:Microsoft.CodeAnalysis.Options.PerLanguageOption`1; Use PerLanguageOption2<T> instead
 T:Microsoft.CodeAnalysis.Options.Option`1; Use 'Microsoft.CodeAnalysis.Options.Option2' instead
 P:Microsoft.CodeAnalysis.Completion.CompletionContext.Options; Use CompletionOptions instead.
+P:Microsoft.CodeAnalysis.Completion.CompletionItem.Properties; Use GetProperties instead.
+M:Microsoft.CodeAnalysis.Completion.CompletionItem.WithProperties(System.Collections.Immutable.ImmutableDictionary{System.String,System.String}); Use ImmutableArray overload instead.
 P:Microsoft.CodeAnalysis.Completion.CompletionList.Items; Use CompletionList.ItemsList instead
 M:Microsoft.CodeAnalysis.Completion.CompletionProvider.ShouldTriggerCompletion(Microsoft.CodeAnalysis.Text.SourceText,System.Int32,Microsoft.CodeAnalysis.Completion.CompletionTrigger,Microsoft.CodeAnalysis.Options.OptionSet); Use internal overload instead
 M:Microsoft.CodeAnalysis.Completion.CompletionProvider.GetDescriptionAsync(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.Completion.CompletionItem,System.Threading.CancellationToken); Use internal overload instead

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUpdateExpressionSyntaxHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUpdateExpressionSyntaxHelper.cs
@@ -15,11 +15,13 @@ internal sealed class CSharpUpdateExpressionSyntaxHelper : IUpdateExpressionSynt
 
     public void GetPartsOfForeachStatement(
         StatementSyntax statement,
+        out SyntaxToken awaitKeyword,
         out SyntaxToken identifier,
         out ExpressionSyntax expression,
         out IEnumerable<StatementSyntax> statements)
     {
         var foreachStatement = (ForEachStatementSyntax)statement;
+        awaitKeyword = foreachStatement.AwaitKeyword;
         identifier = foreachStatement.Identifier;
         expression = foreachStatement.Expression;
         statements = ExtractEmbeddedStatements(foreachStatement.Statement);

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -928,6 +928,39 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             """);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70388")]
+    public async Task TestOnVariableDeclarator_AwaitForeach1()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                async void M(IAsyncEnumerable<int> x)
+                {
+                    List<int> c = [|new|] List<int>();
+                    [|c.Add(|]1);
+                    await foreach (var v in x)
+                        c.Add(v);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                async void M(IAsyncEnumerable<int> x)
+                {
+                    List<int> c = [1];
+                    await foreach (var v in x)
+                        c.Add(v);
+                }
+            }
+            """);
+    }
+
     [Fact]
     public async Task TestOnVariableDeclarator_AddRange1()
     {

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/IUpdateExpressionSyntaxHelper.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/IUpdateExpressionSyntaxHelper.cs
@@ -12,6 +12,6 @@ internal interface IUpdateExpressionSyntaxHelper<
     where TExpressionSyntax : SyntaxNode
     where TStatementSyntax : SyntaxNode
 {
-    void GetPartsOfForeachStatement(TStatementSyntax statement, out SyntaxToken identifier, out TExpressionSyntax expression, out IEnumerable<TStatementSyntax> statements);
+    void GetPartsOfForeachStatement(TStatementSyntax statement, out SyntaxToken awaitKeyword, out SyntaxToken identifier, out TExpressionSyntax expression, out IEnumerable<TStatementSyntax> statements);
     void GetPartsOfIfStatement(TStatementSyntax statement, out TExpressionSyntax condition, out IEnumerable<TStatementSyntax> whenTrueStatements, out IEnumerable<TStatementSyntax>? whenFalseStatements);
 }

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UpdateExpressionState.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UpdateExpressionState.cs
@@ -369,7 +369,10 @@ internal readonly struct UpdateExpressionState<
 
         Match<TStatementSyntax>? TryAnalyzeForeachStatement(TStatementSyntax foreachStatement)
         {
-            syntaxHelper.GetPartsOfForeachStatement(foreachStatement, out var identifier, out _, out var foreachStatements);
+            syntaxHelper.GetPartsOfForeachStatement(foreachStatement, out var awaitKeyword, out var identifier, out _, out var foreachStatements);
+            if (awaitKeyword != default)
+                return null;
+
             // must be of the form:
             //
             //      foreach (var x in expr)

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUpdateExpressionSyntaxHelper.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUpdateExpressionSyntaxHelper.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
 
         Public Shared ReadOnly Instance As New VisualBasicUpdateExpressionSyntaxHelper()
 
-        Public Sub GetPartsOfForeachStatement(statement As StatementSyntax, ByRef identifier As SyntaxToken, ByRef expression As ExpressionSyntax, ByRef statements As IEnumerable(Of StatementSyntax)) Implements IUpdateExpressionSyntaxHelper(Of ExpressionSyntax, StatementSyntax).GetPartsOfForeachStatement
+        Public Sub GetPartsOfForeachStatement(statement As StatementSyntax, ByRef awaitKeyword As SyntaxToken, ByRef identifier As SyntaxToken, ByRef expression As ExpressionSyntax, ByRef statements As IEnumerable(Of StatementSyntax)) Implements IUpdateExpressionSyntaxHelper(Of ExpressionSyntax, StatementSyntax).GetPartsOfForeachStatement
             ' Only called for collection expressions, which VB does not support
             Throw ExceptionUtilities.Unreachable()
         End Sub

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // prevent cascading diagnostics
                 Debug.Assert(hasErrors);
-                return new SourceAttributeData(boundAttribute.Syntax.GetReference(), attributeType, attributeConstructor, hasErrors);
+                return new SourceAttributeData(Compilation, (AttributeSyntax)boundAttribute.Syntax, attributeType, attributeConstructor, hasErrors);
             }
 
             // Validate attribute constructor parameters have valid attribute parameter type
@@ -323,7 +323,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagnostics.Add(boundAttribute.Syntax, useSiteInfo);
 
             return new SourceAttributeData(
-                boundAttribute.Syntax.GetReference(),
+                Compilation,
+                (AttributeSyntax)boundAttribute.Syntax,
                 attributeType,
                 attributeConstructor,
                 rewrittenArguments,

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3818,7 +3818,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override SemanticModel CommonGetSemanticModel(SyntaxTree syntaxTree, bool ignoreAccessibility)
         {
-            return this.GetSemanticModel((SyntaxTree)syntaxTree, ignoreAccessibility);
+            return this.GetSemanticModel(syntaxTree, ignoreAccessibility);
         }
 
         protected internal override ImmutableArray<SyntaxTree> CommonSyntaxTrees

--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var peModule = (Symbols.Metadata.PE.PEModuleSymbol)module;
                     foreach (CSharpAttributeData assemblyLevelAttribute in peModule.GetAssemblyAttributes())
                     {
-                        if (assemblyLevelAttribute.IsTargetAttribute(peModule, AttributeDescription.CLSCompliantAttribute))
+                        if (assemblyLevelAttribute.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute))
                         {
                             sawClsCompliantAttribute = true;
                             break;
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (CSharpAttributeData attribute in symbol.GetAttributes())
             {
-                if (attribute.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute))
+                if (attribute.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute))
                 {
                     Location attributeLocation;
                     if (TryGetAttributeWarningLocation(attribute, out attributeLocation))
@@ -692,7 +692,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = startPos; i < parameters.Length; i++)
             {
                 Location attributeLocation;
-                if (TryGetClsComplianceAttributeLocation(parameters[i].GetAttributes(), parameters[i], out attributeLocation))
+                if (TryGetClsComplianceAttributeLocation(parameters[i].GetAttributes(), out attributeLocation))
                 {
                     this.AddDiagnostic(ErrorCode.WRN_CLS_MeaninglessOnParam, attributeLocation);
                 }
@@ -702,7 +702,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void CheckForMeaninglessOnReturn(MethodSymbol method)
         {
             Location attributeLocation;
-            if (TryGetClsComplianceAttributeLocation(method.GetReturnTypeAttributes(), method, out attributeLocation))
+            if (TryGetClsComplianceAttributeLocation(method.GetReturnTypeAttributes(), out attributeLocation))
             {
                 this.AddDiagnostic(ErrorCode.WRN_CLS_MeaninglessOnReturn, attributeLocation);
             }
@@ -763,11 +763,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool TryGetClsComplianceAttributeLocation(ImmutableArray<CSharpAttributeData> attributes, Symbol targetSymbol, out Location attributeLocation)
+        private bool TryGetClsComplianceAttributeLocation(ImmutableArray<CSharpAttributeData> attributes, out Location attributeLocation)
         {
             foreach (CSharpAttributeData data in attributes)
             {
-                if (data.IsTargetAttribute(targetSymbol, AttributeDescription.CLSCompliantAttribute))
+                if (data.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute))
                 {
                     if (TryGetAttributeWarningLocation(data, out attributeLocation))
                     {
@@ -1187,7 +1187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (CSharpAttributeData data in symbol.GetAttributes())
             {
                 // Check signature before HasErrors to avoid realizing symbols for other attributes.
-                if (data.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute))
+                if (data.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute))
                 {
                     NamedTypeSymbol attributeClass = data.AttributeClass;
                     if ((object)attributeClass != null)

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </remarks>
             private void RecordSyntaxDiagnostics(CSharpSyntaxNode treelessSyntax, Location sourceLocation)
             {
-                if (treelessSyntax.ContainsDiagnostics && ((SyntaxTree)sourceLocation.SourceTree).ReportDocumentationCommentDiagnostics())
+                if (treelessSyntax.ContainsDiagnostics && sourceLocation.SourceTree.ReportDocumentationCommentDiagnostics())
                 {
                     // NOTE: treelessSyntax doesn't have its own SyntaxTree, so we have to access the diagnostics
                     // via the Dummy tree.
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </remarks>
             private void RecordBindingDiagnostics(BindingDiagnosticBag bindingDiagnostics, Location sourceLocation)
             {
-                if (((SyntaxTree)sourceLocation.SourceTree).ReportDocumentationCommentDiagnostics())
+                if (sourceLocation.SourceTree.ReportDocumentationCommentDiagnostics())
                 {
                     if (bindingDiagnostics.DiagnosticBag?.IsEmptyWithoutResolution == false)
                     {

--- a/src/Compilers/CSharp/Portable/DocumentationComments/SourceDocumentationCommentUtils.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/SourceDocumentationCommentUtils.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // In most cases, unprocessed doc comments are reported by UnprocessedDocumentationCommentFinder.
                                 // However, in places where doc comments *are* allowed, it's easier to determine which will
                                 // be unprocessed here.
-                                var tree = (SyntaxTree)trivia.SyntaxTree;
+                                var tree = trivia.SyntaxTree;
                                 if (tree.ReportDocumentationCommentDiagnostics())
                                 {
                                     int start = trivia.Position; // FullSpan start to include /** or ///

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -195,7 +195,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal override SynthesizedAttributeData SynthesizeEmbeddedAttribute()
         {
             // _lazyEmbeddedAttribute should have been created before calling this method.
-            return new SynthesizedAttributeData(
+            return SynthesizedAttributeData.Create(
+                Compilation,
                 _lazyEmbeddedAttribute.Constructors[0],
                 ImmutableArray<TypedConstant>.Empty,
                 ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -206,7 +207,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if ((object)_lazyNullableAttribute != null)
             {
                 var constructorIndex = (member == WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags) ? 1 : 0;
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyNullableAttribute.Constructors[constructorIndex],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -219,7 +221,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyNullableContextAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyNullableContextAttribute.Constructors[0],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -232,7 +235,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyNullablePublicOnlyAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyNullablePublicOnlyAttribute.Constructors[0],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -246,7 +250,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if ((object)_lazyNativeIntegerAttribute != null)
             {
                 var constructorIndex = (member == WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags) ? 1 : 0;
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyNativeIntegerAttribute.Constructors[constructorIndex],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -259,7 +264,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyScopedRefAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyScopedRefAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -272,7 +278,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyRefSafetyRulesAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyRefSafetyRulesAttribute.Constructors[0],
                     arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -285,7 +292,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyIsReadOnlyAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyIsReadOnlyAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -298,7 +306,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyRequiresLocationAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyRequiresLocationAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -311,7 +320,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyIsUnmanagedAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyIsUnmanagedAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
@@ -324,7 +334,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             if ((object)_lazyIsByRefLikeAttribute != null)
             {
-                return new SynthesizedAttributeData(
+                return SynthesizedAttributeData.Create(
+                    Compilation,
                     _lazyIsByRefLikeAttribute.Constructors[0],
                     ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedEvent.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedEvent.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
 
             foreach (var attrData in underlyingContainingType.GetAttributes())
             {
-                if (attrData.IsTargetAttribute(underlyingContainingType, AttributeDescription.ComEventInterfaceAttribute))
+                if (attrData.IsTargetAttribute(AttributeDescription.ComEventInterfaceAttribute))
                 {
                     bool foundMatch = false;
                     NamedTypeSymbol sourceInterface = null;

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             if (hasGuid)
             {
                 // This is an interface with a GuidAttribute, so we will generate the no-parameter TypeIdentifier.
-                return new SynthesizedAttributeData(ctor, ImmutableArray<TypedConstant>.Empty, ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
+                return SynthesizedAttributeData.Create(TypeManager.ModuleBeingBuilt.Compilation, ctor, ImmutableArray<TypedConstant>.Empty, ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
             }
             else
             {
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                 if ((object)stringType != null)
                 {
                     string guidString = TypeManager.GetAssemblyGuidString(UnderlyingNamedType.AdaptedNamedTypeSymbol.ContainingAssembly);
-                    return new SynthesizedAttributeData(ctor,
+                    return SynthesizedAttributeData.Create(TypeManager.ModuleBeingBuilt.Compilation, ctor,
                                     ImmutableArray.Create(new TypedConstant(stringType, TypedConstantKind.Primitive, guidString),
                                                     new TypedConstant(stringType, TypedConstantKind.Primitive,
                                                                             UnderlyingNamedType.AdaptedNamedTypeSymbol.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))),

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypesManager.cs
@@ -116,9 +116,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             return lazyMethod;
         }
 
-        internal override int GetTargetAttributeSignatureIndex(SymbolAdapter underlyingSymbol, CSharpAttributeData attrData, AttributeDescription description)
+        internal override int GetTargetAttributeSignatureIndex(CSharpAttributeData attrData, AttributeDescription description)
         {
-            return attrData.GetTargetAttributeSignatureIndex(underlyingSymbol.AdaptedSymbol, description);
+            return attrData.GetTargetAttributeSignatureIndex(description);
         }
 
         internal override CSharpAttributeData CreateSynthesizedAttribute(WellKnownMember constructor, CSharpAttributeData attrData, SyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                     // When emitting a com event interface, we have to tweak the parameters: the spec requires that we use
                     // the original source interface as both source interface and event provider. Otherwise, we'd have to embed
                     // the event provider class too.
-                    return new SynthesizedAttributeData(ctor,
+                    return SynthesizedAttributeData.Create(ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create<TypedConstant>(attrData.CommonConstructorArguments[0], attrData.CommonConstructorArguments[0]),
                         ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
 
@@ -144,12 +144,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                     // instantiatable. The attribute cannot refer directly to the coclass, however, because we can't embed
                     // classes, and we can't emit a reference to the PIA. We don't actually need
                     // the class name at runtime: we will instead emit a reference to System.Object, as a placeholder.
-                    return new SynthesizedAttributeData(ctor,
+                    return SynthesizedAttributeData.Create(ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create(new TypedConstant(ctor.Parameters[0].Type, TypedConstantKind.Type, ctor.ContainingAssembly.GetSpecialType(SpecialType.System_Object))),
                         ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
 
                 default:
-                    return new SynthesizedAttributeData(ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments);
+                    return SynthesizedAttributeData.Create(ModuleBeingBuilt.Compilation, ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -269,8 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
         {
             var node = (AttributeSyntax)attributeSyntax;
-            CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
-            diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+            diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, ((CSharpAttributeData)attribute).GetAttributeArgumentLocation(parameterIndex), node.GetErrorDisplayName());
         }
 
         protected override void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName)
@@ -287,16 +286,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
-            var node = (AttributeSyntax)attributeSyntax;
-            CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
-            diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeNotValidForFields, attributeArgumentSyntax.Location, unmanagedTypeName);
+            diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeNotValidForFields, ((CSharpAttributeData)attribute).GetAttributeArgumentLocation(parameterIndex), unmanagedTypeName);
         }
 
         protected override void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
-            var node = (AttributeSyntax)attributeSyntax;
-            CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
-            diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeOnlyValidForFields, attributeArgumentSyntax.Location, unmanagedTypeName);
+            diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeOnlyValidForFields, ((CSharpAttributeData)attribute).GetAttributeArgumentLocation(parameterIndex), unmanagedTypeName);
         }
 
         protected override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 foreach (var attrData in @interface.GetAttributes())
                 {
-                    if (attrData.IsTargetAttribute(@interface, AttributeDescription.ComEventInterfaceAttribute) &&
+                    if (attrData.IsTargetAttribute(AttributeDescription.ComEventInterfaceAttribute) &&
                         attrData.CommonConstructorArguments.Length == 2)
                     {
                         return RewriteNoPiaEventAssignmentOperator(node, rewrittenReceiverOpt, rewrittenArgument);

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var kickoffType = KickoffMethod.ContainingType;
                 foreach (var attribute in kickoffType.GetAttributes())
                 {
-                    if (attribute.IsTargetAttribute(kickoffType, AttributeDescription.DebuggerNonUserCodeAttribute) ||
-                        attribute.IsTargetAttribute(kickoffType, AttributeDescription.DebuggerStepThroughAttribute))
+                    if (attribute.IsTargetAttribute(AttributeDescription.DebuggerNonUserCodeAttribute) ||
+                        attribute.IsTargetAttribute(AttributeDescription.DebuggerStepThroughAttribute))
                     {
                         if (builder == null)
                         {

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.cs
@@ -79,10 +79,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var kickoffMethod = StateMachineType.KickoffMethod;
                 foreach (var attribute in kickoffMethod.GetAttributes())
                 {
-                    if (attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerHiddenAttribute) ||
-                        attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerNonUserCodeAttribute) ||
-                        attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerStepperBoundaryAttribute) ||
-                        attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerStepThroughAttribute))
+                    if (attribute.IsTargetAttribute(AttributeDescription.DebuggerHiddenAttribute) ||
+                        attribute.IsTargetAttribute(AttributeDescription.DebuggerNonUserCodeAttribute) ||
+                        attribute.IsTargetAttribute(AttributeDescription.DebuggerStepperBoundaryAttribute) ||
+                        attribute.IsTargetAttribute(AttributeDescription.DebuggerStepThroughAttribute))
                     {
                         if (builder == null)
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -43,20 +43,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // Overridden to be able to apply MemberNotNull to the new members
         [MemberNotNullWhen(true, nameof(AttributeClass), nameof(AttributeConstructor))]
-        internal override bool HasErrors
-        {
-            get
-            {
-                var hasErrors = base.HasErrors;
-                if (!hasErrors)
-                {
-                    Debug.Assert(AttributeClass is not null);
-                    Debug.Assert(AttributeConstructor is not null);
-                }
+        internal abstract override bool HasErrors { get; }
 
-                return hasErrors;
-            }
-        }
+        internal abstract override bool IsConditionallyOmitted { get; }
 
         /// <summary>
         /// Gets the list of constructor arguments specified by this application of the attribute.  This list contains both positional arguments
@@ -79,30 +68,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Compares the namespace and type name with the attribute's namespace and type name.
         /// Returns true if they are the same.
         /// </summary>
-        internal virtual bool IsTargetAttribute(string namespaceName, string typeName)
+        internal abstract bool IsTargetAttribute(string namespaceName, string typeName);
+
+        internal bool IsTargetAttribute(AttributeDescription description)
         {
-            Debug.Assert(this.AttributeClass is object);
-
-            if (!this.AttributeClass.Name.Equals(typeName))
-            {
-                return false;
-            }
-
-            if (this.AttributeClass.IsErrorType() && !(this.AttributeClass is MissingMetadataTypeSymbol))
-            {
-                // Can't guarantee complete name information.
-                return false;
-            }
-
-            return this.AttributeClass.HasNameQualifier(namespaceName);
+            return GetTargetAttributeSignatureIndex(description) != -1;
         }
 
-        internal bool IsTargetAttribute(Symbol targetSymbol, AttributeDescription description)
-        {
-            return GetTargetAttributeSignatureIndex(targetSymbol, description) != -1;
-        }
+        internal abstract int GetTargetAttributeSignatureIndex(AttributeDescription description);
 
-        internal abstract int GetTargetAttributeSignatureIndex(Symbol targetSymbol, AttributeDescription description);
+        internal abstract Location GetAttributeArgumentLocation(int parameterIndex);
 
         /// <summary>
         /// Checks if an applied attribute with the given attributeType matches the namespace name and type name of the given early attribute's description
@@ -247,7 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SecurityWellKnownAttributeData securityData = data.GetOrCreateData();
                 securityData.SetSecurityAttribute(arguments.Index, action, arguments.AttributesCount);
 
-                if (this.IsTargetAttribute(targetSymbol, AttributeDescription.PermissionSetAttribute))
+                if (this.IsTargetAttribute(AttributeDescription.PermissionSetAttribute))
                 {
                     string? resolvedPathForFixup = DecodePermissionSetAttribute(compilation, arguments.AttributeSyntaxOpt, (BindingDiagnosticBag)arguments.Diagnostics);
                     if (resolvedPathForFixup != null)
@@ -377,7 +352,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // attribute argument to have the above mentioned behavior, even though the comment clearly mentions that this behavior was intended only for the HostProtectionAttribute.
                 // We currently allow this case only for the HostProtectionAttribute. In future if need arises, we can exactly match native compiler's behavior.
 
-                if (this.IsTargetAttribute(targetSymbol, AttributeDescription.HostProtectionAttribute))
+                if (this.IsTargetAttribute(AttributeDescription.HostProtectionAttribute))
                 {
                     hasErrors = false;
                     return DeclarativeSecurityAction.LinkDemand;
@@ -412,7 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case (int)DeclarativeSecurityAction.InheritanceDemand:
                 case (int)DeclarativeSecurityAction.LinkDemand:
-                    if (this.IsTargetAttribute(targetSymbol, AttributeDescription.PrincipalPermissionAttribute))
+                    if (this.IsTargetAttribute(AttributeDescription.PrincipalPermissionAttribute))
                     {
                         // CS7052: SecurityAction value '{0}' is invalid for PrincipalPermission attribute
                         object displayString;
@@ -609,8 +584,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 default:
                     // CS0591: Invalid value for argument to '{0}' attribute
-                    Location attributeArgumentSyntaxLocation = this.GetAttributeArgumentSyntaxLocation(0, nodeOpt);
-                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntaxLocation, nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
+                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, this.GetAttributeArgumentLocation(0), nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
                     break;
             }
         }
@@ -636,8 +610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 default:
                     // CS0591: Invalid value for argument to '{0}' attribute
-                    CSharpSyntaxNode attributeArgumentSyntax = this.GetAttributeArgumentSyntax(0, node);
-                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, this.GetAttributeArgumentLocation(0), node.GetErrorDisplayName());
                     break;
             }
         }
@@ -653,7 +626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!Guid.TryParseExact(guidString, "D", out guid))
             {
                 // CS0591: Invalid value for argument to '{0}' attribute
-                Location attributeArgumentSyntaxLocation = this.GetAttributeArgumentSyntaxLocation(0, nodeOpt);
+                Location attributeArgumentSyntaxLocation = this.GetAttributeArgumentLocation(0);
                 diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntaxLocation, nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
                 guidString = String.Empty;
             }
@@ -712,11 +685,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case SymbolKind.Assembly:
                     if ((!emittingAssemblyAttributesInNetModule &&
-                            (IsTargetAttribute(target, AttributeDescription.AssemblyCultureAttribute) ||
-                             IsTargetAttribute(target, AttributeDescription.AssemblyVersionAttribute) ||
-                             IsTargetAttribute(target, AttributeDescription.AssemblyFlagsAttribute) ||
-                             IsTargetAttribute(target, AttributeDescription.AssemblyAlgorithmIdAttribute))) ||
-                        IsTargetAttribute(target, AttributeDescription.TypeForwardedToAttribute) ||
+                            (IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) ||
+                             IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) ||
+                             IsTargetAttribute(AttributeDescription.AssemblyFlagsAttribute) ||
+                             IsTargetAttribute(AttributeDescription.AssemblyAlgorithmIdAttribute))) ||
+                        IsTargetAttribute(AttributeDescription.TypeForwardedToAttribute) ||
                         IsSecurityAttribute(target.DeclaringCompilation))
                     {
                         return false;
@@ -725,7 +698,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.Event:
-                    if (IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute))
+                    if (IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
                     {
                         return false;
                     }
@@ -733,10 +706,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.Field:
-                    if (IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.NonSerializedAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.FieldOffsetAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute))
+                    if (IsTargetAttribute(AttributeDescription.SpecialNameAttribute) ||
+                        IsTargetAttribute(AttributeDescription.NonSerializedAttribute) ||
+                        IsTargetAttribute(AttributeDescription.FieldOffsetAttribute) ||
+                        IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
                     {
                         return false;
                     }
@@ -746,18 +719,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.Method:
                     if (isReturnType)
                     {
-                        if (IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute))
+                        if (IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
                         {
                             return false;
                         }
                     }
                     else
                     {
-                        if (IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) ||
-                            IsTargetAttribute(target, AttributeDescription.MethodImplAttribute) ||
-                            IsTargetAttribute(target, AttributeDescription.DllImportAttribute) ||
-                            IsTargetAttribute(target, AttributeDescription.PreserveSigAttribute) ||
-                            IsTargetAttribute(target, AttributeDescription.DynamicSecurityMethodAttribute) ||
+                        if (IsTargetAttribute(AttributeDescription.SpecialNameAttribute) ||
+                            IsTargetAttribute(AttributeDescription.MethodImplAttribute) ||
+                            IsTargetAttribute(AttributeDescription.DllImportAttribute) ||
+                            IsTargetAttribute(AttributeDescription.PreserveSigAttribute) ||
+                            IsTargetAttribute(AttributeDescription.DynamicSecurityMethodAttribute) ||
                             IsSecurityAttribute(target.DeclaringCompilation))
                         {
                             return false;
@@ -771,11 +744,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.NamedType:
-                    if (IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.ComImportAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.SerializableAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.StructLayoutAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.WindowsRuntimeImportAttribute) ||
+                    if (IsTargetAttribute(AttributeDescription.SpecialNameAttribute) ||
+                        IsTargetAttribute(AttributeDescription.ComImportAttribute) ||
+                        IsTargetAttribute(AttributeDescription.SerializableAttribute) ||
+                        IsTargetAttribute(AttributeDescription.StructLayoutAttribute) ||
+                        IsTargetAttribute(AttributeDescription.WindowsRuntimeImportAttribute) ||
                         IsSecurityAttribute(target.DeclaringCompilation))
                     {
                         return false;
@@ -784,11 +757,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.Parameter:
-                    if (IsTargetAttribute(target, AttributeDescription.OptionalAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.DefaultParameterValueAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.InAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.OutAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute))
+                    if (IsTargetAttribute(AttributeDescription.OptionalAttribute) ||
+                        IsTargetAttribute(AttributeDescription.DefaultParameterValueAttribute) ||
+                        IsTargetAttribute(AttributeDescription.InAttribute) ||
+                        IsTargetAttribute(AttributeDescription.OutAttribute) ||
+                        IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
                     {
                         return false;
                     }
@@ -796,12 +769,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case SymbolKind.Property:
-                    if (IsTargetAttribute(target, AttributeDescription.IndexerNameAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.DisallowNullAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.AllowNullAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.MaybeNullAttribute) ||
-                        IsTargetAttribute(target, AttributeDescription.NotNullAttribute))
+                    if (IsTargetAttribute(AttributeDescription.IndexerNameAttribute) ||
+                        IsTargetAttribute(AttributeDescription.SpecialNameAttribute) ||
+                        IsTargetAttribute(AttributeDescription.DisallowNullAttribute) ||
+                        IsTargetAttribute(AttributeDescription.AllowNullAttribute) ||
+                        IsTargetAttribute(AttributeDescription.MaybeNullAttribute) ||
+                        IsTargetAttribute(AttributeDescription.NotNullAttribute))
                     {
                         return false;
                     }
@@ -816,11 +789,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
     internal static class AttributeDataExtensions
     {
-        internal static int IndexOfAttribute(this ImmutableArray<CSharpAttributeData> attributes, Symbol targetSymbol, AttributeDescription description)
+        internal static int IndexOfAttribute(this ImmutableArray<CSharpAttributeData> attributes, AttributeDescription description)
         {
             for (int i = 0; i < attributes.Length; i++)
             {
-                if (attributes[i].IsTargetAttribute(targetSymbol, description))
+                if (attributes[i].IsTargetAttribute(description))
                 {
                     return i;
                 }
@@ -829,27 +802,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return -1;
         }
 
-        internal static CSharpSyntaxNode GetAttributeArgumentSyntax(this AttributeData attribute, int parameterIndex, AttributeSyntax attributeSyntax)
-        {
-            Debug.Assert(attribute is SourceAttributeData);
-            return ((SourceAttributeData)attribute).GetAttributeArgumentSyntax(parameterIndex, attributeSyntax);
-        }
-
         internal static string? DecodeNotNullIfNotNullAttribute(this CSharpAttributeData attribute)
         {
             var arguments = attribute.CommonConstructorArguments;
             return arguments.Length == 1 && arguments[0].TryDecodeValue(SpecialType.System_String, out string? value) ? value : null;
-        }
-
-        internal static Location GetAttributeArgumentSyntaxLocation(this AttributeData attribute, int parameterIndex, AttributeSyntax? attributeSyntaxOpt)
-        {
-            if (attributeSyntaxOpt == null)
-            {
-                return NoLocation.Singleton;
-            }
-
-            Debug.Assert(attribute is SourceAttributeData);
-            return ((SourceAttributeData)attribute).GetAttributeArgumentSyntax(parameterIndex, attributeSyntaxOpt).Location;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/PEAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/PEAttributeData.cs
@@ -134,17 +134,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         /// Matches an attribute by metadata namespace, metadata type name and metadata signature. Does not load the
         /// type symbol for the attribute.
         /// </summary>
-        /// <param name="targetSymbol">Target symbol.</param>
         /// <param name="description">Attribute to match.</param>
         /// <returns>
         /// An index of the target constructor signature in
         /// signatures array, -1 if
         /// this is not the target attribute.
         /// </returns>
-        internal override int GetTargetAttributeSignatureIndex(Symbol targetSymbol, AttributeDescription description)
+        internal override int GetTargetAttributeSignatureIndex(AttributeDescription description)
         {
             // Matching an attribute by name should not load the attribute class.
             return _decoder.GetTargetAttributeSignatureIndex(_handle, description);
+        }
+
+        internal override Location GetAttributeArgumentLocation(int parameterIndex)
+        {
+            return new MetadataLocation(_decoder.ModuleSymbol);
         }
 
         [MemberNotNullWhen(true, nameof(AttributeClass), nameof(AttributeConstructor))]
@@ -166,5 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return _lazyHasErrors.Value();
             }
         }
+
+        internal override bool IsConditionallyOmitted => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/RetargetingAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/RetargetingAttributeData.cs
@@ -4,43 +4,52 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 {
     /// <summary>
     /// Represents a retargeting custom attribute
     /// </summary>
-    internal sealed class RetargetingAttributeData : SourceAttributeData
+    internal sealed class RetargetingAttributeData : CSharpAttributeData
     {
+        private readonly CSharpAttributeData _underlying;
+        private readonly NamedTypeSymbol _attributeClass;
+        private readonly MethodSymbol? _attributeConstructor;
+        private readonly ImmutableArray<TypedConstant> _constructorArguments;
+        private readonly ImmutableArray<KeyValuePair<string, TypedConstant>> _namedArguments;
+
         internal RetargetingAttributeData(
-            SyntaxReference applicationNode,
+            CSharpAttributeData underlying,
             NamedTypeSymbol attributeClass,
-            MethodSymbol attributeConstructor,
+            MethodSymbol? attributeConstructor,
             ImmutableArray<TypedConstant> constructorArguments,
-            ImmutableArray<int> constructorArgumentsSourceIndices,
-            ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments,
-            bool hasErrors,
-            bool isConditionallyOmitted)
-            : base(applicationNode, attributeClass, attributeConstructor, constructorArguments, constructorArgumentsSourceIndices, namedArguments, hasErrors, isConditionallyOmitted)
+            ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
         {
+            Debug.Assert(underlying is SourceAttributeData or SynthesizedAttributeData);
+
+            _underlying = underlying;
+            _attributeClass = attributeClass;
+            _attributeConstructor = attributeConstructor;
+            _constructorArguments = constructorArguments;
+            _namedArguments = namedArguments;
         }
 
-        /// <summary>
-        /// Gets the retargeted System.Type type symbol.
-        /// </summary>
-        /// <param name="targetSymbol">Target symbol on which this attribute is applied.</param>
-        /// <returns>Retargeted System.Type type symbol.</returns>
-        internal override TypeSymbol GetSystemType(Symbol targetSymbol)
-        {
-            var retargetingAssembly = (RetargetingAssemblySymbol)(targetSymbol.Kind == SymbolKind.Assembly ? targetSymbol : targetSymbol.ContainingAssembly);
-            var underlyingAssembly = (SourceAssemblySymbol)retargetingAssembly.UnderlyingAssembly;
+        public override NamedTypeSymbol AttributeClass => _attributeClass;
+        public override MethodSymbol? AttributeConstructor => _attributeConstructor;
+        protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _constructorArguments;
+        protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _namedArguments;
 
-            // Get the System.Type from the underlying assembly's Compilation
-            TypeSymbol systemType = underlyingAssembly.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Type);
+        public override SyntaxReference? ApplicationSyntaxReference => null;
 
-            // Retarget the type
-            var retargetingModule = (RetargetingModuleSymbol)retargetingAssembly.Modules[0];
-            return retargetingModule.RetargetingTranslator.Retarget(systemType, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
-        }
+        [MemberNotNullWhen(true, nameof(AttributeClass), nameof(AttributeConstructor))]
+        internal override bool HasErrors => _underlying.HasErrors || _attributeConstructor is null;
+
+        internal override bool IsConditionallyOmitted => _underlying.IsConditionallyOmitted;
+
+        internal override Location GetAttributeArgumentLocation(int parameterIndex) => _underlying.GetAttributeArgumentLocation(parameterIndex);
+        internal override int GetTargetAttributeSignatureIndex(AttributeDescription description) => _underlying.GetTargetAttributeSignatureIndex(description);
+        internal override bool IsTargetAttribute(string namespaceName, string typeName) => _underlying.IsTargetAttribute(namespaceName, typeName);
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/SourceAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/SourceAttributeData.cs
@@ -15,8 +15,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// Represents a Source custom attribute specification
     /// </summary>
-    internal class SourceAttributeData : CSharpAttributeData
+    internal sealed class SourceAttributeData : CSharpAttributeData
     {
+        private readonly CSharpCompilation _compilation;
         private readonly NamedTypeSymbol _attributeClass;
         private readonly MethodSymbol? _attributeConstructor;
         private readonly ImmutableArray<TypedConstant> _constructorArguments;
@@ -24,10 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly ImmutableArray<KeyValuePair<string, TypedConstant>> _namedArguments;
         private readonly bool _isConditionallyOmitted;
         private readonly bool _hasErrors;
-        private readonly SyntaxReference? _applicationNode;
+        private readonly SyntaxReference _applicationNode;
 
-        internal SourceAttributeData(
-            SyntaxReference? applicationNode,
+        private SourceAttributeData(
+            CSharpCompilation compilation,
+            SyntaxReference applicationNode,
             NamedTypeSymbol attributeClass,
             MethodSymbol? attributeConstructor,
             ImmutableArray<TypedConstant> constructorArguments,
@@ -43,6 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 constructorArgumentsSourceIndices.Any() && constructorArgumentsSourceIndices.Length == constructorArguments.Length);
             Debug.Assert(attributeConstructor is object || hasErrors);
 
+            _compilation = compilation;
             _attributeClass = attributeClass;
             _attributeConstructor = attributeConstructor;
             _constructorArguments = constructorArguments;
@@ -53,9 +56,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _applicationNode = applicationNode;
         }
 
-        internal SourceAttributeData(SyntaxReference applicationNode, NamedTypeSymbol attributeClass, MethodSymbol? attributeConstructor, bool hasErrors)
+        internal SourceAttributeData(CSharpCompilation compilation, AttributeSyntax attributeSyntax, NamedTypeSymbol attributeClass, MethodSymbol? attributeConstructor, bool hasErrors)
             : this(
-            applicationNode,
+            compilation,
+            attributeSyntax,
             attributeClass,
             attributeConstructor,
             constructorArguments: ImmutableArray<TypedConstant>.Empty,
@@ -63,6 +67,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             namedArguments: ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty,
             hasErrors: hasErrors,
             isConditionallyOmitted: false)
+        {
+        }
+
+        internal SourceAttributeData(
+            CSharpCompilation compilation,
+            AttributeSyntax attributeSyntax,
+            NamedTypeSymbol attributeClass,
+            MethodSymbol? attributeConstructor,
+            ImmutableArray<TypedConstant> constructorArguments,
+            ImmutableArray<int> constructorArgumentsSourceIndices,
+            ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments,
+            bool hasErrors,
+            bool isConditionallyOmitted)
+            : this(compilation, attributeSyntax.GetReference(), attributeClass, attributeConstructor, constructorArguments, constructorArgumentsSourceIndices, namedArguments, hasErrors, isConditionallyOmitted)
         {
         }
 
@@ -82,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override SyntaxReference? ApplicationSyntaxReference
+        public override SyntaxReference ApplicationSyntaxReference
         {
             get
             {
@@ -103,14 +121,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal CSharpSyntaxNode GetAttributeArgumentSyntax(int parameterIndex, AttributeSyntax attributeSyntax)
+        internal CSharpSyntaxNode GetAttributeArgumentSyntax(int parameterIndex)
         {
             // This method is only called when decoding (non-erroneous) well-known attributes.
             Debug.Assert(!this.HasErrors);
             Debug.Assert(this.AttributeConstructor is object);
             Debug.Assert(parameterIndex >= 0);
             Debug.Assert(parameterIndex < this.AttributeConstructor.ParameterCount);
-            Debug.Assert(attributeSyntax != null);
+
+            var attributeSyntax = (AttributeSyntax)_applicationNode.GetSyntax();
 
             if (_constructorArgumentsSourceIndices.IsDefault)
             {
@@ -139,6 +158,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override Location GetAttributeArgumentLocation(int parameterIndex)
+        {
+            return GetAttributeArgumentSyntax(parameterIndex).Location;
+        }
+
         internal override bool IsConditionallyOmitted
         {
             get
@@ -155,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                return new SourceAttributeData(this.ApplicationSyntaxReference, this.AttributeClass, this.AttributeConstructor, this.CommonConstructorArguments,
+                return new SourceAttributeData(this._compilation, this.ApplicationSyntaxReference, this.AttributeClass, this.AttributeConstructor, this.CommonConstructorArguments,
                     this.ConstructorArgumentsSourceIndices, this.CommonNamedArguments, this.HasErrors, isConditionallyOmitted);
             }
         }
@@ -185,16 +209,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// and System.Type.  It will not match an arbitrary signature but it is sufficient to match the signatures of the current set of
         /// well known attributes.
         /// </summary>
-        /// <param name="targetSymbol">The symbol which is the target of the attribute</param>
         /// <param name="description">The attribute to match.</param>
-        internal override int GetTargetAttributeSignatureIndex(Symbol targetSymbol, AttributeDescription description)
+        internal override int GetTargetAttributeSignatureIndex(AttributeDescription description)
         {
-            if (!IsTargetAttribute(description.Namespace, description.Name))
+            return GetTargetAttributeSignatureIndex(_compilation, AttributeClass, AttributeConstructor, description);
+        }
+
+        internal static int GetTargetAttributeSignatureIndex(CSharpCompilation compilation, NamedTypeSymbol attributeClass, MethodSymbol? attributeConstructor, AttributeDescription description)
+        {
+            if (!IsTargetAttribute(attributeClass, description.Namespace, description.Name))
             {
                 return -1;
             }
 
-            var ctor = this.AttributeConstructor;
+            var ctor = attributeConstructor;
 
             // Ensure that the attribute data really has a constructor before comparing the signature.
             if (ctor is null)
@@ -401,7 +429,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             break;
 
                         case (byte)SerializationTypeCode.Type:
-                            lazySystemType ??= GetSystemType(targetSymbol);
+                            lazySystemType ??= compilation.GetWellKnownType(WellKnownType.System_Type);
 
                             if (!TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything))
                             {
@@ -427,14 +455,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        /// <summary>
-        /// Gets the System.Type type symbol from targetSymbol's containing assembly.
-        /// </summary>
-        /// <param name="targetSymbol">Target symbol on which this attribute is applied.</param>
-        /// <returns>System.Type type symbol.</returns>
-        internal virtual TypeSymbol GetSystemType(Symbol targetSymbol)
+        internal override bool IsTargetAttribute(string namespaceName, string typeName)
         {
-            return targetSymbol.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Type);
+            return IsTargetAttribute(AttributeClass, namespaceName, typeName);
+        }
+
+        /// <summary>
+        /// Compares the namespace and type name with the attribute's namespace and type name.
+        /// Returns true if they are the same.
+        /// </summary>
+        internal static bool IsTargetAttribute(NamedTypeSymbol attributeClass, string namespaceName, string typeName)
+        {
+            Debug.Assert(attributeClass is object);
+
+            if (!attributeClass.Name.Equals(typeName))
+            {
+                return false;
+            }
+
+            if (attributeClass.IsErrorType() && !(attributeClass is MissingMetadataTypeSymbol))
+            {
+                // Can't guarantee complete name information.
+                return false;
+            }
+
+            return attributeClass.HasNameQualifier(namespaceName);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 namedStringArguments = builder.ToImmutableAndFree();
             }
 
-            return new SynthesizedAttributeData(ctorSymbol, arguments, namedStringArguments);
+            return SynthesizedAttributeData.Create(this, ctorSymbol, arguments, namedStringArguments);
         }
 
         internal SynthesizedAttributeData? TrySynthesizeAttribute(
@@ -443,7 +443,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            return new SynthesizedAttributeData(
+            return SynthesizedAttributeData.Create(
+                this,
                 ctorSymbol,
                 arguments: ImmutableArray<TypedConstant>.Empty,
                 namedArguments: ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);

--- a/src/Compilers/CSharp/Portable/Symbols/LexicalSortKey.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LexicalSortKey.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // WARNING: Only use this if the location is obtainable without allocating it (even if cached later). E.g., only
         // if the location object is stored in the constructor of the symbol.
         public LexicalSortKey(Location location, CSharpCompilation compilation)
-            : this((SyntaxTree)location.SourceTree, location.SourceSpan.Start, compilation)
+            : this(location.SourceTree, location.SourceSpan.Start, compilation)
         {
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // if the node is stored in the constructor of the symbol. In particular, do not call this on the result of a GetSyntax()
         // call on a SyntaxReference.
         public LexicalSortKey(SyntaxToken token, CSharpCompilation compilation)
-            : this((SyntaxTree)token.SyntaxTree, token.SpanStart, compilation)
+            : this(token.SyntaxTree, token.SpanStart, compilation)
         {
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get
             {
                 var assemblyAttributes = GetAssemblyAttributes();
-                return assemblyAttributes.IndexOfAttribute(this, AttributeDescription.CompilationRelaxationsAttribute) >= 0;
+                return assemblyAttributes.IndexOfAttribute(AttributeDescription.CompilationRelaxationsAttribute) >= 0;
             }
         }
 
@@ -670,7 +670,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get
             {
                 var assemblyAttributes = GetAssemblyAttributes();
-                return assemblyAttributes.IndexOfAttribute(this, AttributeDescription.RuntimeCompatibilityAttribute) >= 0;
+                return assemblyAttributes.IndexOfAttribute(AttributeDescription.RuntimeCompatibilityAttribute) >= 0;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                         // This is a local type explicitly declared in source. Get information from TypeIdentifier attribute.
                         foreach (var attrData in type.GetAttributes())
                         {
-                            int signatureIndex = attrData.GetTargetAttributeSignatureIndex(type, AttributeDescription.TypeIdentifierAttribute);
+                            int signatureIndex = attrData.GetTargetAttributeSignatureIndex(AttributeDescription.TypeIdentifierAttribute);
 
                             if (signatureIndex != -1)
                             {
@@ -1145,11 +1145,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
             internal IEnumerable<CSharpAttributeData> RetargetAttributes(IEnumerable<CSharpAttributeData> attributes)
             {
-#if DEBUG
-                SynthesizedAttributeData x = null;
-                SourceAttributeData y = x; // Code below relies on the fact that SynthesizedAttributeData derives from SourceAttributeData.
-                x = (SynthesizedAttributeData)y;
-#endif
                 foreach (var attributeData in attributes)
                 {
                     yield return this.RetargetAttributeData(attributeData);
@@ -1158,14 +1153,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
             private CSharpAttributeData RetargetAttributeData(CSharpAttributeData oldAttributeData)
             {
-                SourceAttributeData oldAttribute = (SourceAttributeData)oldAttributeData;
-
-                MethodSymbol oldAttributeCtor = oldAttribute.AttributeConstructor;
+                MethodSymbol oldAttributeCtor = oldAttributeData.AttributeConstructor;
                 MethodSymbol newAttributeCtor = (object)oldAttributeCtor == null ?
                     null :
                     Retarget(oldAttributeCtor, MemberSignatureComparer.RetargetedExplicitImplementationComparer);
 
-                NamedTypeSymbol oldAttributeType = oldAttribute.AttributeClass;
+                NamedTypeSymbol oldAttributeType = oldAttributeData.AttributeClass;
                 NamedTypeSymbol newAttributeType;
                 if ((object)newAttributeCtor != null)
                 {
@@ -1180,24 +1173,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                     newAttributeType = null;
                 }
 
-                ImmutableArray<TypedConstant> oldAttributeCtorArguments = oldAttribute.CommonConstructorArguments;
+                ImmutableArray<TypedConstant> oldAttributeCtorArguments = oldAttributeData.CommonConstructorArguments;
                 ImmutableArray<TypedConstant> newAttributeCtorArguments = RetargetAttributeConstructorArguments(oldAttributeCtorArguments);
 
-                ImmutableArray<KeyValuePair<string, TypedConstant>> oldAttributeNamedArguments = oldAttribute.CommonNamedArguments;
+                ImmutableArray<KeyValuePair<string, TypedConstant>> oldAttributeNamedArguments = oldAttributeData.CommonNamedArguments;
                 ImmutableArray<KeyValuePair<string, TypedConstant>> newAttributeNamedArguments = RetargetAttributeNamedArguments(oldAttributeNamedArguments);
 
                 // Must create a RetargetingAttributeData even if the types and
                 // arguments are unchanged since the AttributeData instance is
                 // used to resolve System.Type which may require retargeting.
                 return new RetargetingAttributeData(
-                    oldAttribute.ApplicationSyntaxReference,
+                    oldAttributeData,
                     newAttributeType,
                     newAttributeCtor,
                     newAttributeCtorArguments,
-                    oldAttribute.ConstructorArgumentsSourceIndices,
-                    newAttributeNamedArguments,
-                    hasErrors: oldAttribute.HasErrors || newAttributeCtor is null,
-                    oldAttribute.IsConditionallyOmitted);
+                    newAttributeNamedArguments);
             }
 
             private ImmutableArray<TypedConstant> RetargetAttributeConstructorArguments(ImmutableArray<TypedConstant> constructorArguments)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -168,15 +168,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NonSerializedAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NonSerializedAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasNonSerializedAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.FieldOffsetAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.FieldOffsetAttribute))
             {
                 if (this.IsStatic || this.IsConst)
                 {
@@ -189,8 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (offset < 0)
                     {
                         // Dev10 reports CS0647: "Error emitting attribute ..."
-                        CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, arguments.AttributeSyntaxOpt);
-                        diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
+                        diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(0), arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                         offset = 0;
                     }
 
@@ -199,7 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     arguments.GetOrCreateData<FieldWellKnownAttributeData>().SetFieldOffset(offset);
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
             {
                 MarshalAsAttributeDecoder<FieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
             }
@@ -215,27 +214,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 | ReservedAttributes.RequiredMemberAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DateTimeConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DateTimeConstantAttribute))
             {
                 VerifyConstantValueMatches(attribute.DecodeDateTimeConstantValue(), ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DecimalConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DecimalConstantAttribute))
             {
                 VerifyConstantValueMatches(attribute.DecodeDecimalConstantValue(), ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AllowNullAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasAllowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DisallowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DisallowNullAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasDisallowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasMaybeNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullAttribute))
             {
                 arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasNotNullAttribute = true;
             }
@@ -329,7 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     Debug.Assert(boundAttributes.Any());
 
                     // error CS0636: The FieldOffset attribute can only be placed on members of types marked with the StructLayout(LayoutKind.Explicit)
-                    int i = boundAttributes.IndexOfAttribute(this, AttributeDescription.FieldOffsetAttribute);
+                    int i = boundAttributes.IndexOfAttribute(AttributeDescription.FieldOffsetAttribute);
                     diagnostics.Add(ErrorCode.ERR_StructOffsetOnBadStruct, allAttributeSyntaxNodes[i].Name.Location);
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -1144,24 +1144,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // TODO: This list used to include AssemblyOperatingSystemAttribute and AssemblyProcessorAttribute,
             //       but it doesn't look like they are defined, cannot find them on MSDN.
-            if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyTitleAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyDescriptionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyConfigurationAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCultureAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyVersionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCompanyAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyProductAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyInformationalVersionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCopyrightAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyTrademarkAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyFileAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyNameAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyAlgorithmIdAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyFlagsAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyDelaySignAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblyFileVersionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.SatelliteContractVersionAttribute) ||
-                attribute.IsTargetAttribute(this, AttributeDescription.AssemblySignatureKeyAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.AssemblyTitleAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyConfigurationAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyCompanyAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyProductAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyCopyrightAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyTrademarkAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyAlgorithmIdAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyFlagsAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyDelaySignAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.SatelliteContractVersionAttribute) ||
+                attribute.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute))
             {
                 return true;
             }
@@ -1506,19 +1506,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             void limitedDecodeWellKnownAttribute(CSharpAttributeData attribute, QuickAttributes attributeMatches, ref CommonAssemblyWellKnownAttributeData result)
             {
                 if (attributeMatches is QuickAttributes.AssemblySignatureKey &&
-                    attribute.IsTargetAttribute(this, AttributeDescription.AssemblySignatureKeyAttribute))
+                    attribute.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute))
                 {
                     result ??= new CommonAssemblyWellKnownAttributeData();
                     result.AssemblySignatureKeyAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 }
                 else if (attributeMatches is QuickAttributes.AssemblyKeyFile &&
-                    attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyFileAttribute))
+                    attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute))
                 {
                     result ??= new CommonAssemblyWellKnownAttributeData();
                     result.AssemblyKeyFileAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 }
                 else if (attributeMatches is QuickAttributes.AssemblyKeyName &&
-                    attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyNameAttribute))
+                    attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute))
                 {
                     result ??= new CommonAssemblyWellKnownAttributeData();
                     result.AssemblyKeyContainerAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
@@ -2362,96 +2362,96 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int signature;
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.InternalsVisibleToAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.InternalsVisibleToAttribute))
             {
                 DecodeOneInternalsVisibleToAttribute(arguments.AttributeSyntaxOpt, attribute, diagnostics, index, ref _lazyInternalsVisibleToMap);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblySignatureKeyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute))
             {
                 var signatureKey = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblySignatureKeyAttributeSetting = signatureKey;
 
                 if (!StrongNameKeys.IsValidPublicKeyString(signatureKey))
                 {
-                    diagnostics.Add(ErrorCode.ERR_InvalidSignaturePublicKey, attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt));
+                    diagnostics.Add(ErrorCode.ERR_InvalidSignaturePublicKey, attribute.GetAttributeArgumentLocation(0));
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyFileAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyKeyFileAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyKeyNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyKeyContainerAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyDelaySignAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyDelaySignAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyDelaySignAttributeSetting = (bool)attribute.CommonConstructorArguments[0].ValueInternal ? ThreeState.True : ThreeState.False;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute))
             {
                 string verString = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 Version version;
                 if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: !_compilation.IsEmitDeterministic, version: out version))
                 {
-                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
+                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentLocation(0);
                     bool foundBadWildcard = _compilation.IsEmitDeterministic && verString?.Contains('*') == true;
                     diagnostics.Add(foundBadWildcard ? ErrorCode.ERR_InvalidVersionFormatDeterministic : ErrorCode.ERR_InvalidVersionFormat, attributeArgumentSyntaxLocation, verString ?? "<null>");
                 }
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyVersionAttributeSetting = version;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyFileVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute))
             {
                 Version dummy;
                 string verString = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 if (!VersionHelper.TryParse(verString, version: out dummy))
                 {
-                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
+                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentLocation(0);
                     diagnostics.Add(ErrorCode.WRN_InvalidVersionFormat, attributeArgumentSyntaxLocation, verString ?? "<null>");
                 }
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyFileVersionAttributeSetting = verString;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyTitleAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyTitleAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyTitleAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyDescriptionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyDescriptionAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCultureAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute))
             {
                 var cultureString = (string)attribute.CommonConstructorArguments[0].ValueInternal;
                 if (!string.IsNullOrEmpty(cultureString))
                 {
                     if (_compilation.Options.OutputKind.IsApplication())
                     {
-                        diagnostics.Add(ErrorCode.ERR_InvalidAssemblyCultureForExe, attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt));
+                        diagnostics.Add(ErrorCode.ERR_InvalidAssemblyCultureForExe, attribute.GetAttributeArgumentLocation(0));
                     }
                     else if (!AssemblyIdentity.IsValidCultureName(cultureString))
                     {
-                        diagnostics.Add(ErrorCode.ERR_InvalidAssemblyCulture, attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt));
+                        diagnostics.Add(ErrorCode.ERR_InvalidAssemblyCulture, attribute.GetAttributeArgumentLocation(0));
                         cultureString = null;
                     }
                 }
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyCultureAttributeSetting = cultureString;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCompanyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyCompanyAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyCompanyAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyProductAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyProductAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyProductAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyInformationalVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyInformationalVersionAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SatelliteContractVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SatelliteContractVersionAttribute))
             {
                 //just check the format of this one, don't do anything else with it.
                 Version dummy;
@@ -2459,19 +2459,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: false, version: out dummy))
                 {
-                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
-                    diagnostics.Add(ErrorCode.ERR_InvalidVersionFormat2, attributeArgumentSyntaxLocation, verString ?? "<null>");
+                    diagnostics.Add(ErrorCode.ERR_InvalidVersionFormat2, attribute.GetAttributeArgumentLocation(0), verString ?? "<null>");
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyCopyrightAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyCopyrightAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyCopyrightAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyTrademarkAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AssemblyTrademarkAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyTrademarkAttributeSetting = (string)attribute.CommonConstructorArguments[0].ValueInternal;
             }
-            else if ((signature = attribute.GetTargetAttributeSignatureIndex(this, AttributeDescription.AssemblyFlagsAttribute)) != -1)
+            else if ((signature = attribute.GetTargetAttributeSignatureIndex(AttributeDescription.AssemblyFlagsAttribute)) != -1)
             {
                 object value = attribute.CommonConstructorArguments[0].ValueInternal;
                 AssemblyFlags nameFlags;
@@ -2491,46 +2490,46 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 attribute.DecodeSecurityAttribute<CommonAssemblyWellKnownAttributeData>(this, _compilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ClassInterfaceAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ClassInterfaceAttribute))
             {
                 attribute.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.TypeLibVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.TypeLibVersionAttribute))
             {
                 ValidateIntegralAttributeNonNegativeArguments(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ComCompatibleVersionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ComCompatibleVersionAttribute))
             {
                 ValidateIntegralAttributeNonNegativeArguments(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.GuidAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.GuidAttribute))
             {
                 string guidString = attribute.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, diagnostics);
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().GuidAttribute = guidString;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ImportedFromTypeLibAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ImportedFromTypeLibAttribute))
             {
                 if (attribute.CommonConstructorArguments.Length == 1)
                 {
                     arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().HasImportedFromTypeLibAttribute = true;
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.PrimaryInteropAssemblyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.PrimaryInteropAssemblyAttribute))
             {
                 if (attribute.CommonConstructorArguments.Length == 2)
                 {
                     arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().HasPrimaryInteropAssemblyAttribute = true;
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CompilationRelaxationsAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CompilationRelaxationsAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().HasCompilationRelaxationsAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ReferenceAssemblyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ReferenceAssemblyAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().HasReferenceAssemblyAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.RuntimeCompatibilityAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.RuntimeCompatibilityAttribute))
             {
                 bool wrapNonExceptionThrows = true;
 
@@ -2546,15 +2545,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().RuntimeCompatibilityWrapNonExceptionThrows = wrapNonExceptionThrows;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DebuggableAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DebuggableAttribute))
             {
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().HasDebuggableAttribute = true;
             }
-            else if (!isFromNetModule && attribute.IsTargetAttribute(this, AttributeDescription.TypeForwardedToAttribute))
+            else if (!isFromNetModule && attribute.IsTargetAttribute(AttributeDescription.TypeForwardedToAttribute))
             {
                 DecodeTypeForwardedToAttribute(ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CaseSensitiveExtensionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CaseSensitiveExtensionAttribute))
             {
                 if ((object)arguments.AttributeSyntaxOpt != null)
                 {
@@ -2562,7 +2561,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_ExplicitExtension, arguments.AttributeSyntaxOpt.Location);
                 }
             }
-            else if ((signature = attribute.GetTargetAttributeSignatureIndex(this, AttributeDescription.AssemblyAlgorithmIdAttribute)) != -1)
+            else if ((signature = attribute.GetTargetAttributeSignatureIndex(AttributeDescription.AssemblyAlgorithmIdAttribute)) != -1)
             {
                 object value = attribute.CommonConstructorArguments[0].ValueInternal;
                 AssemblyHashAlgorithm algorithmId;
@@ -2578,7 +2577,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyAlgorithmIdAttributeSetting = algorithmId;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExperimentalAttribute))
             {
                 var obsoleteData = attribute.DecodeExperimentalAttribute();
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().ExperimentalAttributeData = obsoleteData;
@@ -2597,8 +2596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (arg < 0)
                 {
                     // CS0591: Invalid value for argument to '{0}' attribute
-                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(i, nodeOpt);
-                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntaxLocation, (object)nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
+                    diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(i), (object)nodeOpt != null ? nodeOpt.GetErrorDisplayName() : "");
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -733,22 +733,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(AttributeDescription.InterpolatedStringHandlerArgumentAttribute.Signatures.Length == 2);
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.DefaultParameterValueAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.DefaultParameterValueAttribute))
             {
                 // Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DefaultParameterValueAttribute, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DecimalConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DecimalConstantAttribute))
             {
                 // Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DecimalConstantAttribute, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DateTimeConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DateTimeConstantAttribute))
             {
                 // Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DateTimeConstantAttribute, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.OptionalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.OptionalAttribute))
             {
                 Debug.Assert(_lazyHasOptionalAttribute == ThreeState.True);
 
@@ -758,44 +758,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_DefaultValueUsedWithAttributes, arguments.AttributeSyntaxOpt.Name.Location);
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ParamArrayAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ParamArrayAttribute))
             {
                 // error CS0674: Do not use 'System.ParamArrayAttribute'. Use the 'params' keyword instead.
                 diagnostics.Add(ErrorCode.ERR_ExplicitParamArray, arguments.AttributeSyntaxOpt.Name.Location);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.InAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.InAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasInAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.OutAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.OutAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasOutAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
             {
                 MarshalAsAttributeDecoder<ParameterWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Parameter, MessageProvider.Instance);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IDispatchConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.IDispatchConstantAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasIDispatchConstantAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IUnknownConstantAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.IUnknownConstantAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasIUnknownConstantAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CallerLineNumberAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CallerLineNumberAttribute))
             {
                 ValidateCallerLineNumberAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CallerFilePathAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CallerFilePathAttribute))
             {
                 ValidateCallerFilePathAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CallerMemberNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CallerMemberNameAttribute))
             {
                 ValidateCallerMemberNameAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CallerArgumentExpressionAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CallerArgumentExpressionAttribute))
             {
                 ValidateCallerArgumentExpressionAttribute(arguments.AttributeSyntaxOpt, attribute, diagnostics);
             }
@@ -811,48 +811,48 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ReservedAttributes.ScopedRefAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AllowNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasAllowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DisallowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DisallowNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasDisallowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasMaybeNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullWhenAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullWhenAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().MaybeNullWhenAttribute = DecodeMaybeNullWhenOrNotNullWhenOrDoesNotReturnIfAttribute(attribute);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasNotNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullWhenAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullWhenAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().NotNullWhenAttribute = DecodeMaybeNullWhenOrNotNullWhenOrDoesNotReturnIfAttribute(attribute);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DoesNotReturnIfAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DoesNotReturnIfAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().DoesNotReturnIfAttribute = DecodeMaybeNullWhenOrNotNullWhenOrDoesNotReturnIfAttribute(attribute);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullIfNotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullIfNotNullAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().AddNotNullIfParameterNotNull(attribute.DecodeNotNullIfNotNullAttribute());
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.EnumeratorCancellationAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.EnumeratorCancellationAttribute))
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasEnumeratorCancellationAttribute = true;
                 ValidateCancellationTokenAttribute(arguments.AttributeSyntaxOpt, (BindingDiagnosticBag)arguments.Diagnostics);
             }
-            else if (attribute.GetTargetAttributeSignatureIndex(this, AttributeDescription.InterpolatedStringHandlerArgumentAttribute) is (0 or 1) and var index)
+            else if (attribute.GetTargetAttributeSignatureIndex(AttributeDescription.InterpolatedStringHandlerArgumentAttribute) is (0 or 1) and var index)
             {
                 DecodeInterpolatedStringHandlerArgumentAttribute(ref arguments, diagnostics, index);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnscopedRefAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnscopedRefAttribute))
             {
                 if (!this.IsValidUnscopedRefAttributeTarget())
                 {
@@ -1237,7 +1237,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private void DecodeInterpolatedStringHandlerArgumentAttribute(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, BindingDiagnosticBag diagnostics, int attributeIndex)
         {
             Debug.Assert(attributeIndex is 0 or 1);
-            Debug.Assert(arguments.Attribute.IsTargetAttribute(this, AttributeDescription.InterpolatedStringHandlerArgumentAttribute) && arguments.Attribute.CommonConstructorArguments.Length == 1);
+            Debug.Assert(arguments.Attribute.IsTargetAttribute(AttributeDescription.InterpolatedStringHandlerArgumentAttribute) && arguments.Attribute.CommonConstructorArguments.Length == 1);
             Debug.Assert(arguments.AttributeSyntaxOpt is not null);
 
             if (Type is not NamedTypeSymbol { IsInterpolatedStringHandlerType: true } handlerType)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -298,22 +298,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
             else if (ReportExplicitUseOfReservedAttributes(in arguments, ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute | ReservedAttributes.TupleElementNamesAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<CommonEventWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnscopedRefAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnscopedRefAttribute))
             {
                 diagnostics.Add(ErrorCode.ERR_UnscopedRefAttributeUnsupportedMemberTarget, arguments.AttributeSyntaxOpt!.Location);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.FixedBufferAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.FixedBufferAttribute))
             {
                 // error CS1716: Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute. Use the 'fixed' field modifier instead.
                 ((BindingDiagnosticBag)arguments.Diagnostics).Add(ErrorCode.ERR_DoNotUseFixedBufferAttr, arguments.AttributeSyntaxOpt.Name.Location);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -506,35 +506,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
             Debug.Assert(!attribute.HasErrors);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.PreserveSigAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.PreserveSigAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().SetPreserveSignature(arguments.Index);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MethodImplAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MethodImplAttribute))
             {
                 AttributeData.DecodeMethodImplAttribute<MethodWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>(ref arguments, MessageProvider.Instance);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DllImportAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DllImportAttribute))
             {
                 DecodeDllImportAttribute(ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ConditionalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ConditionalAttribute))
             {
                 ValidateConditionalAttribute(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSuppressUnmanagedCodeSecurityAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicSecurityMethodAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DynamicSecurityMethodAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasDynamicSecurityMethodAttribute = true;
             }
@@ -553,42 +553,42 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ReservedAttributes.CaseSensitiveExtensionAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SecurityCriticalAttribute)
-                || attribute.IsTargetAttribute(this, AttributeDescription.SecuritySafeCriticalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SecurityCriticalAttribute)
+                || attribute.IsTargetAttribute(AttributeDescription.SecuritySafeCriticalAttribute))
             {
                 if (IsAsync)
                 {
                     diagnostics.Add(ErrorCode.ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync, arguments.AttributeSyntaxOpt.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<MethodWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DoesNotReturnAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DoesNotReturnAttribute))
             {
                 arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasDoesNotReturnAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MemberNotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MemberNotNullAttribute))
             {
                 MessageID.IDS_FeatureMemberNotNull.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 CSharpAttributeData.DecodeMemberNotNullAttribute<MethodWellKnownAttributeData>(ContainingType, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MemberNotNullWhenAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MemberNotNullWhenAttribute))
             {
                 MessageID.IDS_FeatureMemberNotNull.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 CSharpAttributeData.DecodeMemberNotNullWhenAttribute<MethodWellKnownAttributeData>(ContainingType, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ModuleInitializerAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ModuleInitializerAttribute))
             {
                 MessageID.IDS_FeatureModuleInitializers.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 DecodeModuleInitializerAttribute(arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnmanagedCallersOnlyAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnmanagedCallersOnlyAttribute))
             {
                 DecodeUnmanagedCallersOnlyAttribute(ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnscopedRefAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnscopedRefAttribute))
             {
                 if (this.IsValidUnscopedRefAttributeTarget())
                 {
@@ -599,7 +599,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_UnscopedRefAttributeUnsupportedMemberTarget, arguments.AttributeSyntaxOpt.Location);
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.InterceptsLocationAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.InterceptsLocationAttribute))
             {
                 DecodeInterceptsLocationAttribute(arguments);
             }
@@ -639,7 +639,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments,
             AttributeDescription description)
         {
-            if (arguments.Attribute.IsTargetAttribute(this, description))
+            if (arguments.Attribute.IsTargetAttribute(description))
             {
                 if (this.IsAccessor())
                 {
@@ -709,8 +709,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (name == null || !SyntaxFacts.IsValidIdentifier(name))
                 {
                     // CS0633: The argument to the '{0}' attribute must be a valid identifier
-                    CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, node);
-                    diagnostics.Add(ErrorCode.ERR_BadArgumentToAttribute, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+                    diagnostics.Add(ErrorCode.ERR_BadArgumentToAttribute, attribute.GetAttributeArgumentLocation(0), node.GetErrorDisplayName());
                 }
             }
         }
@@ -736,7 +735,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
             Debug.Assert(!attribute.HasErrors);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.MarshalAsAttribute))
             {
                 // MarshalAs applied to the return value:
                 MarshalAsAttributeDecoder<ReturnTypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.ReturnValue, MessageProvider.Instance);
@@ -752,15 +751,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ReservedAttributes.NativeIntegerAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
             {
                 arguments.GetOrCreateData<ReturnTypeWellKnownAttributeData>().HasMaybeNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullAttribute))
             {
                 arguments.GetOrCreateData<ReturnTypeWellKnownAttributeData>().HasNotNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullIfNotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullIfNotNullAttribute))
             {
                 arguments.GetOrCreateData<ReturnTypeWellKnownAttributeData>().AddNotNullIfParameterNotNull(attribute.DecodeNotNullIfNotNullAttribute());
             }
@@ -803,8 +802,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!MetadataHelpers.IsValidMetadataIdentifier(moduleName))
             {
                 // Dev10 reports CS0647: "Error emitting attribute ..."
-                CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, arguments.AttributeSyntaxOpt);
-                diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
+                diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(0), arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                 hasErrors = true;
                 moduleName = null;
             }
@@ -978,7 +976,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var attributeFilePath = (string?)attributeArguments[0].Value;
             if (attributeFilePath is null)
             {
-                diagnostics.Add(ErrorCode.ERR_InterceptorFilePathCannotBeNull, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax));
+                diagnostics.Add(ErrorCode.ERR_InterceptorFilePathCannotBeNull, attributeData.GetAttributeArgumentLocation(filePathParameterIndex));
                 return;
             }
 
@@ -1015,7 +1013,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     diagnostics.Add(
                         ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate,
-                        attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax),
+                        attributeData.GetAttributeArgumentLocation(filePathParameterIndex),
                         attributeFilePath,
                         mapPath(referenceResolver, unmappedMatch));
                     return;
@@ -1034,19 +1032,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     diagnostics.Add(
                         ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate,
-                        attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax),
+                        attributeData.GetAttributeArgumentLocation(filePathParameterIndex),
                         attributeFilePath,
                         mapPath(referenceResolver, suffixMatch));
                     return;
                 }
 
-                diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilation, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath);
+                diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilation, attributeData.GetAttributeArgumentLocation(filePathParameterIndex), attributeFilePath);
 
                 return;
             }
             else if (matchingTrees.Count > 1)
             {
-                diagnostics.Add(ErrorCode.ERR_InterceptorNonUniquePath, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath);
+                diagnostics.Add(ErrorCode.ERR_InterceptorNonUniquePath, attributeData.GetAttributeArgumentLocation(filePathParameterIndex), attributeFilePath);
                 return;
             }
 
@@ -1057,7 +1055,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (lineNumberZeroBased < 0 || characterNumberZeroBased < 0)
             {
-                var location = attributeData.GetAttributeArgumentSyntaxLocation(lineNumberZeroBased < 0 ? lineNumberParameterIndex : characterNumberParameterIndex, attributeSyntax);
+                var location = attributeData.GetAttributeArgumentLocation(lineNumberZeroBased < 0 ? lineNumberParameterIndex : characterNumberParameterIndex);
                 diagnostics.Add(ErrorCode.ERR_InterceptorLineCharacterMustBePositive, location);
                 return;
             }
@@ -1067,7 +1065,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (lineNumberZeroBased >= referencedLineCount)
             {
-                diagnostics.Add(ErrorCode.ERR_InterceptorLineOutOfRange, attributeData.GetAttributeArgumentSyntaxLocation(lineNumberParameterIndex, attributeSyntax), referencedLineCount, lineNumberOneBased);
+                diagnostics.Add(ErrorCode.ERR_InterceptorLineOutOfRange, attributeData.GetAttributeArgumentLocation(lineNumberParameterIndex), referencedLineCount, lineNumberOneBased);
                 return;
             }
 
@@ -1075,7 +1073,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var lineLength = line.End - line.Start;
             if (characterNumberZeroBased >= lineLength)
             {
-                diagnostics.Add(ErrorCode.ERR_InterceptorCharacterOutOfRange, attributeData.GetAttributeArgumentSyntaxLocation(characterNumberParameterIndex, attributeSyntax), lineLength, characterNumberOneBased);
+                diagnostics.Add(ErrorCode.ERR_InterceptorCharacterOutOfRange, attributeData.GetAttributeArgumentLocation(characterNumberParameterIndex), lineLength, characterNumberOneBased);
                 return;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -476,13 +476,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.DefaultCharSetAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.DefaultCharSetAttribute))
             {
                 CharSet charSet = attribute.GetConstructorArgument<CharSet>(0, SpecialType.System_Enum);
                 if (!ModuleWellKnownAttributeData.IsValidCharSet(charSet))
                 {
-                    CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, arguments.AttributeSyntaxOpt);
-                    ((BindingDiagnosticBag)arguments.Diagnostics).Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
+                    ((BindingDiagnosticBag)arguments.Diagnostics).Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(0), arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                 }
                 else
                 {
@@ -493,11 +492,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ReservedAttributes.NullableContextAttribute | ReservedAttributes.NullablePublicOnlyAttribute | ReservedAttributes.RefSafetyRulesAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<ModuleWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExperimentalAttribute))
             {
                 arguments.GetOrCreateData<ModuleWellKnownAttributeData>().ExperimentalAttributeData = attribute.DecodeExperimentalAttribute();
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1096,60 +1096,60 @@ next:;
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.AttributeUsageAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.AttributeUsageAttribute))
             {
                 DecodeAttributeUsageAttribute(attribute, arguments.AttributeSyntaxOpt, diagnose: true, diagnosticsOpt: diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DefaultMemberAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DefaultMemberAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasDefaultMemberAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CoClassAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CoClassAttribute))
             {
                 DecodeCoClassAttribute(ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ConditionalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ConditionalAttribute))
             {
                 ValidateConditionalAttribute(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.GuidAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.GuidAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().GuidString = attribute.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SerializableAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SerializableAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSerializableAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.StructLayoutAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.StructLayoutAttribute))
             {
                 AttributeData.DecodeStructLayoutAttribute<TypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>(
                     ref arguments, this.DefaultMarshallingCharSet, defaultAutoLayoutSize: 0, messageProvider: MessageProvider.Instance);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSuppressUnmanagedCodeSecurityAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ClassInterfaceAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ClassInterfaceAttribute))
             {
                 attribute.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.InterfaceTypeAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.InterfaceTypeAttribute))
             {
                 attribute.DecodeInterfaceTypeAttribute(arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.WindowsRuntimeImportAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.WindowsRuntimeImportAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasWindowsRuntimeImportAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.RequiredAttributeAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.RequiredAttributeAttribute))
             {
                 // CS1608: The Required attribute is not permitted on C# types
                 diagnostics.Add(ErrorCode.ERR_CantUseRequiredAttribute, arguments.AttributeSyntaxOpt.Name.Location);
@@ -1168,16 +1168,16 @@ next:;
                 | ReservedAttributes.RequiredMemberAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SecurityCriticalAttribute)
-                || attribute.IsTargetAttribute(this, AttributeDescription.SecuritySafeCriticalAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SecurityCriticalAttribute)
+                || attribute.IsTargetAttribute(AttributeDescription.SecuritySafeCriticalAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSecurityCriticalAttributes = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<TypeWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.CollectionBuilderAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.CollectionBuilderAttribute))
             {
                 var builderType = attribute.CommonConstructorArguments[0].ValueInternal as TypeSymbol;
                 if (!IsValidCollectionBuilderType(builderType))
@@ -1195,17 +1195,17 @@ next:;
                     diagnostics.Add(ErrorCode.ERR_CollectionBuilderAttributeInvalidMethodName, arguments.AttributeSyntaxOpt.Name.Location);
                 }
             }
-            else if (_lazyIsExplicitDefinitionOfNoPiaLocalType == ThreeState.Unknown && attribute.IsTargetAttribute(this, AttributeDescription.TypeIdentifierAttribute))
+            else if (_lazyIsExplicitDefinitionOfNoPiaLocalType == ThreeState.Unknown && attribute.IsTargetAttribute(AttributeDescription.TypeIdentifierAttribute))
             {
                 _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.True;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.InlineArrayAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.InlineArrayAttribute))
             {
                 int length = attribute.CommonConstructorArguments[0].DecodeValue<int>(SpecialType.System_Int32);
 
                 if (length <= 0)
                 {
-                    diagnostics.Add(ErrorCode.ERR_InvalidInlineArrayLength, attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt));
+                    diagnostics.Add(ErrorCode.ERR_InvalidInlineArrayLength, attribute.GetAttributeArgumentLocation(0));
                 }
 
                 if (TypeKind != TypeKind.Struct)
@@ -1311,8 +1311,7 @@ next:;
                     if (diagnose)
                     {
                         // invalid attribute target
-                        CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, node);
-                        diagnosticsOpt.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+                        diagnosticsOpt.Add(ErrorCode.ERR_InvalidAttributeArgument, attribute.GetAttributeArgumentLocation(0), node.GetErrorDisplayName());
                     }
 
                     return AttributeUsageInfo.Null;
@@ -1392,8 +1391,7 @@ next:;
                 if (name == null || !SyntaxFacts.IsValidIdentifier(name))
                 {
                     // CS0633: The argument to the '{0}' attribute must be a valid identifier
-                    CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, node);
-                    diagnostics.Add(ErrorCode.ERR_BadArgumentToAttribute, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
+                    diagnostics.Add(ErrorCode.ERR_BadArgumentToAttribute, attribute.GetAttributeArgumentLocation(0), node.GetErrorDisplayName());
                 }
             }
         }
@@ -1570,7 +1568,7 @@ next:;
                 // Symbol with ComImportAttribute must have a GuidAttribute
                 if (data == null || data.GuidString == null)
                 {
-                    int index = boundAttributes.IndexOfAttribute(this, AttributeDescription.ComImportAttribute);
+                    int index = boundAttributes.IndexOfAttribute(AttributeDescription.ComImportAttribute);
                     diagnostics.Add(ErrorCode.ERR_ComImportWithoutUuidAttribute, allAttributeSyntaxNodes[index].Name.Location);
                 }
 
@@ -1618,7 +1616,7 @@ next:;
                 Debug.Assert(boundAttributes.Any());
 
                 // Symbol with CoClassAttribute must have a ComImportAttribute
-                int index = boundAttributes.IndexOfAttribute(this, AttributeDescription.CoClassAttribute);
+                int index = boundAttributes.IndexOfAttribute(AttributeDescription.CoClassAttribute);
                 diagnostics.Add(ErrorCode.WRN_CoClassWithoutComImport, allAttributeSyntaxNodes[index].Location, this.Name);
             }
 
@@ -1627,7 +1625,7 @@ next:;
             {
                 Debug.Assert(boundAttributes.Any());
 
-                int index = boundAttributes.IndexOfAttribute(this, AttributeDescription.DefaultMemberAttribute);
+                int index = boundAttributes.IndexOfAttribute(AttributeDescription.DefaultMemberAttribute);
                 diagnostics.Add(ErrorCode.ERR_DefaultMemberOnIndexedType, allAttributeSyntaxNodes[index].Name.Location);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -773,11 +773,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var annotations = ReturnTypeFlowAnalysisAnnotations;
             if ((annotations & FlowAnalysisAnnotations.MaybeNull) != 0)
             {
-                AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(_property.MaybeNullAttributeIfExists));
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(_property.MaybeNullAttributeIfExists));
             }
             if ((annotations & FlowAnalysisAnnotations.NotNull) != 0)
             {
-                AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(_property.NotNullAttributeIfExists));
+                AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(_property.NotNullAttributeIfExists));
             }
         }
 
@@ -795,7 +795,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 foreach (var attributeData in _property.MemberNotNullAttributeIfExists)
                 {
-                    AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(attributeData));
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(attributeData));
                 }
             }
 
@@ -803,7 +803,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 foreach (var attributeData in _property.MemberNotNullWhenAttributeIfExists)
                 {
-                    AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(attributeData));
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(attributeData));
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -1246,24 +1246,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.IndexerNameAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.IndexerNameAttribute))
             {
                 //NOTE: decoding was done by EarlyDecodeWellKnownAttribute.
                 ValidateIndexerNameAttribute(attribute, arguments.AttributeSyntaxOpt, diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<PropertyWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DynamicAttribute))
             {
                 // DynamicAttribute should not be set explicitly.
                 diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
@@ -1280,33 +1280,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 | ReservedAttributes.RequiredMemberAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DisallowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.DisallowNullAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasDisallowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.AllowNullAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasAllowNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MaybeNullAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasMaybeNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.NotNullAttribute))
             {
                 arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasNotNullAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MemberNotNullAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MemberNotNullAttribute))
             {
                 MessageID.IDS_FeatureMemberNotNull.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 CSharpAttributeData.DecodeMemberNotNullAttribute<PropertyWellKnownAttributeData>(ContainingType, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.MemberNotNullWhenAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.MemberNotNullWhenAttribute))
             {
                 MessageID.IDS_FeatureMemberNotNull.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
                 CSharpAttributeData.DecodeMemberNotNullWhenAttribute<PropertyWellKnownAttributeData>(ContainingType, ref arguments);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.UnscopedRefAttribute))
+            else if (attribute.IsTargetAttribute(AttributeDescription.UnscopedRefAttribute))
             {
                 if (this.IsValidUnscopedRefAttributeTarget())
                 {
@@ -1389,10 +1389,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool HasUnscopedRefAttribute => GetDecodedWellKnownAttributeData()?.HasUnscopedRefAttribute == true;
 
         private SourceAttributeData FindAttribute(AttributeDescription attributeDescription)
-            => (SourceAttributeData)GetAttributes().First(a => a.IsTargetAttribute(this, attributeDescription));
+            => (SourceAttributeData)GetAttributes().First(a => a.IsTargetAttribute(attributeDescription));
 
         private ImmutableArray<SourceAttributeData> FindAttributes(AttributeDescription attributeDescription)
-            => GetAttributes().Where(a => a.IsTargetAttribute(this, attributeDescription)).Cast<SourceAttributeData>().ToImmutableArray();
+            => GetAttributes().Where(a => a.IsTargetAttribute(attributeDescription)).Cast<SourceAttributeData>().ToImmutableArray();
 
         internal override void PostDecodeWellKnownAttributes(ImmutableArray<CSharpAttributeData> boundAttributes, ImmutableArray<AttributeSyntax> allAttributeSyntaxNodes, BindingDiagnosticBag diagnostics, AttributeLocation symbolPart, WellKnownAttributeData decodedData)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SynthesizedAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SynthesizedAttributeData.cs
@@ -11,35 +11,77 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// Class to represent a synthesized attribute
     /// </summary>
-    internal sealed class SynthesizedAttributeData : SourceAttributeData
+    internal abstract class SynthesizedAttributeData : CSharpAttributeData
     {
-        internal SynthesizedAttributeData(MethodSymbol wellKnownMember, ImmutableArray<TypedConstant> arguments, ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
-            : base(
-            applicationNode: null,
-            attributeClass: wellKnownMember.ContainingType,
-            attributeConstructor: wellKnownMember,
-            constructorArguments: arguments,
-            constructorArgumentsSourceIndices: default,
-            namedArguments: namedArguments,
-            hasErrors: false,
-            isConditionallyOmitted: false)
+        public static SynthesizedAttributeData Create(CSharpCompilation compilation, MethodSymbol wellKnownMember, ImmutableArray<TypedConstant> arguments, ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
         {
-            Debug.Assert((object)wellKnownMember != null);
-            Debug.Assert(!arguments.IsDefault);
-            Debug.Assert(!namedArguments.IsDefault); // Frequently empty though.
+            return new FromMethodAndArguments(compilation, wellKnownMember, arguments, namedArguments);
         }
 
-        internal SynthesizedAttributeData(SourceAttributeData original)
-            : base(
-            applicationNode: original.ApplicationSyntaxReference,
-            attributeClass: original.AttributeClass,
-            attributeConstructor: original.AttributeConstructor,
-            constructorArguments: original.CommonConstructorArguments,
-            constructorArgumentsSourceIndices: original.ConstructorArgumentsSourceIndices,
-            namedArguments: original.CommonNamedArguments,
-            hasErrors: original.HasErrors,
-            isConditionallyOmitted: original.IsConditionallyOmitted)
+        public static SynthesizedAttributeData Create(SourceAttributeData original)
         {
+            return new FromSourceAttributeData(original);
+        }
+
+        private sealed class FromMethodAndArguments : SynthesizedAttributeData
+        {
+            private readonly CSharpCompilation _compilation;
+            private readonly MethodSymbol _wellKnownMember;
+            private readonly ImmutableArray<TypedConstant> _arguments;
+            private readonly ImmutableArray<KeyValuePair<string, TypedConstant>> _namedArguments;
+
+            internal FromMethodAndArguments(CSharpCompilation compilation, MethodSymbol wellKnownMember, ImmutableArray<TypedConstant> arguments, ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
+            {
+                Debug.Assert((object)wellKnownMember != null);
+                Debug.Assert(!arguments.IsDefault);
+                Debug.Assert(!namedArguments.IsDefault); // Frequently empty though.
+
+                _compilation = compilation;
+                _wellKnownMember = wellKnownMember;
+                _arguments = arguments;
+                _namedArguments = namedArguments;
+            }
+
+            public override SyntaxReference? ApplicationSyntaxReference => null;
+            public override NamedTypeSymbol AttributeClass => _wellKnownMember.ContainingType;
+            public override MethodSymbol AttributeConstructor => _wellKnownMember;
+            protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _arguments;
+            protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _namedArguments;
+            internal override bool HasErrors => false;
+            internal override bool IsConditionallyOmitted => false;
+            internal override Location GetAttributeArgumentLocation(int parameterIndex) => NoLocation.Singleton;
+
+            internal override int GetTargetAttributeSignatureIndex(AttributeDescription description)
+            {
+                return SourceAttributeData.GetTargetAttributeSignatureIndex(_compilation, AttributeClass, AttributeConstructor, description);
+            }
+
+            internal override bool IsTargetAttribute(string namespaceName, string typeName)
+            {
+                return SourceAttributeData.IsTargetAttribute(AttributeClass, namespaceName, typeName);
+            }
+        }
+
+        private sealed class FromSourceAttributeData : SynthesizedAttributeData
+        {
+            private readonly SourceAttributeData _original;
+
+            internal FromSourceAttributeData(SourceAttributeData original)
+            {
+                _original = original;
+            }
+
+            public override SyntaxReference? ApplicationSyntaxReference => _original.ApplicationSyntaxReference;
+            public override NamedTypeSymbol AttributeClass => _original.AttributeClass;
+            public override MethodSymbol? AttributeConstructor => _original.AttributeConstructor;
+            protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _original.CommonConstructorArguments;
+            protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _original.CommonNamedArguments;
+            internal override bool HasErrors => _original.HasErrors;
+            internal override bool IsConditionallyOmitted => _original.IsConditionallyOmitted;
+
+            internal override Location GetAttributeArgumentLocation(int parameterIndex) => _original.GetAttributeArgumentLocation(parameterIndex);
+            internal override int GetTargetAttributeSignatureIndex(AttributeDescription description) => _original.GetTargetAttributeSignatureIndex(description);
+            internal override bool IsTargetAttribute(string namespaceName, string typeName) => _original.IsTargetAttribute(namespaceName, typeName);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1377,7 +1377,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var attrData in this.GetAttributes())
             {
-                if (attrData.IsTargetAttribute(this, AttributeDescription.GuidAttribute))
+                if (attrData.IsTargetAttribute(AttributeDescription.GuidAttribute))
                 {
                     if (attrData.TryGetGuidAttributeValue(out guidString))
                     {
@@ -1464,7 +1464,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var diagnostics = (BindingDiagnosticBag)arguments.Diagnostics;
 
             if ((reserved & ReservedAttributes.DynamicAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.DynamicAttribute))
             {
                 // DynamicAttribute should not be set explicitly.
                 diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
@@ -1486,12 +1486,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
             }
             else if ((reserved & ReservedAttributes.TupleElementNamesAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute))
             {
                 diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if ((reserved & ReservedAttributes.NullableAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.NullableAttribute))
             {
                 // NullableAttribute should not be set explicitly.
                 diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
@@ -1509,19 +1509,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
             }
             else if ((reserved & ReservedAttributes.CaseSensitiveExtensionAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.CaseSensitiveExtensionAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.CaseSensitiveExtensionAttribute))
             {
                 // ExtensionAttribute should not be set explicitly.
                 diagnostics.Add(ErrorCode.ERR_ExplicitExtension, arguments.AttributeSyntaxOpt.Location);
             }
             else if ((reserved & ReservedAttributes.RequiredMemberAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.RequiredMemberAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.RequiredMemberAttribute))
             {
                 // Do not use 'System.Runtime.CompilerServices.RequiredMemberAttribute'. Use the 'required' keyword on required fields and properties instead.
                 diagnostics.Add(ErrorCode.ERR_ExplicitRequiredMember, arguments.AttributeSyntaxOpt.Location);
             }
             else if ((reserved & ReservedAttributes.ScopedRefAttribute) != 0 &&
-                attribute.IsTargetAttribute(this, AttributeDescription.ScopedRefAttribute))
+                attribute.IsTargetAttribute(AttributeDescription.ScopedRefAttribute))
             {
                 // Do not use 'System.Runtime.CompilerServices.ScopedRefAttribute'. Use the 'scoped' keyword instead.
                 diagnostics.Add(ErrorCode.ERR_ExplicitScopedRef, arguments.AttributeSyntaxOpt.Location);
@@ -1538,7 +1538,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool reportExplicitUseOfReservedAttribute(CSharpAttributeData attribute, in DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, in AttributeDescription attributeDescription)
             {
-                if (attribute.IsTargetAttribute(this, attributeDescription))
+                if (attribute.IsTargetAttribute(attributeDescription))
                 {
                     // Do not use '{FullName}'. This is reserved for compiler usage.
                     diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, attributeDescription.FullName);

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -832,7 +832,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Find the AsyncMethodBuilder attribute.
             foreach (var attr in symbol.GetAttributes())
             {
-                if (attr.IsTargetAttribute(symbol, AttributeDescription.AsyncMethodBuilderAttribute)
+                if (attr.IsTargetAttribute(AttributeDescription.AsyncMethodBuilderAttribute)
                     && attr.CommonConstructorArguments.Length == 1
                     && attr.CommonConstructorArguments[0].Kind == TypedConstantKind.Type)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
@@ -219,16 +219,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(arguments.Diagnostics.DiagnosticBag is not null);
             Debug.Assert(arguments.AttributeSyntaxOpt is not null);
-            if (arguments.Attribute.IsTargetAttribute(this, AttributeDescription.CompilerFeatureRequiredAttribute))
+            if (arguments.Attribute.IsTargetAttribute(AttributeDescription.CompilerFeatureRequiredAttribute))
             {
                 // Do not use '{FullName}'. This is reserved for compiler usage.
                 arguments.Diagnostics.DiagnosticBag.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.CompilerFeatureRequiredAttribute.FullName);
             }
-            else if (arguments.Attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+            else if (arguments.Attribute.IsTargetAttribute(AttributeDescription.ExperimentalAttribute))
             {
                 if (!SyntaxFacts.IsValidIdentifier((string?)arguments.Attribute.CommonConstructorArguments[0].ValueInternal))
                 {
-                    var attrArgumentLocation = arguments.Attribute.GetAttributeArgumentSyntaxLocation(parameterIndex: 0, arguments.AttributeSyntaxOpt);
+                    var attrArgumentLocation = arguments.Attribute.GetAttributeArgumentLocation(parameterIndex: 0);
                     arguments.Diagnostics.DiagnosticBag.Add(ErrorCode.ERR_InvalidExperimentalDiagID, attrArgumentLocation);
                 }
             }
@@ -469,7 +469,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         CSharpAttributeData boundAttribute = boundAttributes[i];
 
-                        if (!boundAttribute.HasErrors && boundAttribute.IsTargetAttribute(this, AttributeDescription.TypeForwardedToAttribute) &&
+                        if (!boundAttribute.HasErrors && boundAttribute.IsTargetAttribute(AttributeDescription.TypeForwardedToAttribute) &&
                             boundAttribute.CommonConstructorArguments[0].ValueInternal is TypeSymbol &&
                             attributesToBind[i].ArgumentList?.Arguments[0].Expression.Location is { } location)
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
@@ -85,11 +85,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var annotations = FlowAnalysisAnnotations;
                 if ((annotations & FlowAnalysisAnnotations.DisallowNull) != 0)
                 {
-                    AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(property.DisallowNullAttributeIfExists));
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.DisallowNullAttributeIfExists));
                 }
                 if ((annotations & FlowAnalysisAnnotations.AllowNull) != 0)
                 {
-                    AddSynthesizedAttribute(ref attributes, new SynthesizedAttributeData(property.AllowNullAttributeIfExists));
+                    AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.AllowNullAttributeIfExists));
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            if (attribute.IsTargetAttribute(this, AttributeDescription.FixedBufferAttribute))
+            if (attribute.IsTargetAttribute(AttributeDescription.FixedBufferAttribute))
             {
                 // error CS8362: Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute on property
                 ((BindingDiagnosticBag)arguments.Diagnostics).Add(ErrorCode.ERR_DoNotUseFixedBufferAttrOnProperty, arguments.AttributeSyntaxOpt.Name.Location);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
@@ -182,7 +182,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             AddSynthesizedAttribute(
                 ref attributes,
-                new SynthesizedAttributeData(
+                SynthesizedAttributeData.Create(
+                    moduleBuilder.Compilation,
                     _inlineArrayAttributeConstructor,
                     arguments: ImmutableArray.Create(new TypedConstant(compilation.GetSpecialType(SpecialType.System_Int32), TypedConstantKind.Primitive, _arrayLength)),
                     namedArguments: ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty));

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpLineDirectiveMap.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpLineDirectiveMap.cs
@@ -105,14 +105,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             }
             return new LineMappingEntry(unmappedLine, unmappedLine, mappedPathOpt: null, PositionState.Unmapped);
 
-            static bool tryGetOneBasedNumericLiteralValue(in SyntaxToken token, out int value)
+            static bool tryGetNumericLiteralValue(in SyntaxToken token, out int value, bool oneBased)
             {
                 if (!token.IsMissing &&
                     token.Kind() == SyntaxKind.NumericLiteralToken &&
                     token.Value is int tokenValue)
                 {
+                    value = tokenValue;
+
                     // convert one-based line number into zero-based line number
-                    value = tokenValue - 1;
+                    if (oneBased)
+                    {
+                        value--;
+                    }
+
                     return true;
                 }
                 value = 0;
@@ -141,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                         return true;
                     }
                     int val = 0;
-                    if (tryGetOneBasedNumericLiteralValue(token, out val))
+                    if (tryGetNumericLiteralValue(token, out val, oneBased: false))
                     {
                         value = val;
                         return true;
@@ -154,8 +160,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             // returns false on error
             static bool tryGetPosition(LineDirectivePositionSyntax syntax, bool isEnd, out LinePosition position)
             {
-                if (tryGetOneBasedNumericLiteralValue(syntax.Line, out int line) &&
-                    tryGetOneBasedNumericLiteralValue(syntax.Character, out int character))
+                if (tryGetNumericLiteralValue(syntax.Line, out int line, oneBased: true) &&
+                    tryGetNumericLiteralValue(syntax.Character, out int character, oneBased: true))
                 {
                     position = new LinePosition(line, isEnd ? character + 1 : character);
                     return true;

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -2984,7 +2984,7 @@ class UsePia5 : ITest30
         }
 
         [Fact]
-        public void DispIdAttribute()
+        public void DispIdAttribute_01()
         {
             string pia = @"
 using System;
@@ -3047,6 +3047,88 @@ class UsePia5 : ITest30
             CompileAndVerify(compilation1, symbolValidator: metadataValidator);
 
             CompileAndVerify(compilation2, symbolValidator: metadataValidator);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70338")]
+        public void DispIdAttribute_02()
+        {
+            string dispId = @"
+namespace System.Runtime.InteropServices
+{
+    public class DispIdAttribute : System.Attribute
+    {
+        public DispIdAttribute (int dispId){}
+    }
+}
+";
+            var dispIdDefinition = CreateCompilation(dispId, options: TestOptions.ReleaseDll, assemblyName: "DispId").EmitToImageReference(aliases: ImmutableArray.Create("dispId"));
+
+            string pia = @"
+extern alias dispId;
+
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: ImportedFromTypeLib(""GeneralPIA.dll"")]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest30
+{
+    [dispId::System.Runtime.InteropServices.DispIdAttribute(124)]
+    void M1();
+}
+";
+
+            var piaCompilation = CreateCompilation(pia, references: new[] { dispIdDefinition }, options: TestOptions.ReleaseDll, assemblyName: "Pia");
+
+            CompileAndVerify(piaCompilation).VerifyDiagnostics();
+
+            string consumer = @"
+class UsePia
+{
+    public static void Main()
+    {
+    }
+}
+
+class UsePia5 : ITest30
+{
+    public void M1()
+    {
+    }
+} 
+";
+
+            var compilation1 = CreateCompilation(consumer, options: TestOptions.ReleaseExe,
+                references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation, embedInteropTypes: true) });
+
+            var compilation2 = CreateCompilation(consumer, options: TestOptions.ReleaseExe,
+                references: new MetadataReference[] { piaCompilation.EmitToImageReference(embedInteropTypes: true) });
+
+            System.Action<ModuleSymbol> metadataValidator =
+                delegate (ModuleSymbol module)
+                {
+                    ((PEModuleSymbol)module).Module.PretendThereArentNoPiaLocalTypes();
+
+                    var itest30 = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMembers("ITest30").Single();
+
+                    var m1 = (PEMethodSymbol)itest30.GetMembers("M1").Single();
+
+                    var attr = m1.GetAttributes("System.Runtime.InteropServices", "DispIdAttribute").Single();
+                    Assert.Equal("System.Runtime.InteropServices.DispIdAttribute(124)", attr.ToString());
+                };
+
+            CompileAndVerify(compilation1.AddReferences(dispIdDefinition), symbolValidator: metadataValidator).VerifyDiagnostics();
+
+            CompileAndVerify(compilation1, symbolValidator: metadataValidator).VerifyDiagnostics();
+
+            CompileAndVerify(compilation2.AddReferences(dispIdDefinition), symbolValidator: metadataValidator).VerifyDiagnostics();
+
+            // https://github.com/dotnet/roslyn/issues/70338: Going to start failing after https://github.com/dotnet/roslyn/pull/70151 is merged
+            //CompileAndVerify(compilation2, symbolValidator: metadataValidator).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -588,9 +588,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.True(attributeData.ConstructorArgumentsSourceIndices.IsDefault);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal("a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"b: new object[] { ""Hello"", ""World"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal("a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"b: new object[] { ""Hello"", ""World"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -620,10 +619,9 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 2, 0, 1 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal("a: 2", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal("b: 0", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
-            Assert.Equal("c: 1", attributeData.GetAttributeArgumentSyntax(parameterIndex: 2, attributeSyntax).ToString());
+            Assert.Equal("a: 2", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal("b: 0", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
+            Assert.Equal("c: 1", attributeData.GetAttributeArgumentSyntax(parameterIndex: 2).ToString());
         }
 
         [Fact]
@@ -1103,9 +1101,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 1, 0 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"b: new object[] { ""Hello"", ""World"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"b: new object[] { ""Hello"", ""World"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -1144,9 +1141,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 1, 0 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = comp.SyntaxTrees[0].GetRoot().DescendantNodes().OfType<AttributeSyntax>().First();
-            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"b: ""Hello""", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"b: ""Hello""", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -1184,9 +1180,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 0, 1 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal(@"true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"new object[] { ""Hello"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"new object[] { ""Hello"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -1224,9 +1219,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 0, 1 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"new object[] { ""Hello"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"new object[] { ""Hello"" }", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]
@@ -1263,9 +1257,8 @@ static class Program
             var attributeData = (SourceAttributeData)program.GetAttributes()[0];
             Assert.Equal(new[] { 1, 0 }, attributeData.ConstructorArgumentsSourceIndices);
 
-            var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal(@"b: null", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal(@"a: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0).ToString());
+            Assert.Equal(@"b: null", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1).ToString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Assembly.cs
@@ -2127,7 +2127,7 @@ public class C { }
 
         private static IEnumerable<CSharpAttributeData> GetAssemblyDescriptionAttributes(AssemblySymbol assembly)
         {
-            return assembly.GetAttributes().Where(data => data.IsTargetAttribute(assembly, AttributeDescription.AssemblyDescriptionAttribute));
+            return assembly.GetAttributes().Where(data => data.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute));
         }
 
         [Fact, WorkItem(530579, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530579")]
@@ -2237,10 +2237,8 @@ public class C { }
 
             CompileAndVerify(appCompilation, symbolValidator: (ModuleSymbol m) =>
             {
-                // var list = new ArrayBuilder<AttributeData>();
-                var asm = m.ContainingAssembly;
                 var attrs = m.ContainingAssembly.GetAttributes();
-                var attrlist = attrs.Where(a => a.IsTargetAttribute(asm, AttributeDescription.AssemblyFileVersionAttribute));
+                var attrlist = attrs.Where(a => a.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute));
 
                 Assert.Equal(1, attrlist.Count());
                 Assert.Equal("System.Reflection.AssemblyFileVersionAttribute(\"4.3.2.1\")", attrlist.First().ToString());
@@ -2267,6 +2265,127 @@ static class Logo
 
             var compilation = CreateCompilation(s, options: TestOptions.ReleaseDll);
             compilation.GetDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70338")]
+        public void ErrorsWithAssemblyAttributesInModules_01()
+        {
+            string attribute1 = @"
+public class A1 : System.Attribute
+{
+    public A1(int a){}
+}
+";
+            var attributeDefinition1 = CreateCompilation(attribute1, options: TestOptions.ReleaseDll, assemblyName: "A1").EmitToImageReference();
+
+            string module = @"
+[assembly:A1(1)]
+";
+            var moduleWithAttribute = CreateCompilation(module, references: new[] { attributeDefinition1 }, options: TestOptions.ReleaseModule, assemblyName: "M1").EmitToImageReference();
+
+            var comp = CreateCompilation("", references: new[] { moduleWithAttribute, attributeDefinition1 }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp, symbolValidator: (m) =>
+                                                    {
+                                                        var attrs = m.ContainingAssembly.GetAttributes();
+                                                        Assert.Equal(4, attrs.Length);
+                                                        AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                        AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                        AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                        AssertEx.Equal("A1(1)", attrs[3].ToString());
+                                                    }).VerifyDiagnostics();
+
+            var comp2 = CreateCompilation("", references: new[] { moduleWithAttribute }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp2, symbolValidator: (m) =>
+                                                     {
+                                                         var attrs = m.ContainingAssembly.GetAttributes();
+                                                         Assert.Equal(3, attrs.Length);
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                         AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                     }).VerifyDiagnostics();
+
+            string attribute2 = @"
+public class A1 : System.Attribute
+{
+    public A1(){}
+}
+";
+            var attributeDefinition2 = CreateCompilation(attribute2, options: TestOptions.ReleaseDll, assemblyName: "A1").EmitToImageReference();
+
+            var comp3 = CreateCompilation("", references: new[] { moduleWithAttribute, attributeDefinition2 }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp3, symbolValidator: (m) =>
+                                                     {
+                                                         var attrs = m.ContainingAssembly.GetAttributes();
+                                                         Assert.Equal(3, attrs.Length);
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                         AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                     }).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70338")]
+        public void ErrorsWithAssemblyAttributesInModules_02()
+        {
+            string c1 = @"
+public class C1
+{
+}
+";
+            var c1Definition = CreateCompilation(c1, options: TestOptions.ReleaseDll, assemblyName: "A1").EmitToImageReference();
+
+            string module1 = @"
+[assembly:A1(typeof(C1))]
+
+public class A1 : System.Attribute
+{
+    public A1(System.Type t){}
+}
+";
+            var module1WithAttribute = CreateCompilation(module1, references: new[] { c1Definition }, options: TestOptions.ReleaseModule, assemblyName: "M1").EmitToImageReference();
+
+            var comp = CreateCompilation("", references: new[] { module1WithAttribute, c1Definition }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp, symbolValidator: (m) =>
+                                                    {
+                                                        var attrs = m.ContainingAssembly.GetAttributes();
+                                                        Assert.Equal(4, attrs.Length);
+                                                        AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                        AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                        AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                        AssertEx.Equal("A1(typeof(C1))", attrs[3].ToString());
+                                                    }).VerifyDiagnostics();
+
+            var comp2 = CreateCompilation("", references: new[] { module1WithAttribute }, options: TestOptions.ReleaseDll);
+
+            comp2.VerifyEmitDiagnostics(
+                // error CS0012: The type 'C1' is defined in an assembly that is not referenced. You must add a reference to assembly 'A1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("C1", "A1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+                );
+
+            string module2 = @"
+[module:A1(typeof(C1))]
+
+public class A1 : System.Attribute
+{
+    public A1(System.Type t){}
+}
+";
+            var module2WithAttribute = CreateCompilation(module2, references: new[] { c1Definition }, options: TestOptions.ReleaseModule, assemblyName: "M1").EmitToImageReference();
+            var comp3 = CreateCompilation("", references: new[] { module2WithAttribute, c1Definition }, options: TestOptions.ReleaseDll);
+
+            CompileAndVerify(comp3, symbolValidator: (m) =>
+                                                     {
+                                                         var attrs = m.ContainingAssembly.GetAttributes();
+                                                         Assert.Equal(3, attrs.Length);
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs[0].ToString());
+                                                         AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows = true)", attrs[1].ToString());
+                                                         AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs[2].ToString());
+                                                     }).VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -115,7 +115,7 @@ public class Test
 
                 foreach (var attrData in m.ContainingAssembly.GetAttributes())
                 {
-                    if (attrData.IsTargetAttribute(m.ContainingAssembly, AttributeDescription.AssemblyKeyFileAttribute))
+                    if (attrData.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute))
                     {
                         haveAttribute = true;
                         break;
@@ -258,7 +258,7 @@ public class Test
 
                 foreach (var attrData in m.ContainingAssembly.GetAttributes())
                 {
-                    if (attrData.IsTargetAttribute(m.ContainingAssembly, AttributeDescription.AssemblyKeyNameAttribute))
+                    if (attrData.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute))
                     {
                         haveAttribute = true;
                         break;
@@ -2795,7 +2795,7 @@ class B
             {
                 var assembly = module.ContainingAssembly;
                 Assert.NotNull(assembly);
-                Assert.False(assembly.GetAttributes().Any(attr => attr.IsTargetAttribute(assembly, AttributeDescription.InternalsVisibleToAttribute)));
+                Assert.False(assembly.GetAttributes().Any(attr => attr.IsTargetAttribute(AttributeDescription.InternalsVisibleToAttribute)));
             });
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -11562,7 +11562,7 @@ public class A
             Assert.Equal(expectedScope, parameter.EffectiveScope);
             Assert.Equal(expectedHasUnscopedRefAttribute, parameter.HasUnscopedRefAttribute);
 
-            var attribute = parameter.GetAttributes().FirstOrDefault(a => a.GetTargetAttributeSignatureIndex(parameter, AttributeDescription.ScopedRefAttribute) != -1);
+            var attribute = parameter.GetAttributes().FirstOrDefault(a => a.GetTargetAttributeSignatureIndex(AttributeDescription.ScopedRefAttribute) != -1);
             Assert.Null(attribute);
 
             VerifyParameterSymbol(parameter.GetPublicSymbol(), expectedDisplayString, expectedRefKind, expectedScope);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -4741,9 +4741,7 @@ public class C
             var enumDecl = tree.GetCompilationUnitRoot().DescendantNodes().OfType<EnumDeclarationSyntax>().Single();
             var eventDecl = tree.GetCompilationUnitRoot().DescendantNodes().OfType<EventDeclarationSyntax>().Single();
 
-            // To repro DevDiv #563572, we need to go through the interface (which, at the time, followed
-            // a different code path).
-            var model = (SemanticModel)compilation.GetSemanticModel(tree);
+            var model = compilation.GetSemanticModel(tree);
 
             var enumSymbol = model.GetDeclaredSymbol(enumDecl); //Used to assert.
             Assert.Equal(SymbolKind.NamedType, enumSymbol.Kind);
@@ -4769,7 +4767,7 @@ public class S
             var structDecl = tree.GetCompilationUnitRoot().DescendantNodes().OfType<StructDeclarationSyntax>().First();
             var interfaceDecl = tree.GetCompilationUnitRoot().DescendantNodes().OfType<InterfaceDeclarationSyntax>().Last();
 
-            var model = (SemanticModel)compilation.GetSemanticModel(tree);
+            var model = compilation.GetSemanticModel(tree);
 
             var structSymbol = model.GetDeclaredSymbol(structDecl);
             var interfaceSymbol = model.GetDeclaredSymbol(interfaceDecl);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -2127,7 +2127,7 @@ class Program
             var indexer = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Program").Indexers.Single();
             Assert.True(indexer.IsIndexer);
             Assert.Equal("A", indexer.MetadataName);
-            Assert.True(indexer.GetAttributes().Single().IsTargetAttribute(indexer, AttributeDescription.IndexerNameAttribute));
+            Assert.True(indexer.GetAttributes().Single().IsTargetAttribute(AttributeDescription.IndexerNameAttribute));
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     static void Main()
     {
-#line (1, 16) - (1, 26) 15 ""a.cs""
+#line (1, 16) - (1, 26) 14 ""a.cs""
         B1(); A2(); A3(); B4();
         B5();
     }
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var expectedTextSpans = new[]
             {
                 (@"B1();", @"[|A2(); A3();|]"),
-                (@"A2();", @"[|A2(); A3();|]"),
+                (@"A2();", @"[|A2();|]"),
                 (@"A3();", @"[|A3();|]"),
                 (@"B4();", @"[|//123|]"),
                 (@"B5();", @"[|0|]"),
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     static void Main()
     {
-#line (1, 16) - (5, 26) 15 ""a.cs""
+#line (1, 16) - (5, 26) 14 ""a.cs""
         B1(); A2(); A3(); B4();
         B5();
     }
@@ -103,10 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 //4567890
 //ABCDEF
 |]".NormalizeLineEndings()),
-                (@"A2();", @"[|A2(); A3(); //123
-//4567890
-//ABCDEF
-|]".NormalizeLineEndings()),
+                (@"A2();", @"[|A2();|]"),
                 (@"A3();", @"[|A3();|]"),
                 (@"B4();", @"[|//123|]"),
                 (@"B5();", @"[|0|]"),
@@ -172,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 @"class Program
 {
  static void Main() {
-#line (1,10)-(1,15) 3 ""a"" // 3
+#line (1,10)-(1,15) 2 ""a"" // 3
   A();B(              // 4
 );C();                // 5
     D();              // 6
@@ -198,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var actualTextSpans = statements.SelectAsArray(s => GetTextMapping(textA, treeB, s));
             var expectedTextSpans = new[]
             {
-                (@"A();", @"[|A();B(|]"),
+                (@"A();", @"[|A();|]"),
                 (@"B(              // 4...", @"[|B(
 );|]".NormalizeLineEndings()),
                 (@"C();", @"[|C();|]"),
@@ -225,7 +222,7 @@ class Page
 {
 void Render()
 {
-#line (2,2)-(4,1) 16 ""page.razor"" // spanof('F(...)')
+#line (2,2)-(4,1) 15 ""page.razor"" // spanof('F(...)')
   _builder.Add(F(() => 1+1,       // 5
    () => 2+2                      // 6
 ));                               // 7
@@ -308,7 +305,7 @@ void Render()
             var expectedLineMappings = new[]
             {
                 "(1,0)-(5,26) -> : (0,0)-(0,0)",
-                "(7,0)-(7,31),14 -> page.razor: (1,7)-(1,19)",
+                "(7,0)-(7,31),15 -> page.razor: (1,7)-(1,19)",
                 "(9,0)-(10,1) -> : (0,0)-(0,0)",
             };
             AssertEx.Equal(expectedLineMappings, actualLineMappings);
@@ -343,7 +340,7 @@ class Page
 {
 void Render()
 {
-#line (2,2)-(6,3) 16 ""page.razor"" // spanof('JsonToHtml(...)')
+#line (2,2)-(6,3) 15 ""page.razor"" // spanof('JsonToHtml(...)')
   _builder.Add(JsonToHtml(@""
 {
   """"key1"""": """"value1"""",
@@ -398,11 +395,11 @@ class Page
     Builder _builder;
     void Execute()
     {
-#line (1, 2) - (5, 2) 22 ""a.razor"" // spanof('HtmlHelper(() => { ... })')
+#line (1, 2) - (5, 2) 21 ""a.razor"" // spanof('HtmlHelper(() => { ... })')
         _builder.Add(Html.Helper(() =>
 #line 2 ""a.razor"" // lineof('{')
         {
-#line (4, 6) - (4, 17) 26 ""a.razor"" // spanof('DateTime.Now')
+#line (4, 6) - (4, 17) 25 ""a.razor"" // spanof('DateTime.Now')
             _builder.Add(DateTime.Now);
 #line 5 ""a.razor"" // lineof('})')
         })
@@ -528,9 +525,9 @@ class Page
                 // b.txt(1,9): error CS0103: The name 'C' does not exist in the current context
                 //         C();
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(1, 9),
-                // a.txt(3,4): error CS0103: The name 'A' does not exist in the current context
+                // a.txt(3,3): error CS0103: The name 'A' does not exist in the current context
                 //         A();
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "A").WithArguments("A").WithLocation(3, 4),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "A").WithArguments("A").WithLocation(3, 3),
                 // (8,9): error CS0103: The name 'B' does not exist in the current context
                 //         B();
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "B").WithArguments("B").WithLocation(8, 9));
@@ -564,9 +561,9 @@ class Page
                 // (10,9): error CS0103: The name 'C' does not exist in the current context
                 //         C();
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(10, 9),
-                // b.txt(200,8): error CS0103: The name 'B' does not exist in the current context
+                // b.txt(200,7): error CS0103: The name 'B' does not exist in the current context
                 //         B();
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "B").WithArguments("B").WithLocation(200, 8),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "B").WithArguments("B").WithLocation(200, 7),
                 // b.txt(201,29): error CS1578: Quoted file name, single-line comment or end-of-line expected
                 // #line (300, 1) - (300, 100) x "c.txt"
                 Diagnostic(ErrorCode.ERR_MissingPPFile, "x").WithLocation(201, 29));
@@ -577,10 +574,39 @@ class Page
             {
                 "(0,0)-(3,7) -> : (0,0)-(3,7)",
                 "(5,0)-(5,14) -> : (5,0)-(5,14)",
-                "(7,0)-(7,14),1 -> b.txt: (199,0)-(199,100)",
+                "(7,0)-(7,14),2 -> b.txt: (199,0)-(199,100)",
                 "(9,0)-(11,1) -> : (9,0)-(11,1)"
             };
             AssertEx.Equal(expectedLineMappings, actualLineMappings);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/razor/issues/9051")]
+        public void Diagnostics_03()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+#line (3, 3) - (6, 6) ""a.txt""
+A(); // 1
+#line (3, 3) - (6, 6) 8 ""a.txt""
+        A(); // 2
+#line 3
+  A(); // 3
+    }
+}".NormalizeLineEndings();
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // a.txt(3,3): error CS0103: The name 'A' does not exist in the current context
+                // A(); // 1
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "A").WithArguments("A").WithLocation(3, 3),
+                // a.txt(3,3): error CS0103: The name 'A' does not exist in the current context
+                //         A(); // 2
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "A").WithArguments("A").WithLocation(3, 3),
+                // (3,3): error CS0103: The name 'A' does not exist in the current context
+                //   A(); // 3
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "A").WithArguments("A").WithLocation(3, 3));
         }
 
         [Fact]
@@ -637,7 +663,7 @@ class Page
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1"" startLine=""3"" startColumn=""4"" endLine=""3"" endColumn=""8"" document=""2"" />
+        <entry offset=""0x1"" startLine=""3"" startColumn=""3"" endLine=""3"" endColumn=""7"" document=""2"" />
         <entry offset=""0x7"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""13"" document=""1"" />
         <entry offset=""0xd"" startLine=""1"" startColumn=""9"" endLine=""1"" endColumn=""13"" document=""3"" />
         <entry offset=""0x13"" startLine=""2"" startColumn=""3"" endLine=""2"" endColumn=""5"" document=""2"" />

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
@@ -1252,7 +1252,7 @@ using goo.bar;
             List<SyntaxToken> tokens = syntaxTree.GetRoot().DescendantTokens().ToList();
 
             List<SyntaxToken> list = new List<SyntaxToken>();
-            SyntaxToken token = ((SyntaxToken)((SyntaxTree)syntaxTree).GetCompilationUnitRoot().EndOfFileToken).GetPreviousToken(includeZeroWidth: true);
+            SyntaxToken token = syntaxTree.GetCompilationUnitRoot().EndOfFileToken.GetPreviousToken(includeZeroWidth: true);
             while (token.RawKind != 0)
             {
                 list.Add(token);

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxRewriterTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxRewriterTests.cs
@@ -541,7 +541,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var rewriter = new BadRewriter();
             var rewrittenRoot = rewriter.Visit(tree.GetCompilationUnitRoot());
             Assert.NotNull(rewrittenRoot.SyntaxTree);
-            Assert.True(((SyntaxTree)rewrittenRoot.SyntaxTree).HasCompilationUnitRoot, "how did we get a non-CompilationUnit root?");
+            Assert.True(rewrittenRoot.SyntaxTree.HasCompilationUnitRoot, "how did we get a non-CompilationUnit root?");
             Assert.Same(rewrittenRoot, rewrittenRoot.SyntaxTree.GetRoot());
         }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.LoggingMetadataFileReferenceResolver.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.LoggingMetadataFileReferenceResolver.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
 
             public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string? baseFilePath, MetadataReferenceProperties properties)
             {
-                string fullPath = _pathResolver.ResolvePath(reference, baseFilePath);
+                string? fullPath = _pathResolver.ResolvePath(reference, baseFilePath);
 
                 if (fullPath != null)
                 {

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMember.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMember.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
                 foreach (var attrData in GetCustomAttributesToEmit(moduleBuilder))
                 {
-                    if (TypeManager.IsTargetAttribute(UnderlyingSymbol, attrData, AttributeDescription.DispIdAttribute))
+                    if (TypeManager.IsTargetAttribute(attrData, AttributeDescription.DispIdAttribute))
                     {
                         if (attrData.CommonConstructorArguments.Length == 1)
                         {

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 // The constructors might be missing (for example, in metadata case) and doing lookup
                 // will ensure that we report appropriate errors.
 
-                if (TypeManager.IsTargetAttribute(UnderlyingMethod, attrData, AttributeDescription.LCIDConversionAttribute))
+                if (TypeManager.IsTargetAttribute(attrData, AttributeDescription.LCIDConversionAttribute))
                 {
                     if (attrData.CommonConstructorArguments.Length == 1)
                     {

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedParameter.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedParameter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
             private bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
             {
-                return TypeManager.IsTargetAttribute(UnderlyingParameter, attrData, description);
+                return TypeManager.IsTargetAttribute(attrData, description);
             }
 
             private ImmutableArray<TAttributeData> GetAttributes(TPEModuleBuilder moduleBuilder, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                     }
                     else
                     {
-                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(UnderlyingParameter, attrData, AttributeDescription.DecimalConstantAttribute);
+                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(attrData, AttributeDescription.DecimalConstantAttribute);
                         if (signatureIndex != -1)
                         {
                             Debug.Assert(signatureIndex == 0 || signatureIndex == 1);

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
             private bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
             {
-                return TypeManager.IsTargetAttribute(UnderlyingNamedType, attrData, description);
+                return TypeManager.IsTargetAttribute(attrData, description);
             }
 
             private ImmutableArray<TAttributeData> GetAttributes(TPEModuleBuilder moduleBuilder, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                     }
                     else
                     {
-                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(UnderlyingNamedType, attrData, AttributeDescription.InterfaceTypeAttribute);
+                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(attrData, AttributeDescription.InterfaceTypeAttribute);
                         if (signatureIndex != -1)
                         {
                             Debug.Assert(signatureIndex == 0 || signatureIndex == 1);

--- a/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
@@ -148,11 +148,11 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
             return false;
         }
 
-        internal abstract int GetTargetAttributeSignatureIndex(TSymbol underlyingSymbol, TAttributeData attrData, AttributeDescription description);
+        internal abstract int GetTargetAttributeSignatureIndex(TAttributeData attrData, AttributeDescription description);
 
-        internal bool IsTargetAttribute(TSymbol underlyingSymbol, TAttributeData attrData, AttributeDescription description)
+        internal bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
         {
-            return GetTargetAttributeSignatureIndex(underlyingSymbol, attrData, description) != -1;
+            return GetTargetAttributeSignatureIndex(attrData, description) != -1;
         }
 
         internal abstract TAttributeData CreateSynthesizedAttribute(WellKnownMember constructor, TAttributeData attrData, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);

--- a/src/Compilers/Core/Portable/FileSystem/RelativePathResolver.cs
+++ b/src/Compilers/Core/Portable/FileSystem/RelativePathResolver.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 #pragma warning disable 436 // The type 'RelativePathResolver' conflicts with imported type
 
 using System;
@@ -18,7 +16,7 @@ namespace Microsoft.CodeAnalysis
     internal class RelativePathResolver : IEquatable<RelativePathResolver>
     {
         public ImmutableArray<string> SearchPaths { get; }
-        public string BaseDirectory { get; }
+        public string? BaseDirectory { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RelativePathResolver"/> class.
@@ -26,7 +24,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="searchPaths">An ordered set of fully qualified 
         /// paths which are searched when resolving assembly names.</param>
         /// <param name="baseDirectory">Directory used when resolving relative paths.</param>
-        public RelativePathResolver(ImmutableArray<string> searchPaths, string baseDirectory)
+        public RelativePathResolver(ImmutableArray<string> searchPaths, string? baseDirectory)
         {
             Debug.Assert(searchPaths.All(PathUtilities.IsAbsolute));
             Debug.Assert(baseDirectory == null || PathUtilities.GetPathKind(baseDirectory) == PathKind.Absolute);
@@ -35,9 +33,9 @@ namespace Microsoft.CodeAnalysis
             BaseDirectory = baseDirectory;
         }
 
-        public string ResolvePath(string reference, string baseFilePath)
+        public string? ResolvePath(string reference, string? baseFilePath)
         {
-            string resolvedPath = FileUtilities.ResolveRelativePath(reference, baseFilePath, BaseDirectory, SearchPaths, FileExists);
+            string? resolvedPath = FileUtilities.ResolveRelativePath(reference, baseFilePath, BaseDirectory, SearchPaths, FileExists);
             if (resolvedPath == null)
             {
                 return null;
@@ -56,15 +54,15 @@ namespace Microsoft.CodeAnalysis
         public RelativePathResolver WithSearchPaths(ImmutableArray<string> searchPaths) =>
             new(searchPaths, BaseDirectory);
 
-        public RelativePathResolver WithBaseDirectory(string baseDirectory) =>
+        public RelativePathResolver WithBaseDirectory(string? baseDirectory) =>
             new(SearchPaths, baseDirectory);
 
-        public bool Equals(RelativePathResolver other) =>
-            BaseDirectory == other.BaseDirectory && SearchPaths.SequenceEqual(other.SearchPaths);
+        public bool Equals(RelativePathResolver? other) =>
+            other is not null && BaseDirectory == other.BaseDirectory && SearchPaths.SequenceEqual(other.SearchPaths);
 
         public override int GetHashCode() =>
             Hash.Combine(BaseDirectory, Hash.CombineValues(SearchPaths));
 
-        public override bool Equals(object obj) => Equals(obj as RelativePathResolver);
+        public override bool Equals(object? obj) => Equals(obj as RelativePathResolver);
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.LineMappingEntry.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.LineMappingEntry.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
             // 0-based mapped span from enhanced #line directive.
             public readonly LinePositionSpan MappedSpan;
 
-            // optional 0-based character offset from enhanced #line directive.
+            // optional character offset from enhanced #line directive.
             public readonly int? UnmappedCharacterOffset;
 
             // raw value from #line or #ExternalDirective, may be null

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis
             // mapped to the entire 'MappedSpan', regardless of the size of the unmapped span,
             // even if the unmapped span ends before 'UnmappedCharacterOffset'.
             if (unmappedStartPos.Line == entry.UnmappedLine &&
-                unmappedStartPos.Character <= entry.UnmappedCharacterOffset.GetValueOrDefault())
+                unmappedStartPos.Character < entry.UnmappedCharacterOffset.GetValueOrDefault())
             {
                 return entry.MappedSpan;
             }

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         public static IEnumerable<CSharpAttributeData> GetAttributes(this Symbol @this, AttributeDescription description)
         {
-            return @this.GetAttributes().Where(a => a.IsTargetAttribute(@this, description));
+            return @this.GetAttributes().Where(a => a.IsTargetAttribute(description));
         }
 
         public static CSharpAttributeData GetAttribute(this Symbol @this, NamedTypeSymbol c)

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -147,7 +147,7 @@ Friend Module Extensions
 
     <Extension>
     Friend Function GetAttributes(this As Symbol, description As AttributeDescription) As IEnumerable(Of VisualBasicAttributeData)
-        Return this.GetAttributes().Where(Function(a) a.IsTargetAttribute(this, description))
+        Return this.GetAttributes().Where(Function(a) a.IsTargetAttribute(description))
     End Function
 
     <Extension>

--- a/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
@@ -98,7 +98,7 @@ Public MustInherit Class SemanticModelTestBase : Inherits BasicTestBase
         Return DirectCast(semanticModel.GetAliasInfo(node), AliasSymbol)
     End Function
 
-    Protected Function GetBlockOrStatementInfoForTest(Of StmtSyntax As SyntaxNode, ISM As SemanticModel)(compilation As Compilation, fileName As String, Optional which As Integer = 0, Optional useParent As Boolean = False) As Object
+    Protected Function GetBlockOrStatementInfoForTest(Of StmtSyntax As SyntaxNode)(compilation As Compilation, fileName As String, Optional which As Integer = 0, Optional useParent As Boolean = False) As Object
         Dim node As SyntaxNode = CompilationUtils.FindBindingText(Of StmtSyntax)(compilation, fileName, which)
         Dim tree = (From t In compilation.SyntaxTrees Where t.FilePath = fileName).Single()
         Dim semanticModel = CType(compilation.GetSemanticModel(tree), VBSemanticModel)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim namedArgs As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)) = visitor.VisitNamedArguments(boundAttribute.NamedArguments, diagnostics)
             Dim isConditionallyOmitted As Boolean = Not visitor.HasErrors AndAlso IsAttributeConditionallyOmitted(boundAttributeType, node, boundAttribute.SyntaxTree)
 
-            Return New SourceAttributeData(node.GetReference(), DirectCast(boundAttribute.Type, NamedTypeSymbol), boundAttribute.Constructor, args, namedArgs, isConditionallyOmitted, hasErrors:=visitor.HasErrors)
+            Return New SourceAttributeData(Compilation, node.GetReference(), DirectCast(boundAttribute.Type, NamedTypeSymbol), boundAttribute.Constructor, args, namedArgs, isConditionallyOmitted, hasErrors:=visitor.HasErrors)
         End Function
 
         Protected Function IsAttributeConditionallyOmitted(attributeType As NamedTypeSymbol, node As AttributeSyntax, syntaxTree As SyntaxTree) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -219,7 +219,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Case MethodKind.PropertyGet, MethodKind.PropertySet
                         ' As in dev11, this warning is not produced for event accessors.
                         For Each attribute In symbol.GetAttributes()
-                            If attribute.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute) Then
+                            If attribute.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute) Then
                                 Dim attributeLocation As Location = Nothing
                                 If TryGetAttributeWarningLocation(attribute, attributeLocation) Then
                                     Dim attributeUsage As AttributeUsageInfo = attribute.AttributeClass.GetAttributeUsageInfo()
@@ -760,7 +760,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             isAttributeInherited = False
             For Each attributeData In symbol.GetAttributes()
                 ' Check signature before HasErrors to avoid realizing symbols for other attributes.
-                If attributeData.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute) Then
+                If attributeData.IsTargetAttribute(AttributeDescription.CLSCompliantAttribute) Then
                     Dim attributeClass = attributeData.AttributeClass
                     If attributeClass IsNot Nothing Then
                         _diagnostics.ReportUseSite(attributeClass, If(symbol.Locations.IsEmpty, NoLocation.Singleton, symbol.Locations(0)))

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -851,7 +851,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Shared Function GetDesignerInitializeComponentMethod(sourceTypeSymbol As SourceMemberContainerTypeSymbol) As MethodSymbol
 
-            If sourceTypeSymbol.TypeKind = TypeKind.Class AndAlso sourceTypeSymbol.GetAttributes().IndexOfAttribute(sourceTypeSymbol, AttributeDescription.DesignerGeneratedAttribute) > -1 Then
+            If sourceTypeSymbol.TypeKind = TypeKind.Class AndAlso sourceTypeSymbol.GetAttributes().IndexOfAttribute(AttributeDescription.DesignerGeneratedAttribute) > -1 Then
                 For Each member As Symbol In sourceTypeSymbol.GetMembers("InitializeComponent")
                     If member.Kind = SymbolKind.Method Then
                         Dim method = DirectCast(member, MethodSymbol)

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedEvent.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedEvent.vb
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Dim underlyingContainingType = ContainingType.UnderlyingNamedType
 
             For Each attrData In underlyingContainingType.AdaptedNamedTypeSymbol.GetAttributes()
-                If attrData.IsTargetAttribute(underlyingContainingType.AdaptedNamedTypeSymbol, AttributeDescription.ComEventInterfaceAttribute) Then
+                If attrData.IsTargetAttribute(AttributeDescription.ComEventInterfaceAttribute) Then
                     Dim foundMatch = False
                     Dim sourceInterface As NamedTypeSymbol = Nothing
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
@@ -202,7 +202,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
             If hasGuid Then
                 ' This is an interface with a GuidAttribute, so we will generate the no-parameter TypeIdentifier.
-                Return New SynthesizedAttributeData(ctor, ImmutableArray(Of TypedConstant).Empty, ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
+                Return New SynthesizedAttributeData(TypeManager.ModuleBeingBuilt.Compilation, ctor, ImmutableArray(Of TypedConstant).Empty, ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
 
             Else
                 ' This is an interface with no GuidAttribute, or some other type, so we will generate the
@@ -216,7 +216,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
                 If stringType IsNot Nothing Then
                     Dim guidString = TypeManager.GetAssemblyGuidString(UnderlyingNamedType.AdaptedNamedTypeSymbol.ContainingAssembly)
-                    Return New SynthesizedAttributeData(ctor,
+                    Return New SynthesizedAttributeData(TypeManager.ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create(New TypedConstant(stringType, TypedConstantKind.Primitive, guidString),
                             New TypedConstant(stringType, TypedConstantKind.Primitive, UnderlyingNamedType.AdaptedNamedTypeSymbol.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))),
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -81,8 +81,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Return lazyMethod
         End Function
 
-        Friend Overrides Function GetTargetAttributeSignatureIndex(underlyingSymbol As SymbolAdapter, attrData As VisualBasicAttributeData, description As AttributeDescription) As Integer
-            Return attrData.GetTargetAttributeSignatureIndex(underlyingSymbol.AdaptedSymbol, description)
+        Friend Overrides Function GetTargetAttributeSignatureIndex(attrData As VisualBasicAttributeData, description As AttributeDescription) As Integer
+            Return attrData.GetTargetAttributeSignatureIndex(description)
         End Function
 
         Friend Overrides Function CreateSynthesizedAttribute(constructor As WellKnownMember, attrData As VisualBasicAttributeData, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As VisualBasicAttributeData
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                     ' When emitting a com event interface, we have to tweak the parameters: the spec requires that we use
                     ' the original source interface as both source interface and event provider. Otherwise, we'd have to embed
                     ' the event provider class too.
-                    Return New SynthesizedAttributeData(ctor,
+                    Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create(attrData.CommonConstructorArguments(0), attrData.CommonConstructorArguments(0)),
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
 
@@ -105,12 +105,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                     ' instantiatable. The attribute cannot refer directly to the coclass, however, because we can't embed
                     ' classes, and we can't emit a reference to the PIA. We don't actually need
                     ' the class name at runtime: we will instead emit a reference to System.Object, as a placeholder.
-                    Return New SynthesizedAttributeData(ctor,
+                    Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor,
                         ImmutableArray.Create(New TypedConstant(ctor.Parameters(0).Type, TypedConstantKind.Type, ctor.ContainingAssembly.GetSpecialType(SpecialType.System_Object))),
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
 
                 Case Else
-                    Return New SynthesizedAttributeData(ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments)
+                    Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments)
 
             End Select
         End Function

--- a/src/Compilers/VisualBasic/Portable/Emit/ParameterSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/ParameterSymbolAdapter.vb
@@ -184,7 +184,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overridable ReadOnly Property IsMetadataOptional As Boolean
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsOptional OrElse GetAttributes().Any(Function(a) a.IsTargetAttribute(Me, AttributeDescription.OptionalAttribute))
+                Return Me.IsOptional OrElse GetAttributes().Any(Function(a) a.IsTargetAttribute(AttributeDescription.OptionalAttribute))
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AddRemoveHandler.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AddRemoveHandler.vb
@@ -215,7 +215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim [interface] = [event].ContainingType
 
                 For Each attrData In [interface].GetAttributes()
-                    If attrData.IsTargetAttribute([interface], AttributeDescription.ComEventInterfaceAttribute) AndAlso
+                    If attrData.IsTargetAttribute(AttributeDescription.ComEventInterfaceAttribute) AndAlso
                         attrData.CommonConstructorArguments.Length = 2 Then
                         expr = RewriteNoPiaAddRemoveHandler(node, receiver, [event], handler)
                         Exit For

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineTypeSymbol.vb
@@ -68,8 +68,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Inherit some attributes from the container of the kickoff method
                 Dim kickoffType = KickoffMethod.ContainingType
                 For Each attribute In kickoffType.GetAttributes()
-                    If attribute.IsTargetAttribute(kickoffType, AttributeDescription.DebuggerNonUserCodeAttribute) OrElse
-                       attribute.IsTargetAttribute(kickoffType, AttributeDescription.DebuggerStepThroughAttribute) Then
+                    If attribute.IsTargetAttribute(AttributeDescription.DebuggerNonUserCodeAttribute) OrElse
+                       attribute.IsTargetAttribute(AttributeDescription.DebuggerStepThroughAttribute) Then
                         If builder Is Nothing Then
                             builder = ArrayBuilder(Of VisualBasicAttributeData).GetInstance(2) ' only 2 different attributes are inherited at the moment
                         End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.vb
@@ -208,10 +208,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Inherit some attributes from the kickoff method
                 Dim kickoffMethod = StateMachineType.KickoffMethod
                 For Each attribute In kickoffMethod.GetAttributes()
-                    If attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerHiddenAttribute) OrElse
-                       attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerNonUserCodeAttribute) OrElse
-                       attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerStepperBoundaryAttribute) OrElse
-                       attribute.IsTargetAttribute(kickoffMethod, AttributeDescription.DebuggerStepThroughAttribute) Then
+                    If attribute.IsTargetAttribute(AttributeDescription.DebuggerHiddenAttribute) OrElse
+                       attribute.IsTargetAttribute(AttributeDescription.DebuggerNonUserCodeAttribute) OrElse
+                       attribute.IsTargetAttribute(AttributeDescription.DebuggerStepperBoundaryAttribute) OrElse
+                       attribute.IsTargetAttribute(AttributeDescription.DebuggerStepThroughAttribute) Then
                         If builder Is Nothing Then
                             builder = ArrayBuilder(Of VisualBasicAttributeData).GetInstance(4) ' only 4 different attributes are inherited at the moment
                         End If

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.vb
@@ -162,7 +162,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim compilation = semanticModelOpt.Compilation
 
             Dim sourceModule = DirectCast(compilation.SourceModule, SourceModuleSymbol)
-            Dim sourceFile = sourceModule.TryGetSourceFile(DirectCast(GetSyntaxTree(DirectCast(semanticModelOpt, SemanticModel)), VisualBasicSyntaxTree))
+            Dim sourceFile = sourceModule.TryGetSourceFile(DirectCast(GetSyntaxTree(semanticModelOpt), VisualBasicSyntaxTree))
             Debug.Assert(sourceFile IsNot Nothing)
 
             If Not sourceFile.AliasImportsOpt Is Nothing Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
@@ -58,29 +58,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Friend MustOverride Overrides ReadOnly Property HasErrors As Boolean
+
+        Friend MustOverride Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+
         ''' <summary>
         ''' Compares the namespace and type name with the attribute's namespace and type name.  Returns true if they are the same.
         ''' </summary>
-        Friend Overridable Function IsTargetAttribute(
+        Friend MustOverride Function IsTargetAttribute(
             namespaceName As String,
             typeName As String,
             Optional ignoreCase As Boolean = False
         ) As Boolean
-            If AttributeClass.IsErrorType() AndAlso Not TypeOf AttributeClass Is MissingMetadataTypeSymbol Then
-                ' Can't guarantee complete name information.
-                Return False
-            End If
 
-            Dim options As StringComparison = If(ignoreCase, StringComparison.OrdinalIgnoreCase, StringComparison.Ordinal)
-            Return AttributeClass.HasNameQualifier(namespaceName, options) AndAlso
-                AttributeClass.Name.Equals(typeName, options)
+        Friend Function IsTargetAttribute(description As AttributeDescription) As Boolean
+            Return GetTargetAttributeSignatureIndex(description) <> -1
         End Function
 
-        Friend Function IsTargetAttribute(targetSymbol As Symbol, description As AttributeDescription) As Boolean
-            Return GetTargetAttributeSignatureIndex(targetSymbol, description) <> -1
-        End Function
-
-        Friend MustOverride Function GetTargetAttributeSignatureIndex(targetSymbol As Symbol, description As AttributeDescription) As Integer
+        Friend MustOverride Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
 
         ''' <summary>
         ''' Checks if an applied attribute with the given attributeType matches the namespace name and type name of the given early attribute's description
@@ -196,7 +191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim securityData As SecurityWellKnownAttributeData = data.GetOrCreateData()
                 securityData.SetSecurityAttribute(arguments.Index, action, arguments.AttributesCount)
 
-                If Me.IsTargetAttribute(targetSymbol, AttributeDescription.PermissionSetAttribute) Then
+                If Me.IsTargetAttribute(AttributeDescription.PermissionSetAttribute) Then
                     Dim resolvedPathForFixup As String = Me.DecodePermissionSetAttribute(compilation, arguments)
                     If resolvedPathForFixup IsNot Nothing Then
                         securityData.SetPathForPermissionSetAttributeFixup(arguments.Index, resolvedPathForFixup, arguments.AttributesCount)
@@ -229,7 +224,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' attribute argument to have the above mentioned behavior, even though the comment clearly mentions that this behavior was intended only for the HostProtectionAttribute.
                 ' We currently allow this case only for the HostProtectionAttribute. In future if need arises, we can exactly match native compiler's behavior.
 
-                If Me.IsTargetAttribute(targetSymbol, AttributeDescription.HostProtectionAttribute) Then
+                If Me.IsTargetAttribute(AttributeDescription.HostProtectionAttribute) Then
                     Return DeclarativeSecurityAction.LinkDemand
                 End If
             Else
@@ -294,7 +289,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Case DeclarativeSecurityAction.InheritanceDemand,
                      DeclarativeSecurityAction.LinkDemand
 
-                    If Me.IsTargetAttribute(targetSymbol, AttributeDescription.PrincipalPermissionAttribute) Then
+                    If Me.IsTargetAttribute(AttributeDescription.PrincipalPermissionAttribute) Then
                         ' BC31215: SecurityAction value '{0}' is invalid for PrincipalPermission attribute
                         Dim displayAndLocation As (ArgumentDisplay As String, Location As Location) = GetFirstArgumentDisplayAndLocation(nodeOpt, securityAction)
                         diagnostics.Add(ERRID.ERR_PrincipalPermissionInvalidAction, displayAndLocation.Location, displayAndLocation.ArgumentDisplay)
@@ -553,71 +548,71 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Select Case target.Kind
                 Case SymbolKind.Assembly
                     If (Not emittingAssemblyAttributesInNetModule AndAlso
-                            (IsTargetAttribute(target, AttributeDescription.AssemblyCultureAttribute) OrElse
-                             IsTargetAttribute(target, AttributeDescription.AssemblyVersionAttribute) OrElse
-                             IsTargetAttribute(target, AttributeDescription.AssemblyFlagsAttribute) OrElse
-                             IsTargetAttribute(target, AttributeDescription.AssemblyAlgorithmIdAttribute))) OrElse
-                       (IsTargetAttribute(target, AttributeDescription.CLSCompliantAttribute) AndAlso
+                            (IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) OrElse
+                             IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) OrElse
+                             IsTargetAttribute(AttributeDescription.AssemblyFlagsAttribute) OrElse
+                             IsTargetAttribute(AttributeDescription.AssemblyAlgorithmIdAttribute))) OrElse
+                       (IsTargetAttribute(AttributeDescription.CLSCompliantAttribute) AndAlso
                             target.DeclaringCompilation.Options.OutputKind = OutputKind.NetModule) OrElse
-                       IsTargetAttribute(target, AttributeDescription.TypeForwardedToAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.TypeForwardedToAttribute) OrElse
                        Me.IsSecurityAttribute(target.DeclaringCompilation) Then
                         Return False
                     End If
 
                 Case SymbolKind.Event
-                    If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.NonSerializedAttribute) Then
+                    If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.NonSerializedAttribute) Then
                         Return False
                     End If
 
                 Case SymbolKind.Field
-                    If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.NonSerializedAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.FieldOffsetAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute) Then
+                    If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.NonSerializedAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.FieldOffsetAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                         Return False
                     End If
 
                 Case SymbolKind.Method
                     If isReturnType Then
-                        If IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute) Then
+                        If IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                             Return False
                         End If
                     Else
-                        If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) OrElse
-                           IsTargetAttribute(target, AttributeDescription.MethodImplAttribute) OrElse
-                           IsTargetAttribute(target, AttributeDescription.DllImportAttribute) OrElse
-                           IsTargetAttribute(target, AttributeDescription.PreserveSigAttribute) OrElse
+                        If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) OrElse
+                           IsTargetAttribute(AttributeDescription.MethodImplAttribute) OrElse
+                           IsTargetAttribute(AttributeDescription.DllImportAttribute) OrElse
+                           IsTargetAttribute(AttributeDescription.PreserveSigAttribute) OrElse
                            Me.IsSecurityAttribute(target.DeclaringCompilation) Then
                             Return False
                         End If
                     End If
 
                 Case SymbolKind.NetModule
-                    If (IsTargetAttribute(target, AttributeDescription.CLSCompliantAttribute) AndAlso
+                    If (IsTargetAttribute(AttributeDescription.CLSCompliantAttribute) AndAlso
                             target.DeclaringCompilation.Options.OutputKind <> OutputKind.NetModule) Then
                         Return False
                     End If
                 Case SymbolKind.NamedType
-                    If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.ComImportAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.SerializableAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.StructLayoutAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.WindowsRuntimeImportAttribute) OrElse
+                    If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.ComImportAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.SerializableAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.StructLayoutAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.WindowsRuntimeImportAttribute) OrElse
                        Me.IsSecurityAttribute(target.DeclaringCompilation) Then
                         Return False
                     End If
 
                 Case SymbolKind.Parameter
-                    If IsTargetAttribute(target, AttributeDescription.OptionalAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.MarshalAsAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.InAttribute) OrElse
-                       IsTargetAttribute(target, AttributeDescription.OutAttribute) Then
+                    If IsTargetAttribute(AttributeDescription.OptionalAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.MarshalAsAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.InAttribute) OrElse
+                       IsTargetAttribute(AttributeDescription.OutAttribute) Then
                         Return False
                     End If
 
                 Case SymbolKind.Property
-                    If IsTargetAttribute(target, AttributeDescription.SpecialNameAttribute) Then
+                    If IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                         Return False
                     End If
             End Select
@@ -628,9 +623,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
     Friend Module AttributeDataExtensions
         <System.Runtime.CompilerServices.Extension()>
-        Public Function IndexOfAttribute(attributes As ImmutableArray(Of VisualBasicAttributeData), targetSymbol As Symbol, description As AttributeDescription) As Integer
+        Public Function IndexOfAttribute(attributes As ImmutableArray(Of VisualBasicAttributeData), description As AttributeDescription) As Integer
             For i As Integer = 0 To attributes.Length - 1
-                If attributes(i).IsTargetAttribute(targetSymbol, description) Then
+                If attributes(i).IsTargetAttribute(description) Then
                     Return i
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/PEAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/PEAttributeData.vb
@@ -114,7 +114,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         ''' -1 if this is not the target attribute.
         ''' </returns>
         ''' <remarks>Matching an attribute by name does not load the attribute class.</remarks>
-        Friend Overrides Function GetTargetAttributeSignatureIndex(targetSymbol As Symbol, description As AttributeDescription) As Integer
+        Friend Overrides Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
             Return _decoder.GetTargetAttributeSignatureIndex(_handle, description)
         End Function
 
@@ -191,6 +191,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 End If
 
                 Return _lazyHasErrors.Value
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+            Get
+                Return False
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/RetargetingAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/RetargetingAttributeData.vb
@@ -13,33 +13,77 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
     ''' <summary>
     ''' Represents a retargeting custom attribute
     ''' </summary>
-    Friend Class RetargetingAttributeData
-        Inherits SourceAttributeData
-        Friend Sub New(ByVal applicationNode As SyntaxReference,
+    Friend NotInheritable Class RetargetingAttributeData
+        Inherits VisualBasicAttributeData
+
+        Private ReadOnly _underlying As VisualBasicAttributeData
+        Private ReadOnly _attributeClass As NamedTypeSymbol
+        Private ReadOnly _attributeConstructor As MethodSymbol
+        Private ReadOnly _constructorArguments As ImmutableArray(Of TypedConstant)
+        Private ReadOnly _namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+
+        Friend Sub New(ByVal underlying As VisualBasicAttributeData,
                        ByVal attributeClass As NamedTypeSymbol,
                        ByVal attributeConstructor As MethodSymbol,
                        ByVal constructorArguments As ImmutableArray(Of TypedConstant),
-                       ByVal namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)),
-                       ByVal isConditionallyOmitted As Boolean,
-                       ByVal hasErrors As Boolean)
-            MyBase.New(applicationNode, attributeClass, attributeConstructor, constructorArguments, namedArguments, isConditionallyOmitted, hasErrors)
+                       ByVal namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)))
+            Debug.Assert(TypeOf underlying Is SourceAttributeData OrElse TypeOf underlying Is SynthesizedAttributeData)
+
+            _underlying = underlying
+            Me._attributeClass = attributeClass
+            Me._attributeConstructor = attributeConstructor
+            Me._constructorArguments = constructorArguments.NullToEmpty()
+            Me._namedArguments = namedArguments.NullToEmpty()
         End Sub
 
-        ''' <summary>
-        ''' Gets the retargeted System.Type type symbol.
-        ''' </summary>
-        ''' <param name="targetSymbol">Target symbol on which this attribute is applied.</param>
-        ''' <returns>Retargeted System.Type type symbol.</returns>
-        Friend Overrides Function GetSystemType(ByVal targetSymbol As Symbol) As TypeSymbol
-            Dim retargetingAssembly = DirectCast(If(targetSymbol.Kind = SymbolKind.Assembly, targetSymbol, targetSymbol.ContainingAssembly), RetargetingAssemblySymbol)
-            Dim underlyingAssembly = DirectCast(retargetingAssembly.UnderlyingAssembly, SourceAssemblySymbol)
+        Public Overrides ReadOnly Property AttributeClass As NamedTypeSymbol
+            Get
+                Return _attributeClass
+            End Get
+        End Property
 
-            ' Get the System.Type from the underlying assembly's Compilation
-            Dim systemType As TypeSymbol = underlyingAssembly.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Type)
+        Public Overrides ReadOnly Property AttributeConstructor As MethodSymbol
+            Get
+                Return _attributeConstructor
+            End Get
+        End Property
 
-            ' Retarget the type
-            Dim retargetingModule = DirectCast(retargetingAssembly.Modules(0), RetargetingModuleSymbol)
-            Return retargetingModule.RetargetingTranslator.Retarget(systemType, RetargetOptions.RetargetPrimitiveTypesByTypeCode)
+        Public Overrides ReadOnly Property ApplicationSyntaxReference As SyntaxReference
+            Get
+                Return Nothing
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property CommonConstructorArguments As ImmutableArray(Of TypedConstant)
+            Get
+                Return _constructorArguments
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property CommonNamedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+            Get
+                Return _namedArguments
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+            Get
+                Return _underlying.IsConditionallyOmitted
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property HasErrors As Boolean
+            Get
+                Return _underlying.HasErrors OrElse _attributeConstructor Is Nothing
+            End Get
+        End Property
+
+        Friend Overrides Function IsTargetAttribute(namespaceName As String, typeName As String, Optional ignoreCase As Boolean = False) As Boolean
+            Return _underlying.IsTargetAttribute(namespaceName, typeName, ignoreCase)
+        End Function
+
+        Friend Overrides Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
+            Return _underlying.GetTargetAttributeSignatureIndex(description)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
@@ -16,9 +16,10 @@ Imports System.Reflection.Metadata
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
-    Friend Class SourceAttributeData
+    Friend NotInheritable Class SourceAttributeData
         Inherits VisualBasicAttributeData
 
+        Private ReadOnly _compilation As VisualBasicCompilation
         Private ReadOnly _attributeClass As NamedTypeSymbol ' TODO - Remove attribute class. It is available from the constructor.
         Private ReadOnly _attributeConstructor As MethodSymbol
         Private ReadOnly _constructorArguments As ImmutableArray(Of TypedConstant)
@@ -27,7 +28,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly _hasErrors As Boolean
         Private ReadOnly _applicationNode As SyntaxReference
 
-        Friend Sub New(ByVal applicationNode As SyntaxReference,
+        Friend Sub New(ByVal compilation As VisualBasicCompilation,
+                       ByVal applicationNode As SyntaxReference,
                        ByVal attrClass As NamedTypeSymbol,
                        ByVal attrMethod As MethodSymbol,
                        ByVal constructorArgs As ImmutableArray(Of TypedConstant),
@@ -36,6 +38,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                        ByVal hasErrors As Boolean)
             Debug.Assert(attrMethod IsNot Nothing OrElse hasErrors)
 
+            Me._compilation = compilation
             Me._applicationNode = applicationNode
             Me._attributeClass = attrClass
             Me._attributeConstructor = attrMethod
@@ -75,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend NotOverridable Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+        Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
             Get
                 Return _isConditionallyOmitted
             End Get
@@ -86,7 +89,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Me
             End If
 
-            Return New SourceAttributeData(Me.ApplicationSyntaxReference,
+            Return New SourceAttributeData(Me._compilation,
+                                           Me.ApplicationSyntaxReference,
                                            Me.AttributeClass,
                                            Me.AttributeConstructor,
                                            Me.CommonConstructorArguments,
@@ -95,7 +99,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                            Me.HasErrors)
         End Function
 
-        Friend NotOverridable Overrides ReadOnly Property HasErrors As Boolean
+        Friend Overrides ReadOnly Property HasErrors As Boolean
             Get
                 Return _hasErrors
             End Get
@@ -108,14 +112,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' well known attributes.
         ''' </summary>
         ''' <param name="description">Attribute to match.</param>
-        Friend Overrides Function GetTargetAttributeSignatureIndex(targetSymbol As Symbol, description As AttributeDescription) As Integer
-            If Not IsTargetAttribute(description.Namespace, description.Name, description.MatchIgnoringCase) Then
+        Friend Overrides Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
+            Return GetTargetAttributeSignatureIndex(_compilation, AttributeClass, AttributeConstructor, description)
+        End Function
+
+        Friend Overloads Shared Function GetTargetAttributeSignatureIndex(compilation As VisualBasicCompilation, attributeClass As NamedTypeSymbol, attributeConstructor As MethodSymbol, description As AttributeDescription) As Integer
+            If Not IsTargetAttribute(attributeClass, description.Namespace, description.Name, description.MatchIgnoringCase) Then
                 Return -1
             End If
 
             Dim lazySystemType As TypeSymbol = Nothing
 
-            Dim ctor = AttributeConstructor
+            Dim ctor = attributeConstructor
             ' Ensure that the attribute data really has a constructor before comparing the signature.
             If ctor Is Nothing Then
                 Return -1
@@ -235,7 +243,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                         Case CByte(SerializationTypeCode.Type)
                             If lazySystemType Is Nothing Then
-                                lazySystemType = GetSystemType(targetSymbol)
+                                lazySystemType = compilation.GetWellKnownType(WellKnownType.System_Type)
                             End If
 
                             foundMatch = TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything)
@@ -264,14 +272,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         ''' <summary>
-        ''' Gets the System.Type type symbol from targetSymbol's containing assembly.
+        ''' Compares the namespace and type name with the attribute's namespace and type name.  Returns true if they are the same.
         ''' </summary>
-        ''' <param name="targetSymbol">Target symbol on which this attribute is applied.</param>
-        ''' <returns>System.Type type symbol.</returns>
-        Friend Overridable Function GetSystemType(targetSymbol As Symbol) As TypeSymbol
-            Return targetSymbol.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Type)
+        Friend Overrides Function IsTargetAttribute(
+            namespaceName As String,
+            typeName As String,
+            Optional ignoreCase As Boolean = False
+        ) As Boolean
+            Return IsTargetAttribute(AttributeClass, namespaceName, typeName, ignoreCase)
         End Function
 
+        Friend Overloads Shared Function IsTargetAttribute(
+            attributeClass As NamedTypeSymbol,
+            namespaceName As String,
+            typeName As String,
+            Optional ignoreCase As Boolean = False
+        ) As Boolean
+            If attributeClass.IsErrorType() AndAlso Not TypeOf attributeClass Is MissingMetadataTypeSymbol Then
+                ' Can't guarantee complete name information.
+                Return False
+            End If
+
+            Dim options As StringComparison = If(ignoreCase, StringComparison.OrdinalIgnoreCase, StringComparison.Ordinal)
+            Return attributeClass.HasNameQualifier(namespaceName, options) AndAlso
+                attributeClass.Name.Equals(typeName, options)
+        End Function
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
@@ -387,14 +387,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Friend Overrides ReadOnly Property HasAssemblyCompilationRelaxationsAttribute As Boolean
             Get
                 Dim assemblyAttributes = GetAssemblyAttributes()
-                Return assemblyAttributes.IndexOfAttribute(Me, AttributeDescription.CompilationRelaxationsAttribute) >= 0
+                Return assemblyAttributes.IndexOfAttribute(AttributeDescription.CompilationRelaxationsAttribute) >= 0
             End Get
         End Property
 
         Friend Overrides ReadOnly Property HasAssemblyRuntimeCompatibilityAttribute As Boolean
             Get
                 Dim assemblyAttributes = GetAssemblyAttributes()
-                Return assemblyAttributes.IndexOfAttribute(Me, AttributeDescription.RuntimeCompatibilityAttribute) >= 0
+                Return assemblyAttributes.IndexOfAttribute(AttributeDescription.RuntimeCompatibilityAttribute) >= 0
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -265,7 +265,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                     If type.ContainingModule Is _retargetingModule.UnderlyingModule Then
                         ' This is a local type explicitly declared in source. Get information from TypeIdentifier attribute.
                         For Each attrData In type.GetAttributes()
-                            Dim signatureIndex = attrData.GetTargetAttributeSignatureIndex(type, AttributeDescription.TypeIdentifierAttribute)
+                            Dim signatureIndex = attrData.GetTargetAttributeSignatureIndex(AttributeDescription.TypeIdentifierAttribute)
 
                             If signatureIndex <> -1 Then
                                 Debug.Assert(signatureIndex = 0 OrElse signatureIndex = 1)
@@ -660,11 +660,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             End Function
 
             Friend Iterator Function RetargetAttributes(attributes As IEnumerable(Of VisualBasicAttributeData)) As IEnumerable(Of VisualBasicAttributeData)
-#If DEBUG Then
-                Dim x As SynthesizedAttributeData = Nothing
-                Dim y As SourceAttributeData = x ' Code below relies on the fact that SynthesizedAttributeData derives from SourceAttributeData.
-                x = DirectCast(y, SynthesizedAttributeData)
-#End If
                 For Each attrData In attributes
                     Yield RetargetAttributeData(attrData)
                 Next
@@ -696,13 +691,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                 ' Must create a RetargetingAttributeData even if the types and
                 ' arguments are unchanged since the AttributeData instance is
                 ' used to resolve System.Type which may require retargeting.
-                Return New RetargetingAttributeData(oldAttribute.ApplicationSyntaxReference,
+                Return New RetargetingAttributeData(oldAttribute,
                                                     newAttributeType,
                                                     newAttributeCtor,
                                                     newCtorArguments,
-                                                    newNamedArguments,
-                                                    oldAttribute.IsConditionallyOmitted,
-                                                    hasErrors:=oldAttribute.HasErrors OrElse newAttributeCtor Is Nothing)
+                                                    newNamedArguments)
             End Function
 
             Private Function RetargetAttributeConstructorArguments(constructorArguments As ImmutableArray(Of TypedConstant)) As ImmutableArray(Of TypedConstant)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -175,24 +175,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ' TODO: This list used to include AssemblyOperatingSystemAttribute and AssemblyProcessorAttribute,
             '       but it doesn't look like they are defined, cannot find them on MSDN.
-            If attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyTitleAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyDescriptionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyConfigurationAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyCultureAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyVersionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyCompanyAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyProductAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyInformationalVersionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyCopyrightAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyTrademarkAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyKeyFileAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyKeyNameAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyAlgorithmIdAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyFlagsAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyDelaySignAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblyFileVersionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.SatelliteContractVersionAttribute) OrElse
-               attribute.IsTargetAttribute(Me, AttributeDescription.AssemblySignatureKeyAttribute) Then
+            If attribute.IsTargetAttribute(AttributeDescription.AssemblyTitleAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyConfigurationAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyCompanyAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyProductAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyCopyrightAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyTrademarkAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyAlgorithmIdAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyFlagsAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyDelaySignAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.SatelliteContractVersionAttribute) OrElse
+               attribute.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute) Then
 
                 Return True
             End If
@@ -1012,13 +1012,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(arguments.SymbolPart = AttributeLocation.None)
             Dim diagnostics = DirectCast(arguments.Diagnostics, BindingDiagnosticBag)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.CaseInsensitiveExtensionAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.CaseInsensitiveExtensionAttribute) Then
                 ' Already have an attribute, no need to add another one.
                 Debug.Assert(_lazyEmitExtensionAttribute <> ThreeState.True)
                 _lazyEmitExtensionAttribute = ThreeState.False
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.InternalsVisibleToAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.InternalsVisibleToAttribute) Then
                 ProcessOneInternalsVisibleToAttribute(arguments.AttributeSyntaxOpt, attrData, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblySignatureKeyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblySignatureKeyAttribute) Then
                 Dim signatureKey = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblySignatureKeyAttributeSetting = signatureKey
 
@@ -1026,20 +1026,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     diagnostics.Add(ERRID.ERR_InvalidSignaturePublicKey, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
                 End If
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyKeyFileAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyKeyFileAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyKeyFileAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyKeyNameAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyKeyNameAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyKeyContainerAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyDelaySignAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyDelaySignAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyDelaySignAttributeSetting = If(DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, Boolean), ThreeState.True, ThreeState.False)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyVersionAttribute) Then
                 Dim verString = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 Dim version As Version = Nothing
                 If Not VersionHelper.TryParseAssemblyVersion(verString, allowWildcard:=Not _compilation.IsEmitDeterministic, version:=version) Then
                     diagnostics.Add(ERRID.ERR_InvalidVersionFormat, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
                 End If
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyVersionAttributeSetting = version
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyFileVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyFileVersionAttribute) Then
                 Dim dummy As Version = Nothing
                 Dim verString = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 If Not VersionHelper.TryParse(verString, version:=dummy) Then
@@ -1047,13 +1047,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyFileVersionAttributeSetting = verString
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyInformationalVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyInformationalVersionAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyTitleAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyTitleAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyTitleAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyDescriptionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyDescriptionAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyCultureAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyCultureAttribute) Then
                 Dim cultureString = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 If Not String.IsNullOrEmpty(cultureString) Then
                     If Me.DeclaringCompilation.Options.OutputKind.IsApplication() Then
@@ -1065,55 +1065,55 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyCultureAttributeSetting = cultureString
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyCompanyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyCompanyAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyCompanyAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyProductAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyProductAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyProductAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyInformationalVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyInformationalVersionAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyInformationalVersionAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SatelliteContractVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.SatelliteContractVersionAttribute) Then
                 'just check the format of this one, don't do anything else with it.
                 Dim dummy As Version = Nothing
                 Dim verString = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
                 If Not VersionHelper.TryParseAssemblyVersion(verString, allowWildcard:=False, version:=dummy) Then
                     diagnostics.Add(ERRID.ERR_InvalidVersionFormat2, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
                 End If
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyCopyrightAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyCopyrightAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyCopyrightAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyTrademarkAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.AssemblyTrademarkAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyTrademarkAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
             ElseIf attrData.IsSecurityAttribute(Me.DeclaringCompilation) Then
                 attrData.DecodeSecurityAttribute(Of CommonAssemblyWellKnownAttributeData)(Me, Me.DeclaringCompilation, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ClassInterfaceAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ClassInterfaceAttribute) Then
                 attrData.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.TypeLibVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.TypeLibVersionAttribute) Then
                 ValidateIntegralAttributeNonNegativeArguments(attrData, arguments.AttributeSyntaxOpt, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ComCompatibleVersionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ComCompatibleVersionAttribute) Then
                 ValidateIntegralAttributeNonNegativeArguments(attrData, arguments.AttributeSyntaxOpt, diagnostics)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.GuidAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.GuidAttribute) Then
                 Dim guidString As String = attrData.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, diagnostics)
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().GuidAttribute = guidString
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ImportedFromTypeLibAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ImportedFromTypeLibAttribute) Then
                 If attrData.CommonConstructorArguments.Length = 1 Then
                     arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasImportedFromTypeLibAttribute = True
                 End If
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.PrimaryInteropAssemblyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.PrimaryInteropAssemblyAttribute) Then
                 If attrData.CommonConstructorArguments.Length = 2 Then
                     arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasPrimaryInteropAssemblyAttribute = True
                 End If
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.CompilationRelaxationsAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.CompilationRelaxationsAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasCompilationRelaxationsAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ReferenceAssemblyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ReferenceAssemblyAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasReferenceAssemblyAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.RuntimeCompatibilityAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.RuntimeCompatibilityAttribute) Then
                 ' VB doesn't need to decode argument values
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().RuntimeCompatibilityWrapNonExceptionThrows = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DebuggableAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DebuggableAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasDebuggableAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ExperimentalAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().ExperimentalAttributeData = attrData.DecodeExperimentalAttribute()
             Else
-                Dim signature As Integer = attrData.GetTargetAttributeSignatureIndex(Me, AttributeDescription.AssemblyAlgorithmIdAttribute)
+                Dim signature As Integer = attrData.GetTargetAttributeSignatureIndex(AttributeDescription.AssemblyAlgorithmIdAttribute)
 
                 If signature <> -1 Then
                     Dim value As Object = attrData.CommonConstructorArguments(0).ValueInternal
@@ -1127,7 +1127,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyAlgorithmIdAttributeSetting = algorithmId
                 Else
-                    signature = attrData.GetTargetAttributeSignatureIndex(Me, AttributeDescription.AssemblyFlagsAttribute)
+                    signature = attrData.GetTargetAttributeSignatureIndex(AttributeDescription.AssemblyFlagsAttribute)
 
                     If signature <> -1 Then
                         Dim value As Object = attrData.CommonConstructorArguments(0).ValueInternal

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
@@ -652,11 +652,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(arguments.AttributeSyntaxOpt IsNot Nothing)
             Dim attrData = arguments.Attribute
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.NonSerializedAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.NonSerializedAttribute) Then
                 ' Although NonSerialized attribute is only applicable on fields we relax that restriction and allow application on events as well
                 ' to allow making the backing field non-serializable.
 
@@ -666,9 +666,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_InvalidNonSerializedUsage, arguments.AttributeSyntaxOpt.GetLocation())
                 End If
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                 arguments.GetOrCreateData(Of EventWellKnownAttributeData).HasSpecialNameAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
                 arguments.GetOrCreateData(Of EventWellKnownAttributeData).HasExcludeFromCodeCoverageAttribute = True
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
@@ -720,13 +720,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(arguments.SymbolPart = AttributeLocation.None)
             Dim diagnostics = DirectCast(arguments.Diagnostics, BindingDiagnosticBag)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 diagnostics.Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                 arguments.GetOrCreateData(Of CommonFieldWellKnownAttributeData)().HasSpecialNameAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.NonSerializedAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.NonSerializedAttribute) Then
 
                 If Me.ContainingType.IsSerializable Then
                     arguments.GetOrCreateData(Of CommonFieldWellKnownAttributeData)().HasNonSerializedAttribute = True
@@ -734,7 +734,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     diagnostics.Add(ERRID.ERR_InvalidNonSerializedUsage, arguments.AttributeSyntaxOpt.GetLocation())
                 End If
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.FieldOffsetAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.FieldOffsetAttribute) Then
                 Dim offset = attrData.CommonConstructorArguments(0).DecodeValue(Of Integer)(SpecialType.System_Int32)
                 If offset < 0 Then
                     diagnostics.Add(ERRID.ERR_BadAttribute1, VisualBasicAttributeData.GetFirstArgumentLocation(arguments.AttributeSyntaxOpt), attrData.AttributeClass)
@@ -743,11 +743,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 arguments.GetOrCreateData(Of CommonFieldWellKnownAttributeData)().SetFieldOffset(offset)
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MarshalAsAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                 MarshalAsAttributeDecoder(Of CommonFieldWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation).Decode(arguments, AttributeTargets.Field, MessageProvider.Instance)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DateTimeConstantAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DateTimeConstantAttribute) Then
                 VerifyConstantValueMatches(attrData.DecodeDateTimeConstantValue(), arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DecimalConstantAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DecimalConstantAttribute) Then
                 VerifyConstantValueMatches(attrData.DecodeDecimalConstantValue(), arguments)
             Else
                 MyBase.DecodeWellKnownAttribute(arguments)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -1570,9 +1570,9 @@ lReportErrorOnTwoTokens:
             Dim attrData = arguments.Attribute
             Debug.Assert(Not attrData.HasErrors)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.UnmanagedCallersOnlyAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.UnmanagedCallersOnlyAttribute) Then
                 ' VB does not support UnmanagedCallersOnly attributes on methods at all
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_UnmanagedCallersOnlyNotSupported, arguments.AttributeSyntaxOpt.Location)
             End If
@@ -1597,7 +1597,7 @@ lReportErrorOnTwoTokens:
             ' Decode well-known attributes applied to method
             Dim attrData = arguments.Attribute
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.CaseInsensitiveExtensionAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.CaseInsensitiveExtensionAttribute) Then
                 ' Just report errors here. The extension attribute is decoded early.
 
                 If Me.MethodKind <> MethodKind.Ordinary AndAlso Me.MethodKind <> MethodKind.DeclareMethod Then
@@ -1626,7 +1626,7 @@ lReportErrorOnTwoTokens:
                     End If
                 End If
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.WebMethodAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.WebMethodAttribute) Then
 
                 ' Check for optional parameters
                 For Each parameter In Me.Parameters
@@ -1635,12 +1635,12 @@ lReportErrorOnTwoTokens:
                     End If
                 Next
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.PreserveSigAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.PreserveSigAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().SetPreserveSignature(arguments.Index)
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MethodImplAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.MethodImplAttribute) Then
                 AttributeData.DecodeMethodImplAttribute(Of MethodWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation)(arguments, MessageProvider.Instance)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DllImportAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DllImportAttribute) Then
                 If Not IsDllImportAttributeAllowed(arguments.AttributeSyntaxOpt, diagnostics) Then
                     Return
                 End If
@@ -1708,35 +1708,35 @@ lReportErrorOnTwoTokens:
                     DllImportData.MakeFlags(exactSpelling, charSet, setLastError, callingConvention, bestFitMapping, throwOnUnmappable),
                     preserveSig)
 
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasSpecialNameAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasExcludeFromCodeCoverageAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasSuppressUnmanagedCodeSecurityAttribute = True
             ElseIf attrData.IsSecurityAttribute(Me.DeclaringCompilation) Then
                 attrData.DecodeSecurityAttribute(Of MethodWellKnownAttributeData)(Me, Me.DeclaringCompilation, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.STAThreadAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.STAThreadAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasSTAThreadAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MTAThreadAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.MTAThreadAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasMTAThreadAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ConditionalAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ConditionalAttribute) Then
                 If Not Me.IsSub Then
                     ' BC41007: Attribute 'Conditional' is only valid on 'Sub' declarations.
                     diagnostics.Add(ERRID.WRN_ConditionalNotValidOnFunction, Me.Locations(0))
                 End If
             ElseIf VerifyObsoleteAttributeAppliedToMethod(arguments, AttributeDescription.ObsoleteAttribute) Then
             ElseIf VerifyObsoleteAttributeAppliedToMethod(arguments, AttributeDescription.DeprecatedAttribute) Then
-            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ModuleInitializerAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(AttributeDescription.ModuleInitializerAttribute) Then
                 diagnostics.Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.ModuleInitializerAttribute.FullName)
             Else
                 Dim methodImpl As MethodSymbol = If(Me.IsPartial, PartialImplementationPart, Me)
 
                 If methodImpl IsNot Nothing AndAlso (methodImpl.IsAsync OrElse methodImpl.IsIterator) AndAlso Not methodImpl.ContainingType.IsInterfaceType() Then
-                    If attrData.IsTargetAttribute(Me, AttributeDescription.SecurityCriticalAttribute) Then
+                    If attrData.IsTargetAttribute(AttributeDescription.SecurityCriticalAttribute) Then
                         Binder.ReportDiagnostic(diagnostics, arguments.AttributeSyntaxOpt.GetLocation(), ERRID.ERR_SecurityCriticalAsync, "SecurityCritical")
                         Return
-                    ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SecuritySafeCriticalAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.SecuritySafeCriticalAttribute) Then
                         Binder.ReportDiagnostic(diagnostics, arguments.AttributeSyntaxOpt.GetLocation(), ERRID.ERR_SecurityCriticalAsync, "SecuritySafeCritical")
                         Return
                     End If
@@ -1748,7 +1748,7 @@ lReportErrorOnTwoTokens:
             ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation),
             description As AttributeDescription
         ) As Boolean
-            If arguments.Attribute.IsTargetAttribute(Me, description) Then
+            If arguments.Attribute.IsTargetAttribute(description) Then
                 ' Obsolete Attribute is not allowed on event accessors.
                 If Me.IsAccessor() AndAlso Me.AssociatedSymbol.Kind = SymbolKind.Event Then
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ObsoleteInvalidOnEventMember, Me.Locations(0), description.FullName)
@@ -1765,7 +1765,7 @@ lReportErrorOnTwoTokens:
             Dim attrData = arguments.Attribute
             Debug.Assert(Not attrData.HasErrors)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.MarshalAsAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                 MarshalAsAttributeDecoder(Of CommonReturnTypeWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation).Decode(arguments, AttributeTargets.ReturnValue, MessageProvider.Instance)
             End If
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -1074,20 +1074,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(Not attrData.HasErrors)
             Debug.Assert(arguments.SymbolPart = AttributeLocation.None)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.DefaultCharSetAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.DefaultCharSetAttribute) Then
                 Dim charSet As CharSet = attrData.GetConstructorArgument(Of CharSet)(0, SpecialType.System_Enum)
                 If Not CommonModuleWellKnownAttributeData.IsValidCharSet(charSet) Then
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_BadAttribute1, VisualBasicAttributeData.GetFirstArgumentLocation(arguments.AttributeSyntaxOpt), attrData.AttributeClass)
                 Else
                     arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData)().DefaultCharacterSet = charSet
                 End If
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DebuggableAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DebuggableAttribute) Then
                 arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).HasDebuggableAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.ExperimentalAttribute) Then
                 arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).ExperimentalAttributeData = attrData.DecodeObsoleteAttribute(ObsoleteAttributeKind.Experimental)
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -1976,7 +1976,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' it is worth to intercept this attribute in DecodeWellKnownAttribute and cache the fact of attribute's
             ' presence and the guid value. If we start caching that information, implementation of this function 
             ' should change to take advantage of the cache.
-            Return GetAttributes().IndexOfAttribute(Me, AttributeDescription.GuidAttribute) > -1
+            Return GetAttributes().IndexOfAttribute(AttributeDescription.GuidAttribute) > -1
         End Function
 
         ''' <summary>
@@ -1987,7 +1987,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' it is worth to intercept this attribute in DecodeWellKnownAttribute and cache the fact of attribute's
             ' presence and its data. If we start caching that information, implementation of this function 
             ' should change to take advantage of the cache.
-            Return GetAttributes().IndexOfAttribute(Me, AttributeDescription.ClassInterfaceAttribute) > -1
+            Return GetAttributes().IndexOfAttribute(AttributeDescription.ClassInterfaceAttribute) > -1
         End Function
 
         ''' <summary>
@@ -1998,7 +1998,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' it is worth to intercept this attribute in DecodeWellKnownAttribute and cache the fact of attribute's
             ' presence and the its data. If we start caching that information, implementation of this function 
             ' should change to take advantage of the cache.
-            Return GetAttributes().IndexOfAttribute(Me, AttributeDescription.ComSourceInterfacesAttribute) > -1
+            Return GetAttributes().IndexOfAttribute(AttributeDescription.ComSourceInterfacesAttribute) > -1
         End Function
 
         Friend Overrides Function EarlyDecodeWellKnownAttribute(ByRef arguments As EarlyDecodeWellKnownAttributeArguments(Of EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation)) As VisualBasicAttributeData
@@ -2173,7 +2173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' If we start caching information about ComSourceInterfacesAttribute here, implementation of HasComSourceInterfacesAttribute function should be changed accordingly.
             ' If we start caching information about ComVisibleAttribute here, implementation of GetComVisibleState function should be changed accordingly.
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 diagnostics.Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
@@ -2181,11 +2181,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Select Case Me.TypeKind
                 Case TypeKind.Class
-                    If attrData.IsTargetAttribute(Me, AttributeDescription.CaseInsensitiveExtensionAttribute) Then
+                    If attrData.IsTargetAttribute(AttributeDescription.CaseInsensitiveExtensionAttribute) Then
                         diagnostics.Add(ErrorFactory.ErrorInfo(ERRID.ERR_ExtensionOnlyAllowedOnModuleSubOrFunction), Me.Locations(0))
                         decoded = True
 
-                    ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.VisualBasicComClassAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.VisualBasicComClassAttribute) Then
                         If Me.IsGenericType Then
                             diagnostics.Add(ERRID.ERR_ComClassOnGeneric, Me.Locations(0))
                         Else
@@ -2194,7 +2194,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                         decoded = True
 
-                    ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DefaultEventAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.DefaultEventAttribute) Then
                         If attrData.CommonConstructorArguments.Length = 1 AndAlso attrData.CommonConstructorArguments(0).Kind = TypedConstantKind.Primitive Then
                             Dim eventName = TryCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
 
@@ -2208,7 +2208,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End If
 
                 Case TypeKind.Interface
-                    If attrData.IsTargetAttribute(Me, AttributeDescription.CoClassAttribute) Then
+                    If attrData.IsTargetAttribute(AttributeDescription.CoClassAttribute) Then
                         Debug.Assert(Not attrData.CommonConstructorArguments.IsDefault AndAlso attrData.CommonConstructorArguments.Length = 1)
                         Dim argument As TypedConstant = attrData.CommonConstructorArguments(0)
 
@@ -2228,12 +2228,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End If
 
                 Case TypeKind.Module
-                    If ContainingSymbol.Kind = SymbolKind.Namespace AndAlso attrData.IsTargetAttribute(Me, AttributeDescription.CaseInsensitiveExtensionAttribute) Then
+                    If ContainingSymbol.Kind = SymbolKind.Namespace AndAlso attrData.IsTargetAttribute(AttributeDescription.CaseInsensitiveExtensionAttribute) Then
                         ' Already have an attribute, no need to add another one.
                         SuppressExtensionAttributeSynthesis()
                         decoded = True
 
-                    ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.VisualBasicComClassAttribute) Then
+                    ElseIf attrData.IsTargetAttribute(AttributeDescription.VisualBasicComClassAttribute) Then
                         ' Can't apply ComClassAttribute to a Module
                         diagnostics.Add(ErrorFactory.ErrorInfo(ERRID.ERR_InvalidAttributeUsage2, AttributeDescription.VisualBasicComClassAttribute.Name, Me.Name), Me.Locations(0))
                         decoded = True
@@ -2241,7 +2241,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Select
 
             If Not decoded Then
-                If attrData.IsTargetAttribute(Me, AttributeDescription.DefaultMemberAttribute) Then
+                If attrData.IsTargetAttribute(AttributeDescription.DefaultMemberAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasDefaultMemberAttribute = True
 
                     ' Check that the explicit <DefaultMember(...)> argument matches the default property if any.
@@ -2252,14 +2252,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         diagnostics.Add(ERRID.ERR_ConflictDefaultPropertyAttribute, Locations(0), Me)
                     End If
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SerializableAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.SerializableAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSerializableAttribute = True
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasExcludeFromCodeCoverageAttribute = True
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSpecialNameAttribute = True
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.StructLayoutAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.StructLayoutAttribute) Then
                     Debug.Assert(arguments.AttributeSyntaxOpt IsNot Nothing)
 
                     Dim defaultAutoLayoutSize = If(Me.TypeKind = TypeKind.Structure, 1, 0)
@@ -2270,33 +2270,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         diagnostics.Add(ERRID.ERR_StructLayoutAttributeNotAllowed, arguments.AttributeSyntaxOpt.GetLocation(), Me)
                     End If
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSuppressUnmanagedCodeSecurityAttribute = True
 
                 ElseIf attrData.IsSecurityAttribute(Me.DeclaringCompilation) Then
                     attrData.DecodeSecurityAttribute(Of CommonTypeWellKnownAttributeData)(Me, Me.DeclaringCompilation, arguments)
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ClassInterfaceAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.ClassInterfaceAttribute) Then
                     attrData.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, diagnostics)
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.InterfaceTypeAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.InterfaceTypeAttribute) Then
                     attrData.DecodeInterfaceTypeAttribute(arguments.AttributeSyntaxOpt, diagnostics)
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.GuidAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.GuidAttribute) Then
                     attrData.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, diagnostics)
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.WindowsRuntimeImportAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.WindowsRuntimeImportAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasWindowsRuntimeImportAttribute = True
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SecurityCriticalAttribute) OrElse
-                       attrData.IsTargetAttribute(Me, AttributeDescription.SecuritySafeCriticalAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.SecurityCriticalAttribute) OrElse
+                       attrData.IsTargetAttribute(AttributeDescription.SecuritySafeCriticalAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSecurityCriticalAttributes = True
 
                 ElseIf _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.Unknown AndAlso
-                    attrData.IsTargetAttribute(Me, AttributeDescription.TypeIdentifierAttribute) Then
+                    attrData.IsTargetAttribute(AttributeDescription.TypeIdentifierAttribute) Then
                     _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.True
 
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.RequiredAttributeAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.RequiredAttributeAttribute) Then
                     Debug.Assert(arguments.AttributeSyntaxOpt IsNot Nothing)
                     diagnostics.Add(ERRID.ERR_CantUseRequiredAttribute, arguments.AttributeSyntaxOpt.GetLocation(), Me)
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
@@ -304,7 +304,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' presence and its value. If we start caching that information, implementation of this function 
                 ' should change to take advantage of the cache.
                 Dim attrData As ImmutableArray(Of VisualBasicAttributeData) = target.GetAttributes()
-                Dim comVisible = attrData.IndexOfAttribute(target, AttributeDescription.ComVisibleAttribute)
+                Dim comVisible = attrData.IndexOfAttribute(AttributeDescription.ComVisibleAttribute)
 
                 If comVisible > -1 Then
                     Dim typedValue As TypedConstant = attrData(comVisible).CommonConstructorArguments(0)
@@ -478,7 +478,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' presence and its value. If we start caching that information, implementation of this function 
                 ' should change to take advantage of the cache.
                 Dim attrData As ImmutableArray(Of VisualBasicAttributeData) = target.GetAttributes()
-                Dim dispIdIndex = attrData.IndexOfAttribute(target, AttributeDescription.DispIdAttribute)
+                Dim dispIdIndex = attrData.IndexOfAttribute(AttributeDescription.DispIdAttribute)
 
                 If dispIdIndex > -1 Then
                     Dim typedValue As TypedConstant = attrData(dispIdIndex).CommonConstructorArguments(0)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_GroupClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_GroupClass.vb
@@ -176,7 +176,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                         Dim generatedDiagnostics As Boolean = False
                                         Dim data As VisualBasicAttributeData = (New EarlyWellKnownAttributeBinder(Me, binder)).GetAttribute(attr, attributeType, generatedDiagnostics)
                                         If Not data.HasErrors AndAlso Not generatedDiagnostics AndAlso
-                                           data.IsTargetAttribute(Me, AttributeDescription.MyGroupCollectionAttribute) Then
+                                           data.IsTargetAttribute(AttributeDescription.MyGroupCollectionAttribute) Then
                                             ' Looks like we've found MyGroupCollectionAttribute
                                             If attributeData IsNot Nothing Then
                                                 ' Ambiguity, the attribute cannot be applied multiple times. Let's ignore all of them,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -282,7 +282,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             Continue For
                         End If
                         Dim newArgs = ImmutableArray.Create(New TypedConstant(oldTypedConstant.TypeInternal, oldTypedConstant.Kind, correctedParameterName))
-                        Yield New SourceAttributeData(attribute.ApplicationSyntaxReference, attribute.AttributeClass, attribute.AttributeConstructor, newArgs, attribute.CommonNamedArguments, attribute.IsConditionallyOmitted, attribute.HasErrors)
+                        Yield New SourceAttributeData(DeclaringCompilation, attribute.ApplicationSyntaxReference, attribute.AttributeClass, attribute.AttributeConstructor, newArgs, attribute.CommonNamedArguments, attribute.IsConditionallyOmitted, attribute.HasErrors)
                         Continue For
                     End If
                 End If
@@ -339,26 +339,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             '  InAttribute, OutAttribute
             '     - metadata flag set, no diagnostics reported, don't influence language semantics
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.DefaultParameterValueAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.DefaultParameterValueAttribute) Then
                 ' Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DefaultParameterValueAttribute, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DecimalConstantAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DecimalConstantAttribute) Then
                 ' Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DecimalConstantAttribute, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DateTimeConstantAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.DateTimeConstantAttribute) Then
                 ' Attribute decoded and constant value stored during EarlyDecodeWellKnownAttribute.
                 DecodeDefaultParameterValueAttribute(AttributeDescription.DateTimeConstantAttribute, arguments)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.InAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.InAttribute) Then
                 arguments.GetOrCreateData(Of CommonParameterWellKnownAttributeData)().HasInAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.OutAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.OutAttribute) Then
                 arguments.GetOrCreateData(Of CommonParameterWellKnownAttributeData)().HasOutAttribute = True
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MarshalAsAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.MarshalAsAttribute) Then
                 MarshalAsAttributeDecoder(Of CommonParameterWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation).Decode(arguments, AttributeTargets.Parameter, MessageProvider.Instance)
-            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.CallerArgumentExpressionAttribute) Then
+            ElseIf attrData.IsTargetAttribute(AttributeDescription.CallerArgumentExpressionAttribute) Then
                 Dim index = GetEarlyDecodedWellKnownAttributeData()?.CallerArgumentExpressionParameterIndex
                 If index = Ordinal Then
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.WRN_CallerArgumentExpressionAttributeSelfReferential, arguments.AttributeSyntaxOpt.Location, Me.Name)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
@@ -478,7 +478,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend Overrides Sub DecodeWellKnownAttribute(ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation))
             If arguments.SymbolPart = AttributeLocation.None Then
-                If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.DebuggerHiddenAttribute) Then
+                If arguments.Attribute.IsTargetAttribute(AttributeDescription.DebuggerHiddenAttribute) Then
                     arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().IsPropertyAccessorWithDebuggerHiddenAttribute = True
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
@@ -556,12 +556,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim attrData = arguments.Attribute
             Dim diagnostics = DirectCast(arguments.Diagnostics, BindingDiagnosticBag)
 
-            If attrData.IsTargetAttribute(Me, AttributeDescription.TupleElementNamesAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.TupleElementNamesAttribute) Then
                 diagnostics.Add(ERRID.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location)
             End If
 
             If arguments.SymbolPart = AttributeLocation.Return Then
-                Dim isMarshalAs = attrData.IsTargetAttribute(Me, AttributeDescription.MarshalAsAttribute)
+                Dim isMarshalAs = attrData.IsTargetAttribute(AttributeDescription.MarshalAsAttribute)
 
                 ' write-only property doesn't accept any return type attributes other than MarshalAs
                 ' MarshalAs is applied on the "Value" parameter of the setter if the property has no parameters and the containing type is an interface .
@@ -579,13 +579,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return
                 End If
             Else
-                If attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
+                If attrData.IsTargetAttribute(AttributeDescription.SpecialNameAttribute) Then
                     arguments.GetOrCreateData(Of CommonPropertyWellKnownAttributeData).HasSpecialNameAttribute = True
                     Return
-                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+                ElseIf attrData.IsTargetAttribute(AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
                     arguments.GetOrCreateData(Of CommonPropertyWellKnownAttributeData).HasExcludeFromCodeCoverageAttribute = True
                     Return
-                ElseIf Not IsWithEvents AndAlso attrData.IsTargetAttribute(Me, AttributeDescription.DebuggerHiddenAttribute) Then
+                ElseIf Not IsWithEvents AndAlso attrData.IsTargetAttribute(AttributeDescription.DebuggerHiddenAttribute) Then
                     ' if neither getter or setter is marked by DebuggerHidden Dev11 reports a warning
                     If Not (_getMethod IsNot Nothing AndAlso DirectCast(_getMethod, SourcePropertyAccessorSymbol).HasDebuggerHiddenAttribute OrElse
                             _setMethod IsNot Nothing AndAlso DirectCast(_setMethod, SourcePropertyAccessorSymbol).HasDebuggerHiddenAttribute) Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -716,7 +716,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Friend Function GetGuidStringDefaultImplementation(<Out> ByRef guidString As String) As Boolean
             For Each attrData In GetAttributes()
-                If attrData.IsTargetAttribute(Me, AttributeDescription.GuidAttribute) Then
+                If attrData.IsTargetAttribute(AttributeDescription.GuidAttribute) Then
                     If attrData.TryGetGuidAttributeValue(guidString) Then
                         Return True
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
@@ -198,13 +198,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             MarkEmbeddedAttributeTypeReference(arguments.Attribute, arguments.AttributeSyntaxOpt, compilation)
             ReportExtensionAttributeUseSiteInfo(arguments.Attribute, arguments.AttributeSyntaxOpt, compilation, DirectCast(arguments.Diagnostics, BindingDiagnosticBag))
 
-            If arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.SkipLocalsInitAttribute) Then
+            If arguments.Attribute.IsTargetAttribute(AttributeDescription.SkipLocalsInitAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.WRN_AttributeNotSupportedInVB, arguments.AttributeSyntaxOpt.Location, AttributeDescription.SkipLocalsInitAttribute.FullName)
-            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.CompilerFeatureRequiredAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(AttributeDescription.CompilerFeatureRequiredAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_DoNotUseCompilerFeatureRequired, arguments.AttributeSyntaxOpt.Location)
-            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.RequiredMemberAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(AttributeDescription.RequiredMemberAttribute) Then
                 DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_DoNotUseRequiredMember, arguments.AttributeSyntaxOpt.Location)
-            ElseIf arguments.Attribute.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+            ElseIf arguments.Attribute.IsTargetAttribute(AttributeDescription.ExperimentalAttribute) Then
                 If Not SyntaxFacts.IsValidIdentifier(DirectCast(arguments.Attribute.CommonConstructorArguments(0).ValueInternal, String)) Then
                     Dim attrArgumentLocation = VisualBasicAttributeData.GetFirstArgumentLocation(arguments.AttributeSyntaxOpt)
                     DirectCast(arguments.Diagnostics, BindingDiagnosticBag).Add(ERRID.ERR_InvalidExperimentalDiagID, attrArgumentLocation)

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedAttributeData.vb
@@ -14,21 +14,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' Class to represent a synthesized attribute
     ''' </summary>
     Friend NotInheritable Class SynthesizedAttributeData
-        Inherits SourceAttributeData
+        Inherits VisualBasicAttributeData
 
-        Friend Sub New(wellKnownMember As MethodSymbol,
+        Private ReadOnly _compilation As VisualBasicCompilation
+        Private ReadOnly _attributeConstructor As MethodSymbol
+        Private ReadOnly _constructorArguments As ImmutableArray(Of TypedConstant)
+        Private ReadOnly _namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+
+        Friend Sub New(compilation As VisualBasicCompilation,
+                       wellKnownMember As MethodSymbol,
                        arguments As ImmutableArray(Of TypedConstant),
                        namedArgs As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)))
 
-            MyBase.New(Nothing,
-                       wellKnownMember.ContainingType,
-                       wellKnownMember,
-                       arguments,
-                       namedArgs,
-                       isConditionallyOmitted:=False,
-                       hasErrors:=False)
-
             Debug.Assert(wellKnownMember IsNot Nothing AndAlso Not arguments.IsDefault)
+
+            Me._compilation = compilation
+            Me._attributeConstructor = wellKnownMember
+            Me._constructorArguments = arguments.NullToEmpty()
+            Me._namedArguments = namedArgs.NullToEmpty()
         End Sub
 
         ''' <summary>
@@ -36,6 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' If the constructor has UseSiteErrors and the attribute is optional returns Nothing.
         ''' </summary>
         Friend Shared Function Create(
+            compilation As VisualBasicCompilation,
             constructorSymbol As MethodSymbol,
             constructor As WellKnownMember,
             Optional arguments As ImmutableArray(Of TypedConstant) = Nothing,
@@ -58,8 +62,58 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     namedArguments = ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty
                 End If
 
-                Return New SynthesizedAttributeData(constructorSymbol, arguments, namedArguments)
+                Return New SynthesizedAttributeData(compilation, constructorSymbol, arguments, namedArguments)
             End If
+        End Function
+
+        Public Overrides ReadOnly Property AttributeClass As NamedTypeSymbol
+            Get
+                Return _attributeConstructor.ContainingType
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property AttributeConstructor As MethodSymbol
+            Get
+                Return _attributeConstructor
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property ApplicationSyntaxReference As SyntaxReference
+            Get
+                Return Nothing
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property CommonConstructorArguments As ImmutableArray(Of TypedConstant)
+            Get
+                Return _constructorArguments
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property CommonNamedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+            Get
+                Return _namedArguments
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property HasErrors As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        Friend Overrides Function IsTargetAttribute(namespaceName As String, typeName As String, Optional ignoreCase As Boolean = False) As Boolean
+            Return SourceAttributeData.IsTargetAttribute(AttributeClass, namespaceName, typeName, ignoreCase)
+        End Function
+
+        Friend Overrides Function GetTargetAttributeSignatureIndex(description As AttributeDescription) As Integer
+            Return SourceAttributeData.GetTargetAttributeSignatureIndex(_compilation, AttributeClass, AttributeConstructor, description)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -184,7 +184,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 namedStringArguments = builder.ToImmutableAndFree()
             End If
 
-            Return New SynthesizedAttributeData(constructorSymbol, arguments, namedStringArguments)
+            Return New SynthesizedAttributeData(Me, constructorSymbol, arguments, namedStringArguments)
         End Function
 
         Private Shared Function ReturnNothingOrThrowIfAttributeNonOptional(constructor As WellKnownMember, Optional isOptionalUse As Boolean = False) As SynthesizedAttributeData
@@ -202,7 +202,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                          constructor.GetUseSiteInfo().DiagnosticInfo Is Nothing AndAlso
                          constructor.ContainingType.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
-            Return SynthesizedAttributeData.Create(constructor, WellKnownMember.System_Runtime_CompilerServices_ExtensionAttribute__ctor)
+            Return SynthesizedAttributeData.Create(Me, constructor, WellKnownMember.System_Runtime_CompilerServices_ExtensionAttribute__ctor)
         End Function
 
         Friend Function SynthesizeStateMachineAttribute(method As MethodSymbol, compilationState As ModuleCompilationState) As SynthesizedAttributeData

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
@@ -2077,7 +2077,7 @@ System.Reflection.AssemblyTrademarkAttribute("Roslyn")
 
     Private Shared Sub GetAssemblyDescriptionAttributes(assembly As AssemblySymbol, list As ArrayBuilder(Of VisualBasicAttributeData))
         For Each attrData In assembly.GetAttributes()
-            If attrData.IsTargetAttribute(assembly, AttributeDescription.AssemblyDescriptionAttribute) Then
+            If attrData.IsTargetAttribute(AttributeDescription.AssemblyDescriptionAttribute) Then
                 list.Add(attrData)
             End If
         Next
@@ -2225,6 +2225,153 @@ BC42370: Attribute 'AssemblyDescriptionAttribute' from module 'M2.netmodule' wil
                                                               Assert.Equal("System.Reflection.AssemblyDescriptionAttribute(""Module1"")", list(0).ToString())
                                                           End Sub)
 
+    End Sub
+
+    <Fact>
+    <WorkItem("https://github.com/dotnet/roslyn/issues/70338")>
+    Public Sub ErrorsWithAssemblyAttributesInModules_01()
+        Dim attribute1 =
+<compilation name="A1">
+    <file><![CDATA[
+public class A1 
+    Inherits System.Attribute
+
+    public Sub New(a As Integer)
+    End Sub    
+End Class
+    ]]></file>
+</compilation>
+
+        Dim attributeDefinition1 = CreateCompilation(attribute1, options:=TestOptions.ReleaseDll).EmitToImageReference()
+
+        Dim [module] =
+<compilation name="M1">
+    <file><![CDATA[
+<assembly:A1(1)>
+    ]]></file>
+</compilation>
+
+        Dim moduleWithAttribute = CreateCompilation([module], references:={attributeDefinition1}, options:=TestOptions.ReleaseModule).EmitToImageReference()
+
+        Dim comp = CreateCompilation("", references:={moduleWithAttribute, attributeDefinition1}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp, symbolValidator:=Sub(m)
+                                                    Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                    Assert.Equal(4, attrs.Length)
+                                                    AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                    AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                    AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                    AssertEx.Equal("A1(1)", attrs(3).ToString())
+                                                End Sub).VerifyDiagnostics()
+
+        Dim comp2 = CreateCompilation("", references:={moduleWithAttribute}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp2, symbolValidator:=Sub(m)
+                                                     Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                     Assert.Equal(3, attrs.Length)
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                     AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                 End Sub).VerifyDiagnostics()
+
+        Dim attribute2 =
+<compilation name="A1">
+    <file><![CDATA[
+public class A1 
+    Inherits System.Attribute
+
+    public Sub New()
+    End Sub    
+End Class
+    ]]></file>
+</compilation>
+
+        Dim attributeDefinition2 = CreateCompilation(attribute2, options:=TestOptions.ReleaseDll).EmitToImageReference()
+
+        Dim comp3 = CreateCompilation("", references:={moduleWithAttribute, attributeDefinition2}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp3, symbolValidator:=Sub(m)
+                                                     Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                     Assert.Equal(3, attrs.Length)
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                     AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                 End Sub).VerifyDiagnostics()
+    End Sub
+
+    <Fact>
+    <WorkItem("https://github.com/dotnet/roslyn/issues/70338")>
+    Public Sub ErrorsWithAssemblyAttributesInModules_02()
+        Dim c1 =
+<compilation name="A1">
+    <file><![CDATA[
+public class C1 
+End Class
+    ]]></file>
+</compilation>
+
+        Dim c1Definition = CreateCompilation(c1, options:=TestOptions.ReleaseDll).EmitToImageReference()
+
+        Dim module1 =
+<compilation name="M1">
+    <file><![CDATA[
+<assembly:A1(GetType(C1))>
+
+public class A1 
+    Inherits System.Attribute
+
+    public Sub New(a As System.Type)
+    End Sub    
+End Class
+    ]]></file>
+</compilation>
+
+        Dim module1WithAttribute = CreateCompilation(module1, references:={c1Definition}, options:=TestOptions.ReleaseModule).EmitToImageReference()
+
+        Dim comp = CreateCompilation("", references:={module1WithAttribute, c1Definition}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp, symbolValidator:=Sub(m)
+                                                    Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                    Assert.Equal(4, attrs.Length)
+                                                    AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                    AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                    AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                    AssertEx.Equal("A1(GetType(C1))", attrs(3).ToString())
+                                                End Sub).VerifyDiagnostics()
+
+        Dim comp2 = CreateCompilation("", references:={module1WithAttribute}, options:=TestOptions.ReleaseDll)
+
+        comp2.AssertTheseEmitDiagnostics(
+<expected>
+BC30652: Reference required to assembly 'A1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'C1'. Add one to your project.
+</expected>
+        )
+
+        Dim module2 =
+<compilation name="M1">
+    <file><![CDATA[
+<module:A1(GetType(C1))>
+
+public class A1 
+    Inherits System.Attribute
+
+    public Sub New(a As System.Type)
+    End Sub    
+End Class
+    ]]></file>
+</compilation>
+
+        Dim module2WithAttribute = CreateCompilation(module2, references:={c1Definition}, options:=TestOptions.ReleaseModule).EmitToImageReference()
+
+        Dim comp3 = CreateCompilation("", references:={module2WithAttribute}, options:=TestOptions.ReleaseDll)
+
+        CompileAndVerify(comp3, symbolValidator:=Sub(m)
+                                                     Dim attrs = m.ContainingAssembly.GetAttributes()
+                                                     Assert.Equal(3, attrs.Length)
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
+                                                     AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
+                                                     AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
+                                                 End Sub).VerifyDiagnostics()
     End Sub
 
 End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
@@ -6221,25 +6221,15 @@ End Class
             Dim current = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__Current), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                     useParent:=useBlock),
+                                            ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6273,25 +6263,15 @@ End Class
             Dim current = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__Current), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6321,25 +6301,15 @@ End Class
             Dim current = DirectCast(getEnumerator.ReturnType.GetMember("get_Current"), MethodSymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(DirectCast(current.AssociatedSymbol, PropertySymbol), semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(DirectCast(current.AssociatedSymbol, PropertySymbol), semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6387,25 +6357,15 @@ End Class
             Dim moveNext = DirectCast(compilation.GlobalNamespace.GetTypeMember("Custom").GetTypeMember("CustomEnumerator").GetMember("MoveNext"), MethodSymbol)
             Dim current = DirectCast(compilation.GlobalNamespace.GetTypeMember("Custom").GetTypeMember("CustomEnumerator").GetMember("Current"), PropertySymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Null(semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Null(semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6459,25 +6419,15 @@ End Class
             Dim current = DirectCast(compilation.GlobalNamespace.GetTypeMember("Custom").GetTypeMember("CustomEnumerator").GetMember("Current"), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6536,25 +6486,15 @@ BC30149: Class 'CustomEnumerator' must implement 'Sub Dispose()' for interface '
             ' the type claimed to implement IDisposable and we believed it ...
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6601,25 +6541,15 @@ End Class
 
             Dim getEnumerator = DirectCast(compilation.GlobalNamespace.GetTypeMember("Custom").GetMember("GetEnumerator"), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod) ' methods are partly present up to the point where the pattern was violated.
-                    Assert.Null(semanticInfoEx.MoveNextMethod)
-                    Assert.Null(semanticInfoEx.CurrentProperty)
-                    Assert.Null(semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod) ' methods are partly present up to the point where the pattern was violated.
+                Assert.Null(semanticInfoEx.MoveNextMethod)
+                Assert.Null(semanticInfoEx.CurrentProperty)
+                Assert.Null(semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6655,25 +6585,15 @@ End Class
             Dim current = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__Current), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6713,25 +6633,15 @@ End Class
             Dim current = DirectCast(ienumerator.GetMember("Current"), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6756,28 +6666,18 @@ End Class
             Dim moveNext = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__MoveNext), MethodSymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal("Function System.Collections.Generic.IEnumerable(Of System.Int32).GetEnumerator() As System.Collections.Generic.IEnumerator(Of System.Int32)",
-                                 semanticInfoEx.GetEnumeratorMethod.ToDisplayString(SymbolDisplayFormat.TestFormat))
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    ' the first matching symbol on IEnumerable(Of T)
-                    Assert.Equal("ReadOnly Property System.Collections.Generic.IEnumerator(Of System.Int32).Current As System.Int32",
-                                 semanticInfoEx.CurrentProperty.ToDisplayString(SymbolDisplayFormat.TestFormat))
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal("Function System.Collections.Generic.IEnumerable(Of System.Int32).GetEnumerator() As System.Collections.Generic.IEnumerator(Of System.Int32)",
+                             semanticInfoEx.GetEnumeratorMethod.ToDisplayString(SymbolDisplayFormat.TestFormat))
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                ' the first matching symbol on IEnumerable(Of T)
+                Assert.Equal("ReadOnly Property System.Collections.Generic.IEnumerator(Of System.Int32).Current As System.Int32",
+                             semanticInfoEx.CurrentProperty.ToDisplayString(SymbolDisplayFormat.TestFormat))
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6800,25 +6700,15 @@ End Class
 ]]></file>
 </compilation>)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Null(semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Null(semanticInfoEx.MoveNextMethod)
-                    Assert.Null(semanticInfoEx.CurrentProperty)
-                    Assert.Null(semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Null(semanticInfoEx.GetEnumeratorMethod)
+                Assert.Null(semanticInfoEx.MoveNextMethod)
+                Assert.Null(semanticInfoEx.CurrentProperty)
+                Assert.Null(semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6843,28 +6733,18 @@ End Class
             Dim moveNext = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__MoveNext), MethodSymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
+                Assert.Equal("Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator",
+                             semanticInfoEx.GetEnumeratorMethod.ToDisplayString(SymbolDisplayFormat.TestFormat))
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
 
-                    Assert.Equal("Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator",
-                                 semanticInfoEx.GetEnumeratorMethod.ToDisplayString(SymbolDisplayFormat.TestFormat))
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-
-                    Assert.Equal("ReadOnly Property System.Collections.IEnumerator.Current As System.Object",
-                                 semanticInfoEx.CurrentProperty.ToDisplayString(SymbolDisplayFormat.TestFormat))
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal("ReadOnly Property System.Collections.IEnumerator.Current As System.Object",
+                             semanticInfoEx.CurrentProperty.ToDisplayString(SymbolDisplayFormat.TestFormat))
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_SemanticModel.vb
@@ -1177,7 +1177,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            commonSymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(DirectCast(node11, SyntaxNode))
+            commonSymbolInfo = semanticModel.GetSymbolInfo(DirectCast(node11, SyntaxNode))
 
             Assert.Same(symbolInfo.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(CandidateReason.None, commonSymbolInfo.CandidateReason)
@@ -1429,7 +1429,7 @@ End Module
                 Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
                 Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-                Dim commonSymbolInfo As SymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(ordering)
+                Dim commonSymbolInfo As SymbolInfo = semanticModel.GetSymbolInfo(ordering)
                 Assert.Null(commonSymbolInfo.Symbol)
                 Assert.Equal(CandidateReason.None, commonSymbolInfo.CandidateReason)
                 Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -1480,7 +1480,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            Dim commonSymbolInfo As SymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(node1)
+            Dim commonSymbolInfo As SymbolInfo = semanticModel.GetSymbolInfo(node1)
             Assert.Same(symbolInfo.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(symbolInfo.CandidateReason, commonSymbolInfo.CandidateReason)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -1492,7 +1492,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            commonSymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(node2)
+            commonSymbolInfo = semanticModel.GetSymbolInfo(node2)
             Assert.Same(symbolInfo.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(symbolInfo.CandidateReason, commonSymbolInfo.CandidateReason)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -1707,7 +1707,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            Dim commonSymbolInfo As SymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(node6)
+            Dim commonSymbolInfo As SymbolInfo = semanticModel.GetSymbolInfo(node6)
             Assert.Null(commonSymbolInfo.Symbol)
             Assert.Equal(CandidateReason.None, commonSymbolInfo.CandidateReason)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -1726,7 +1726,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            commonSymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(node8)
+            commonSymbolInfo = semanticModel.GetSymbolInfo(node8)
             Assert.Same(symbolInfo.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(symbolInfo.CandidateReason, commonSymbolInfo.CandidateReason)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -3385,7 +3385,7 @@ End Module
             Assert.Same(symbolInfo1.Symbol, symbolInfo2.Symbol)
             Assert.Equal(0, symbolInfo2.CandidateSymbols.Length)
 
-            Dim commonSymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(DirectCast(node9, SyntaxNode))
+            Dim commonSymbolInfo = semanticModel.GetSymbolInfo(DirectCast(node9, SyntaxNode))
             Assert.Equal(symbolInfo1.CandidateReason, commonSymbolInfo.CandidateReason)
             Assert.Same(symbolInfo1.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -3917,7 +3917,7 @@ End Module
             Dim semanticModel = compilation.GetSemanticModel(tree)
             Dim node = tree.GetCompilationUnitRoot().FindToken(tree.GetCompilationUnitRoot().ToString().IndexOf("By", StringComparison.Ordinal)).Parent.Parent.DescendantNodes().OfType(Of IdentifierNameSyntax)().First()
 
-            Dim containingSymbol = DirectCast(semanticModel, SemanticModel).GetEnclosingSymbol(node.SpanStart)
+            Dim containingSymbol = semanticModel.GetEnclosingSymbol(node.SpanStart)
 
             Assert.Equal("Function (z As System.Int32) As <anonymous type: Key z As System.Int32, Key Group As ?>", DirectCast(containingSymbol, Symbol).ToTestDisplayString())
         End Sub

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OperatorCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OperatorCompletionProviderTests.cs
@@ -302,7 +302,7 @@ public class Program
 ", SourceCodeKind.Regular);
             Assert.Equal(
                 numberOfSuggestions,
-                completionItems.Count(c => c.Properties[UnnamedSymbolCompletionProvider.KindName] == UnnamedSymbolCompletionProvider.OperatorKindName));
+                completionItems.Count(c => c.GetProperty(UnnamedSymbolCompletionProvider.KindName) == UnnamedSymbolCompletionProvider.OperatorKindName));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/47511")]

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.ExtractMethod;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
@@ -13,6 +12,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ExtractMethod;
 using Microsoft.CodeAnalysis.Notification;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
         }
 
         [WpfFact]
-        public void TestExtractMethodCommandHandlerErrorMessage()
+        public async Task TestExtractMethodCommandHandlerErrorMessage()
         {
             var markupCode = """
                 class A
@@ -132,13 +132,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             view.Selection.Select(new SnapshotSpan(
                 view.TextBuffer.CurrentSnapshot, testDocument.SelectedSpans[0].Start, testDocument.SelectedSpans[0].Length), isReversed: false);
 
-            var callBackService = workspace.Services.GetService<INotificationService>() as INotificationServiceCallback;
+            var callBackService = (INotificationServiceCallback)workspace.Services.GetRequiredService<INotificationService>();
             var called = false;
-            callBackService.NotificationCallback = (t, m, s) => called = true;
+            callBackService.NotificationCallback = (_, _, _) => called = true;
 
             var handler = workspace.ExportProvider.GetCommandHandler<ExtractMethodCommandHandler>(PredefinedCommandHandlerNames.ExtractMethod, ContentTypeNames.CSharpContentType);
 
             handler.ExecuteCommand(new ExtractMethodCommandArgs(view, view.TextBuffer), TestCommandExecutionContext.Create());
+
+            var waiter = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.ExtractMethod);
+            await waiter.ExpeditedWaitAsync();
 
             Assert.True(called);
         }

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             var suggestionItemOptions = new AsyncCompletionData.SuggestionItemOptions(
                 completionList.SuggestionModeItem.DisplayText,
-                completionList.SuggestionModeItem.Properties.TryGetValue(CommonCompletionItem.DescriptionProperty, out var description) ? description : string.Empty);
+                completionList.SuggestionModeItem.TryGetProperty(CommonCompletionItem.DescriptionProperty, out var description) ? description : string.Empty);
 
             return (new(completionItemList, suggestionItemOptions, selectionHint: AsyncCompletionData.InitialSelectionHint.SoftSelection, filters, isIncomplete: false, null), completionList);
         }

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Microsoft.VisualStudio.Text;
 using EditorAsyncCompletionData = Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
@@ -35,14 +36,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return item;
 
             Debug.Assert(item.DisplayText.StartsWith(Completion.Utilities.UnicodeStarAndSpace));
+            var newProperties = item.GetProperties().WhereAsArray((kvp, propName) => kvp.Key != propName, PromotedItemOriginalIndexPropertyName);
             return item
                 .WithDisplayText(item.DisplayText[Completion.Utilities.UnicodeStarAndSpace.Length..])
-                .WithProperties(item.Properties.Remove(PromotedItemOriginalIndexPropertyName));
+                .WithProperties(newProperties);
         }
 
         public static bool TryGetOriginalIndexOfPromotedItem(RoslynCompletionItem item, out int originalIndex)
         {
-            if (item.Properties.TryGetValue(PromotedItemOriginalIndexPropertyName, out var indexString))
+            if (item.TryGetProperty(PromotedItemOriginalIndexPropertyName, out var indexString))
             {
                 originalIndex = int.Parse(indexString);
                 return true;

--- a/src/EditorFeatures/Test/Completion/FileSystemCompletionHelperTests.cs
+++ b/src/EditorFeatures/Test/Completion/FileSystemCompletionHelperTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             AssertEx.Equal(
                 expected,
-                actual.Select(c => $"'{c.DisplayText}', {string.Join(", ", c.Tags)}, '{c.Properties[CommonCompletionItem.DescriptionProperty]}'"),
+                actual.Select(c => $"'{c.DisplayText}', {string.Join(", ", c.Tags)}, '{c.GetProperty(CommonCompletionItem.DescriptionProperty)}'"),
                 itemInspector: c => $"@\"{c}\"");
 
             Assert.True(actual.All(i => i.Rules == TestFileSystemCompletionHelper.CompletionRules));

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
                 var span = GetCompletionItemSpan(text, position);
-                var serializedOptions = ImmutableDictionary<string, string>.Empty.Add(HideAdvancedMembers, options.HideAdvancedMembers.ToString());
+                var serializedOptions = ImmutableArray.Create(new KeyValuePair<string, string>(HideAdvancedMembers, options.HideAdvancedMembers.ToString()));
 
                 var items = CreateCompletionItems(semanticModel, symbols, token, position, serializedOptions);
 
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private static IEnumerable<CompletionItem> CreateCompletionItems(
-            SemanticModel semanticModel, ImmutableArray<ISymbol> symbols, SyntaxToken token, int position, ImmutableDictionary<string, string> options)
+            SemanticModel semanticModel, ImmutableArray<ISymbol> symbols, SyntaxToken token, int position, ImmutableArray<KeyValuePair<string, string>> options)
         {
             var builder = SharedPools.Default<StringBuilder>().Allocate();
             try
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         private static bool TryCreateSpecialTypeItem(
             SemanticModel semanticModel, ISymbol symbol, SyntaxToken token, int position, StringBuilder builder,
-            ImmutableDictionary<string, string> options, [NotNullWhen(true)] out CompletionItem? item)
+            ImmutableArray<KeyValuePair<string, string>> options, [NotNullWhen(true)] out CompletionItem? item)
         {
             // If the type is a SpecialType, create an additional item using 
             // its actual name (as opposed to intrinsic type keyword)
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             SyntaxToken token,
             int position,
             StringBuilder builder,
-            ImmutableDictionary<string, string> options,
+            ImmutableArray<KeyValuePair<string, string>> options,
             SymbolDisplayFormat unqualifiedCrefFormat)
         {
             builder.Clear();
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return CreateItemFromBuilder(symbol, position, builder, options);
         }
 
-        private static CompletionItem CreateItemFromBuilder(ISymbol symbol, int position, StringBuilder builder, ImmutableDictionary<string, string> options)
+        private static CompletionItem CreateItemFromBuilder(ISymbol symbol, int position, StringBuilder builder, ImmutableArray<KeyValuePair<string, string>> options)
         {
             var symbolText = builder.ToString();
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             char? commitKey,
             CancellationToken cancellationToken)
         {
-            var kind = item.Properties[KindName];
+            var kind = item.GetProperty(KindName);
             return kind switch
             {
                 IndexerKindName => GetIndexerChangeAsync(document, item, cancellationToken),
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             SymbolDescriptionOptions displayOptions,
             CancellationToken cancellationToken)
         {
-            var kind = item.Properties[KindName];
+            var kind = item.GetProperty(KindName);
             return kind switch
             {
                 IndexerKindName => await GetIndexerDescriptionAsync(document, item, displayOptions, cancellationToken).ConfigureAwait(false),

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Indexers.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Indexers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,8 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
     internal partial class UnnamedSymbolCompletionProvider
     {
-        private readonly ImmutableDictionary<string, string> IndexerProperties =
-            ImmutableDictionary<string, string>.Empty.Add(KindName, IndexerKindName);
+        private readonly ImmutableArray<KeyValuePair<string, string>> IndexerProperties =
+            ImmutableArray.Create(new KeyValuePair<string, string>(KindName, IndexerKindName));
 
         private void AddIndexers(CompletionContext context, ImmutableArray<ISymbol> indexers)
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
@@ -75,15 +75,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         private static bool IsPartialTypeDeclaration(SyntaxNode syntax)
             => syntax is BaseTypeDeclarationSyntax declarationSyntax && declarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword);
 
-        protected override ImmutableDictionary<string, string> GetProperties(INamedTypeSymbol symbol, CSharpSyntaxContext context)
-            => ImmutableDictionary<string, string>.Empty.Add(InsertionTextOnLessThan, symbol.Name.EscapeIdentifier());
+        protected override ImmutableArray<KeyValuePair<string, string>> GetProperties(INamedTypeSymbol symbol, CSharpSyntaxContext context)
+            => ImmutableArray.Create(new KeyValuePair<string, string>(InsertionTextOnLessThan, symbol.Name.EscapeIdentifier()));
 
         public override async Task<TextChange?> GetTextChangeAsync(
             Document document, CompletionItem selectedItem, char? ch, CancellationToken cancellationToken)
         {
             if (ch == '<')
             {
-                if (selectedItem.Properties.TryGetValue(InsertionTextOnLessThan, out var insertionText))
+                if (selectedItem.TryGetProperty(InsertionTextOnLessThan, out var insertionText))
                 {
                     return new TextChange(selectedItem.Span, insertionText);
                 }

--- a/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Tags;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Completion
             string? sortText = null,
             string? filterText = null,
             bool showsWarningIcon = false,
-            ImmutableDictionary<string, string>? properties = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
             ImmutableArray<string> tags = default,
             string? inlineDescription = null,
             string? displayTextPrefix = null,
@@ -41,13 +42,12 @@ namespace Microsoft.CodeAnalysis.Completion
                 tags = tags.Add(WellKnownTags.Warning);
             }
 
-            properties ??= ImmutableDictionary<string, string>.Empty;
             if (!description.IsDefault && description.Length > 0)
             {
-                properties = properties.Add(DescriptionProperty, EncodeDescription(description.ToTaggedText()));
+                properties = properties.NullToEmpty().Add(new KeyValuePair<string, string>(DescriptionProperty, EncodeDescription(description.ToTaggedText())));
             }
 
-            return CompletionItem.Create(
+            return CompletionItem.CreateInternal(
                 displayText: displayText,
                 displayTextSuffix: displayTextSuffix,
                 displayTextPrefix: displayTextPrefix,
@@ -61,11 +61,11 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         public static bool HasDescription(CompletionItem item)
-            => item.Properties.ContainsKey(DescriptionProperty);
+            => item.TryGetProperty(DescriptionProperty, out var _);
 
         public static CompletionDescription GetDescription(CompletionItem item)
         {
-            if (item.Properties.TryGetValue(DescriptionProperty, out var encodedDescription))
+            if (item.TryGetProperty(DescriptionProperty, out var encodedDescription))
             {
                 return DecodeDescription(encodedDescription);
             }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAggregateEmbeddedLanguageCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAggregateEmbeddedLanguageCompletionProvider.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             if (_languageProviders.IsDefault)
                 throw ExceptionUtilities.Unreachable();
 
-            return _languageProviders.Single(lang => lang.CompletionProvider?.Name == item.Properties[EmbeddedProviderName]);
+            return _languageProviders.Single(lang => lang.CompletionProvider?.Name == item.GetProperty(EmbeddedProviderName));
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Text;
@@ -98,49 +99,55 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var token = syntaxContext.TargetToken;
             var declaration = GetAsyncSupportingDeclaration(token);
 
-            var properties = ImmutableDictionary<string, string>.Empty
-                .Add(AwaitCompletionTargetTokenPosition, token.SpanStart.ToString());
+            using var builder = TemporaryArray<KeyValuePair<string, string>>.Empty;
+
+            builder.Add(new KeyValuePair<string, string>(AwaitCompletionTargetTokenPosition, token.SpanStart.ToString()));
 
             var makeContainerAsync = declaration is not null && !SyntaxGenerator.GetGenerator(document).GetModifiers(declaration).IsAsync;
             if (makeContainerAsync)
-                properties = properties.Add(MakeContainerAsync, string.Empty);
+                builder.Add(new KeyValuePair<string, string>(MakeContainerAsync, string.Empty));
 
             if (isAwaitKeywordContext)
             {
-                properties = properties.Add(AddAwaitAtCurrentPosition, string.Empty);
+                builder.Add(new KeyValuePair<string, string>(AddAwaitAtCurrentPosition, string.Empty));
+                var properties = builder.ToImmutableAndClear();
+
                 context.AddItem(CreateCompletionItem(
                     properties, _awaitKeyword, _awaitKeyword,
                     FeaturesResources.Asynchronously_waits_for_the_task_to_finish,
-                    isComplexTextEdit: makeContainerAsync));
+                    isComplexTextEdit: makeContainerAsync,
+                    appendConfigureAwait: false));
             }
             else
             {
                 Contract.ThrowIfTrue(dotAwaitContext == DotAwaitContext.None);
 
+                var properties = builder.ToImmutableAndClear();
+
                 // add the `await` option that will remove the dot and add `await` to the start of the expression.
                 context.AddItem(CreateCompletionItem(
                     properties, _awaitKeyword, _awaitKeyword,
                     FeaturesResources.Await_the_preceding_expression,
-                    isComplexTextEdit: true));
+                    isComplexTextEdit: true,
+                    appendConfigureAwait: false));
 
                 if (dotAwaitContext == DotAwaitContext.AwaitAndConfigureAwait)
                 {
                     // add the `awaitf` option to do the same, but also add .ConfigureAwait(false);
-                    properties = properties.Add(AppendConfigureAwait, string.Empty);
+                    properties = properties.Add(new KeyValuePair<string, string>(AppendConfigureAwait, string.Empty));
                     context.AddItem(CreateCompletionItem(
                         properties, _awaitfDisplayText, _awaitfFilterText,
                         string.Format(FeaturesResources.Await_the_preceding_expression_and_add_ConfigureAwait_0, _falseKeyword),
-                        isComplexTextEdit: true));
+                        isComplexTextEdit: true,
+                        appendConfigureAwait: true));
                 }
             }
 
             return;
 
             static CompletionItem CreateCompletionItem(
-                ImmutableDictionary<string, string> completionProperties, string displayText, string filterText, string tooltip, bool isComplexTextEdit)
+                ImmutableArray<KeyValuePair<string, string>> completionProperties, string displayText, string filterText, string tooltip, bool isComplexTextEdit, bool appendConfigureAwait)
             {
-                var appendConfigureAwait = completionProperties.ContainsKey(AppendConfigureAwait);
-
                 var description = appendConfigureAwait
                     ? ImmutableArray.Create(new SymbolDisplayPart(SymbolDisplayPartKind.Text, null, tooltip))
                     : RecommendedKeyword.CreateDisplayParts(displayText, tooltip);
@@ -168,12 +175,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             var syntaxKinds = syntaxFacts.SyntaxKinds;
-            var properties = item.Properties;
 
-            if (properties.ContainsKey(MakeContainerAsync))
+            if (item.TryGetProperty(MakeContainerAsync, out var _))
             {
                 var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-                var tokenPosition = int.Parse(properties[AwaitCompletionTargetTokenPosition]);
+                var tokenPosition = int.Parse(item.GetProperty(AwaitCompletionTargetTokenPosition));
                 var declaration = GetAsyncSupportingDeclaration(root.FindToken(tokenPosition));
                 if (declaration is null)
                 {
@@ -186,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 builder.Add(new TextChange(new TextSpan(GetSpanStart(declaration), 0), syntaxFacts.GetText(syntaxKinds.AsyncKeyword) + " "));
             }
 
-            if (properties.ContainsKey(AddAwaitAtCurrentPosition))
+            if (item.TryGetProperty(AddAwaitAtCurrentPosition, out var _))
             {
                 builder.Add(new TextChange(item.Span, _awaitKeyword));
             }
@@ -203,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 builder.Add(new TextChange(new TextSpan(expr.SpanStart, 0), _awaitKeyword + " "));
 
                 // remove any text after dot, including the dot token and optionally append .ConfigureAwait(false)
-                var replacementText = properties.ContainsKey(AppendConfigureAwait)
+                var replacementText = item.TryGetProperty(AppendConfigureAwait, out var _)
                     ? $".{nameof(Task.ConfigureAwait)}({_falseKeyword})"
                     : "";
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractCrefCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractCrefCompletionProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var position = SymbolCompletionItem.GetContextPosition(item);
 
             // What EditorBrowsable settings were we previously passed in (if it mattered)?
-            if (item.Properties.TryGetValue(HideAdvancedMembers, out var hideAdvancedMembersString) &&
+            if (item.TryGetProperty(HideAdvancedMembers, out var hideAdvancedMembersString) &&
                 bool.TryParse(hideAdvancedMembersString, out var hideAdvancedMembers))
             {
                 options = options with { HideAdvancedMembers = hideAdvancedMembers };

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -3,13 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     displayTextSuffix: "",
                     rules: CompletionItemRules.Default,
                     glyph: project.GetGlyph(),
-                    properties: ImmutableDictionary.Create<string, string>().Add(ProjectGuidKey, projectGuid));
+                    properties: ImmutableArray.Create(new KeyValuePair<string, string>(ProjectGuidKey, projectGuid)));
                 context.AddItem(completionItem);
             }
 
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey = null, CancellationToken cancellationToken = default)
         {
-            var projectIdGuid = item.Properties[ProjectGuidKey];
+            var projectIdGuid = item.GetProperty(ProjectGuidKey);
             var projectId = ProjectId.CreateFromSerialized(new Guid(projectIdGuid));
             var project = document.Project.Solution.GetRequiredProject(projectId);
             var assemblyName = item.DisplayText;

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 rules: CompletionItemRules.Default);
         }
 
-        protected abstract ImmutableDictionary<string, string> GetProperties(INamedTypeSymbol symbol, TSyntaxContext context);
+        protected abstract ImmutableArray<KeyValuePair<string, string>> GetProperties(INamedTypeSymbol symbol, TSyntaxContext context);
 
         protected abstract SyntaxNode? GetPartialTypeSyntaxNode(SyntaxTree tree, int position, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
@@ -37,30 +38,30 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             (string methodSymbolKey, string receiverTypeSymbolKey, int overloadCount)? extensionMethodData,
             bool includedInTargetTypeCompletion = false)
         {
-            ImmutableDictionary<string, string>? properties = null;
+            ImmutableArray<KeyValuePair<string, string>> properties = default;
 
             if (extensionMethodData != null || arity > 0)
             {
-                var builder = PooledDictionary<string, string>.GetInstance();
+                using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var builder);
 
                 if (extensionMethodData.HasValue)
                 {
-                    builder.Add(MethodKey, extensionMethodData.Value.methodSymbolKey);
-                    builder.Add(ReceiverKey, extensionMethodData.Value.receiverTypeSymbolKey);
+                    builder.Add(new KeyValuePair<string, string>(MethodKey, extensionMethodData.Value.methodSymbolKey));
+                    builder.Add(new KeyValuePair<string, string>(ReceiverKey, extensionMethodData.Value.receiverTypeSymbolKey));
 
                     if (extensionMethodData.Value.overloadCount > 0)
                     {
-                        builder.Add(OverloadCountKey, extensionMethodData.Value.overloadCount.ToString());
+                        builder.Add(new KeyValuePair<string, string>(OverloadCountKey, extensionMethodData.Value.overloadCount.ToString()));
                     }
                 }
                 else
                 {
                     // We don't need arity to recover symbol if we already have SymbolKeyData or it's 0.
                     // (but it still needed below to decide whether to show generic suffix)
-                    builder.Add(TypeAritySuffixName, ArityUtilities.GetMetadataAritySuffix(arity));
+                    builder.Add(new KeyValuePair<string, string>(TypeAritySuffixName, ArityUtilities.GetMetadataAritySuffix(arity)));
                 }
 
-                properties = builder.ToImmutableDictionaryAndFree();
+                properties = builder.ToImmutable();
             }
 
             // Use "<display name> <namespace>" as sort text. The space before namespace makes items with identical display name
@@ -69,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var sortTextBuilder = PooledStringBuilder.GetInstance();
             sortTextBuilder.Builder.AppendFormat(GetSortTextFormatString(containingNamespace), name, containingNamespace);
 
-            var item = CompletionItem.Create(
+            var item = CompletionItem.CreateInternal(
                  displayText: name,
                  sortText: sortTextBuilder.ToStringAndFree(),
                  properties: properties,
@@ -91,18 +92,22 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static CompletionItem CreateAttributeItemWithoutSuffix(CompletionItem attributeItem, string attributeNameWithoutSuffix, CompletionItemFlags flags)
         {
-            Debug.Assert(!attributeItem.Properties.ContainsKey(AttributeFullName));
+            Debug.Assert(!attributeItem.TryGetProperty(AttributeFullName, out var _));
+
+            var attributeItems = attributeItem.GetProperties();
 
             // Remember the full type name so we can get the symbol when description is displayed.
-            var newProperties = attributeItem.Properties.Add(AttributeFullName, attributeItem.DisplayText);
+            using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(attributeItems.Length + 1, out var builder);
+            builder.AddRange(attributeItems);
+            builder.Add(new KeyValuePair<string, string>(AttributeFullName, attributeItem.DisplayText));
 
             var sortTextBuilder = PooledStringBuilder.GetInstance();
             sortTextBuilder.Builder.AppendFormat(GetSortTextFormatString(attributeItem.InlineDescription), attributeNameWithoutSuffix, attributeItem.InlineDescription);
 
-            var item = CompletionItem.Create(
+            var item = CompletionItem.CreateInternal(
                  displayText: attributeNameWithoutSuffix,
                  sortText: sortTextBuilder.ToStringAndFree(),
-                 properties: newProperties,
+                 properties: builder.ToImmutable(),
                  tags: attributeItem.Tags,
                  rules: attributeItem.Rules,
                  displayTextPrefix: attributeItem.DisplayTextPrefix,
@@ -153,11 +158,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static string GetTypeName(CompletionItem item)
         {
-            var typeName = item.Properties.TryGetValue(AttributeFullName, out var attributeFullName)
+            var typeName = item.TryGetProperty(AttributeFullName, out var attributeFullName)
                 ? attributeFullName
                 : item.DisplayText;
 
-            if (item.Properties.TryGetValue(TypeAritySuffixName, out var aritySuffix))
+            if (item.TryGetProperty(TypeAritySuffixName, out var aritySuffix))
             {
                 return typeName + aritySuffix;
             }
@@ -171,16 +176,16 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         private static (ISymbol? symbol, int overloadCount) GetSymbolAndOverloadCount(CompletionItem item, Compilation compilation)
         {
             // If we have SymbolKey data (i.e. this is an extension method item), use it to recover symbol
-            if (item.Properties.TryGetValue(MethodKey, out var methodSymbolKey))
+            if (item.TryGetProperty(MethodKey, out var methodSymbolKey))
             {
                 var methodSymbol = SymbolKey.ResolveString(methodSymbolKey, compilation).GetAnySymbol() as IMethodSymbol;
 
                 if (methodSymbol != null)
                 {
-                    var overloadCount = item.Properties.TryGetValue(OverloadCountKey, out var overloadCountString) && int.TryParse(overloadCountString, out var count) ? count : 0;
+                    var overloadCount = item.TryGetProperty(OverloadCountKey, out var overloadCountString) && int.TryParse(overloadCountString, out var count) ? count : 0;
 
                     // Get reduced extension method symbol for the given receiver type.
-                    if (item.Properties.TryGetValue(ReceiverKey, out var receiverTypeKey))
+                    if (item.TryGetProperty(ReceiverKey, out var receiverTypeKey))
                     {
                         if (SymbolKey.ResolveString(receiverTypeKey, compilation).GetAnySymbol() is ITypeSymbol receiverTypeSymbol)
                         {
@@ -197,13 +202,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             // Otherwise, this is a type item, so we don't have SymbolKey data. But we should still have all 
             // the data to construct its full metadata name
             var containingNamespace = GetContainingNamespace(item);
-            var typeName = item.Properties.TryGetValue(AttributeFullName, out var attributeFullName) ? attributeFullName : item.DisplayText;
+            var typeName = item.TryGetProperty(AttributeFullName, out var attributeFullName) ? attributeFullName : item.DisplayText;
             var fullyQualifiedName = GetFullyQualifiedName(containingNamespace, typeName);
 
             // We choose not to display the number of "type overloads" for simplicity.
             // Otherwise, we need additional logic to track internal and public visible
             // types separately, and cache both completion items.
-            if (item.Properties.TryGetValue(TypeAritySuffixName, out var aritySuffix))
+            if (item.TryGetProperty(TypeAritySuffixName, out var aritySuffix))
             {
                 return (compilation.GetTypeByMetadataName(fullyQualifiedName + aritySuffix), 0);
             }
@@ -211,8 +216,17 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return (compilation.GetTypeByMetadataName(fullyQualifiedName), 0);
         }
 
-        public static CompletionItem MarkItemToAlwaysFullyQualify(CompletionItem item) => item.WithProperties(item.Properties.Add(AlwaysFullyQualifyKey, AlwaysFullyQualifyKey));
+        public static CompletionItem MarkItemToAlwaysFullyQualify(CompletionItem item)
+        {
+            var itemProperties = item.GetProperties();
 
-        public static bool ShouldAlwaysFullyQualify(CompletionItem item) => item.Properties.ContainsKey(AlwaysFullyQualifyKey);
+            using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(itemProperties.Length + 1, out var builder);
+            builder.AddRange(itemProperties);
+            builder.Add(new KeyValuePair<string, string>(AlwaysFullyQualifyKey, AlwaysFullyQualifyKey));
+
+            return item.WithProperties(builder.ToImmutable());
+        }
+
+        public static bool ShouldAlwaysFullyQualify(CompletionItem item) => item.TryGetProperty(AlwaysFullyQualifyKey, out var _);
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/MemberInsertingCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/MemberInsertingCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,10 +23,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             int descriptionPosition,
             CompletionItemRules rules)
         {
-            var props = ImmutableDictionary<string, string>.Empty
-                .Add("Line", line.ToString())
-                .Add("Modifiers", modifiers.ToString())
-                .Add("TokenSpanEnd", token.Span.End.ToString());
+            var props = ImmutableArray.Create(
+                new KeyValuePair<string, string>("Line", line.ToString()),
+                new KeyValuePair<string, string>("Modifiers", modifiers.ToString()),
+                new KeyValuePair<string, string>("TokenSpanEnd", token.Span.End.ToString()));
 
             return SymbolCompletionItem.CreateWithSymbolId(
                 displayText: displayText,
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static DeclarationModifiers GetModifiers(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("Modifiers", out var text) &&
+            if (item.TryGetProperty("Modifiers", out var text) &&
                 DeclarationModifiers.TryParse(text, out var modifiers))
             {
                 return modifiers;
@@ -53,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static int GetLine(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("Line", out var text)
+            if (item.TryGetProperty("Line", out var text)
                 && int.TryParse(text, out var number))
             {
                 return number;
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static int GetTokenSpanEnd(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("TokenSpanEnd", out var text)
+            if (item.TryGetProperty("TokenSpanEnd", out var text)
                 && int.TryParse(text, out var number))
             {
                 return number;

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
             string inlineDescription,
             ImmutableArray<string> additionalFilterTexts)
         {
-            var props = ImmutableDictionary<string, string>.Empty
-                .Add("Position", position.ToString())
-                .Add(SnippetIdentifierKey, snippetIdentifier);
+            var props = ImmutableArray.Create(
+                new KeyValuePair<string, string>("Position", position.ToString()),
+                new KeyValuePair<string, string>(SnippetIdentifierKey, snippetIdentifier));
 
             return CommonCompletionItem.Create(
                 displayText: displayText,
@@ -44,20 +44,20 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
 
         public static string GetSnippetIdentifier(CompletionItem item)
         {
-            Contract.ThrowIfFalse(item.Properties.TryGetValue(SnippetIdentifierKey, out var text));
+            Contract.ThrowIfFalse(item.TryGetProperty(SnippetIdentifierKey, out var text));
             return text;
         }
 
         public static int GetInvocationPosition(CompletionItem item)
         {
-            Contract.ThrowIfFalse(item.Properties.TryGetValue("Position", out var text));
+            Contract.ThrowIfFalse(item.TryGetProperty("Position", out var text));
             Contract.ThrowIfFalse(int.TryParse(text, out var num));
             return num;
         }
 
         public static bool IsSnippet(CompletionItem item)
         {
-            return item.Properties.TryGetValue(SnippetIdentifierKey, out var _);
+            return item.TryGetProperty(SnippetIdentifierKey, out var _);
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
     {
         private const string InsertionTextProperty = "InsertionText";
 
-        private static readonly Action<IReadOnlyList<ISymbol>, ImmutableDictionary<string, string>.Builder> s_addSymbolEncoding = AddSymbolEncoding;
-        private static readonly Action<IReadOnlyList<ISymbol>, ImmutableDictionary<string, string>.Builder> s_addSymbolInfo = AddSymbolInfo;
+        private static readonly Action<IReadOnlyList<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> s_addSymbolEncoding = AddSymbolEncoding;
+        private static readonly Action<IReadOnlyList<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> s_addSymbolInfo = AddSymbolInfo;
         private static readonly char[] s_projectSeperators = new[] { ';' };
 
         private static CompletionItem CreateWorker(
@@ -30,26 +30,29 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             IReadOnlyList<ISymbol> symbols,
             CompletionItemRules rules,
             int contextPosition,
-            Action<IReadOnlyList<ISymbol>, ImmutableDictionary<string, string>.Builder> symbolEncoder,
+            Action<IReadOnlyList<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> symbolEncoder,
             string? sortText = null,
             string? insertionText = null,
             string? filterText = null,
             SupportedPlatformData? supportedPlatforms = null,
-            ImmutableDictionary<string, string>? properties = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
             ImmutableArray<string> tags = default,
             string? displayTextPrefix = null,
             string? inlineDescription = null,
             Glyph? glyph = null,
             bool isComplexTextEdit = false)
         {
-            var builder = properties != null ? properties.ToBuilder() : ImmutableDictionary<string, string>.Empty.ToBuilder();
+            using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var builder);
+
+            if (!properties.IsDefault)
+                builder.AddRange(properties);
 
             if (insertionText != null)
             {
-                builder.Add(InsertionTextProperty, insertionText);
+                builder.Add(new KeyValuePair<string, string>(InsertionTextProperty, insertionText));
             }
 
-            builder.Add("ContextPosition", contextPosition.ToString());
+            builder.Add(new KeyValuePair<string, string>("ContextPosition", contextPosition.ToString()));
             AddSupportedPlatforms(builder, supportedPlatforms);
             symbolEncoder(symbols, builder);
 
@@ -71,18 +74,18 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return item;
         }
 
-        private static void AddSymbolEncoding(IReadOnlyList<ISymbol> symbols, ImmutableDictionary<string, string>.Builder properties)
-            => properties.Add("Symbols", EncodeSymbols(symbols));
+        private static void AddSymbolEncoding(IReadOnlyList<ISymbol> symbols, ArrayBuilder<KeyValuePair<string, string>> properties)
+            => properties.Add(new KeyValuePair<string, string>("Symbols", EncodeSymbols(symbols)));
 
-        private static void AddSymbolInfo(IReadOnlyList<ISymbol> symbols, ImmutableDictionary<string, string>.Builder properties)
+        private static void AddSymbolInfo(IReadOnlyList<ISymbol> symbols, ArrayBuilder<KeyValuePair<string, string>> properties)
         {
             var symbol = symbols[0];
             var isGeneric = symbol.GetArity() > 0;
-            properties.Add("SymbolKind", ((int)symbol.Kind).ToString());
-            properties.Add("SymbolName", symbol.Name);
+            properties.Add(new KeyValuePair<string, string>("SymbolKind", ((int)symbol.Kind).ToString()));
+            properties.Add(new KeyValuePair<string, string>("SymbolName", symbol.Name));
 
             if (isGeneric)
-                properties.Add("IsGeneric", isGeneric.ToString());
+                properties.Add(new KeyValuePair<string, string>("IsGeneric", isGeneric.ToString()));
         }
 
         public static CompletionItem AddShouldProvideParenthesisCompletion(CompletionItem item)
@@ -90,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static bool GetShouldProvideParenthesisCompletion(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("ShouldProvideParenthesisCompletion", out _))
+            if (item.TryGetProperty("ShouldProvideParenthesisCompletion", out _))
             {
                 return true;
             }
@@ -118,13 +121,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             => SymbolKey.CreateString(symbol);
 
         public static bool HasSymbols(CompletionItem item)
-            => item.Properties.ContainsKey("Symbols");
+            => item.TryGetProperty("Symbols", out var _);
 
         private static readonly char[] s_symbolSplitters = new[] { '|' };
 
         public static async Task<ImmutableArray<ISymbol>> GetSymbolsAsync(CompletionItem item, Document document, CancellationToken cancellationToken)
         {
-            if (item.Properties.TryGetValue("Symbols", out var symbolIds))
+            if (item.TryGetProperty("Symbols", out var symbolIds))
             {
                 var idList = symbolIds.Split(s_symbolSplitters, StringSplitOptions.RemoveEmptyEntries).ToList();
                 using var _ = ArrayBuilder<ISymbol>.GetInstance(out var symbols);
@@ -213,19 +216,19 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return document;
         }
 
-        private static void AddSupportedPlatforms(ImmutableDictionary<string, string>.Builder properties, SupportedPlatformData? supportedPlatforms)
+        private static void AddSupportedPlatforms(ArrayBuilder<KeyValuePair<string, string>> properties, SupportedPlatformData? supportedPlatforms)
         {
             if (supportedPlatforms != null)
             {
-                properties.Add("InvalidProjects", string.Join(";", supportedPlatforms.InvalidProjects.Select(id => id.Id)));
-                properties.Add("CandidateProjects", string.Join(";", supportedPlatforms.CandidateProjects.Select(id => id.Id)));
+                properties.Add(new KeyValuePair<string, string>("InvalidProjects", string.Join(";", supportedPlatforms.InvalidProjects.Select(id => id.Id))));
+                properties.Add(new KeyValuePair<string, string>("CandidateProjects", string.Join(";", supportedPlatforms.CandidateProjects.Select(id => id.Id))));
             }
         }
 
         public static SupportedPlatformData? GetSupportedPlatforms(CompletionItem item, Solution solution)
         {
-            if (item.Properties.TryGetValue("InvalidProjects", out var invalidProjects)
-                && item.Properties.TryGetValue("CandidateProjects", out var candidateProjects))
+            if (item.TryGetProperty("InvalidProjects", out var invalidProjects)
+                && item.TryGetProperty("CandidateProjects", out var candidateProjects))
             {
                 return new SupportedPlatformData(
                     solution,
@@ -238,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static int GetContextPosition(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("ContextPosition", out var text) &&
+            if (item.TryGetProperty("ContextPosition", out var text) &&
                 int.TryParse(text, out var number))
             {
                 return number;
@@ -253,10 +256,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             => GetContextPosition(item);
 
         public static string GetInsertionText(CompletionItem item)
-            => item.Properties[InsertionTextProperty];
+            => item.GetProperty(InsertionTextProperty);
 
         public static bool TryGetInsertionText(CompletionItem item, [NotNullWhen(true)] out string? insertionText)
-            => item.Properties.TryGetValue(InsertionTextProperty, out insertionText);
+            => item.TryGetProperty(InsertionTextProperty, out insertionText);
 
         // COMPAT OVERLOAD: This is used by IntelliCode.
         public static CompletionItem CreateWithSymbolId(
@@ -285,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 inlineDescription: null,
                 glyph: null,
                 supportedPlatforms,
-                properties,
+                properties.AsImmutableOrNull(),
                 tags,
                 isComplexTextEdit);
         }
@@ -303,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             string? inlineDescription = null,
             Glyph? glyph = null,
             SupportedPlatformData? supportedPlatforms = null,
-            ImmutableDictionary<string, string>? properties = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
             ImmutableArray<string> tags = default,
             bool isComplexTextEdit = false)
         {
@@ -327,7 +330,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             string? inlineDescription = null,
             Glyph? glyph = null,
             SupportedPlatformData? supportedPlatforms = null,
-            ImmutableDictionary<string, string>? properties = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
             ImmutableArray<string> tags = default,
             bool isComplexTextEdit = false)
         {
@@ -339,13 +342,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         internal static string? GetSymbolName(CompletionItem item)
-            => item.Properties.TryGetValue("SymbolName", out var name) ? name : null;
+            => item.TryGetProperty("SymbolName", out var name) ? name : null;
 
         internal static SymbolKind? GetKind(CompletionItem item)
-            => item.Properties.TryGetValue("SymbolKind", out var kind) ? (SymbolKind?)int.Parse(kind) : null;
+            => item.TryGetProperty("SymbolKind", out var kind) ? (SymbolKind?)int.Parse(kind) : null;
 
         internal static bool GetSymbolIsGeneric(CompletionItem item)
-            => item.Properties.TryGetValue("IsGeneric", out var v) && bool.TryParse(v, out var isGeneric) && isGeneric;
+            => item.TryGetProperty("IsGeneric", out var v) && bool.TryParse(v, out var isGeneric) && isGeneric;
 
         public static async Task<CompletionDescription> GetDescriptionAsync(
             CompletionItem item, IReadOnlyList<ISymbol> symbols, Document document, SemanticModel semanticModel, SymbolDescriptionOptions options, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Completion/Providers/XmlDocCommentCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/XmlDocCommentCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
@@ -13,9 +14,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static CompletionItem Create(string displayText, string beforeCaretText, string afterCaretText, CompletionItemRules rules)
         {
-            var props = ImmutableDictionary<string, string>.Empty
-                .Add(BeforeCaretText, beforeCaretText)
-                .Add(AfterCaretText, afterCaretText);
+            var props = ImmutableArray.Create(
+                new KeyValuePair<string, string>(BeforeCaretText, beforeCaretText),
+                new KeyValuePair<string, string>(AfterCaretText, afterCaretText));
 
             // Set isComplexTextEdit to be always true for simplicity, even
             // though we don't always need to make change outside the default
@@ -32,9 +33,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         public static string GetBeforeCaretText(CompletionItem item)
-            => item.Properties[BeforeCaretText];
+            => item.GetProperty(BeforeCaretText);
 
         public static string? GetAfterCaretText(CompletionItem item)
-            => item.Properties[AfterCaretText];
+            => item.GetProperty(AfterCaretText);
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
 
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
-            using var _ = ArrayBuilder<DateAndTimeItem>.GetInstance(out var items);
+            using var _1 = ArrayBuilder<DateAndTimeItem>.GetInstance(out var items);
 
             var embeddedContext = new EmbeddedCompletionContext(text, context, virtualChars, items);
 
@@ -102,20 +103,22 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
             if (items.Count == 0)
                 return;
 
+            using var _2 = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var properties);
             foreach (var embeddedItem in items)
             {
+                properties.Clear();
+
                 var textChange = embeddedItem.Change.TextChange;
 
-                var properties = ImmutableDictionary.CreateBuilder<string, string>();
-                properties.Add(StartKey, textChange.Span.Start.ToString());
-                properties.Add(LengthKey, textChange.Span.Length.ToString());
-                properties.Add(NewTextKey, textChange.NewText!);
-                properties.Add(DescriptionKey, embeddedItem.FullDescription);
-                properties.Add(AbstractAggregateEmbeddedLanguageCompletionProvider.EmbeddedProviderName, Name);
+                properties.Add(new(StartKey, textChange.Span.Start.ToString()));
+                properties.Add(new(LengthKey, textChange.Span.Length.ToString()));
+                properties.Add(new(NewTextKey, textChange.NewText!));
+                properties.Add(new(DescriptionKey, embeddedItem.FullDescription));
+                properties.Add(new(AbstractAggregateEmbeddedLanguageCompletionProvider.EmbeddedProviderName, Name));
 
                 // Keep everything sorted in the order we just produced the items in.
                 var sortText = context.Items.Count.ToString("0000");
-                context.AddItem(CompletionItem.Create(
+                context.AddItem(CompletionItem.CreateInternal(
                     displayText: embeddedItem.DisplayText,
                     inlineDescription: embeddedItem.InlineDescription,
                     sortText: sortText,
@@ -212,9 +215,9 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
         public override Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey, CancellationToken cancellationToken)
         {
             // These values have always been added by us.
-            var startString = item.Properties[StartKey];
-            var lengthString = item.Properties[LengthKey];
-            var newText = item.Properties[NewTextKey];
+            var startString = item.GetProperty(StartKey);
+            var lengthString = item.GetProperty(LengthKey);
+            var newText = item.GetProperty(NewTextKey);
 
             Contract.ThrowIfNull(startString);
             Contract.ThrowIfNull(lengthString);
@@ -226,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
 
         public override Task<CompletionDescription?> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
         {
-            if (!item.Properties.TryGetValue(DescriptionKey, out var description))
+            if (!item.TryGetProperty(DescriptionKey, out var description))
                 return SpecializedTasks.Null<CompletionDescription>();
 
             return Task.FromResult((CompletionDescription?)CompletionDescription.Create(

--- a/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
             ImmutableDictionary<string, string>? properties = null,
             ImmutableArray<string> tags = default,
             string? inlineDescription = null)
-            => CommonCompletionItem.Create(displayText, displayTextSuffix, rules, (Glyph?)glyph, description, sortText, filterText, showsWarningIcon, properties, tags, inlineDescription);
+            => CommonCompletionItem.Create(displayText, displayTextSuffix, rules, (Glyph?)glyph, description, sortText, filterText, showsWarningIcon, properties.AsImmutableOrNull(), tags, inlineDescription);
 
         public static CompletionItem CreateSymbolCompletionItem(
             string displayText,
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
             ImmutableDictionary<string, string>? properties = null,
             ImmutableArray<string> tags = default)
             => SymbolCompletionItem.CreateWithSymbolId(displayText, displayTextSuffix: null, symbols, rules, contextPosition, sortText, insertionText,
-                filterText, displayTextPrefix: null, inlineDescription: null, glyph: null, supportedPlatforms, properties, tags);
+                filterText, displayTextPrefix: null, inlineDescription: null, glyph: null, supportedPlatforms, properties.AsImmutableOrNull(), tags);
 
         public static ImmutableArray<SymbolDisplayPart> CreateRecommendedKeywordDisplayParts(string keyword, string toolTip)
             => RecommendedKeyword.CreateDisplayParts(keyword, toolTip);

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -89,7 +89,7 @@ internal sealed class LanguageServerProjectSystem
     {
         using (await _gate.DisposableWaitAsync())
         {
-            _logger.LogInformation($"Loading {solutionFilePath}...");
+            _logger.LogInformation(string.Format(LanguageServerResources.Loading_0, solutionFilePath));
             _workspaceFactory.ProjectSystemProjectFactory.SolutionPath = solutionFilePath;
 
             // We'll load solutions out-of-proc, since it's possible we might be running on a runtime that doesn't have a matching SDK installed,
@@ -176,7 +176,7 @@ internal sealed class LanguageServerProjectSystem
         }
         finally
         {
-            _logger.LogInformation($"Completed (re)load of all projects in {stopwatch.Elapsed}");
+            _logger.LogInformation(string.Format(LanguageServerResources.Completed_reload_of_all_projects_in_0, stopwatch.Elapsed));
         }
     }
 
@@ -234,7 +234,7 @@ internal sealed class LanguageServerProjectSystem
 
                     if (existingProject != null)
                     {
-                        projectFileInfos[loadedProjectInfo] = await existingProject.UpdateWithNewProjectInfoAsync(loadedProjectInfo);
+                        projectFileInfos[loadedProjectInfo] = await existingProject.UpdateWithNewProjectInfoAsync(loadedProjectInfo, _logger);
                     }
                     else
                     {
@@ -251,7 +251,7 @@ internal sealed class LanguageServerProjectSystem
                         loadedProject.NeedsReload += (_, _) => _projectsToLoadAndReload.AddWork(projectToLoad);
                         existingProjects.Add(loadedProject);
 
-                        projectFileInfos[loadedProjectInfo] = await loadedProject.UpdateWithNewProjectInfoAsync(loadedProjectInfo);
+                        projectFileInfos[loadedProjectInfo] = await loadedProject.UpdateWithNewProjectInfoAsync(loadedProjectInfo, _logger);
                     }
                 }
 
@@ -260,7 +260,7 @@ internal sealed class LanguageServerProjectSystem
                 var errorLevel = LogDiagnostics(projectPath, diagnosticLogItems);
                 if (errorLevel == null)
                 {
-                    _logger.LogInformation($"Successfully completed load of {projectToLoad}");
+                    _logger.LogInformation(string.Format(LanguageServerResources.Successfully_completed_load_of_0, projectPath));
                 }
 
                 return (errorLevel, preferredBuildHostKind);
@@ -270,7 +270,7 @@ internal sealed class LanguageServerProjectSystem
         }
         catch (Exception e)
         {
-            _logger.LogError(e, $"Exception thrown while loading {projectToLoad.Path}");
+            _logger.LogError(e, string.Format(LanguageServerResources.Exception_thrown_while_loading_0, projectToLoad.Path));
             return (LSP.MessageType.Error, preferredBuildHostKind);
         }
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DebugConfiguration;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
@@ -75,7 +76,7 @@ internal sealed class LoadedProject : IDisposable
         _projectSystemProject.RemoveFromWorkspace();
     }
 
-    public async ValueTask<(ImmutableArray<CommandLineReference>, OutputKind)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo)
+    public async ValueTask<(ImmutableArray<CommandLineReference>, OutputKind)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, ILogger logger)
     {
         if (_mostRecentFileInfo != null)
         {
@@ -86,13 +87,17 @@ internal sealed class LoadedProject : IDisposable
 
         await using var batch = _projectSystemProject.CreateBatchScope();
 
-        var projectDisplayName = Path.GetFileNameWithoutExtension(newProjectInfo.FilePath);
+        var projectDisplayName = Path.GetFileNameWithoutExtension(newProjectInfo.FilePath)!;
+        var projectFullPathWithTargetFramework = newProjectInfo.FilePath;
 
         if (newProjectInfo.TargetFramework != null)
         {
-            projectDisplayName += " (" + newProjectInfo.TargetFramework + ")";
+            var targetFrameworkSuffix = " (" + newProjectInfo.TargetFramework + ")";
+            projectDisplayName += targetFrameworkSuffix;
+            projectFullPathWithTargetFramework += targetFrameworkSuffix;
         }
 
+        _projectSystemProject.DisplayName = projectDisplayName;
         _projectSystemProject.OutputFilePath = newProjectInfo.OutputFilePath;
         _projectSystemProject.OutputRefFilePath = newProjectInfo.OutputRefFilePath;
 
@@ -102,57 +107,80 @@ internal sealed class LoadedProject : IDisposable
         }
 
         _optionsProcessor.SetCommandLine(newProjectInfo.CommandLineArgs);
+        var commandLineArguments = _optionsProcessor.GetParsedCommandLineArguments();
 
         UpdateProjectSystemProjectCollection(
             newProjectInfo.Documents,
             _mostRecentFileInfo?.Documents,
             DocumentFileInfoComparer.Instance,
             document => _projectSystemProject.AddSourceFile(document.FilePath, folders: document.Folders),
-            document => _projectSystemProject.RemoveSourceFile(document.FilePath));
+            document => _projectSystemProject.RemoveSourceFile(document.FilePath),
+            "Project {0} now has {1} source file(s).");
 
-        var metadataReferences = _optionsProcessor.GetParsedCommandLineArguments().MetadataReferences.Distinct();
+        var relativePathResolver = new RelativePathResolver(commandLineArguments.ReferencePaths, commandLineArguments.BaseDirectory);
+        var metadataReferences = commandLineArguments.MetadataReferences.Select(cr =>
+        {
+            // The relative path resolver calls File.Exists() to see if the path doesn't exist; it guarantees that generally the path returned
+            // is to an actual file on disk. And it needs to call File.Exists() in some cases if there are reference paths to have to search. But as a fallback
+            // we'll accept the resolved path since in the common case it's a file that just might not exist on disk yet.
+            var absolutePath =
+                relativePathResolver.ResolvePath(cr.Reference, baseFilePath: null) ??
+                FileUtilities.ResolveRelativePath(cr.Reference, commandLineArguments.BaseDirectory);
+
+            return absolutePath is not null ? new CommandLineReference(absolutePath, cr.Properties) : default;
+        }).Where(static cr => cr.Reference is not null).ToImmutableArray();
 
         UpdateProjectSystemProjectCollection(
             metadataReferences,
             _mostRecentMetadataReferences,
             EqualityComparer<CommandLineReference>.Default, // CommandLineReference already implements equality
             reference => _projectSystemProject.AddMetadataReference(reference.Reference, reference.Properties),
-            reference => _projectSystemProject.RemoveMetadataReference(reference.Reference, reference.Properties));
+            reference => _projectSystemProject.RemoveMetadataReference(reference.Reference, reference.Properties),
+            "Project {0} now has {1} reference(s).");
 
         // Now that we've updated it hold onto the old list of references so we can remove them if there's a later update
         _mostRecentMetadataReferences = metadataReferences;
 
-        var analyzerReferences = _optionsProcessor.GetParsedCommandLineArguments().AnalyzerReferences.Distinct();
+        var analyzerReferences = commandLineArguments.AnalyzerReferences.Select(cr =>
+        {
+            // Note that unlike regular references, we do not resolve these with the relative path resolver that searches reference paths
+            var absolutePath = FileUtilities.ResolveRelativePath(cr.FilePath, commandLineArguments.BaseDirectory);
+            return absolutePath is not null ? new CommandLineAnalyzerReference(absolutePath) : default;
+        }).Where(static cr => cr.FilePath is not null).ToImmutableArray();
 
         UpdateProjectSystemProjectCollection(
             analyzerReferences,
             _mostRecentAnalyzerReferences,
             EqualityComparer<CommandLineAnalyzerReference>.Default, // CommandLineAnalyzerReference already implements equality
             reference => _projectSystemProject.AddAnalyzerReference(reference.FilePath),
-            reference => _projectSystemProject.RemoveAnalyzerReference(reference.FilePath));
+            reference => _projectSystemProject.RemoveAnalyzerReference(reference.FilePath),
+            "Project {0} now has {1} analyzer reference(s).");
 
         _mostRecentAnalyzerReferences = analyzerReferences;
 
         UpdateProjectSystemProjectCollection(
-            newProjectInfo.AdditionalDocuments.Distinct(DocumentFileInfoComparer.Instance), // TODO: figure out why we have duplicates
-            _mostRecentFileInfo?.AdditionalDocuments.Distinct(DocumentFileInfoComparer.Instance),
+            newProjectInfo.AdditionalDocuments,
+            _mostRecentFileInfo?.AdditionalDocuments,
             DocumentFileInfoComparer.Instance,
             document => _projectSystemProject.AddAdditionalFile(document.FilePath),
-            document => _projectSystemProject.RemoveAdditionalFile(document.FilePath));
+            document => _projectSystemProject.RemoveAdditionalFile(document.FilePath),
+            "Project {0} now has {1} additional file(s).");
 
         UpdateProjectSystemProjectCollection(
             newProjectInfo.AnalyzerConfigDocuments,
             _mostRecentFileInfo?.AnalyzerConfigDocuments,
             DocumentFileInfoComparer.Instance,
             document => _projectSystemProject.AddAnalyzerConfigFile(document.FilePath),
-            document => _projectSystemProject.RemoveAnalyzerConfigFile(document.FilePath));
+            document => _projectSystemProject.RemoveAnalyzerConfigFile(document.FilePath),
+            "Project {0} now has {1} analyzer config file(s).");
 
         UpdateProjectSystemProjectCollection(
-            newProjectInfo.AdditionalDocuments.Where(TreatAsIsDynamicFile).Distinct(DocumentFileInfoComparer.Instance), // TODO: figure out why we have duplicates
-            _mostRecentFileInfo?.AdditionalDocuments.Where(TreatAsIsDynamicFile).Distinct(DocumentFileInfoComparer.Instance),
+            newProjectInfo.AdditionalDocuments.Where(TreatAsIsDynamicFile),
+            _mostRecentFileInfo?.AdditionalDocuments.Where(TreatAsIsDynamicFile),
             DocumentFileInfoComparer.Instance,
             document => _projectSystemProject.AddDynamicSourceFile(document.FilePath, folders: ImmutableArray<string>.Empty),
-            document => _projectSystemProject.RemoveDynamicSourceFile(document.FilePath));
+            document => _projectSystemProject.RemoveDynamicSourceFile(document.FilePath),
+            "Project {0} now has {1} dynamic file(s).");
 
         _mostRecentFileInfo = newProjectInfo;
 
@@ -160,9 +188,12 @@ internal sealed class LoadedProject : IDisposable
         var outputKind = _projectSystemProject.CompilationOptions.OutputKind;
         return (metadataReferences, outputKind);
 
-        static void UpdateProjectSystemProjectCollection<T>(IEnumerable<T> loadedCollection, IEnumerable<T>? oldLoadedCollection, IEqualityComparer<T> comparer, Action<T> addItem, Action<T> removeItem)
+        // logMessage should be a string with two placeholders; the first is the project name, the second is the number of items.
+        void UpdateProjectSystemProjectCollection<T>(IEnumerable<T> loadedCollection, IEnumerable<T>? oldLoadedCollection, IEqualityComparer<T> comparer, Action<T> addItem, Action<T> removeItem, string logMessage)
         {
+            var newItems = new HashSet<T>(loadedCollection, comparer);
             var oldItems = new HashSet<T>(comparer);
+            var oldItemsCount = oldItems.Count;
 
             if (oldLoadedCollection != null)
             {
@@ -170,7 +201,7 @@ internal sealed class LoadedProject : IDisposable
                     oldItems.Add(item);
             }
 
-            foreach (var newItem in loadedCollection)
+            foreach (var newItem in newItems)
             {
                 // If oldItems already has this, we don't need to add it again. We'll remove it, and what is left in oldItems is stuff to remove
                 if (!oldItems.Remove(newItem))
@@ -181,6 +212,9 @@ internal sealed class LoadedProject : IDisposable
             {
                 removeItem(oldItem);
             }
+
+            if (newItems.Count != oldItemsCount)
+                logger.LogTrace(logMessage, projectFullPathWithTargetFramework, newItems.Count);
         }
     }
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/WorkspaceProjectFactoryService.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/WorkspaceProjectFactoryService.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote.ProjectSystem;
+using Microsoft.Extensions.Logging;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 
@@ -19,13 +20,15 @@ internal class WorkspaceProjectFactoryService : IWorkspaceProjectFactoryService,
 {
     private readonly LanguageServerWorkspaceFactory _workspaceFactory;
     private readonly ProjectInitializationHandler _projectInitializationHandler;
+    private readonly ILogger _logger;
 
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public WorkspaceProjectFactoryService(LanguageServerWorkspaceFactory workspaceFactory, ProjectInitializationHandler projectInitializationHandler)
+    public WorkspaceProjectFactoryService(LanguageServerWorkspaceFactory workspaceFactory, ProjectInitializationHandler projectInitializationHandler, ILoggerFactory loggerFactory)
     {
         _workspaceFactory = workspaceFactory;
         _projectInitializationHandler = projectInitializationHandler;
+        _logger = loggerFactory.CreateLogger(nameof(WorkspaceProjectFactoryService));
     }
 
     ServiceRpcDescriptor IExportedBrokeredService.Descriptor => WorkspaceProjectFactoryServiceDescriptor.ServiceDescriptor;
@@ -37,6 +40,8 @@ internal class WorkspaceProjectFactoryService : IWorkspaceProjectFactoryService,
 
     public async Task<IWorkspaceProject> CreateAndAddProjectAsync(WorkspaceProjectCreationInfo creationInfo, CancellationToken _)
     {
+        _logger.LogInformation(string.Format(LanguageServerResources.Project_0_loaded_by_CSharp_Dev_Kit, creationInfo.FilePath));
+
         if (creationInfo.BuildSystemProperties.TryGetValue("SolutionPath", out var solutionPath))
         {
             _workspaceFactory.ProjectSystemProjectFactory.SolutionPath = solutionPath;

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -132,6 +132,10 @@
   <data name="Client_failed_to_attach_the_debugger" xml:space="preserve">
     <value>Client failed to attach the debugger</value>
   </data>
+  <data name="Completed_reload_of_all_projects_in_0" xml:space="preserve">
+    <value>Completed (re)load of all projects in {0}</value>
+    <comment>The placeholder is a time duration like 00:15</comment>
+  </data>
   <data name="Debugger_attached" xml:space="preserve">
     <value>Debugger attached</value>
   </data>
@@ -140,6 +144,9 @@
   </data>
   <data name="Discovering_tests" xml:space="preserve">
     <value>Discovering tests...</value>
+  </data>
+  <data name="Exception_thrown_while_loading_0" xml:space="preserve">
+    <value>Exception thrown while loading {0}</value>
   </data>
   <data name="Failed" xml:space="preserve">
     <value>Failed!</value>
@@ -152,6 +159,10 @@
   </data>
   <data name="Found_0_tests_in_1" xml:space="preserve">
     <value>Found {0} tests in {1}</value>
+  </data>
+  <data name="Loading_0" xml:space="preserve">
+    <value>Loading {0}...</value>
+    <comment>The placeholder is a name of a file</comment>
   </data>
   <data name="Message" xml:space="preserve">
     <value>Message</value>
@@ -167,6 +178,10 @@
   </data>
   <data name="Projects_failed_to_load_because_MSBuild_could_not_be_found" xml:space="preserve">
     <value>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</value>
+  </data>
+  <data name="Project_0_loaded_by_CSharp_Dev_Kit" xml:space="preserve">
+    <value>Project {0} loaded by C# Dev Kit</value>
+    <comment>The placeholder is a name of a file</comment>
   </data>
   <data name="Running_tests" xml:space="preserve">
     <value>Running tests...</value>
@@ -185,6 +200,9 @@
   </data>
   <data name="Starting_test_run" xml:space="preserve">
     <value>Starting test run</value>
+  </data>
+  <data name="Successfully_completed_load_of_0" xml:space="preserve">
+    <value>Successfully completed load of {0}</value>
   </data>
   <data name="Summary" xml:space="preserve">
     <value>Summary</value>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Klientovi se nepodařilo připojit ladicí program.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Připojený ladicí program</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">V {1} se našly {0} testy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Zpráva</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Spouští se testovací běh.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Fehler beim Anfügen des Debuggers durch den Client.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Debugger angefügt</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">In {1} wurden {0} Tests gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Meldung</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Testlauf wird gestartet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">El cliente no pudo asociar el depurador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Depurador asociado</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">Se encontraron pruebas {0} en {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Mensaje</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Iniciando serie de pruebas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Le client n’a pas pu attacher le débogueur</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Débogueur attaché</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">Tests {0} trouvés dans {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Message</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Démarrage de la série de tests</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Il client non è riuscito a collegare il debugger</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Debugger collegato</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">Sono stati trovati test {0} in {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Messaggio</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Avvio dell'esecuzione dei test</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">クライアントはデバッガーをアタッチできませんでした</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">デバッガーがアタッチされました</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">{1} で {0} テストが見つかりました</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">メッセージ</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">テストの実行を開始しています</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">클라이언트가 디버거를 연결하지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">디버거가 연결됨</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">{1} {0} 테스트를 찾았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">메시지</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">테스트 실행을 시작하는 중</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Klient nie może dołączyć debugera</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Dołączono debuger</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">Znaleziono testy {0} w {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Komunikat</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Rozpoczynanie przebiegu testu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Falha do cliente ao anexar o depurador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Depurador anexado</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">Testes {0} encontrados em {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Mensagem</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Iniciando execução de teste</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Клиенту не удалось подключить отладчик</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Отладчик подключен</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">Обнаружены {0} тестов в {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Сообщение</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Запуск тестового запуска</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">İstemci hata ayıklayıcıyı ekleyemedi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">Hata ayıklayıcı eklendi</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">Bu {0} testler {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">İleti</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">Test çalıştırması başlatılıyor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">客户端未能附加调试器</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">已附加调试程序</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">在 {1} 中找到 {0} 个测试</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">消息</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">正在启动测试运行</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">用戶端無法附加偵錯工具</target>
         <note />
       </trans-unit>
+      <trans-unit id="Completed_reload_of_all_projects_in_0">
+        <source>Completed (re)load of all projects in {0}</source>
+        <target state="new">Completed (re)load of all projects in {0}</target>
+        <note>The placeholder is a time duration like 00:15</note>
+      </trans-unit>
       <trans-unit id="Debugger_attached">
         <source>Debugger attached</source>
         <target state="translated">已附加偵錯工具</target>
@@ -40,6 +45,11 @@
       <trans-unit id="Discovering_tests">
         <source>Discovering tests...</source>
         <target state="new">Discovering tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_thrown_while_loading_0">
+        <source>Exception thrown while loading {0}</source>
+        <target state="new">Exception thrown while loading {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Failed">
@@ -62,6 +72,11 @@
         <target state="translated">在 {1} 中找到 {0} 測試</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loading_0">
+        <source>Loading {0}...</source>
+        <target state="new">Loading {0}...</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">訊息</target>
@@ -76,6 +91,11 @@
         <source>Passed!</source>
         <target state="new">Passed!</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
+        <source>Project {0} loaded by C# Dev Kit</source>
+        <target state="new">Project {0} loaded by C# Dev Kit</target>
+        <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Projects_failed_to_load_because_MSBuild_could_not_be_found">
         <source>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</source>
@@ -115,6 +135,11 @@
       <trans-unit id="Starting_test_run">
         <source>Starting test run</source>
         <target state="translated">正在開始測試回合</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Successfully_completed_load_of_0">
+        <source>Successfully completed load of {0}</source>
+        <target state="new">Successfully completed load of {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Summary">

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -223,7 +223,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
         End Function
 
         Protected Overrides Function GetQueryClauseInfo(
-                model As SemanticModel,
+                semanticModel As SemanticModel,
                 node As SyntaxNode,
                 cancellationToken As CancellationToken) As ITypeSymbol
 
@@ -232,8 +232,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
             If query Is Nothing Then
                 query = node.GetAncestor(Of QueryExpressionSyntax)()
             End If
-
-            Dim semanticModel = DirectCast(model, SemanticModel)
 
             For Each clause In query.Clauses
                 If TypeOf clause Is AggregateClauseSyntax Then

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
@@ -319,7 +319,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         Protected Overrides Function GetInsertionText(item As CompletionItem, ch As Char) As String
             If ch = "("c Then
                 Dim insertionText As String = Nothing
-                If item.Properties.TryGetValue(InsertionTextOnOpenParen, insertionText) Then
+                If item.TryGetProperty(InsertionTextOnOpenParen, insertionText) Then
                     Return insertionText
                 End If
             End If

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.vb
@@ -65,15 +65,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return (displayText, "", insertionText)
         End Function
 
-        Protected Overrides Function GetProperties(symbol As INamedTypeSymbol, context As VisualBasicSyntaxContext) As ImmutableDictionary(Of String, String)
-            Return ImmutableDictionary(Of String, String).Empty.Add(
-                InsertionTextOnOpenParen, symbol.Name.EscapeIdentifier())
+        Protected Overrides Function GetProperties(symbol As INamedTypeSymbol, context As VisualBasicSyntaxContext) As ImmutableArray(Of KeyValuePair(Of String, String))
+            Return ImmutableArray.Create(
+                New KeyValuePair(Of String, String)(InsertionTextOnOpenParen, symbol.Name.EscapeIdentifier()))
         End Function
 
         Public Overrides Async Function GetTextChangeAsync(document As Document, selectedItem As CompletionItem, ch As Char?, cancellationToken As CancellationToken) As Task(Of TextChange?)
             If ch = "("c Then
                 Dim insertionText As String = Nothing
-                If selectedItem.Properties.TryGetValue(InsertionTextOnOpenParen, insertionText) Then
+                If selectedItem.TryGetProperty(InsertionTextOnOpenParen, insertionText) Then
                     Return New TextChange(selectedItem.Span, insertionText)
                 End If
             End If

--- a/src/Features/VisualBasic/Portable/GenerateMember/GenerateVariable/VisualBasicGenerateVariableService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateMember/GenerateVariable/VisualBasicGenerateVariableService.vb
@@ -90,7 +90,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateVariable
                 simpleNameOrMemberAccessExpression = identifierName
             End If
 
-            Dim semanticModel = DirectCast(document.SemanticModel, SemanticModel)
+            Dim semanticModel = document.SemanticModel
             If Not IsLegal(semanticModel, simpleNameOrMemberAccessExpression, cancellationToken) AndAlso
                Not simpleNameOrMemberAccessExpression.Parent.IsKind(SyntaxKind.NameOfExpression, SyntaxKind.NamedFieldInitializer) Then
                 identifierToken = Nothing

--- a/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
 
                 if (PathResolver != null)
                 {
-                    string resolvedPath = PathResolver.ResolvePath(reference, baseFilePath);
+                    string? resolvedPath = PathResolver.ResolvePath(reference, baseFilePath);
                     if (resolvedPath != null)
                     {
                         return ImmutableArray.Create(_fileReferenceProvider(resolvedPath, properties));

--- a/src/Scripting/Core/ScriptMetadataResolver.cs
+++ b/src/Scripting/Core/ScriptMetadataResolver.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         private readonly RuntimeMetadataReferenceResolver _resolver;
 
         public ImmutableArray<string> SearchPaths => _resolver.PathResolver.SearchPaths;
-        public string BaseDirectory => _resolver.PathResolver.BaseDirectory;
+        public string? BaseDirectory => _resolver.PathResolver.BaseDirectory;
 
         internal ScriptMetadataResolver(RuntimeMetadataReferenceResolver resolver)
         {

--- a/src/Tools/ExternalAccess/FSharp/Completion/FSharpCommonCompletionItem.cs
+++ b/src/Tools/ExternalAccess/FSharp/Completion/FSharpCommonCompletionItem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
         {
             var roslynGlyph = glyph.HasValue ? FSharpGlyphHelpers.ConvertTo(glyph.Value) : (Glyph?)null;
             return CommonCompletionItem.Create(
-                displayText, displayTextSuffix, rules, roslynGlyph, description, sortText, filterText, showsWarningIcon, properties, tags, inlineDescription);
+                displayText, displayTextSuffix, rules, roslynGlyph, description, sortText, filterText, showsWarningIcon, properties.AsImmutableOrNull(), tags, inlineDescription);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractIntegrationTest.cs
@@ -30,6 +30,8 @@ namespace Roslyn.VisualStudio.IntegrationTests
 
             await TestServices.StateReset.ResetGlobalOptionsAsync(HangMitigatingCancellationToken);
             await TestServices.StateReset.ResetHostSettingsAsync(HangMitigatingCancellationToken);
+
+            await TestServices.Workarounds.WaitForGitHubCoPilotAsync(HangMitigatingCancellationToken);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkaroundsInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkaroundsInProcess.cs
@@ -2,10 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Extensibility.Testing;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 {
@@ -37,6 +42,40 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 
             // Wait for operations dispatched to the main thread without other tracking
             await WaitForApplicationIdleAsync(cancellationToken);
+        }
+
+        private static bool s_gitHubCopilotWorkaroundApplied = false;
+
+        /// <summary>
+        /// GitHub Copilot opens it's output window and steals focus randomly after a file is open. This forces that to happen sooner.
+        /// </summary>
+        public async Task WaitForGitHubCoPilotAsync(CancellationToken cancellationToken)
+        {
+            if (s_gitHubCopilotWorkaroundApplied)
+                return;
+
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var shell = await TestServices.Shell.GetRequiredGlobalServiceAsync<SVsShell, IVsShell>(cancellationToken);
+            var packageGuid = new Guid("{22818076-b98c-4525-b959-c9e12ff2433c}");
+
+            if (ErrorHandler.Succeeded(shell.IsPackageInstalled(packageGuid, out var fInstalled)) && fInstalled != 0)
+            {
+                shell.LoadPackage(packageGuid, out _);
+
+                var tempFile = Path.Combine(Path.GetTempPath(), "GitHubCopilotWorkaround.txt");
+                File.WriteAllText(tempFile, "");
+                VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, tempFile, VSConstants.LOGVIEWID.Code_guid, out _, out _, out var windowFrame, out _);
+
+                await Task.Delay(TimeSpan.FromSeconds(10));
+
+                windowFrame.CloseFrame(grfSaveOptions: 0);
+
+                // Opening a file implicitly created a "solution" so close it so other tests don't care
+                await TestServices.SolutionExplorer.CloseSolutionAsync(cancellationToken);
+
+                s_gitHubCopilotWorkaroundApplied = true;
+            }
         }
     }
 }

--- a/src/Workspaces/Core/MSBuild.BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Build/ProjectBuildManager.cs
@@ -103,7 +103,20 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
                 // path explicitly is necessary so that the reserved properties like $(MSBuildProjectDirectory) will work.
                 xml.FullPath = path;
 
-                var project = new MSB.Evaluation.Project(xml, globalProperties: null, toolsVersion: null, projectCollection);
+                // Roughly matches the VS project load settings for their design time builds.
+                var projectLoadSettings = MSB.Evaluation.ProjectLoadSettings.RejectCircularImports
+                    | MSB.Evaluation.ProjectLoadSettings.IgnoreEmptyImports
+                    | MSB.Evaluation.ProjectLoadSettings.IgnoreMissingImports
+                    | MSB.Evaluation.ProjectLoadSettings.IgnoreInvalidImports
+                    | MSB.Evaluation.ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition
+                    | MSB.Evaluation.ProjectLoadSettings.FailOnUnresolvedSdk;
+
+                var project = new MSB.Evaluation.Project(
+                    xml,
+                    globalProperties: null,
+                    toolsVersion: null,
+                    projectCollection,
+                    projectLoadSettings);
 
                 return (project, log);
             }

--- a/src/Workspaces/Core/MSBuild.BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Build/ProjectBuildManager.cs
@@ -123,7 +123,10 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             }
             else
             {
-                var projectCollection = new MSB.Evaluation.ProjectCollection(AllGlobalProperties);
+                var projectCollection = new MSB.Evaluation.ProjectCollection(
+                    AllGlobalProperties,
+                    _msbuildLogger != null ? ImmutableArray.Create(_msbuildLogger) : ImmutableArray<MSB.Framework.ILogger>.Empty,
+                    MSB.Evaluation.ToolsetDefinitionLocations.Default);
                 try
                 {
                     return LoadProjectAsync(path, projectCollection, cancellationToken);
@@ -158,18 +161,27 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
 
             globalProperties ??= ImmutableDictionary<string, string>.Empty;
             var allProperties = s_defaultGlobalProperties.RemoveRange(globalProperties.Keys).AddRange(globalProperties);
-            _batchBuildProjectCollection = new MSB.Evaluation.ProjectCollection(allProperties);
+
             _batchBuildLogger = new MSBuildDiagnosticLogger()
             {
                 Verbosity = MSB.Framework.LoggerVerbosity.Normal
             };
 
+            // Pass in the binlog (if any) to the ProjectCollection to ensure evaluation results are included in it.
+            //
+            // We do not need to include the _batchBuildLogger in the ProjectCollection - it just collects the
+            // DiagnosticLog from the build steps, but evaluation already separately reports the DiagnosticLog.
+            var loggers = _msbuildLogger is not null
+                ? ImmutableArray.Create(_msbuildLogger)
+                : ImmutableArray<MSB.Framework.ILogger>.Empty;
+
+            _batchBuildProjectCollection = new MSB.Evaluation.ProjectCollection(allProperties, loggers, MSB.Evaluation.ToolsetDefinitionLocations.Default);
+
             var buildParameters = new MSB.Execution.BuildParameters(_batchBuildProjectCollection)
             {
-                Loggers = _msbuildLogger is null
-                    ? (new MSB.Framework.ILogger[] { _batchBuildLogger })
-                    : (new MSB.Framework.ILogger[] { _batchBuildLogger, _msbuildLogger }),
-
+                // The loggers are not inherited from the project collection, so specify both the
+                // binlog logger and the _batchBuildLogger for the build steps.
+                Loggers = loggers.Add(_batchBuildLogger),
                 // If we have an additional logger and it's diagnostic, then we need to opt into task inputs globally, or otherwise
                 // it won't get any log events. This logic matches https://github.com/dotnet/msbuild/blob/fa6710d2720dcf1230a732a8858ffe71bcdbe110/src/Build/Instance/ProjectInstance.cs#L2365-L2371
                 LogTaskInputs = _msbuildLogger is not null && _msbuildLogger.Verbosity == LoggerVerbosity.Diagnostic

--- a/src/Workspaces/MSBuildTest/NetCoreTests.cs
+++ b/src/Workspaces/MSBuildTest/NetCoreTests.cs
@@ -6,9 +6,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.MSBuild.Build;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.UnitTests;
 using Microsoft.CodeAnalysis.UnitTests.TestFiles;
@@ -494,6 +497,66 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
                 var projectRefId = projectReference.ProjectId;
                 Assert.Equal(projectRefFilePath, project.Solution.GetProject(projectRefId).FilePath);
             }
+        }
+
+        [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]
+        [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [Trait(Traits.Feature, Traits.Features.NetCore)]
+        public async Task TestOpenProject_LogsEvaluationAndBuild()
+        {
+            CreateFiles(GetNetCoreAppFiles());
+
+            var projectFilePath = GetSolutionFileName("Project.csproj");
+
+            DotNetRestore("Project.csproj");
+
+            using var workspace = CreateMSBuildWorkspace();
+
+            var loader = workspace.Services
+                .GetLanguageServices(LanguageNames.CSharp)
+                .GetRequiredService<IProjectFileLoader>();
+
+            var logger = new TestMSBuildLogger();
+            var buildManager = new ProjectBuildManager(ImmutableDictionary<string, string>.Empty, logger);
+            buildManager.StartBatchBuild();
+
+            var projectFile = await loader.LoadProjectFileAsync(projectFilePath, buildManager, CancellationToken.None);
+            var projectFileInfo = (await projectFile.GetProjectFileInfosAsync(CancellationToken.None)).Single();
+            buildManager.EndBatchBuild();
+
+            Assert.True(logger.WasInitialized);
+            var logLines = logger.GetLogLines();
+            Assert.StartsWith("Build started", logLines.First());
+            Assert.StartsWith("Evaluation started", logLines[1]);
+            Assert.Single(logLines.Where(line => line.StartsWith("Evaluation finished")));
+            Assert.StartsWith("Build succeeded", logLines.Last());
+        }
+
+        [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]
+        [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [Trait(Traits.Feature, Traits.Features.NetCore)]
+        public async Task TestOpenProject_LogsEvaluationOnly()
+        {
+            CreateFiles(GetNetCoreAppFiles());
+
+            var projectFilePath = GetSolutionFileName("Project.csproj");
+
+            DotNetRestore("Project.csproj");
+
+            using var workspace = CreateMSBuildWorkspace();
+
+            var loader = workspace.Services
+                .GetLanguageServices(LanguageNames.CSharp)
+                .GetRequiredService<IProjectFileLoader>();
+
+            var logger = new TestMSBuildLogger();
+            var buildManager = new ProjectBuildManager(ImmutableDictionary<string, string>.Empty, logger);
+            var projectFile = await loader.LoadProjectFileAsync(projectFilePath, buildManager, CancellationToken.None);
+
+            Assert.True(logger.WasInitialized);
+            var logLines = logger.GetLogLines();
+            Assert.StartsWith("Evaluation started", logLines.First());
+            Assert.StartsWith("Evaluation finished", logLines.Last());
         }
     }
 }

--- a/src/Workspaces/MSBuildTest/Utilities/TestMSBuildLogger.cs
+++ b/src/Workspaces/MSBuildTest/Utilities/TestMSBuildLogger.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Roslyn.Utilities;
+internal class TestMSBuildLogger : ILogger
+{
+    public LoggerVerbosity Verbosity { get; set; }
+    public string Parameters { get; set; } = string.Empty;
+
+    public bool WasInitialized = false;
+
+    private readonly List<string> _logLines = new List<string>();
+
+    public void Initialize(IEventSource eventSource)
+    {
+        WasInitialized = true;
+        eventSource.AnyEventRaised += EventSource_AnyEventRaised;
+    }
+
+    public void Shutdown()
+    {
+    }
+
+    public List<string> GetLogLines()
+    {
+        Contract.ThrowIfFalse(WasInitialized);
+        return _logLines;
+    }
+
+    private void EventSource_AnyEventRaised(object sender, BuildEventArgs e)
+    {
+        _logLines.Add(e.Message);
+    }
+}

--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
@@ -2989,7 +2989,7 @@ class C { }";
             var diagnostic = Assert.Single(workspace.Diagnostics);
             Assert.StartsWith("Msbuild failed", diagnostic.Message);
 
-            Assert.Empty(proj.DocumentIds);
+            Assert.Equal(2, proj.DocumentIds.Count);
         }
 
         [ConditionalFact(typeof(IsEnglishLocal), typeof(VisualStudioMSBuildInstalled))]
@@ -3007,7 +3007,7 @@ class C { }";
             Assert.StartsWith("Msbuild failed", diagnostic.Message);
 
             var project = Assert.Single(solution.Projects);
-            Assert.Empty(project.DocumentIds);
+            Assert.Equal(2, project.DocumentIds.Count);
         }
 
         [ConditionalFact(typeof(IsEnglishLocal), typeof(VisualStudioMSBuildInstalled))]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.cs
@@ -124,6 +124,13 @@ namespace Roslyn.Utilities
                 result.Add(new string(_concatenatedLowerCaseWords, characterSpan.Start, characterSpan.Length));
             }
 
+            // The GetEditDistance call above serves two purposes:
+            // 1) To determine whether currentNode should be added to the result (handled above)
+            // 2) To determine whether children need to be searched (handled below)
+            //
+            // If there are no edges, we don't need the information to determine case 2. So, as a
+            // performance optimization, in that case we send in a threshold to GetEditDistance
+            // that indicates only the work necessary to determine case 1 need be performed.
             if (edgesExist)
             {
                 var min = editDistance - threshold;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SemanticFacts/VisualBasicSemanticFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SemanticFacts/VisualBasicSemanticFacts.vb
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function GetAliasNameSet(model As SemanticModel, cancellationToken As CancellationToken) As ImmutableHashSet(Of String) Implements ISemanticFacts.GetAliasNameSet
-            Dim original = DirectCast(model.GetOriginalSemanticModel(), SemanticModel)
+            Dim original = model.GetOriginalSemanticModel()
 
             If Not original.SyntaxTree.HasCompilationUnitRoot Then
                 Return ImmutableHashSet.Create(Of String)()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/INamespaceOrTypeSymbolExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/INamespaceOrTypeSymbolExtensions.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return Nothing
             End If
 
-            Dim originalSemanticModel = DirectCast(semanticModel.GetOriginalSemanticModel(), SemanticModel)
+            Dim originalSemanticModel = semanticModel.GetOriginalSemanticModel()
             If Not originalSemanticModel.SyntaxTree.HasCompilationUnitRoot Then
                 Return Nothing
             End If

--- a/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
 
             Private ReadOnly _createAliasSet As Func(Of ImmutableHashSet(Of String)) =
                 Function()
-                    Dim model = DirectCast(Me._semanticModel.GetOriginalSemanticModel(), SemanticModel)
+                    Dim model = Me._semanticModel.GetOriginalSemanticModel()
 
                     ' root should be already available
                     If Not model.SyntaxTree.HasCompilationUnitRoot Then

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -1036,7 +1036,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
 
             Dim isInNamespaceOrTypeContext = SyntaxFacts.IsInNamespaceOrTypeContext(TryCast(syntax, ExpressionSyntax))
             Dim position = nodeToSpeculate.SpanStart
-            Return SpeculationAnalyzer.CreateSpeculativeSemanticModelForNode(nodeToSpeculate, DirectCast(originalSemanticModel, SemanticModel), position, isInNamespaceOrTypeContext)
+            Return SpeculationAnalyzer.CreateSpeculativeSemanticModelForNode(nodeToSpeculate, originalSemanticModel, position, isInNamespaceOrTypeContext)
         End Function
 
 #End Region

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.AbstractReductionRewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.AbstractReductionRewriter.vb
@@ -172,7 +172,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             End Function
 
             Public Function VisitNodeOrToken(nodeOrToken As SyntaxNodeOrToken, semanticModel As SemanticModel, simplifyAllDescendants As Boolean) As SyntaxNodeOrToken Implements IReductionRewriter.VisitNodeOrToken
-                _semanticModel = DirectCast(semanticModel, SemanticModel)
+                _semanticModel = semanticModel
                 _alwaysSimplify = simplifyAllDescendants
                 _hasMoreWork = False
                 _processedParentNodes.Clear()


### PR DESCRIPTION
GetEditDistance has various optimizations that are used when a threshold is passed in that weren't being allowed to execute when called from BKTree.Lookup as it needed the precise edit distance. However, this method only needs the precise edit distance if it has edges to later inspect.

I tested this out locally adding stopwatch calls in Lookup with both the old and new code and saw a 25-30% reduction in overall time spent in Lookup with this change.