### PR TITLE
Ensure errors are reported when compiler is unable to emit a required attribute.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    _lazyIsSecurityAttribute = false.ToThreeState();
+                    _lazyIsSecurityAttribute = ThreeState.False;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -45,6 +45,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         [MemberNotNullWhen(true, nameof(AttributeClass), nameof(AttributeConstructor))]
         internal abstract override bool HasErrors { get; }
 
+        internal abstract DiagnosticInfo? ErrorInfo { get; }
+
         internal abstract override bool IsConditionallyOmitted { get; }
 
         /// <summary>
@@ -99,8 +101,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (_lazyIsSecurityAttribute == ThreeState.Unknown)
             {
-                Debug.Assert(!this.HasErrors);
-
                 // CLI spec (Partition II Metadata), section 21.11 "DeclSecurity : 0x0E" states:
                 // SPEC:    If the attribute's type is derived (directly or indirectly) from System.Security.Permissions.SecurityAttribute then
                 // SPEC:    it is a security custom attribute and requires special treatment.
@@ -110,12 +110,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // NOTE:    We will follow the specification.
                 // NOTE:    See Devdiv Bug #13762 "Custom security attributes deriving from SecurityAttribute are not treated as security attributes" for details.
 
-                // Well-known type SecurityAttribute is optional.
-                // Native compiler doesn't generate a use-site error if it is not found, we do the same.
-                var wellKnownType = compilation.GetWellKnownType(WellKnownType.System_Security_Permissions_SecurityAttribute);
-                Debug.Assert(AttributeClass is object);
-                var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-                _lazyIsSecurityAttribute = AttributeClass.IsDerivedFrom(wellKnownType, TypeCompareKind.ConsiderEverything, useSiteInfo: ref discardedUseSiteInfo).ToThreeState();
+                if (AttributeClass is object)
+                {
+                    // Well-known type SecurityAttribute is optional.
+                    // Native compiler doesn't generate a use-site error if it is not found, we do the same.
+                    var wellKnownType = compilation.GetWellKnownType(WellKnownType.System_Security_Permissions_SecurityAttribute);
+                    var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+                    _lazyIsSecurityAttribute = AttributeClass.IsDerivedFrom(wellKnownType, TypeCompareKind.ConsiderEverything, useSiteInfo: ref discardedUseSiteInfo).ToThreeState();
+                }
+                else
+                {
+                    _lazyIsSecurityAttribute = false.ToThreeState();
+                }
             }
 
             return _lazyIsSecurityAttribute.Value();
@@ -667,11 +673,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal bool ShouldEmitAttribute(Symbol target, bool isReturnType, bool emittingAssemblyAttributesInNetModule)
         {
             Debug.Assert(target is SourceAssemblySymbol || target.ContainingAssembly is SourceAssemblySymbol);
-
-            if (HasErrors)
-            {
-                throw ExceptionUtilities.Unreachable();
-            }
 
             // Attribute type is conditionally omitted if both the following are true:
             //  (a) It has at least one applied/inherited conditional attribute AND

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/PEAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/PEAttributeData.cs
@@ -171,6 +171,41 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        internal override DiagnosticInfo? ErrorInfo
+        {
+            get
+            {
+                if (HasErrors)
+                {
+                    switch (AttributeConstructor)
+                    {
+                        case { HasUseSiteError: true } attributeConstructor:
+                            return attributeConstructor.GetUseSiteInfo().DiagnosticInfo;
+
+                        case { }:
+                            return new CSDiagnosticInfo(ErrorCode.ERR_BogusType, string.Empty);
+
+                        default:
+                            switch (AttributeClass)
+                            {
+                                case { HasUseSiteError: true } attributeClass:
+                                    return attributeClass.GetUseSiteInfo().DiagnosticInfo;
+
+                                case { } attributeClass:
+                                    return new CSDiagnosticInfo(ErrorCode.ERR_MissingPredefinedMember, attributeClass, WellKnownMemberNames.InstanceConstructorName);
+
+                                default:
+                                    return new CSDiagnosticInfo(ErrorCode.ERR_BogusType, string.Empty);
+                            }
+                    }
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
         internal override bool IsConditionallyOmitted => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/RetargetingAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/RetargetingAttributeData.cs
@@ -15,19 +15,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
     internal sealed class RetargetingAttributeData : CSharpAttributeData
     {
         private readonly CSharpAttributeData _underlying;
-        private readonly NamedTypeSymbol _attributeClass;
+        private readonly NamedTypeSymbol? _attributeClass;
         private readonly MethodSymbol? _attributeConstructor;
         private readonly ImmutableArray<TypedConstant> _constructorArguments;
         private readonly ImmutableArray<KeyValuePair<string, TypedConstant>> _namedArguments;
 
         internal RetargetingAttributeData(
             CSharpAttributeData underlying,
-            NamedTypeSymbol attributeClass,
+            NamedTypeSymbol? attributeClass,
             MethodSymbol? attributeConstructor,
             ImmutableArray<TypedConstant> constructorArguments,
             ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
         {
             Debug.Assert(underlying is SourceAttributeData or SynthesizedAttributeData);
+            Debug.Assert(attributeClass is object || underlying.HasErrors);
 
             _underlying = underlying;
             _attributeClass = attributeClass;
@@ -36,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             _namedArguments = namedArguments;
         }
 
-        public override NamedTypeSymbol AttributeClass => _attributeClass;
+        public override NamedTypeSymbol? AttributeClass => _attributeClass;
         public override MethodSymbol? AttributeConstructor => _attributeConstructor;
         protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _constructorArguments;
         protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _namedArguments;
@@ -45,6 +46,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
         [MemberNotNullWhen(true, nameof(AttributeClass), nameof(AttributeConstructor))]
         internal override bool HasErrors => _underlying.HasErrors || _attributeConstructor is null;
+
+        internal override DiagnosticInfo? ErrorInfo
+        {
+            get
+            {
+                Debug.Assert(AttributeClass is object || _underlying.HasErrors);
+
+                if (_underlying.HasErrors)
+                {
+                    return _underlying.ErrorInfo;
+                }
+                else if (HasErrors)
+                {
+                    Debug.Assert(AttributeConstructor is null);
+
+                    if (AttributeClass is { HasUseSiteError: true })
+                    {
+                        return AttributeClass.GetUseSiteInfo().DiagnosticInfo;
+                    }
+
+                    return new CSDiagnosticInfo(ErrorCode.ERR_MissingPredefinedMember, AttributeClass, WellKnownMemberNames.InstanceConstructorName);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
 
         internal override bool IsConditionallyOmitted => _underlying.IsConditionallyOmitted;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/SourceAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/SourceAttributeData.cs
@@ -38,6 +38,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool hasErrors,
             bool isConditionallyOmitted)
         {
+            Debug.Assert(compilation is object);
+            Debug.Assert(applicationNode is object);
             Debug.Assert(!isConditionallyOmitted || attributeClass is object && attributeClass.IsConditional);
             Debug.Assert(!constructorArguments.IsDefault);
             Debug.Assert(!namedArguments.IsDefault);
@@ -192,6 +194,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return _hasErrors;
             }
         }
+
+        internal override DiagnosticInfo? ErrorInfo => null; // Binder reported errors
 
         protected internal sealed override ImmutableArray<TypedConstant> CommonConstructorArguments
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -1335,6 +1335,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var totalIndex = i + sourceAttributesCount;
 
                 CSharpAttributeData attribute = attributesFromNetModules[i];
+
+                diagnostics.Add(attribute.ErrorInfo, NoLocation.Singleton);
+
                 if (!attribute.HasErrors && ValidateAttributeUsageForNetModuleAttribute(attribute, netModuleNames[i], diagnostics, ref uniqueAttributes))
                 {
                     arguments.Attribute = attribute;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SynthesizedAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SynthesizedAttributeData.cs
@@ -48,6 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _arguments;
             protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _namedArguments;
             internal override bool HasErrors => false;
+            internal override DiagnosticInfo? ErrorInfo => null;
             internal override bool IsConditionallyOmitted => false;
             internal override Location GetAttributeArgumentLocation(int parameterIndex) => NoLocation.Singleton;
 
@@ -77,6 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             protected internal override ImmutableArray<TypedConstant> CommonConstructorArguments => _original.CommonConstructorArguments;
             protected internal override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _original.CommonNamedArguments;
             internal override bool HasErrors => _original.HasErrors;
+            internal override DiagnosticInfo? ErrorInfo => _original.ErrorInfo;
             internal override bool IsConditionallyOmitted => _original.IsConditionallyOmitted;
 
             internal override Location GetAttributeArgumentLocation(int parameterIndex) => _original.GetAttributeArgumentLocation(parameterIndex);

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -3123,12 +3123,145 @@ class UsePia5 : ITest30
 
             CompileAndVerify(compilation1.AddReferences(dispIdDefinition), symbolValidator: metadataValidator).VerifyDiagnostics();
 
-            CompileAndVerify(compilation1, symbolValidator: metadataValidator).VerifyDiagnostics();
+            compilation1.VerifyEmitDiagnostics(
+                // error CS0012: The type 'DispIdAttribute' is defined in an assembly that is not referenced. You must add a reference to assembly 'DispId, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("System.Runtime.InteropServices.DispIdAttribute", "DispId, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+                );
 
             CompileAndVerify(compilation2.AddReferences(dispIdDefinition), symbolValidator: metadataValidator).VerifyDiagnostics();
 
-            // https://github.com/dotnet/roslyn/issues/70338: Going to start failing after https://github.com/dotnet/roslyn/pull/70151 is merged
-            //CompileAndVerify(compilation2, symbolValidator: metadataValidator).VerifyDiagnostics();
+            compilation2.VerifyEmitDiagnostics(
+                // error CS0012: The type 'DispIdAttribute' is defined in an assembly that is not referenced. You must add a reference to assembly 'DispId, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("System.Runtime.InteropServices.DispIdAttribute", "DispId, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70338")]
+        public void DispIdAttribute_03()
+        {
+            var empty = CreateCompilation("", options: TestOptions.ReleaseDll).EmitToImageReference();
+
+            string pia = @"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: ImportedFromTypeLib(""GeneralPIA.dll"")]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest30
+{
+    [System.Runtime.InteropServices.DispIdAttribute(""124"")]
+    void M1();
+}
+";
+
+            var piaCompilation = CreateCompilation(pia, references: new[] { empty }, options: TestOptions.ReleaseDll, assemblyName: "Pia");
+
+            piaCompilation.VerifyDiagnostics(
+                // (12,53): error CS1503: Argument 1: cannot convert from 'string' to 'int'
+                //     [System.Runtime.InteropServices.DispIdAttribute("124")]
+                Diagnostic(ErrorCode.ERR_BadArgType, @"""124""").WithArguments("1", "string", "int").WithLocation(12, 53)
+                );
+
+            string consumer = @"
+class UsePia
+{
+    public static void Main()
+    {
+    }
+}
+
+class UsePia5 : ITest30
+{
+    public void M1()
+    {
+    }
+} 
+";
+
+            var compilation1 = CreateCompilation(consumer, options: TestOptions.ReleaseExe,
+                references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation, embedInteropTypes: true) });
+
+            System.Action<ModuleSymbol> metadataValidator =
+                delegate (ModuleSymbol module)
+                {
+                    ((PEModuleSymbol)module).Module.PretendThereArentNoPiaLocalTypes();
+
+                    var itest30 = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMembers("ITest30").Single();
+
+                    var m1 = (PEMethodSymbol)itest30.GetMembers("M1").Single();
+
+                    Assert.Empty(m1.GetAttributes());
+                };
+
+            CompileAndVerify(compilation1, symbolValidator: metadataValidator);
+
+            CompileAndVerify(compilation1.AddReferences(empty), symbolValidator: metadataValidator);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70338")]
+        public void DispIdAttribute_04()
+        {
+            string pia = @"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: ImportedFromTypeLib(""GeneralPIA.dll"")]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest30
+{
+    [System.Runtime.InteropServices.DispIdAttribute(124, Something = 10)]
+    void M1();
+}
+";
+
+            var piaCompilation = CreateCompilation(pia, options: TestOptions.ReleaseDll, assemblyName: "Pia");
+
+            piaCompilation.VerifyDiagnostics(
+                // (12,58): error CS0246: The type or namespace name 'Something' could not be found (are you missing a using directive or an assembly reference?)
+                //     [System.Runtime.InteropServices.DispIdAttribute(124, Something = 10)]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Something").WithArguments("Something").WithLocation(12, 58)
+                );
+
+            string consumer = @"
+class UsePia
+{
+    public static void Main()
+    {
+    }
+}
+
+class UsePia5 : ITest30
+{
+    public void M1()
+    {
+    }
+} 
+";
+
+            var compilation1 = CreateCompilation(consumer, options: TestOptions.ReleaseExe,
+                references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation, embedInteropTypes: true) });
+
+            System.Action<ModuleSymbol> metadataValidator =
+                delegate (ModuleSymbol module)
+                {
+                    ((PEModuleSymbol)module).Module.PretendThereArentNoPiaLocalTypes();
+
+                    var itest30 = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMembers("ITest30").Single();
+
+                    var m1 = (PEMethodSymbol)itest30.GetMembers("M1").Single();
+
+                    Assert.Empty(m1.GetAttributes());
+                };
+
+            CompileAndVerify(compilation1, symbolValidator: metadataValidator);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMember.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMember.cs
@@ -69,11 +69,11 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
                 foreach (var attrData in GetCustomAttributesToEmit(moduleBuilder))
                 {
-                    if (TypeManager.IsTargetAttribute(attrData, AttributeDescription.DispIdAttribute))
+                    if (TypeManager.IsTargetAttribute(attrData, AttributeDescription.DispIdAttribute, out int signatureIndex))
                     {
-                        if (attrData.CommonConstructorArguments.Length == 1)
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out var constructorArguments, out var namedArguments, syntaxNodeOpt, diagnostics))
                         {
-                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_DispIdAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_DispIdAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
                     }
                     else

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
@@ -82,11 +82,11 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 // The constructors might be missing (for example, in metadata case) and doing lookup
                 // will ensure that we report appropriate errors.
 
-                if (TypeManager.IsTargetAttribute(attrData, AttributeDescription.LCIDConversionAttribute))
+                if (TypeManager.IsTargetAttribute(attrData, AttributeDescription.LCIDConversionAttribute, out int signatureIndex))
                 {
-                    if (attrData.CommonConstructorArguments.Length == 1)
+                    if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out var constructorArguments, out var namedArguments, syntaxNodeOpt, diagnostics))
                     {
-                        return TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_LCIDConversionAttribute__ctor, attrData, syntaxNodeOpt, diagnostics);
+                        return TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_LCIDConversionAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics);
                     }
                 }
 

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedParameter.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedParameter.cs
@@ -69,9 +69,9 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
             protected abstract ushort Index { get; }
             protected abstract IEnumerable<TAttributeData> GetCustomAttributesToEmit(TPEModuleBuilder moduleBuilder);
 
-            private bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
+            private bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description, out int signatureIndex)
             {
-                return TypeManager.IsTargetAttribute(attrData, description);
+                return TypeManager.IsTargetAttribute(attrData, description, out signatureIndex);
             }
 
             private ImmutableArray<TAttributeData> GetAttributes(TPEModuleBuilder moduleBuilder, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
@@ -86,41 +86,39 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
                 foreach (var attrData in GetCustomAttributesToEmit(moduleBuilder))
                 {
-                    if (IsTargetAttribute(attrData, AttributeDescription.ParamArrayAttribute))
-                    {
-                        if (attrData.CommonConstructorArguments.Length == 0)
-                        {
-                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_ParamArrayAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
-                        }
-                    }
-                    else if (IsTargetAttribute(attrData, AttributeDescription.DateTimeConstantAttribute))
-                    {
-                        if (attrData.CommonConstructorArguments.Length == 1)
-                        {
-                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DateTimeConstantAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
-                        }
-                    }
-                    else
-                    {
-                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(attrData, AttributeDescription.DecimalConstantAttribute);
-                        if (signatureIndex != -1)
-                        {
-                            Debug.Assert(signatureIndex == 0 || signatureIndex == 1);
+                    int signatureIndex;
+                    ImmutableArray<TypedConstant> constructorArguments;
+                    ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments;
 
-                            if (attrData.CommonConstructorArguments.Length == 5)
-                            {
-                                builder.AddOptional(TypeManager.CreateSynthesizedAttribute(
-                                    signatureIndex == 0 ? WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctor :
-                                        WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctorByteByteInt32Int32Int32,
-                                    attrData, syntaxNodeOpt, diagnostics));
-                            }
-                        }
-                        else if (IsTargetAttribute(attrData, AttributeDescription.DefaultParameterValueAttribute))
+                    if (IsTargetAttribute(attrData, AttributeDescription.ParamArrayAttribute, out signatureIndex))
+                    {
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
                         {
-                            if (attrData.CommonConstructorArguments.Length == 1)
-                            {
-                                builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_DefaultParameterValueAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
-                            }
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_ParamArrayAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
+                        }
+                    }
+                    else if (IsTargetAttribute(attrData, AttributeDescription.DateTimeConstantAttribute, out signatureIndex))
+                    {
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
+                        {
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DateTimeConstantAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
+                        }
+                    }
+                    else if (IsTargetAttribute(attrData, AttributeDescription.DecimalConstantAttribute, out signatureIndex))
+                    {
+                        if ((signatureIndex == 0 || signatureIndex == 1) && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
+                        {
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(
+                                signatureIndex == 0 ? WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctor :
+                                    WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctorByteByteInt32Int32Int32,
+                                constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
+                        }
+                    }
+                    else if (IsTargetAttribute(attrData, AttributeDescription.DefaultParameterValueAttribute, out signatureIndex))
+                    {
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
+                        {
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_DefaultParameterValueAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
                     }
                 }

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -80,9 +80,9 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
             protected abstract IEnumerable<TAttributeData> GetCustomAttributesToEmit(TPEModuleBuilder moduleBuilder);
             protected abstract void ReportMissingAttribute(AttributeDescription description, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
 
-            private bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
+            private bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description, out int signatureIndex)
             {
-                return TypeManager.IsTargetAttribute(attrData, description);
+                return TypeManager.IsTargetAttribute(attrData, description, out signatureIndex);
             }
 
             private ImmutableArray<TAttributeData> GetAttributes(TPEModuleBuilder moduleBuilder, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
@@ -104,78 +104,76 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
                 foreach (var attrData in GetCustomAttributesToEmit(moduleBuilder))
                 {
-                    if (IsTargetAttribute(attrData, AttributeDescription.GuidAttribute))
+                    int signatureIndex;
+                    ImmutableArray<TypedConstant> constructorArguments;
+                    ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments;
+
+                    if (IsTargetAttribute(attrData, AttributeDescription.GuidAttribute, out signatureIndex))
                     {
-                        string guidString;
-                        if (attrData.TryGetGuidAttributeValue(out guidString))
+                        if (TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics) && constructorArguments[0].TryGetGuidAttributeValue(out _))
                         {
                             // If this type has a GuidAttribute, we should emit it.
                             hasGuid = true;
-                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_GuidAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_GuidAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
                     }
-                    else if (IsTargetAttribute(attrData, AttributeDescription.ComEventInterfaceAttribute))
+                    else if (IsTargetAttribute(attrData, AttributeDescription.ComEventInterfaceAttribute, out signatureIndex))
                     {
-                        if (attrData.CommonConstructorArguments.Length == 2)
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
                         {
                             hasComEventInterfaceAttribute = true;
-                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_ComEventInterfaceAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_ComEventInterfaceAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
                     }
-                    else
+                    else if (IsTargetAttribute(attrData, AttributeDescription.InterfaceTypeAttribute, out signatureIndex))
                     {
-                        int signatureIndex = TypeManager.GetTargetAttributeSignatureIndex(attrData, AttributeDescription.InterfaceTypeAttribute);
-                        if (signatureIndex != -1)
+                        if ((signatureIndex == 0 || signatureIndex == 1) && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
                         {
-                            Debug.Assert(signatureIndex == 0 || signatureIndex == 1);
-                            if (attrData.CommonConstructorArguments.Length == 1)
-                            {
-                                builder.AddOptional(TypeManager.CreateSynthesizedAttribute(signatureIndex == 0 ? WellKnownMember.System_Runtime_InteropServices_InterfaceTypeAttribute__ctorInt16 :
-                                    WellKnownMember.System_Runtime_InteropServices_InterfaceTypeAttribute__ctorComInterfaceType,
-                                    attrData, syntaxNodeOpt, diagnostics));
-                            }
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(signatureIndex == 0 ? WellKnownMember.System_Runtime_InteropServices_InterfaceTypeAttribute__ctorInt16 :
+                                WellKnownMember.System_Runtime_InteropServices_InterfaceTypeAttribute__ctorComInterfaceType,
+                                constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
-                        else if (IsTargetAttribute(attrData, AttributeDescription.BestFitMappingAttribute))
+                    }
+                    else if (IsTargetAttribute(attrData, AttributeDescription.BestFitMappingAttribute, out signatureIndex))
+                    {
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
                         {
-                            if (attrData.CommonConstructorArguments.Length == 1)
-                            {
-                                builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_BestFitMappingAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
-                            }
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_BestFitMappingAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
-                        else if (IsTargetAttribute(attrData, AttributeDescription.CoClassAttribute))
+                    }
+                    else if (IsTargetAttribute(attrData, AttributeDescription.CoClassAttribute, out signatureIndex))
+                    {
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
                         {
-                            if (attrData.CommonConstructorArguments.Length == 1)
-                            {
-                                builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_CoClassAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
-                            }
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_CoClassAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
-                        else if (IsTargetAttribute(attrData, AttributeDescription.FlagsAttribute))
+                    }
+                    else if (IsTargetAttribute(attrData, AttributeDescription.FlagsAttribute, out signatureIndex))
+                    {
+                        if (UnderlyingNamedType.IsEnum && signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
                         {
-                            if (attrData.CommonConstructorArguments.Length == 0 && UnderlyingNamedType.IsEnum)
-                            {
-                                builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_FlagsAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
-                            }
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_FlagsAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
-                        else if (IsTargetAttribute(attrData, AttributeDescription.DefaultMemberAttribute))
+                    }
+                    else if (IsTargetAttribute(attrData, AttributeDescription.DefaultMemberAttribute, out signatureIndex))
+                    {
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
                         {
-                            if (attrData.CommonConstructorArguments.Length == 1)
-                            {
-                                builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Reflection_DefaultMemberAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Reflection_DefaultMemberAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
 
-                                // Embed members matching default member name.
-                                string defaultMember = attrData.CommonConstructorArguments[0].ValueInternal as string;
-                                if (defaultMember != null)
-                                {
-                                    EmbedDefaultMembers(defaultMember, syntaxNodeOpt, diagnostics);
-                                }
+                            // Embed members matching default member name.
+                            string defaultMember = constructorArguments[0].ValueInternal as string;
+                            if (defaultMember != null)
+                            {
+                                EmbedDefaultMembers(defaultMember, syntaxNodeOpt, diagnostics);
                             }
                         }
-                        else if (IsTargetAttribute(attrData, AttributeDescription.UnmanagedFunctionPointerAttribute))
+                    }
+                    else if (IsTargetAttribute(attrData, AttributeDescription.UnmanagedFunctionPointerAttribute, out signatureIndex))
+                    {
+                        if (signatureIndex == 0 && TypeManager.TryGetAttributeArguments(attrData, out constructorArguments, out namedArguments, syntaxNodeOpt, diagnostics))
                         {
-                            if (attrData.CommonConstructorArguments.Length == 1)
-                            {
-                                builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_UnmanagedFunctionPointerAttribute__ctor, attrData, syntaxNodeOpt, diagnostics));
-                            }
+                            builder.AddOptional(TypeManager.CreateSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_UnmanagedFunctionPointerAttribute__ctor, constructorArguments, namedArguments, syntaxNodeOpt, diagnostics));
                         }
                     }
                 }

--- a/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
         where TModuleCompilationState : CommonModuleCompilationState
         where TEmbeddedTypesManager : EmbeddedTypesManager<TPEModuleBuilder, TModuleCompilationState, TEmbeddedTypesManager, TSyntaxNode, TAttributeData, TSymbol, TAssemblySymbol, TNamedTypeSymbol, TFieldSymbol, TMethodSymbol, TEventSymbol, TPropertySymbol, TParameterSymbol, TTypeParameterSymbol, TEmbeddedType, TEmbeddedField, TEmbeddedMethod, TEmbeddedEvent, TEmbeddedProperty, TEmbeddedParameter, TEmbeddedTypeParameter>
         where TSyntaxNode : SyntaxNode
-        where TAttributeData : AttributeData, Cci.ICustomAttribute
+        where TAttributeData : class, Cci.ICustomAttribute
         where TAssemblySymbol : class
         where TNamedTypeSymbol : class, TSymbol, Cci.INamespaceTypeReference
         where TFieldSymbol : class, TSymbol, Cci.IFieldReference
@@ -150,12 +150,14 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
         internal abstract int GetTargetAttributeSignatureIndex(TAttributeData attrData, AttributeDescription description);
 
-        internal bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description)
+        internal bool IsTargetAttribute(TAttributeData attrData, AttributeDescription description, out int signatureIndex)
         {
-            return GetTargetAttributeSignatureIndex(attrData, description) != -1;
+            signatureIndex = GetTargetAttributeSignatureIndex(attrData, description);
+            return signatureIndex != -1;
         }
 
-        internal abstract TAttributeData CreateSynthesizedAttribute(WellKnownMember constructor, TAttributeData attrData, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
+        internal abstract TAttributeData CreateSynthesizedAttribute(WellKnownMember constructor, ImmutableArray<TypedConstant> constructorArguments, ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
+        internal abstract bool TryGetAttributeArguments(TAttributeData attrData, out ImmutableArray<TypedConstant> constructorArguments, out ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
         internal abstract void ReportIndirectReferencesToLinkedAssemblies(TAssemblySymbol assembly, DiagnosticBag diagnostics);
 
         protected abstract void OnGetTypesCompleted(ImmutableArray<TEmbeddedType> types, DiagnosticBag diagnostics);

--- a/src/Compilers/Core/Portable/Symbols/CommonAttributeDataExtensions.cs
+++ b/src/Compilers/Core/Portable/Symbols/CommonAttributeDataExtensions.cs
@@ -10,13 +10,21 @@ namespace Microsoft.CodeAnalysis
         {
             if (attrData.CommonConstructorArguments.Length == 1)
             {
-                object? value = attrData.CommonConstructorArguments[0].ValueInternal;
+                return attrData.CommonConstructorArguments[0].TryGetGuidAttributeValue(out guidString);
+            }
 
-                if (value == null || value is string)
-                {
-                    guidString = (string?)value;
-                    return true;
-                }
+            guidString = null;
+            return false;
+        }
+
+        public static bool TryGetGuidAttributeValue(this TypedConstant typedConstant, out string? guidString)
+        {
+            object? value = typedConstant.ValueInternal;
+
+            if (value == null || value is string)
+            {
+                guidString = (string?)value;
+                return true;
             }
 
             guidString = null;

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -85,7 +85,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Return attrData.GetTargetAttributeSignatureIndex(description)
         End Function
 
-        Friend Overrides Function CreateSynthesizedAttribute(constructor As WellKnownMember, attrData As VisualBasicAttributeData, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As VisualBasicAttributeData
+        Friend Overrides Function CreateSynthesizedAttribute(constructor As WellKnownMember, constructorArguments As ImmutableArray(Of TypedConstant), namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)), syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As VisualBasicAttributeData
             Dim ctor = GetWellKnownMethod(constructor, syntaxNodeOpt, diagnostics)
             If ctor Is Nothing Then
                 Return Nothing
@@ -97,7 +97,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                     ' the original source interface as both source interface and event provider. Otherwise, we'd have to embed
                     ' the event provider class too.
                     Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor,
-                        ImmutableArray.Create(attrData.CommonConstructorArguments(0), attrData.CommonConstructorArguments(0)),
+                        ImmutableArray.Create(constructorArguments(0), constructorArguments(0)),
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
 
                 Case WellKnownMember.System_Runtime_InteropServices_CoClassAttribute__ctor
@@ -110,9 +110,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
 
                 Case Else
-                    Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor, attrData.CommonConstructorArguments, attrData.CommonNamedArguments)
+                    Return New SynthesizedAttributeData(ModuleBeingBuilt.Compilation, ctor, constructorArguments, namedArguments)
 
             End Select
+        End Function
+
+        Friend Overrides Function TryGetAttributeArguments(attrData As VisualBasicAttributeData, ByRef constructorArguments As ImmutableArray(Of TypedConstant), ByRef namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)), syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As Boolean
+            Dim result As Boolean = Not attrData.HasErrors
+
+            constructorArguments = attrData.CommonConstructorArguments
+            namedArguments = attrData.CommonNamedArguments
+
+            Dim errorInfo As DiagnosticInfo = attrData.ErrorInfo
+            If errorInfo IsNot Nothing Then
+                diagnostics.Add(errorInfo, If(syntaxNodeOpt?.Location, NoLocation.Singleton))
+            End If
+
+            Return result
         End Function
 
         Friend Function GetAssemblyGuidString(assembly As AssemblySymbol) As String

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
@@ -60,6 +60,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend MustOverride Overrides ReadOnly Property HasErrors As Boolean
 
+        Friend MustOverride ReadOnly Property ErrorInfo As DiagnosticInfo
+
         Friend MustOverride Overrides ReadOnly Property IsConditionallyOmitted As Boolean
 
         ''' <summary>
@@ -527,10 +529,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         '''  </summary>
         Friend Function ShouldEmitAttribute(target As Symbol, isReturnType As Boolean, emittingAssemblyAttributesInNetModule As Boolean) As Boolean
             Debug.Assert(TypeOf target Is SourceAssemblySymbol OrElse TypeOf target.ContainingAssembly Is SourceAssemblySymbol)
-
-            If HasErrors Then
-                Throw ExceptionUtilities.Unreachable
-            End If
 
             ' Attribute type is conditionally omitted if both the following are true:
             '  (a) It has at least one applied conditional attribute AND

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/PEAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/PEAttributeData.vb
@@ -194,6 +194,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End Get
         End Property
 
+        Friend Overrides ReadOnly Property ErrorInfo As DiagnosticInfo
+            Get
+                If HasErrors Then
+
+                    If AttributeConstructor IsNot Nothing Then
+                        Return If(AttributeConstructor.GetUseSiteInfo().DiagnosticInfo,
+                                  ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, String.Empty))
+
+                    ElseIf AttributeClass IsNot Nothing Then
+                        Return If(AttributeClass.GetUseSiteInfo().DiagnosticInfo,
+                                  ErrorFactory.ErrorInfo(ERRID.ERR_MissingRuntimeHelper, AttributeClass.MetadataName & "." & WellKnownMemberNames.InstanceConstructorName))
+                    Else
+                        Return ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, String.Empty)
+                    End If
+                Else
+                    Return Nothing
+                End If
+            End Get
+        End Property
+
         Friend Overrides ReadOnly Property IsConditionallyOmitted As Boolean
             Get
                 Return False

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/RetargetingAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/RetargetingAttributeData.vb
@@ -28,6 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                        ByVal constructorArguments As ImmutableArray(Of TypedConstant),
                        ByVal namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)))
             Debug.Assert(TypeOf underlying Is SourceAttributeData OrElse TypeOf underlying Is SynthesizedAttributeData)
+            Debug.Assert(attributeClass IsNot Nothing OrElse underlying.HasErrors)
 
             _underlying = underlying
             Me._attributeClass = attributeClass
@@ -75,6 +76,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         Friend Overrides ReadOnly Property HasErrors As Boolean
             Get
                 Return _underlying.HasErrors OrElse _attributeConstructor Is Nothing
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property ErrorInfo As DiagnosticInfo
+            Get
+                Debug.Assert(AttributeClass IsNot Nothing OrElse _underlying.HasErrors)
+
+                If _underlying.HasErrors Then
+                    Return _underlying.ErrorInfo
+                ElseIf HasErrors Then
+                    Debug.Assert(AttributeConstructor Is Nothing)
+
+                    Return If(AttributeClass.GetUseSiteInfo().DiagnosticInfo,
+                              ErrorFactory.ErrorInfo(ERRID.ERR_MissingRuntimeHelper, AttributeClass.MetadataName & "." & WellKnownMemberNames.InstanceConstructorName))
+                Else
+                    Return Nothing
+                End If
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
@@ -36,6 +36,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                        ByVal namedArgs As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)),
                        ByVal isConditionallyOmitted As Boolean,
                        ByVal hasErrors As Boolean)
+            Debug.Assert(compilation IsNot Nothing)
+            Debug.Assert(applicationNode IsNot Nothing)
             Debug.Assert(attrMethod IsNot Nothing OrElse hasErrors)
 
             Me._compilation = compilation
@@ -102,6 +104,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides ReadOnly Property HasErrors As Boolean
             Get
                 Return _hasErrors
+            End Get
+        End Property
+
+        Friend Overrides ReadOnly Property ErrorInfo As DiagnosticInfo
+            Get
+                Return Nothing ' Binder reports errors
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -341,6 +341,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' That is why we are iterating attributes backwards.
             For i As Integer = netModuleAttributesCount - 1 To 0 Step -1
                 Dim attribute As VisualBasicAttributeData = attributesFromNetModules(i)
+
+                Dim errorInfo As DiagnosticInfo = attribute.ErrorInfo
+                If errorInfo IsNot Nothing Then
+                    diagnostics.Add(errorInfo, NoLocation.Singleton)
+                End If
+
                 If Not attribute.HasErrors AndAlso ValidateAttributeUsageForNetModuleAttribute(attribute, netModuleNames(i), diagnostics, uniqueAttributes) Then
                     arguments.Attribute = attribute
                     arguments.Index = i

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedAttributeData.vb
@@ -108,6 +108,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Friend Overrides ReadOnly Property ErrorInfo As DiagnosticInfo
+            Get
+                Return Nothing
+            End Get
+        End Property
+
         Friend Overrides Function IsTargetAttribute(namespaceName As String, typeName As String, Optional ignoreCase As Boolean = False) As Boolean
             Return SourceAttributeData.IsTargetAttribute(AttributeClass, namespaceName, typeName, ignoreCase)
         End Function

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
@@ -2266,13 +2266,11 @@ End Class
 
         Dim comp2 = CreateCompilation("", references:={moduleWithAttribute}, options:=TestOptions.ReleaseDll)
 
-        CompileAndVerify(comp2, symbolValidator:=Sub(m)
-                                                     Dim attrs = m.ContainingAssembly.GetAttributes()
-                                                     Assert.Equal(3, attrs.Length)
-                                                     AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
-                                                     AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
-                                                     AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
-                                                 End Sub).VerifyDiagnostics()
+        comp2.AssertTheseEmitDiagnostics(
+<expected>
+BC30652: Reference required to assembly 'A1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'A1'. Add one to your project.
+</expected>
+        )
 
         Dim attribute2 =
 <compilation name="A1">
@@ -2290,13 +2288,11 @@ End Class
 
         Dim comp3 = CreateCompilation("", references:={moduleWithAttribute, attributeDefinition2}, options:=TestOptions.ReleaseDll)
 
-        CompileAndVerify(comp3, symbolValidator:=Sub(m)
-                                                     Dim attrs = m.ContainingAssembly.GetAttributes()
-                                                     Assert.Equal(3, attrs.Length)
-                                                     AssertEx.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)", attrs(0).ToString())
-                                                     AssertEx.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows:=True)", attrs(1).ToString())
-                                                     AssertEx.Equal("System.Diagnostics.DebuggableAttribute(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)", attrs(2).ToString())
-                                                 End Sub).VerifyDiagnostics()
+        comp3.AssertTheseEmitDiagnostics(
+<expected>
+BC35000: Requested operation is not available because the runtime library function 'A1..ctor' is not defined.
+</expected>
+        )
     End Sub
 
     <Fact>


### PR DESCRIPTION
Related to #70338.