### PR TITLE
Bump Razor to 7.0.0-preview.23525.7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -84,7 +84,7 @@
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildPackagesVersion)</MicrosoftBuildUtilitiesCoreVersion>
     <NuGetVisualStudioContractsVersion>6.0.0-preview.0.15</NuGetVisualStudioContractsVersion>
     <MicrosoftVisualStudioRpcContractsVersion>17.5.14-alpha</MicrosoftVisualStudioRpcContractsVersion>
-    <MicrosoftAspNetCoreRazorExternalAccessRoslynWorkspaceVersion>8.0.0-preview.23465.2</MicrosoftAspNetCoreRazorExternalAccessRoslynWorkspaceVersion>
+    <MicrosoftAspNetCoreRazorExternalAccessRoslynWorkspaceVersion>7.0.0-preview.23525.7</MicrosoftAspNetCoreRazorExternalAccessRoslynWorkspaceVersion>
     <!--
       Since the Microsoft.CodeAnalysis.Analyzers package is a public dependency of our NuGet
       packages we will keep it untied to the RoslynDiagnosticsNugetPackageVersion we use for


### PR DESCRIPTION
Need to bump razor due to a serialization format change. 

Affects VS Code only.
Yes I know the version number goes backwards. We went to v8 but then had to revert.  Trust me, it's fine. Also, confusingly, we'll be back on v8 [soon enough](https://github.com/dotnet/razor/pull/9303)