### PR TITLE
Workaround issue #70570

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -147,6 +147,10 @@ file_header_template = Licensed to the .NET Foundation under one or more agreeme
 # RS0016: Only enable if API files are present
 dotnet_public_api_analyzer.require_api_files = true
 
+# IDE0055: Fix formatting
+# Workaround for https://github.com/dotnet/roslyn/issues/70570
+dotnet_diagnostic.IDE0055.severity = warning
+
 # CSharp code style settings:
 [*.cs]
 # Newline settings

--- a/eng/config/globalconfigs/Common.globalconfig
+++ b/eng/config/globalconfigs/Common.globalconfig
@@ -10,9 +10,6 @@ dotnet_diagnostic.CA2009.severity = warning
 # CA2012: Use ValueTasks correctly
 dotnet_diagnostic.CA2012.severity = warning
 
-# IDE0055: Fix formatting
-dotnet_diagnostic.IDE0055.severity = warning
-
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning
 


### PR DESCRIPTION
Short term workaround for issue #70570 by moving IDE00555 warning configuration entry from globalconfig to editorconfig. Verified that IDE0055 warnings are now getting reported locally on the repo.