### PR TITLE
Add restore support to the language server

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestorableProjectsHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestorableProjectsHandler.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.DebugConfiguration;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer;
+
+/// <summary>
+/// Handler that allows the client to retrieve a set of restorable projects.
+/// Used to populate a list of projects that can be restored.
+/// </summary>
+[ExportCSharpVisualBasicStatelessLspService(typeof(RestorableProjectsHandler)), Shared]
+[Method(MethodName)]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class RestorableProjectsHandler(ProjectTargetFrameworkManager projectTargetFrameworkManager) : ILspServiceRequestHandler<string[]>
+{
+    internal const string MethodName = "workspace/restorableProjects";
+
+    public bool MutatesSolutionState => false;
+
+    public bool RequiresLSPSolution => true;
+
+    public Task<string[]> HandleRequestAsync(RequestContext context, CancellationToken cancellationToken)
+    {
+        Contract.ThrowIfNull(context.Solution);
+
+        using var _ = ArrayBuilder<string>.GetInstance(out var projectsBuilder);
+        foreach (var project in context.Solution.Projects)
+        {
+            // Restorable projects are dotnet core projects with file paths.
+            if (project.FilePath != null && projectTargetFrameworkManager.IsDotnetCoreProject(project.Id))
+            {
+                projectsBuilder.Add(project.FilePath);
+            }
+        }
+
+        // We may have multiple projects with the same file path in multi-targeting scenarios.
+        // They'll all get restored together so we only want one result per project file.
+        var projects = projectsBuilder.Distinct().ToArray();
+
+        // Ensure the client gets a consistent ordering.
+        Array.Sort(projects, StringComparer.OrdinalIgnoreCase);
+
+        return Task.FromResult(projects.ToArray());
+    }
+}

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreHandler.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+/// <summary>
+/// Given an input project (or none), runs restore on the project and streams the output
+/// back to the client to display.
+/// </summary>
+[ExportCSharpVisualBasicStatelessLspService(typeof(RestoreHandler)), Shared]
+[Method(MethodName)]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class RestoreHandler(DotnetCliHelper dotnetCliHelper) : ILspServiceRequestHandler<RestoreParams, RestorePartialResult[]>
+{
+    internal const string MethodName = "workspace/restore";
+
+    public bool MutatesSolutionState => false;
+
+    public bool RequiresLSPSolution => true;
+
+    public async Task<RestorePartialResult[]> HandleRequestAsync(RestoreParams request, RequestContext context, CancellationToken cancellationToken)
+    {
+        Contract.ThrowIfNull(context.Solution);
+        using var progress = BufferedProgress.Create(request.PartialResultToken);
+
+        progress.Report(new RestorePartialResult(LanguageServerResources.Restore, LanguageServerResources.Restore_started));
+
+        var restorePaths = GetRestorePaths(request, context.Solution, context);
+        if (restorePaths.IsEmpty)
+        {
+            progress.Report(new RestorePartialResult(LanguageServerResources.Restore, LanguageServerResources.Nothing_found_to_restore));
+            return progress.GetValues() ?? [];
+        }
+
+        await RestoreAsync(restorePaths, progress, cancellationToken);
+
+        progress.Report(new RestorePartialResult(LanguageServerResources.Restore, $"{LanguageServerResources.Restore_complete}{Environment.NewLine}"));
+        return progress.GetValues() ?? [];
+    }
+
+    private async Task RestoreAsync(ImmutableArray<string> pathsToRestore, BufferedProgress<RestorePartialResult> progress, CancellationToken cancellationToken)
+    {
+        foreach (var path in pathsToRestore)
+        {
+            var arguments = $"restore \"{path}\"";
+            var workingDirectory = Path.GetDirectoryName(path);
+            var stageName = string.Format(LanguageServerResources.Restoring_0, Path.GetFileName(path));
+            ReportProgress(progress, stageName, string.Format(LanguageServerResources.Running_dotnet_restore_on_0, path));
+
+            var process = dotnetCliHelper.Run(arguments, workingDirectory, shouldLocalizeOutput: true);
+
+            process.OutputDataReceived += (sender, args) => ReportProgress(progress, stageName, args.Data);
+            process.ErrorDataReceived += (sender, args) => ReportProgress(progress, stageName, args.Data);
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            await process.WaitForExitAsync(cancellationToken);
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(LanguageServerResources.Failed_to_run_restore_see_output_for_details);
+            }
+        }
+
+        static void ReportProgress(BufferedProgress<RestorePartialResult> progress, string stage, string? restoreOutput)
+        {
+            if (restoreOutput != null)
+            {
+                progress.Report(new RestorePartialResult(stage, restoreOutput));
+            }
+        }
+    }
+
+    private static ImmutableArray<string> GetRestorePaths(RestoreParams request, Solution solution, RequestContext context)
+    {
+        if (request.ProjectFilePath != null)
+        {
+            return ImmutableArray.Create(request.ProjectFilePath);
+        }
+
+        // No file paths were specified - this means we should restore all projects in the solution.
+        // If there is a valid solution path, use that as the restore path.
+        if (solution.FilePath != null)
+        {
+            return ImmutableArray.Create(solution.FilePath);
+        }
+
+        // We don't have an addressable solution, so lets find all addressable projects.
+        // We can only restore projects with file paths as we are using the dotnet CLI to address them.
+        // We also need to remove duplicates as in multi targeting scenarios there will be multiple projects with the same file path.
+        var projects = solution.Projects
+            .Select(p => p.FilePath)
+            .WhereNotNull()
+            .Distinct()
+            .ToImmutableArray();
+
+        context.TraceInformation($"Found {projects.Length} restorable projects from {solution.Projects.Count()} projects in solution");
+        return projects;
+    }
+}

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreParams.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreParams.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+[DataContract]
+internal record RestoreParams(
+    [property: DataMember(Name = "projectFilePath"), JsonProperty(NullValueHandling = NullValueHandling.Ignore)] string? ProjectFilePath
+) : IPartialResultParams<RestorePartialResult>
+{
+    [DataMember(Name = Methods.PartialResultTokenName)]
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public IProgress<RestorePartialResult>? PartialResultToken { get; set; }
+}

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestorePartialResult.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestorePartialResult.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+[DataContract]
+internal record RestorePartialResult(
+    [property: DataMember(Name = "stage")] string Stage,
+    [property: DataMember(Name = "message")] string Message
+);

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -150,11 +150,17 @@
   <data name="Failed_to_read_runsettings_file_at_0:1" xml:space="preserve">
     <value>Failed to read .runsettings file at {0}:{1}</value>
   </data>
+  <data name="Failed_to_run_restore_see_output_for_details" xml:space="preserve">
+    <value>Failed to run restore, see output for details</value>
+  </data>
   <data name="Found_0_tests_in_1" xml:space="preserve">
     <value>Found {0} tests in {1}</value>
   </data>
   <data name="Message" xml:space="preserve">
     <value>Message</value>
+  </data>
+  <data name="Nothing_found_to_restore" xml:space="preserve">
+    <value>Nothing found to restore</value>
   </data>
   <data name="No_test_methods_found_in_requested_range" xml:space="preserve">
     <value>No test methods found in requested range</value>
@@ -167,6 +173,21 @@
   </data>
   <data name="Projects_failed_to_load_because_MSBuild_could_not_be_found" xml:space="preserve">
     <value>Projects failed to load because the .NET Framework build tools could not be found. Try installing Visual Studio or the Visual Studio Build Tools package, or check the logs for details.</value>
+  </data>
+  <data name="Restore" xml:space="preserve">
+    <value>Restore</value>
+  </data>
+  <data name="Restore_complete" xml:space="preserve">
+    <value>Restore complete</value>
+  </data>
+  <data name="Restore_started" xml:space="preserve">
+    <value>Restore started</value>
+  </data>
+  <data name="Restoring_0" xml:space="preserve">
+    <value>Restoring {0}</value>
+  </data>
+  <data name="Running_dotnet_restore_on_0" xml:space="preserve">
+    <value>Running dotnet restore on {0}</value>
   </data>
   <data name="Running_tests" xml:space="preserve">
     <value>Running tests...</value>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Čtení souboru .runsettings na {0} se nezdařilo:{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">V {1} se našly {0} testy.</target>
@@ -72,6 +77,11 @@
         <target state="translated">V požadovaném rozsahu se nenašly žádné testovací metody.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Fehler beim Lesen der RUNSETTINGS-Datei unter {0}:{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">In {1} wurden {0} Tests gefunden.</target>
@@ -72,6 +77,11 @@
         <target state="translated">Im angeforderten Bereich wurden keine Testmethoden gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">No se pudo leer el archivo .runsettings en {0}:{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">Se encontraron pruebas {0} en {1}</target>
@@ -72,6 +77,11 @@
         <target state="translated">No se encontraron métodos de prueba en el intervalo solicitado</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Échec de la lecture du fichier .runsettings à l'adresse {0} :{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">Tests {0} trouvés dans {1}</target>
@@ -72,6 +77,11 @@
         <target state="translated">Méthodes de test introuvables dans la plage demandée</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Non è stato possibile leggere il file con estensione runsettings in {0}:{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">Sono stati trovati test {0} in {1}</target>
@@ -72,6 +77,11 @@
         <target state="translated">Non sono stati trovati metodi di test nell'intervallo richiesto</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0}:{1} の .runsettings ファイルを読み取れできませんでした</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">{1} で {0} テストが見つかりました</target>
@@ -72,6 +77,11 @@
         <target state="translated">要求された範囲内にテスト メソッドが見つかりません</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0}:{1}에서 .runsettings 파일을 읽지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">{1} {0} 테스트를 찾았습니다.</target>
@@ -72,6 +77,11 @@
         <target state="translated">요청된 범위에서 테스트 메서드를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Nie można odczytać pliku .runsettings w {0}:{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">Znaleziono testy {0} w {1}</target>
@@ -72,6 +77,11 @@
         <target state="translated">Nie znaleziono metod testowych w żądanym zakresie</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Falha ao ler o arquivo .runsettings em {0}:{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">Testes {0} encontrados em {1}</target>
@@ -72,6 +77,11 @@
         <target state="translated">Nenhum método de teste encontrado no intervalo solicitado</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Не удалось прочитать файл RUNSETTINGS в {0}:{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">Обнаружены {0} тестов в {1}</target>
@@ -72,6 +77,11 @@
         <target state="translated">Методы тестирования не найдены в запрашиваемом диапазоне</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Şu konumdaki .runsettings dosyası okunamadı: {0}:{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">Bu {0} testler {1}</target>
@@ -72,6 +77,11 @@
         <target state="translated">İstenen aralıkta test yöntemi bulunamadı</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">无法读取 {0}:{1}的 .runsettings 文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">在 {1} 中找到 {0} 个测试</target>
@@ -72,6 +77,11 @@
         <target state="translated">在请求的范围内找不到测试方法</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">無法讀取位於 {0} 的 .runsettings 檔案: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_run_restore_see_output_for_details">
+        <source>Failed to run restore, see output for details</source>
+        <target state="new">Failed to run restore, see output for details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="translated">在 {1} 中找到 {0} 測試</target>
@@ -72,6 +77,11 @@
         <target state="translated">在要求的範圍內找不到測試方法</target>
         <note />
       </trans-unit>
+      <trans-unit id="Nothing_found_to_restore">
+        <source>Nothing found to restore</source>
+        <target state="new">Nothing found to restore</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Passed">
         <source>Passed!</source>
         <target state="new">Passed!</target>
@@ -85,6 +95,31 @@
       <trans-unit id="Projects_failed_to_load_because_Mono_could_not_be_found">
         <source>Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</source>
         <target state="new">Projects failed to load because the Mono could not be found. Ensure that Mono and MSBuild are installed, and check the logs for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore">
+        <source>Restore</source>
+        <target state="new">Restore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_complete">
+        <source>Restore complete</source>
+        <target state="new">Restore complete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restore_started">
+        <source>Restore started</source>
+        <target state="new">Restore started</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Restoring_0">
+        <source>Restoring {0}</source>
+        <target state="new">Restoring {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_dotnet_restore_on_0">
+        <source>Running dotnet restore on {0}</source>
+        <target state="new">Running dotnet restore on {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_tests">


### PR DESCRIPTION
First part of https://github.com/dotnet/vscode-csharp/issues/5725

Adds support on the server side for
1.  A handler to retrieve the set of possible projects to restore.  This is used to show a project picker for the project to restore on the client side.
2.  A handler to restore a specified project (or all projects).  This is used once a project is picked from 1), or for the restore all command on the client side.

Will be following up with integration tests on the client side.