### PR TITLE
Keep unsplit states when analyzing sequence points and sequences

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -3063,7 +3063,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            VisitRvalue(node.Value);
+            Visit(node.Value);
             return null;
         }
 
@@ -3079,7 +3079,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitSequencePointExpression(BoundSequencePointExpression node)
         {
-            VisitRvalue(node.Expression);
+            Visit(node.Expression);
             return null;
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
@@ -4248,5 +4248,40 @@ class C
 }
 """);
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70200")]
+        public void Repro70200()
+        {
+            var source = """
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    async Task M()
+    {
+        return;
+
+        try
+        {
+            Console.WriteLine(string.Empty);
+        }
+        catch (Exception e1) when (e1.InnerException is Exception { InnerException: { } e2 })
+        {
+            Console.WriteLine(e2.Message);
+        }
+    }
+}
+""";
+
+            CompileAndVerify(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (6,16): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     async Task M()
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(6, 16),
+                // (10,9): warning CS0162: Unreachable code detected
+                //         try
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "try").WithLocation(10, 9)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
@@ -4274,13 +4274,47 @@ class C
 }
 """;
 
-            CompileAndVerify(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (6,16): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     async Task M()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(6, 16),
                 // (10,9): warning CS0162: Unreachable code detected
                 //         try
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "try").WithLocation(10, 9)
+            };
+
+            CompileAndVerify(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            CompileAndVerify(source, options: TestOptions.DebugDll).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70200")]
+        public void Repro70200_WithoutReturn()
+        {
+            var source = """
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    async Task M()
+    {
+        try
+        {
+            Console.WriteLine(string.Empty);
+        }
+        catch (Exception e1) when (e1.InnerException is Exception { InnerException: { } e2 })
+        {
+            Console.WriteLine(e2.Message);
+        }
+    }
+}
+""";
+
+            CompileAndVerify(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (6,16): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     async Task M()
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(6, 16)
                 );
         }
     }


### PR DESCRIPTION
We were hitting an assertion in `MethodToStateMachineRewriter.VisitAssignmentOperator` (line 835) due to an unexpected local for which we didn't assign a proxy. In Release mode, it looks like we generally don't want to pre-allocate proxies (see `ShouldPreallocateNonReusableProxy`), so that explains why we didn't assign a proxy. The question was then whether we really needed to hoist this local. 
The logic that decides which variables to hoist and what proxies to assign is in `IteratorAndAsyncCaptureWalker.Analyze` (in particular `variablesToHoist.AddRange(walker._variablesToHoist)`). I noticed that in Release mode, we don't hoist `e1` in this scenario, so I followed the trail to see why we decided to hoist `e2`.

It turns out that in `VisitCall` we check whether the receiver is assigned (`CheckAssigned`) and if it's not then `CaptureVariable` adds it to `_variablesToHoist`. That's where the problem became apparent: in the body of the `catch` clause, we should consider `e2` assigned.

We did not consider `e2` assigned, because we were losing useful conditional definite assignment information due to calls to `Unsplit()` in `VisitRvalue()` which was used in `VisitSequencePointExpression(...)` and `VisitSequence(...)`.

Fixes https://github.com/dotnet/roslyn/issues/70200
