### PR TITLE
Watch project.assets.json files for nuget restore

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -29,7 +29,7 @@ internal sealed class LoadedProject : IDisposable
     /// The most recent version of the project design time build information; held onto so the next reload we can diff against this.
     /// </summary>
     private ProjectFileInfo? _mostRecentFileInfo;
-    private ProjectAssetsFileWatcher? _mostRecentProjectAssetsFileWatcher;
+    private IWatchedFile? _mostRecentProjectAssetsFileWatcher;
     private ImmutableArray<CommandLineReference> _mostRecentMetadataReferences = ImmutableArray<CommandLineReference>.Empty;
     private ImmutableArray<CommandLineAnalyzerReference> _mostRecentAnalyzerReferences = ImmutableArray<CommandLineAnalyzerReference>.Empty;
 
@@ -222,7 +222,7 @@ internal sealed class LoadedProject : IDisposable
 
         void WatchProjectAssetsFile(ProjectFileInfo currentProjectInfo, IFileChangeContext fileChangeContext)
         {
-            if (_mostRecentProjectAssetsFileWatcher?.WatchedPath == currentProjectInfo.ProjectAssetsFilePath)
+            if (_mostRecentFileInfo?.ProjectAssetsFilePath == currentProjectInfo.ProjectAssetsFilePath)
             {
                 // The file path hasn't changed, just keep using the same watcher.
                 return;
@@ -231,11 +231,10 @@ internal sealed class LoadedProject : IDisposable
             // Dispose of the last once since we're changing the file we're watching.
             _mostRecentProjectAssetsFileWatcher?.Dispose();
 
-            ProjectAssetsFileWatcher? currentWatcher = null;
+            IWatchedFile? currentWatcher = null;
             if (currentProjectInfo.ProjectAssetsFilePath != null)
             {
-                var watcher = fileChangeContext.EnqueueWatchingFile(currentProjectInfo.ProjectAssetsFilePath);
-                currentWatcher = new ProjectAssetsFileWatcher(currentProjectInfo.ProjectAssetsFilePath, watcher);
+                currentWatcher = fileChangeContext.EnqueueWatchingFile(currentProjectInfo.ProjectAssetsFilePath);
             }
 
             _mostRecentProjectAssetsFileWatcher = currentWatcher;
@@ -264,14 +263,6 @@ internal sealed class LoadedProject : IDisposable
         public int GetHashCode(DocumentFileInfo obj)
         {
             return StringComparer.Ordinal.GetHashCode(obj.FilePath);
-        }
-    }
-
-    private record ProjectAssetsFileWatcher(string WatchedPath, IWatchedFile Watcher) : IDisposable
-    {
-        public void Dispose()
-        {
-            Watcher.Dispose();
         }
     }
 }

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/PropertyNames.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/PropertyNames.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string AllowUnsafeBlocks = nameof(AllowUnsafeBlocks);
         public const string AppConfigForCompiler = nameof(AppConfigForCompiler);
         public const string BaseAddress = nameof(BaseAddress);
+        public const string BaseIntermediateOutputPath = nameof(BaseIntermediateOutputPath);
         public const string BuildProjectReferences = nameof(BuildProjectReferences);
         public const string BuildingInsideVisualStudio = nameof(BuildingInsideVisualStudio);
         public const string BuildingProject = nameof(BuildingProject);
@@ -48,6 +49,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string PdbFile = nameof(PdbFile);
         public const string PlatformTarget = nameof(PlatformTarget);
         public const string Prefer32Bit = nameof(Prefer32Bit);
+        public const string ProjectAssetsFile = nameof(ProjectAssetsFile);
         public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
         public const string RemoveIntegerChecks = nameof(RemoveIntegerChecks);
         public const string ResolvedCodeAnalysisRuleSet = nameof(ResolvedCodeAnalysisRuleSet);

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/PropertyNames.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/PropertyNames.cs
@@ -9,7 +9,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string AllowUnsafeBlocks = nameof(AllowUnsafeBlocks);
         public const string AppConfigForCompiler = nameof(AppConfigForCompiler);
         public const string BaseAddress = nameof(BaseAddress);
-        public const string BaseIntermediateOutputPath = nameof(BaseIntermediateOutputPath);
         public const string BuildProjectReferences = nameof(BuildProjectReferences);
         public const string BuildingInsideVisualStudio = nameof(BuildingInsideVisualStudio);
         public const string BuildingProject = nameof(BuildingProject);

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -133,6 +133,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 intermediateOutputFilePath = GetAbsolutePathRelativeToProject(intermediateOutputFilePath);
             }
 
+            var projectAssetsFilePath = project.ReadPropertyString(PropertyNames.ProjectAssetsFile);
+
             // Right now VB doesn't have the concept of "default namespace". But we conjure one in workspace 
             // by assigning the value of the project's root namespace to it. So various feature can choose to 
             // use it for their own purpose.
@@ -174,6 +176,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 defaultNamespace,
                 targetFramework,
                 targetFrameworkIdentifier,
+                projectAssetsFilePath,
                 commandLineArgs,
                 docs,
                 additionalDocs,

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -127,6 +127,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         [DataMember(Order = 16)]
         public bool IsSdkStyle { get; }
 
+        /// <summary>
+        /// The path to the project.assets.json path in obj/.
+        /// </summary>
+        [DataMember(Order = 17)]
+        public string? ProjectAssetsFilePath { get; }
+
         public override string ToString()
             => RoslynString.IsNullOrWhiteSpace(TargetFramework)
                 ? FilePath ?? string.Empty
@@ -142,6 +148,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             string? defaultNamespace,
             string? targetFramework,
             string? targetFrameworkIdentifier,
+            string? projectAssetsFilePath,
             ImmutableArray<string> commandLineArgs,
             ImmutableArray<DocumentFileInfo> documents,
             ImmutableArray<DocumentFileInfo> additionalDocuments,
@@ -162,6 +169,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             this.DefaultNamespace = defaultNamespace;
             this.TargetFramework = targetFramework;
             this.TargetFrameworkIdentifier = targetFrameworkIdentifier;
+            this.ProjectAssetsFilePath = projectAssetsFilePath;
             this.CommandLineArgs = commandLineArgs;
             this.Documents = documents;
             this.AdditionalDocuments = additionalDocuments;
@@ -181,6 +189,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             string? defaultNamespace,
             string? targetFramework,
             string? targetFrameworkIdentifier,
+            string? projectAssetsFilePath,
             ImmutableArray<string> commandLineArgs,
             ImmutableArray<DocumentFileInfo> documents,
             ImmutableArray<DocumentFileInfo> additionalDocuments,
@@ -199,6 +208,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 defaultNamespace,
                 targetFramework,
                 targetFrameworkIdentifier,
+                projectAssetsFilePath,
                 commandLineArgs,
                 documents,
                 additionalDocuments,
@@ -219,6 +229,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 defaultNamespace: null,
                 targetFramework: null,
                 targetFrameworkIdentifier: null,
+                projectAssetsFilePath: null,
                 commandLineArgs: ImmutableArray<string>.Empty,
                 documents: ImmutableArray<DocumentFileInfo>.Empty,
                 additionalDocuments: ImmutableArray<DocumentFileInfo>.Empty,


### PR DESCRIPTION
Previously, we were not reloading the project when a restore happened, until you actually modified a file.  This adds a file watcher for the `project.assets.json` file to tell us if a restore has happened and that the server needs to reload the project.

After:
```
[Trace - 11:15:07 AM] Sending notification 'workspace/didChangeWatchedFiles'.
Params: {
    "changes": [
        {
            "uri": "file:///c:/Users/dabarbet/source/repos/trash/MultipleTestProjects/XunitProject/obj/project.assets.json",
            "type": 1
        }
    ]
}
```