### PR TITLE
Remove Tiered Compilation opt-out from AnalyzerRunner

### DIFF
--- a/src/Tools/AnalyzerRunner/AnalyzerRunner.csproj
+++ b/src/Tools/AnalyzerRunner/AnalyzerRunner.csproj
@@ -9,14 +9,6 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <!--
-      Avoid allocation interference due to a boxing bug which was fixed for .NET 5.
-      https://github.com/dotnet/runtime/issues/1713
-    -->
-    <TieredCompilation>false</TieredCompilation>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawbundle_greenVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />


### PR DESCRIPTION
Digging through source control history, we disabled this against our netcore3.1 builds since it had bugs at the time. We've then been updating the TFM being checked against every time we upgraded TFMs, without ever removing this.

I just noticed this while cleaning up project files for unrelated work.