### PR TITLE
Improve Hover markdown on 'await' keyword

### DIFF
--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -668,7 +668,7 @@ Do you want to continue?</value>
     <value>&lt;Pending&gt;</value>
   </data>
   <data name="Awaited_task_returns_0" xml:space="preserve">
-    <value>Awaited task returns '{0}'</value>
+    <value>Awaited task returns {0}</value>
   </data>
   <data name="Awaited_task_returns_no_value" xml:space="preserve">
     <value>Awaited task returns no value</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -316,8 +316,8 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">Očekávaná úloha vrací {0}.</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">Očekávaná úloha vrací {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -316,8 +316,8 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">Erwartete Aufgabe gibt "{0}" zurück</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">Erwartete Aufgabe gibt "{0}" zurück</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -316,8 +316,8 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">La tarea esperada devuelve "{0}".</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">La tarea esperada devuelve "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -316,8 +316,8 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">La tâche attendue retourne '{0}'</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">La tâche attendue retourne '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -316,8 +316,8 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">L'attività attesa restituisce '{0}'</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">L'attività attesa restituisce '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -316,8 +316,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">待機中のタスクから '{0}' が返されました</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">待機中のタスクから '{0}' が返されました</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -316,8 +316,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">대기된 작업에서 '{0}'이(가) 반환됨</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">대기된 작업에서 '{0}'이(가) 반환됨</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -316,8 +316,8 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">Zadanie, na które oczekiwano, zwraca wartość „{0}”</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">Zadanie, na które oczekiwano, zwraca wartość „{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -316,8 +316,8 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">A tarefa esperada retorna '{0}'</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">A tarefa esperada retorna '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -316,8 +316,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">Ожидаемая задача возвращает "{0}".</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">Ожидаемая задача возвращает "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -316,8 +316,8 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">Beklenen görev '{0}' döndürüyor</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">Beklenen görev '{0}' döndürüyor</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -316,8 +316,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">等待任务返回“{0}”</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">等待任务返回“{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -316,8 +316,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note>{Locked="ConfigureAwait"} "ConfigureAwait" is an api name and should not be localized. {0} is a placeholder for the language specific keyword 'false'.</note>
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
-        <source>Awaited task returns '{0}'</source>
-        <target state="translated">等待的工作會傳回 '{0}'</target>
+        <source>Awaited task returns {0}</source>
+        <target state="needs-review-translation">等待的工作會傳回 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_no_value">

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.MarkdownContentBuilder.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.MarkdownContentBuilder.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.LanguageServer
+{
+    internal static partial class ProtocolConversions
+    {
+        private readonly struct MarkdownContentBuilder : IDisposable
+        {
+            private readonly ArrayBuilder<string> _linesBuilder;
+
+            public MarkdownContentBuilder()
+            {
+                _linesBuilder = ArrayBuilder<string>.GetInstance();
+            }
+
+            public void Append(string text)
+            {
+                if (_linesBuilder.Count == 0)
+                {
+                    _linesBuilder.Add(text);
+                }
+                else
+                {
+                    _linesBuilder[^1] = _linesBuilder[^1] + text;
+                }
+            }
+
+            public void AppendLine(string text = "")
+            {
+                _linesBuilder.Add(text);
+            }
+
+            public bool IsLineEmpty()
+            {
+                return _linesBuilder.Count == 0 ? true : string.IsNullOrEmpty(_linesBuilder[^1]);
+            }
+
+            public string Build()
+            {
+                return string.Join(Environment.NewLine, _linesBuilder);
+            }
+
+            public void Dispose()
+            {
+                _linesBuilder.Free();
+            }
+        }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.MarkdownContentBuilder.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.MarkdownContentBuilder.cs
@@ -5,50 +5,49 @@
 using System;
 using Microsoft.CodeAnalysis.PooledObjects;
 
-namespace Microsoft.CodeAnalysis.LanguageServer
+namespace Microsoft.CodeAnalysis.LanguageServer;
+
+internal static partial class ProtocolConversions
 {
-    internal static partial class ProtocolConversions
+    private readonly ref struct MarkdownContentBuilder
     {
-        private readonly struct MarkdownContentBuilder : IDisposable
+        private readonly ArrayBuilder<string> _linesBuilder;
+
+        public MarkdownContentBuilder()
         {
-            private readonly ArrayBuilder<string> _linesBuilder;
+            _linesBuilder = ArrayBuilder<string>.GetInstance();
+        }
 
-            public MarkdownContentBuilder()
-            {
-                _linesBuilder = ArrayBuilder<string>.GetInstance();
-            }
-
-            public void Append(string text)
-            {
-                if (_linesBuilder.Count == 0)
-                {
-                    _linesBuilder.Add(text);
-                }
-                else
-                {
-                    _linesBuilder[^1] = _linesBuilder[^1] + text;
-                }
-            }
-
-            public void AppendLine(string text = "")
+        public void Append(string text)
+        {
+            if (_linesBuilder.Count == 0)
             {
                 _linesBuilder.Add(text);
             }
-
-            public bool IsLineEmpty()
+            else
             {
-                return _linesBuilder.Count == 0 ? true : string.IsNullOrEmpty(_linesBuilder[^1]);
+                _linesBuilder[^1] = _linesBuilder[^1] + text;
             }
+        }
 
-            public string Build()
-            {
-                return string.Join(Environment.NewLine, _linesBuilder);
-            }
+        public void AppendLine(string text = "")
+        {
+            _linesBuilder.Add(text);
+        }
 
-            public void Dispose()
-            {
-                _linesBuilder.Free();
-            }
+        public bool IsLineEmpty()
+        {
+            return _linesBuilder is [] or [.., ""];
+        }
+
+        public string Build(string newLine)
+        {
+            return string.Join(newLine, _linesBuilder);
+        }
+
+        public void Dispose()
+        {
+            _linesBuilder.Free();
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -30,11 +30,13 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer
 {
-    internal static class ProtocolConversions
+    internal static partial class ProtocolConversions
     {
         private const string CSharpMarkdownLanguageName = "csharp";
         private const string VisualBasicMarkdownLanguageName = "vb";
         private const string SourceGeneratedDocumentBaseUri = "source-generated:///";
+        private const string BlockCodeFence = "```";
+        private const string InlineCodeFence = "`";
 
 #pragma warning disable RS0030 // Do not use banned APIs
         private static readonly Uri s_sourceGeneratedDocumentBaseUri = new(SourceGeneratedDocumentBaseUri, UriKind.Absolute);
@@ -844,40 +846,65 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 };
             }
 
-            var builder = new StringBuilder();
-            var isInCodeBlock = false;
+            using var markdownBuilder = new MarkdownContentBuilder();
+            string? codeFence = null;
             foreach (var taggedText in tags)
             {
                 switch (taggedText.Tag)
                 {
                     case TextTags.CodeBlockStart:
-                        var codeBlockLanguageName = GetCodeBlockLanguageName(language);
-                        builder.Append($"```{codeBlockLanguageName}{Environment.NewLine}");
-                        builder.Append(taggedText.Text);
-                        isInCodeBlock = true;
+                        if (markdownBuilder.IsLineEmpty())
+                        {
+                            // If the current line is empty, we can append a code block.
+                            codeFence = BlockCodeFence;
+                            var codeBlockLanguageName = GetCodeBlockLanguageName(language);
+                            markdownBuilder.AppendLine($"{codeFence}{codeBlockLanguageName}");
+                            markdownBuilder.AppendLine(taggedText.Text);
+                        }
+                        else
+                        {
+                            // There is text on the line already - we should append an in-line code block.
+                            codeFence = InlineCodeFence;
+                            markdownBuilder.Append(codeFence + taggedText.Text);
+                        }
                         break;
                     case TextTags.CodeBlockEnd:
-                        builder.Append($"{Environment.NewLine}```{Environment.NewLine}");
-                        builder.Append(taggedText.Text);
-                        isInCodeBlock = false;
+                        if (codeFence == BlockCodeFence)
+                        {
+                            markdownBuilder.AppendLine(codeFence);
+                            markdownBuilder.AppendLine(taggedText.Text);
+                        }
+                        else if (codeFence == InlineCodeFence)
+                        {
+                            markdownBuilder.Append(codeFence + taggedText.Text);
+                        }
+                        else
+                        {
+                            throw ExceptionUtilities.UnexpectedValue(codeFence);
+                        }
+
+                        codeFence = null;
+
                         break;
                     case TextTags.LineBreak:
                         // A line ending with double space and a new line indicates to markdown
                         // to render a single-spaced line break.
-                        builder.Append("  ");
-                        builder.Append(Environment.NewLine);
+                        markdownBuilder.Append("  ");
+                        markdownBuilder.AppendLine();
                         break;
                     default:
-                        var styledText = GetStyledText(taggedText, isInCodeBlock);
-                        builder.Append(styledText);
+                        var styledText = GetStyledText(taggedText, codeFence != null);
+                        markdownBuilder.Append(styledText);
                         break;
                 }
             }
 
+            var content = markdownBuilder.Build();
+
             return new LSP.MarkupContent
             {
                 Kind = LSP.MarkupKind.Markdown,
-                Value = builder.ToString(),
+                Value = content,
             };
 
             static string GetCodeBlockLanguageName(string language)

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -899,7 +899,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 }
             }
 
-            var content = markdownBuilder.Build();
+            var content = markdownBuilder.Build(Environment.NewLine);
 
             return new LSP.MarkupContent
             {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -428,6 +428,34 @@ void A.AMethod(int i)
             Assert.Equal(expectedMarkdown, results.Contents.Value.Fourth.Value);
         }
 
+        [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/6577")]
+        public async Task TestGetHoverAsync_UsesInlineCodeFencesInAwaitReturn(bool mutatingLspWorkspace)
+        {
+            var markup =
+@"using System.Threading.Tasks;
+class C
+{
+    public async Task<string> DoAsync()
+    {
+        return {|caret:await|} DoAsync();
+    }
+}";
+            var clientCapabilities = new LSP.ClientCapabilities
+            {
+                TextDocument = new LSP.TextDocumentClientCapabilities { Hover = new LSP.HoverSetting { ContentFormat = [LSP.MarkupKind.Markdown] } }
+            };
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, clientCapabilities);
+            var expectedLocation = testLspServer.GetLocations("caret").Single();
+
+            var expectedMarkdown = @"Awaited task returns '`class System.String`'  
+";
+
+            var results = await RunGetHoverAsync(
+                testLspServer,
+                expectedLocation).ConfigureAwait(false);
+            Assert.Equal(expectedMarkdown, results.Contents.Value.Fourth.Value);
+        }
+
         private static async Task<LSP.Hover> RunGetHoverAsync(
             TestLspServer testLspServer,
             LSP.Location caret,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -447,7 +447,7 @@ class C
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, clientCapabilities);
             var expectedLocation = testLspServer.GetLocations("caret").Single();
 
-            var expectedMarkdown = @"Awaited task returns '`class System.String`'  
+            var expectedMarkdown = $@"{string.Format(FeaturesResources.Awaited_task_returns_0, "`class System.String`")}  
 ";
 
             var results = await RunGetHoverAsync(


### PR DESCRIPTION
Improve the appearance of hover on await with return by using an inline code fence.
Resolves https://github.com/dotnet/vscode-csharp/issues/6577

This is not perfect - unfortunately VSCode / markdown doesn't allow us to specify a language name for inline code fences, so it is not colorized.  The alternative is to modify this to be a code block on a new line, but that doesn't look great either.  This approach seemed reasonable to me.

Now looks like
<img width="389" alt="image" src="https://github.com/dotnet/roslyn/assets/5749229/5bf922a2-7676-41fa-a473-e8747db00311">
