### PR TITLE
Skip test, that fails on renamed project template tracked by issue #70627

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpErrorListWeb.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpErrorListWeb.cs
@@ -22,7 +22,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
 
         protected override string LanguageName => LanguageNames.CSharp;
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/70627")]
         public async Task ClosedRazorFile()
         {
             var source = """


### PR DESCRIPTION
Error is presumably caused by a rename of project templates for Blazor.

Eventual fixed tracked by #70627
