### PR TITLE
Fix indentation of labels following selection/iteration statements without braces

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -2487,6 +2487,78 @@ goto Goo;
 }");
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38245")]
+        public async Task FormatLabelAndGoto3()
+        {
+            await AssertFormatAsync(@"class C
+{
+    void M()
+    {
+        while (true)
+        {
+            if (true) goto Baz;
+
+        Baz:
+            goto Baz;
+        }
+
+        if (true)
+            goto Bar;
+
+    Goo:
+        for (; ; ) Console.WriteLine(""Goo"");
+    Bar:
+        goto Bar;
+    }
+}", @"class C
+{
+    void M()
+    {
+while (true)
+{
+if (true) goto Baz;
+
+Baz:
+goto Baz;
+}
+
+if (true)
+goto Bar;
+
+Goo:
+for(;;) Console.WriteLine(""Goo"");
+Bar:
+goto Bar;
+    }
+}");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38245")]
+        public async Task FormatLabelAndGoto4()
+        {
+            var changingOptions = new OptionsCollection(LanguageNames.CSharp)
+            {
+                { CSharpFormattingOptions2.NewLineBeforeOpenBrace, NewLineBeforeOpenBracePlacement.None }
+            };
+            await AssertFormatAsync(@"class C {
+    void M() {
+        if (true) goto Goo;
+
+    Goo:
+        goto Goo;
+    }
+}", @"class C
+{
+    void M()
+    {
+if (true) goto Goo;
+
+Goo:
+goto Goo;
+    }
+}", changedOptionSet: changingOptions);
+        }
+
         [Fact]
         public async Task FormatNestedLabelAndGoto1_Bug2588()
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/BaseFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/BaseFormattingRule.cs
@@ -13,46 +13,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
     internal abstract class BaseFormattingRule : AbstractFormattingRule
     {
-        protected static void AddUnindentBlockOperation(
-            List<IndentBlockOperation> list,
-            SyntaxToken startToken,
-            SyntaxToken endToken,
-            TextSpan textSpan,
-            IndentBlockOption option = IndentBlockOption.RelativePosition)
-        {
-            if (startToken.Kind() == SyntaxKind.None || endToken.Kind() == SyntaxKind.None)
-            {
-                return;
-            }
-
-            list.Add(FormattingOperations.CreateIndentBlockOperation(startToken, endToken, textSpan, indentationDelta: -1, option: option));
-        }
-
-        protected static void AddUnindentBlockOperation(
-            List<IndentBlockOperation> list,
-            SyntaxToken startToken,
-            SyntaxToken endToken,
-            bool includeTriviaAtEnd = false,
-            IndentBlockOption option = IndentBlockOption.RelativePosition)
-        {
-            if (startToken.Kind() == SyntaxKind.None || endToken.Kind() == SyntaxKind.None)
-            {
-                return;
-            }
-
-            if (includeTriviaAtEnd)
-            {
-                list.Add(FormattingOperations.CreateIndentBlockOperation(startToken, endToken, indentationDelta: -1, option: option));
-            }
-            else
-            {
-                var startPosition = CommonFormattingHelpers.GetStartPositionOfSpan(startToken);
-                var endPosition = endToken.Span.End;
-
-                list.Add(FormattingOperations.CreateIndentBlockOperation(startToken, endToken, TextSpan.FromBounds(startPosition, endPosition), indentationDelta: -1, option: option));
-            }
-        }
-
         protected static void AddAbsoluteZeroIndentBlockOperation(
             List<IndentBlockOperation> list,
             SyntaxToken startToken,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -138,7 +138,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 if (_options.LabelPositioning == LabelPositionOptions.OneLess)
                 {
-                    AddUnindentBlockOperation(list, labeledStatement.Identifier, labeledStatement.ColonToken);
+                    if (node.Parent != null)
+                    {
+                        var option = IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine;
+                        var baseToken = node.Parent.GetFirstToken();
+
+                        SetAlignmentBlockOperation(list, baseToken, labeledStatement.Identifier, labeledStatement.ColonToken, option);
+                    }
                 }
                 else if (_options.LabelPositioning == LabelPositionOptions.LeftMost)
                 {


### PR DESCRIPTION
`AddUnindentBlockOperation` tried to look at the token preceding the label and use an indentation delta of -1 to achieve the "one less" option. This doesn't work if the preceding token is an expression inside a statement like if/for without braces since then we'd take the indentation of that block.

We can align the label to the parent node instead to fix this.

I also removed `AddUnindentBlockOperation` since it wasn't used anymore.

Fixes https://github.com/dotnet/roslyn/issues/38245