### PR TITLE
Collection expressions: handle missing cases for ref struct collections in HasLocalScope

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4025,6 +4025,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (collectionTypeKind)
             {
                 case CollectionExpressionTypeKind.ReadOnlySpan:
+                case CollectionExpressionTypeKind.ImmutableArray: // Error case.
                     Debug.Assert(elementType.Type is { });
                     return !LocalRewriter.ShouldUseRuntimeHelpersCreateSpan(expr, elementType.Type);
                 case CollectionExpressionTypeKind.Span:
@@ -4053,8 +4054,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 case CollectionExpressionTypeKind.ImplementsIEnumerable:
                 case CollectionExpressionTypeKind.ImplementsIEnumerableT:
-                case CollectionExpressionTypeKind.ImmutableArray:
-                    // Error conditions. Restrict the collection to local scope.
+                    // Error cases. Restrict the collection to local scope.
                     return true;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(collectionTypeKind); // ref struct collection type with unexpected type kind

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4051,6 +4051,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return false;
                     }
                     return true;
+                case CollectionExpressionTypeKind.ImplementsIEnumerable:
+                case CollectionExpressionTypeKind.ImplementsIEnumerableT:
+                case CollectionExpressionTypeKind.ImmutableArray:
+                    // Error conditions. Restrict the collection to local scope.
+                    return true;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(collectionTypeKind); // ref struct collection type with unexpected type kind
             }


### PR DESCRIPTION
Fixes #70638