### PR TITLE
Avoid duplicate analyzer callbacks for PrimaryConstructorBaseTypeSyntax and BaseListSyntax nodes

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2514,22 +2514,42 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode node, ISymbol containingSymbol)
         {
-            if (containingSymbol.Kind is SymbolKind.Method)
+            switch (containingSymbol.Kind)
             {
-                switch (node)
-                {
-                    case TypeDeclarationSyntax:
-                        // Skip the topmost type declaration syntax node when analyzing primary constructor
-                        // to avoid duplicate syntax node callbacks.
-                        // We will analyze this node when analyzing the type declaration type symbol.
-                        return true;
+                case SymbolKind.Method:
+                    switch (node)
+                    {
+                        case TypeDeclarationSyntax:
+                            // Skip the topmost type declaration syntax node when analyzing primary constructor
+                            // to avoid duplicate syntax node callbacks.
+                            // We will analyze this node when analyzing the type declaration type symbol.
+                            return true;
 
-                    case CompilationUnitSyntax:
-                        // Skip compilation unit syntax node when analyzing synthesized top level entry point method
+                        case CompilationUnitSyntax:
+                            // Skip compilation unit syntax node when analyzing synthesized top level entry point method
+                            // to avoid duplicate syntax node callbacks.
+                            // We will analyze this node when analyzing the global namespace symbol.
+                            return true;
+
+                        case BaseListSyntax:
+                            // Skip the base list syntax node when analyzing primary constructor
+                            // to avoid duplicate syntax node callbacks.
+                            // We will analyze this node when analyzing the type declaration type symbol.
+                            return true;
+                    }
+
+                    break;
+
+                case SymbolKind.NamedType:
+                    if (node is PrimaryConstructorBaseTypeSyntax)
+                    {
+                        // Skip the PrimaryConstructorBaseTypeSyntax when analyzing type declaration symbol
                         // to avoid duplicate syntax node callbacks.
-                        // We will analyze this node when analyzing the global namespace symbol.
+                        // We will analyze this node when analyzing the primary constructor symbol.
                         return true;
-                }
+                    }
+
+                    break;
             }
 
             return false;

--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -4051,7 +4051,7 @@ public record A(int X, int Y);";
 class Base(int a) { }
 
 class Derived(int a) : Base(a);";
-            
+
             var compilation = CreateCompilation(source);
 
             var tree = compilation.SyntaxTrees[0];

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PrimaryConstructorTests.cs
@@ -3695,7 +3695,6 @@ class Attr3 : System.Attribute {}
             Assert.Equal(1, analyzer.FireCount13);
             Assert.Equal(1, analyzer.FireCount15);
             Assert.Equal(1, analyzer.FireCount16);
-            Assert.Equal(1, analyzer.FireCount17);
             Assert.Equal(1, analyzer.FireCount18);
             Assert.Equal(1, analyzer.FireCount19);
             Assert.Equal(1, analyzer.FireCount20);
@@ -3729,7 +3728,6 @@ class Attr3 : System.Attribute {}
             public int FireCount13;
             public int FireCount15;
             public int FireCount16;
-            public int FireCount17;
             public int FireCount18;
             public int FireCount19;
             public int FireCount20;
@@ -3865,9 +3863,6 @@ class Attr3 : System.Attribute {}
                         {
                             case "B..ctor([System.Int32 Y = 1])":
                                 Interlocked.Increment(ref FireCount9);
-                                break;
-                            case "B":
-                                Interlocked.Increment(ref FireCount17);
                                 break;
                             default:
                                 Assert.True(false);
@@ -4924,7 +4919,6 @@ interface I1 {}
             Assert.Equal(0, analyzer.FireCount13);
             Assert.Equal(1, analyzer.FireCount15);
             Assert.Equal(1, analyzer.FireCount16);
-            Assert.Equal(0, analyzer.FireCount17);
             Assert.Equal(0, analyzer.FireCount18);
             Assert.Equal(0, analyzer.FireCount19);
             Assert.Equal(0, analyzer.FireCount20);

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RecordTests.cs
@@ -26144,7 +26144,6 @@ class Attr3 : System.Attribute {}
             Assert.Equal(1, analyzer.FireCount13);
             Assert.Equal(1, analyzer.FireCount15);
             Assert.Equal(1, analyzer.FireCount16);
-            Assert.Equal(1, analyzer.FireCount17);
             Assert.Equal(1, analyzer.FireCount18);
             Assert.Equal(1, analyzer.FireCount19);
             Assert.Equal(1, analyzer.FireCount20);
@@ -26178,7 +26177,6 @@ class Attr3 : System.Attribute {}
             public int FireCount13;
             public int FireCount15;
             public int FireCount16;
-            public int FireCount17;
             public int FireCount18;
             public int FireCount19;
             public int FireCount20;
@@ -26314,9 +26312,6 @@ class Attr3 : System.Attribute {}
                         {
                             case "B..ctor([System.Int32 Y = 1])":
                                 Interlocked.Increment(ref FireCount9);
-                                break;
-                            case "B":
-                                Interlocked.Increment(ref FireCount17);
                                 break;
                             default:
                                 Assert.True(false);
@@ -27396,7 +27391,6 @@ interface I1 {}
             Assert.Equal(0, analyzer.FireCount13);
             Assert.Equal(1, analyzer.FireCount15);
             Assert.Equal(1, analyzer.FireCount16);
-            Assert.Equal(0, analyzer.FireCount17);
             Assert.Equal(0, analyzer.FireCount18);
             Assert.Equal(0, analyzer.FireCount19);
             Assert.Equal(0, analyzer.FireCount20);


### PR DESCRIPTION
Fixes #70488

Fix is on the same lines as #58482. We have common syntax nodes shared between two symbols and we need to ensure that we do not make duplicate callbacks for nodes when processing symbol declared events for these symbols.

- We analyze `BaseListSyntax` when processing the named type symbol, but skip it when processing the primary constructor symbol.
- We analyze `PrimaryConstructorBaseTypeSyntax` when processing the primary constructor symbol, but skip it when processing the named type symbol. Note that this is required as `PrimaryConstructorBaseTypeSyntax` is the topmost node for the primary constructor executable code block, and we already make CodeBlock and OperationBlock callbacks with this node as the block root.  Attempting to do it the other way caused a large number of unit test failures.