### PR TITLE
Only change documents in solution

### DIFF
--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -14,7 +14,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
@@ -470,7 +472,20 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 .ConfigureAwait(false);
             var solutionWithChangedNamespace = documentWithNewNamespace.Project.Solution;
 
-            var refLocationGroups = refLocationsInOtherDocuments.Where(loc => solutionWithChangedNamespace.ContainsDocument(loc.Document.Id)).GroupBy(loc => loc.Document.Id);
+            var refLocationsInSolution = refLocationsInOtherDocuments
+                .Where(loc => solutionWithChangedNamespace.ContainsDocument(loc.Document.Id))
+                .ToImmutableArray();
+
+            if (refLocationsInSolution.Length != refLocationsInOtherDocuments.Count)
+            {
+                // We have received feedback indicate some documents are not in the solution.
+                // Report this as non-fatal error if this happens.
+                FatalError.ReportNonFatalError(
+                    new SyncNamespaceDocumentsNotInSolutionException(refLocationsInOtherDocuments
+                    .Where(loc => !solutionWithChangedNamespace.ContainsDocument(loc.Document.Id)).Distinct().SelectAsArray(loc => loc.Document.Id)));
+            }
+
+            var refLocationGroups = refLocationsInSolution.GroupBy(loc => loc.Document.Id);
 
             var fixedDocuments = await Task.WhenAll(
                 refLocationGroups.Select(refInOneDocument =>

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -470,7 +470,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 .ConfigureAwait(false);
             var solutionWithChangedNamespace = documentWithNewNamespace.Project.Solution;
 
-            var refLocationGroups = refLocationsInOtherDocuments.GroupBy(loc => loc.Document.Id);
+            var refLocationGroups = refLocationsInOtherDocuments.Where(loc => solutionWithChangedNamespace.ContainsDocument(loc.Document.Id)).GroupBy(loc => loc.Document.Id);
 
             var fixedDocuments = await Task.WhenAll(
                 refLocationGroups.Select(refInOneDocument =>

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/SyncNamespaceDocumentsNotInSolutionException.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/SyncNamespaceDocumentsNotInSolutionException.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace
+{
+    internal class SyncNamespaceDocumentsNotInSolutionException(ImmutableArray<DocumentId> documentIds) : Exception
+    {
+        private readonly ImmutableArray<DocumentId> _documentIds = documentIds;
+
+        public override string ToString()
+        {
+            using var _ = PooledStringBuilder.GetInstance(out var builder);
+            foreach (var documentId in _documentIds)
+            {
+                builder.AppendLine($"{documentId.GetDebuggerDisplay()}, IsSourcedGeneratedDocument: {documentId.IsSourceGenerated}");
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/SyncNamespaceDocumentsNotInSolutionException.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/SyncNamespaceDocumentsNotInSolutionException.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace
             using var _ = PooledStringBuilder.GetInstance(out var builder);
             foreach (var documentId in _documentIds)
             {
-                builder.AppendLine($"{documentId.GetDebuggerDisplay()}, IsSourcedGeneratedDocument: {documentId.IsSourceGenerated}");
+                builder.AppendLine($"{documentId.GetDebuggerDisplay()}, IsSourceGeneratedDocument: {documentId.IsSourceGenerated}");
             }
 
             return builder.ToString();


### PR DESCRIPTION
So according to the dump:
```
Microsoft_CodeAnalysis_Workspaces_ni!Microsoft.CodeAnalysis.Shared.Extensions.ISolutionExtensions.GetRequiredDocument(Microsoft.CodeAnalysis.Solution, Microsoft.CodeAnalysis.DocumentId)+0x2ab3ada
Microsoft_CodeAnalysis_Features_ni!Microsoft.CodeAnalysis.ChangeNamespace.AbstractChangeNamespaceService`3+<>c__DisplayClass26_0[[System.__Canon, mscorlib],[System.__Canon, mscorlib],[System.__Canon, mscorlib]].<ChangeNamespaceInSingleDocumentAsync>b__4(System.Linq.IGrouping`2<Microsoft.CodeAnalysis.DocumentId,LocationForAffectedSymbol<System.__Canon,System.__Canon,System.__Canon>>)+0x59
```
It indicates in some cases, [AbstractChangeNamespaceService.cs](https://github.com/dotnet/roslyn/compare/release/dev17.8...Cosifne:dev/shech/FilterDocumentsInSolution?expand=1#diff-1258b1f4414057819e82f3f7fec71f26796931c7d429b45c30a98ed85ae76e8f), line 478
`solutionWithChangedNamespace.GetRequiredDocument(refInOneDocument.Key)` would throw

However, we don't know the repro case : ( 
So there is no test could cover it