### PR TITLE
Indicate when syntax errors are first calculated.

### DIFF
--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Preview;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -23,6 +22,7 @@ using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.CodeAnalysis.Workspaces;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
@@ -44,9 +44,13 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag>
         ITextBufferVisibilityTracker? visibilityTracker,
         IAsynchronousOperationListener listener) : AsynchronousTaggerProvider<TTag>(threadingContext, globalOptions, visibilityTracker, listener)
     {
+        private static readonly object s_initialDiagnosticRequestInfoKey = new();
+        private const string SyntaxSquiggleCountPropertyName = "syntax-squiggle-count";
+
         private readonly DiagnosticKind _diagnosticKind = diagnosticKind;
         private readonly IDiagnosticService _diagnosticService = diagnosticService;
         private readonly IDiagnosticAnalyzerService _analyzerService = analyzerService;
+        private readonly bool _requiresBeforeTagsChangedNotification = diagnosticKind == DiagnosticKind.CompilerSyntax && typeof(TTag).IsAssignableFrom(typeof(IErrorTag));
 
         private readonly AbstractDiagnosticsTaggerProvider<TTag> _callback = callback;
 
@@ -70,6 +74,35 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag>
             TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition, CancellationToken cancellationToken)
         {
             return ProduceTagsAsync(context, spanToTag, cancellationToken);
+        }
+
+        protected override void BeforeTagsChanged(ITextSnapshot snapshot)
+        {
+            if (!_requiresBeforeTagsChangedNotification)
+                return;
+
+            var properties = snapshot.TextBuffer.Properties;
+
+            // Verify this is the initial diagnostic result
+            if (properties.GetProperty<int>(s_initialDiagnosticRequestInfoKey) != snapshot.Version.VersionNumber)
+                return;
+
+            // Verify we haven't already set the property used to determine time taken to first error calculated
+            if (properties.ContainsProperty(SyntaxSquiggleCountPropertyName))
+                return;
+
+            // Set the property value to -1 indicating there were syntax errors
+            properties[SyntaxSquiggleCountPropertyName] = -1;
+        }
+
+        private void CacheInitialDiagnosticRequestInfo(ITextSnapshot snapshot)
+        {
+            if (!_requiresBeforeTagsChangedNotification)
+                return;
+
+            var properties = snapshot.TextBuffer.Properties;
+            if (!properties.ContainsProperty(s_initialDiagnosticRequestInfoKey))
+                properties[s_initialDiagnosticRequestInfoKey] = snapshot.Version.VersionNumber;
         }
 
         private async Task ProduceTagsAsync(
@@ -96,13 +129,15 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag>
             // is generating code that it doesn't want errors shown for.
             var buffer = snapshot.TextBuffer;
             var suppressedDiagnosticsSpans = (NormalizedSnapshotSpanCollection?)null;
-            buffer?.Properties.TryGetProperty(PredefinedPreviewTaggerKeys.SuppressDiagnosticsSpansKey, out suppressedDiagnosticsSpans);
+            buffer.Properties.TryGetProperty(PredefinedPreviewTaggerKeys.SuppressDiagnosticsSpansKey, out suppressedDiagnosticsSpans);
 
             var sourceText = snapshot.AsText();
 
             try
             {
                 var requestedSpan = documentSpanToTag.SnapshotSpan;
+
+                CacheInitialDiagnosticRequestInfo(snapshot);
 
                 // NOTE: We pass 'includeSuppressedDiagnostics: true' to ensure that IDE0079 (unnecessary suppressions)
                 // are flagged and faded in the editor. IDE0079 analyzer requires all source suppressed diagnostics to

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_TagsChanged.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_TagsChanged.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                         ? new NormalizedSnapshotSpanCollection(snapshot.GetSpanFromBounds(collection.First().Start, collection.Last().End))
                         : collection;
 
+                    _dataSource.BeforeTagsChanged(snapshot);
+
                     foreach (var span in coalesced)
                         tagsChanged(this, new SnapshotSpanEventArgs(span));
                 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -95,6 +95,10 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// </summary>
         protected virtual bool CancelOnNewWork { get; }
 
+        protected virtual void BeforeTagsChanged(ITextSnapshot snapshot)
+        {
+        }
+
         /// <summary>
         /// Comparer used to check if two tags are the same.  Used so that when new tags are produced, they can be
         /// appropriately 'diffed' to determine what changes to actually report in <see cref="ITagger{T}.TagsChanged"/>.

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/PullDiagnosticCategories.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/PullDiagnosticCategories.cs
@@ -22,7 +22,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
         // Fine-grained document pull categories to allow diagnostics to more quickly reach the user.
 
-        public const string DocumentCompilerSyntax = nameof(DocumentCompilerSyntax);
+        // alternatively, VSInternalDiagnosticKind.Syntax.Value
+        public const string DocumentCompilerSyntax = "syntax";
+
         public const string DocumentCompilerSemantic = nameof(DocumentCompilerSemantic);
         public const string DocumentAnalyzerSyntax = nameof(DocumentAnalyzerSyntax);
         public const string DocumentAnalyzerSemantic = nameof(DocumentAnalyzerSemantic);

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/PullDiagnosticCategories.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/PullDiagnosticCategories.cs
@@ -22,7 +22,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
         // Fine-grained document pull categories to allow diagnostics to more quickly reach the user.
 
-        // alternatively, VSInternalDiagnosticKind.Syntax.Value
+        // VSLanguageServerClient's RemoteDocumentDiagnosticBroker uses this exact string to determine
+        // when syntax errors are being provided via pull diagnostics. Alternatively when 17.9 preview 1 packages
+        // are consumable by Roslyn, this could be updated to reference VSInternalDiagnosticKind.Syntax.Value directly.
         public const string DocumentCompilerSyntax = "syntax";
 
         public const string DocumentCompilerSemantic = nameof(DocumentCompilerSemantic);


### PR DESCRIPTION
(This is a 3rd PR to see if it has better test results than the original PR here: #70668 by removing the packages update part of the change)

Just need to change our category to match the syntax value added here: https://devdiv.visualstudio.com/DevDiv/_git/ad3abf5b-6c20-437a-b326-31162c54701f/pullrequest/505601

In the non-LSP (push) case:

This was a bit more tricky as the system is quite async in nature. After talking with Kayle, it was determined that we could just set the syntax-squiggle-count buffer property added here (https://devdiv.visualstudio.com/DevDiv/_git/VS-Platform/pullrequest/503148) when the initial syntax diagnostics are non-empty.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1906408