### PR TITLE
Include razor diagnostic details in assert text

### DIFF
--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
@@ -483,13 +483,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return specifiers;
         }
 
-        public static string GetAssertText(DiagnosticDescription[] expected, IEnumerable<Diagnostic> actual, DiagnosticDescription[] unamtchedExpected, IEnumerable<Diagnostic> unmatchedActual)
+        public static string GetAssertText(DiagnosticDescription[] expected, IEnumerable<Diagnostic> actual, DiagnosticDescription[] unmatchedExpected, IEnumerable<Diagnostic> unmatchedActual)
         {
-            const int CSharp = 1;
-            const int VisualBasic = 2;
-            var language = actual.Any() && actual.First() is CSDiagnostic ? CSharp : VisualBasic;
-            var includeDiagnosticMessagesAsComments = (language == CSharp);
-            int indentDepth = (language == CSharp) ? 4 : 1;
+            var isCSharpOrRazor = actual.Any() && actual.First() is CSDiagnostic or { Descriptor.Category: "Razor" };
+            var includeDiagnosticMessagesAsComments = isCSharpOrRazor;
+            int indentDepth = isCSharpOrRazor ? 4 : 1;
             var includeDefaultSeverity = expected.Any() && expected.All(d => d.DefaultSeverity != null);
             var includeEffectiveSeverity = expected.Any() && expected.All(d => d.EffectiveSeverity != null);
 
@@ -556,7 +554,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             assertText.AppendLine("Diff:");
 
             var unmatchedExpectedText = ArrayBuilder<string>.GetInstance();
-            foreach (var d in unamtchedExpected)
+            foreach (var d in unmatchedExpected)
             {
                 unmatchedExpectedText.Add(GetDiagnosticDescription(d, indentDepth));
             }


### PR DESCRIPTION
See https://github.com/dotnet/razor/pull/9512#discussion_r1380798487.

Before:

```
Expected:
Actual:
    Diagnostic("RZ10001").WithLocation(3, 1)
Diff:
++>     Diagnostic("RZ10001").WithLocation(3, 1)
Expected: True
Actual:   False
```

After:

```
Expected:
Actual:
                // Shared/Component1.razor(3,1): error RZ10001: The type of component 'Component1' cannot be inferred based on the values provided. Consider specifying the type arguments directly using the following attributes: 'T'.
                Diagnostic("RZ10001").WithLocation(3, 1)
Diff:
++>                 Diagnostic("RZ10001").WithLocation(3, 1)
Expected: True
Actual:   False
```

The syntax from razor is not included in the comment because it's an external diagnostic which doesn't have access to the external source file text contents.

cc @333fred