### PR TITLE
Add null literal to list of standard implicit conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -607,7 +607,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        // See https://github.com/dotnet/csharplang/blob/main/spec/conversions.md#standard-conversions:
+        // See https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/conversions.md#1042-standard-implicit-conversions:
         // "The standard conversions are those pre-defined conversions that can occur as part of a user-defined conversion."
         private static bool IsStandardImplicitConversionFromType(ConversionKind kind)
         {
@@ -616,6 +616,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.Identity:
                 case ConversionKind.ImplicitNumeric:
                 case ConversionKind.ImplicitNullable:
+                case ConversionKind.NullLiteral:
                 case ConversionKind.ImplicitReference:
                 case ConversionKind.Boxing:
                 case ConversionKind.ImplicitConstant:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -592,6 +592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to include conversions from expression.
             switch (kind)
             {
+                case ConversionKind.NullLiteral:
                 case ConversionKind.AnonymousFunction:
                 case ConversionKind.MethodGroup:
                 case ConversionKind.ImplicitEnumeration:
@@ -616,7 +617,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.Identity:
                 case ConversionKind.ImplicitNumeric:
                 case ConversionKind.ImplicitNullable:
-                case ConversionKind.NullLiteral:
                 case ConversionKind.ImplicitReference:
                 case ConversionKind.Boxing:
                 case ConversionKind.ImplicitConstant:
@@ -640,6 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: Identity conversions
             // SPEC: Implicit numeric conversions
             // SPEC: Implicit nullable conversions
+            // SPEC: Null literal conversions
             // SPEC: Implicit reference conversions
             // SPEC: Boxing conversions
             // SPEC: Implicit constant expression conversions

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -11920,7 +11920,7 @@ class B : A
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70659")]
-        public void Issue70659()
+        public void IsStandardImplicitConversion_NullLiteral()
         {
             var source = """
                 class C

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -11918,5 +11918,31 @@ class B : A
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "F<object>").WithArguments("B.F<T>(T)", "T", "object").WithLocation(11, 9)
                 );
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70659")]
+        public void Issue70659()
+        {
+            var source = """
+                class C
+                {
+                    void M(S? s)
+                    {
+                        if (s == null)
+                        {
+                        }
+                    }
+                }
+
+                readonly struct S
+                {
+                    public static implicit operator S(bool? x) => default;
+                    public static bool operator ==(S left, S right) => false;
+                    public static bool operator !=(S left, S right) => true;
+                    public override bool Equals(object obj) => false;
+                    public override int GetHashCode() => 0;
+                }
+                """;
+            CreateCompilation(source).VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70659.

"Null literal conversions" should be in the list per the spec: https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/conversions.md#1042-standard-implicit-conversions