### PR TITLE
Avoid some first-chance exceptions by returning instead

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,6 +42,7 @@
     <SourceGeneratorMicrosoftCodeAnalysisVersion>4.1.0</SourceGeneratorMicrosoftCodeAnalysisVersion>
     <MicrosoftILVerificationVersion>7.0.0-alpha.1.22060.1</MicrosoftILVerificationVersion>
     <MicrosoftVisualStudioThreadingPackagesVersion>17.7.30</MicrosoftVisualStudioThreadingPackagesVersion>
+    <MicrosoftVisualStudioThreadingAnalyzersPackagesVersion>17.9.12-alpha</MicrosoftVisualStudioThreadingAnalyzersPackagesVersion>
     <MicrosoftTestPlatformVersion>17.4.1</MicrosoftTestPlatformVersion>
   </PropertyGroup>
   <!--
@@ -198,7 +199,7 @@
     <MicrosoftVisualStudioTextLogicVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextLogicVersion>
     <MicrosoftVisualStudioTextUIVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextUIVersion>
     <MicrosoftVisualStudioTextUIWpfVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextUIWpfVersion>
-    <MicrosoftVisualStudioThreadingAnalyzersVersion>$(MicrosoftVisualStudioThreadingPackagesVersion)</MicrosoftVisualStudioThreadingAnalyzersVersion>
+    <MicrosoftVisualStudioThreadingAnalyzersVersion>$(MicrosoftVisualStudioThreadingAnalyzersPackagesVersion)</MicrosoftVisualStudioThreadingAnalyzersVersion>
     <MicrosoftVisualStudioThreadingVersion>$(MicrosoftVisualStudioThreadingPackagesVersion)</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioUtilitiesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioUtilitiesInternalVersion>16.3.53</MicrosoftVisualStudioUtilitiesInternalVersion>

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -346,9 +346,9 @@ namespace Microsoft.CodeAnalysis
                 return selector(source[0], arg, cancellationToken);
             }
 
-            return CreateTask();
+            return CreateTaskAsync();
 
-            async ValueTask<ImmutableArray<TResult>> CreateTask()
+            async ValueTask<ImmutableArray<TResult>> CreateTaskAsync()
             {
                 var builder = ArrayBuilder<TResult>.GetInstance();
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -82,11 +82,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         return _lazySessionScopeTask;
                     }
 
-                    task = getSessionAnalysisScopeTaskSlow(this, analyzerExecutor, cancellationToken);
+                    task = getSessionAnalysisScopeTaskSlowAsync(this, analyzerExecutor, cancellationToken);
                     _lazySessionScopeTask = task;
                     return task;
 
-                    static Task<HostSessionStartAnalysisScope> getSessionAnalysisScopeTaskSlow(AnalyzerExecutionContext context, AnalyzerExecutor executor, CancellationToken cancellationToken)
+                    static Task<HostSessionStartAnalysisScope> getSessionAnalysisScopeTaskSlowAsync(AnalyzerExecutionContext context, AnalyzerExecutor executor, CancellationToken cancellationToken)
                     {
                         return Task.Run(() =>
                         {

--- a/src/Compilers/Server/VBCSCompiler/ClientConnectionHandler.cs
+++ b/src/Compilers/Server/VBCSCompiler/ClientConnectionHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         {
             try
             {
-                return await ProcessCore().ConfigureAwait(false);
+                return await ProcessCoreAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 return CompletionData.RequestError;
             }
 
-            async Task<CompletionData> ProcessCore()
+            async Task<CompletionData> ProcessCoreAsync()
             {
                 using var clientConnection = await clientConnectionTask.ConfigureAwait(false);
                 var request = await clientConnection.ReadBuildRequestAsync(cancellationToken).ConfigureAwait(false);
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             // suddenly disconnects we need to cancel the compilation that is occurring. It could be the 
             // client hit Ctrl-C due to a run away analyzer.
             var buildCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            var compilationTask = ProcessCompilationRequestCore(CompilerServerHost, request, buildCancellationTokenSource.Token);
+            var compilationTask = ProcessCompilationRequestCoreAsync(CompilerServerHost, request, buildCancellationTokenSource.Token);
             await Task.WhenAny(compilationTask, clientConnection.DisconnectTask).ConfigureAwait(false);
 
             try
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 buildCancellationTokenSource.Cancel();
             }
 
-            static Task<BuildResponse> ProcessCompilationRequestCore(ICompilerServerHost compilerServerHost, BuildRequest buildRequest, CancellationToken cancellationToken)
+            static Task<BuildResponse> ProcessCompilationRequestCoreAsync(ICompilerServerHost compilerServerHost, BuildRequest buildRequest, CancellationToken cancellationToken)
             {
                 Func<BuildResponse> func = () =>
                 {

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -63,11 +63,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
             // The result is deliberately discarded here. The idea is to kick off the monitor code and 
             // when it completes it will trigger the task. Don't want to block on that here.
-            _ = MonitorDisconnect();
+            _ = MonitorDisconnectAsync();
 
             return request;
 
-            async Task MonitorDisconnect()
+            async Task MonitorDisconnectAsync()
             {
                 try
                 {

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 return new IncorrectHashBuildResponse();
             }
 
-            using var pipe = await tryConnectToServer(pipeName, timeoutOverride, logger, tryCreateServerFunc, cancellationToken).ConfigureAwait(false);
+            using var pipe = await tryConnectToServerAsync(pipeName, timeoutOverride, logger, tryCreateServerFunc, cancellationToken).ConfigureAwait(false);
             if (pipe is null)
             {
                 return new CannotConnectResponse();
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             // This code uses a Mutex.WaitOne / ReleaseMutex pairing. Both of these calls must occur on the same thread 
             // or an exception will be thrown. This code lives in a separate non-async function to help ensure this 
             // invariant doesn't get invalidated in the future by an `await` being inserted. 
-            static Task<NamedPipeClientStream?> tryConnectToServer(
+            static Task<NamedPipeClientStream?> tryConnectToServerAsync(
                 string pipeName,
                 int? timeoutOverride,
                 ICompilerServerLogger logger,

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -25,7 +25,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         private async ValueTask<NavigationBarModel?> ComputeModelAndSelectItemAsync(ImmutableSegmentedList<bool> unused, CancellationToken cancellationToken)
         {
             // Jump back to the UI thread to determine what snapshot the user is processing.
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken).NoThrowAwaitable();
+#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
+
+            // Cancellation exceptions are ignored in AsyncBatchingWorkQueue, so return without throwing if cancellation
+            // occurred while switching to the main thread.
+            if (cancellationToken.IsCancellationRequested)
+                return null;
+
             var textSnapshot = _subjectBuffer.CurrentSnapshot;
 
             // Ensure we switch to the threadpool before calling GetDocumentWithFrozenPartialSemantics.  It ensures
@@ -100,7 +108,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         {
             // Switch to the UI so we can determine where the user is and determine the state the last time we updated
             // the UI.
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken).NoThrowAwaitable();
+#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
+
+            // Cancellation exceptions are ignored in AsyncBatchingWorkQueue, so return without throwing if cancellation
+            // occurred while switching to the main thread.
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
             await SelectItemWorkerAsync(cancellationToken).ConfigureAwait(true);
 
             // Once we've computed and selected the latest navbar items, pause ourselves if we're no longer visible.

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -25,9 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         private async ValueTask<NavigationBarModel?> ComputeModelAndSelectItemAsync(ImmutableSegmentedList<bool> unused, CancellationToken cancellationToken)
         {
             // Jump back to the UI thread to determine what snapshot the user is processing.
-#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken).NoThrowAwaitable();
-#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
 
             // Cancellation exceptions are ignored in AsyncBatchingWorkQueue, so return without throwing if cancellation
             // occurred while switching to the main thread.
@@ -108,9 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         {
             // Switch to the UI so we can determine where the user is and determine the state the last time we updated
             // the UI.
-#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken).NoThrowAwaitable();
-#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
 
             // Cancellation exceptions are ignored in AsyncBatchingWorkQueue, so return without throwing if cancellation
             // occurred while switching to the main thread.

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -82,9 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     _isRenamableIdentifierTask.SafeContinueWithFromAsync(
                         async t =>
                         {
-#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
                             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken).NoThrowAwaitable();
-#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
 
                             // Avoid throwing an exception in this common case
                             if (_cancellationToken.IsCancellationRequested)
@@ -115,9 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
                 task.SafeContinueWithFromAsync(async t =>
                    {
-#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken).NoThrowAwaitable();
-#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
 
                        // Avoid throwing an exception in this common case
                        if (_cancellationToken.IsCancellationRequested)

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -82,7 +82,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     _isRenamableIdentifierTask.SafeContinueWithFromAsync(
                         async t =>
                         {
-                            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken);
+#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
+                            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken).NoThrowAwaitable();
+#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
+
+                            // Avoid throwing an exception in this common case
+                            if (_cancellationToken.IsCancellationRequested)
+                                return;
 
                             stateMachine.UpdateTrackingSessionIfRenamable();
                         },
@@ -109,7 +115,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
                 task.SafeContinueWithFromAsync(async t =>
                    {
-                       await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken);
+#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
+                       await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken).NoThrowAwaitable();
+#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
+
+                       // Avoid throwing an exception in this common case
+                       if (_cancellationToken.IsCancellationRequested)
+                           return;
 
                        if (_isRenamableIdentifierTask.Result != TriggerIdentifierKind.NotRenamable)
                        {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -193,9 +193,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             /// </param>
             private async Task<VoidResult> RecomputeTagsAsync(bool highPriority, CancellationToken cancellationToken)
             {
-#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
                 await _dataSource.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken).NoThrowAwaitable();
-#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
                 if (cancellationToken.IsCancellationRequested)
                     return default;
 
@@ -251,9 +249,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     var bufferToChanges = ProcessNewTagTrees(spansToTag, oldTagTrees, newTagTrees, cancellationToken);
 
                     // Then switch back to the UI thread to update our state and kick off the work to notify the editor.
-#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
                     await _dataSource.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken).NoThrowAwaitable();
-#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
                     if (cancellationToken.IsCancellationRequested)
                         return default;
 

--- a/src/EditorFeatures/Core/Workspaces/ITextBufferVisibilityTracker.cs
+++ b/src/EditorFeatures/Core/Workspaces/ITextBufferVisibilityTracker.cs
@@ -80,9 +80,7 @@ namespace Microsoft.CodeAnalysis.Workspaces
                 if (cancellationToken.IsCancellationRequested)
                     return;
 
-#pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync
                 await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken).NoThrowAwaitable();
-#pragma warning restore VSTHRD004 // Await SwitchToMainThreadAsync
                 if (cancellationToken.IsCancellationRequested)
                     return;
 

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -105,7 +105,7 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
 
         // Find any field/properties whose initializer references a primary constructor parameter.  These initializers
         // will have to move inside the constructor we generate.
-        var initializedFieldsAndProperties = await GetExistingAssignedFieldsOrProperties().ConfigureAwait(false);
+        var initializedFieldsAndProperties = await GetExistingAssignedFieldsOrPropertiesAsync().ConfigureAwait(false);
 
         var constructorAnnotation = new SyntaxAnnotation();
 
@@ -208,7 +208,7 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
             return result.ToImmutableDictionary();
         }
 
-        async Task<ImmutableHashSet<(ISymbol fieldOrProperty, EqualsValueClauseSyntax initializer)>> GetExistingAssignedFieldsOrProperties()
+        async Task<ImmutableHashSet<(ISymbol fieldOrProperty, EqualsValueClauseSyntax initializer)>> GetExistingAssignedFieldsOrPropertiesAsync()
         {
             using var _1 = PooledHashSet<EqualsValueClauseSyntax>.GetInstance(out var initializers);
             foreach (var (parameter, references) in parameterReferences)

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -724,7 +724,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return nullableReturnOperations;
 
                 var returnType = syntaxNode is MethodDeclarationSyntax method ? method.ReturnType : ((LocalFunctionStatementSyntax)syntaxNode).ReturnType;
-                var newDocument = await GenerateNewDocument(methodSymbol, returnType, originalDocument, cancellationToken).ConfigureAwait(false);
+                var newDocument = await GenerateNewDocumentAsync(methodSymbol, returnType, originalDocument, cancellationToken).ConfigureAwait(false);
 
                 return await SemanticDocument.CreateAsync(newDocument, cancellationToken).ConfigureAwait(false);
 
@@ -770,7 +770,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return null;
                 }
 
-                static async Task<Document> GenerateNewDocument(
+                static async Task<Document> GenerateNewDocumentAsync(
                     IMethodSymbol methodSymbol,
                     TypeSyntax returnType,
                     SemanticDocument originalDocument,

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -787,7 +787,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 linkedDocumentsToSkip.AddRange(document.GetLinkedDocumentIds());
                 documentsToProcessBuilder.Add(document);
 
-                document = await RemoveUnnecessaryImportsWorker(
+                document = await RemoveUnnecessaryImportsWorkerAsync(
                     document,
                     CreateImports(document, names, withFormatterAnnotation: false),
                     cancellationToken).ConfigureAwait(false);
@@ -797,14 +797,14 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             var documentsToProcess = documentsToProcessBuilder.ToImmutableAndFree();
 
             var changeDocuments = await Task.WhenAll(documentsToProcess.Select(
-                    doc => RemoveUnnecessaryImportsWorker(
+                    doc => RemoveUnnecessaryImportsWorkerAsync(
                         doc,
                         CreateImports(doc, names, withFormatterAnnotation: false),
                         cancellationToken))).ConfigureAwait(false);
 
             return await MergeDocumentChangesAsync(solution, changeDocuments, cancellationToken).ConfigureAwait(false);
 
-            async Task<Document> RemoveUnnecessaryImportsWorker(
+            async Task<Document> RemoveUnnecessaryImportsWorkerAsync(
                 Document doc,
                 IEnumerable<SyntaxNode> importsToRemove,
                 CancellationToken token)

--- a/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Completion
 
             var triggeredProviders = GetTriggeredProviders(document, providers, caretPosition, options, trigger, roles, text);
 
-            var additionalAugmentingProviders = await GetAugmentingProviders(document, triggeredProviders, caretPosition, trigger, options, cancellationToken).ConfigureAwait(false);
+            var additionalAugmentingProviders = await GetAugmentingProvidersAsync(document, triggeredProviders, caretPosition, trigger, options, cancellationToken).ConfigureAwait(false);
             triggeredProviders = triggeredProviders.Except(additionalAugmentingProviders).ToImmutableArray();
 
             // PERF: Many CompletionProviders compute identical contexts. This actually shows up on the 2-core typing test.
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 }
             }
 
-            static async Task<ImmutableArray<CompletionProvider>> GetAugmentingProviders(
+            static async Task<ImmutableArray<CompletionProvider>> GetAugmentingProvidersAsync(
                 Document document, ImmutableArray<CompletionProvider> triggeredProviders, int caretPosition, CompletionTrigger trigger, CompletionOptions options, CancellationToken cancellationToken)
             {
                 var additionalAugmentingProviders = ArrayBuilder<CompletionProvider>.GetInstance(triggeredProviders.Length);

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 CompletionProvidersLogger.LogCustomizedCommitToAddParenthesis(commitKey);
             }
 
-            if (await ShouldCompleteWithFullyQualifyTypeName().ConfigureAwait(false))
+            if (await ShouldCompleteWithFullyQualifyTypeNameAsync().ConfigureAwait(false))
             {
                 var completionText = $"{containingNamespace}.{insertText}";
                 return CompletionChange.Create(new TextChange(completionItem.Span, completionText));
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var change = Utilities.Collapse(newText, changes);
             return CompletionChange.Create(change, changes);
 
-            async Task<bool> ShouldCompleteWithFullyQualifyTypeName()
+            async Task<bool> ShouldCompleteWithFullyQualifyTypeNameAsync()
             {
                 if (ImportCompletionItem.ShouldAlwaysFullyQualify(completionItem))
                     return true;

--- a/src/Features/Core/Portable/ValueTracking/ValueTracker.OperationCollector.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTracker.OperationCollector.cs
@@ -125,19 +125,19 @@ namespace Microsoft.CodeAnalysis.ValueTracking
 
                     // If the parameter is not a ref or out param, track the reference assignments that count
                     // as input to the argument being passed to the method.
-                    return AddReference(operation, cancellationToken);
+                    return AddReferenceAsync(operation, cancellationToken);
                 }
 
                 if (IsContainedIn<IReturnOperation>(operation) || IsContainedIn<IAssignmentOperation>(operation))
                 {
                     // If the reference is part of a return operation or assignment operation we want to track where the values come from
                     // since they contribute to the "output" of the method/assignment and are relavent for value tracking.
-                    return AddReference(operation, cancellationToken);
+                    return AddReferenceAsync(operation, cancellationToken);
                 }
 
                 return Task.CompletedTask;
 
-                Task AddReference(IOperation operation, CancellationToken cancellationToken)
+                Task AddReferenceAsync(IOperation operation, CancellationToken cancellationToken)
                     => operation switch
                     {
                         IParameterReferenceOperation parameterReference => AddOperationAsync(operation, parameterReference.Parameter, cancellationToken),

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -441,11 +441,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
             var result = await GetMappedSpanResultAsync(document, ImmutableArray.Create(textSpan), cancellationToken).ConfigureAwait(false);
             if (result == null)
-                return await ConvertTextSpanToLocation(document, textSpan, isStale, cancellationToken).ConfigureAwait(false);
+                return await ConvertTextSpanToLocationAsync(document, textSpan, isStale, cancellationToken).ConfigureAwait(false);
 
             var mappedSpan = result.Value.Single();
             if (mappedSpan.IsDefault)
-                return await ConvertTextSpanToLocation(document, textSpan, isStale, cancellationToken).ConfigureAwait(false);
+                return await ConvertTextSpanToLocationAsync(document, textSpan, isStale, cancellationToken).ConfigureAwait(false);
 
             Uri? uri = null;
             try
@@ -469,7 +469,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 Range = MappedSpanResultToRange(mappedSpan)
             };
 
-            static async Task<LSP.Location?> ConvertTextSpanToLocation(
+            static async Task<LSP.Location?> ConvertTextSpanToLocationAsync(
                 Document document,
                 TextSpan span,
                 bool isStale,

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
@@ -141,11 +141,11 @@ internal abstract class AbstractWorkspacePullDiagnosticsHandler<TDiagnosticsPara
         var codeAnalysisService = solution.Workspace.Services.GetRequiredService<ICodeAnalysisDiagnosticAnalyzerService>();
 
         foreach (var project in GetProjectsInPriorityOrder(solution, context.SupportedLanguages))
-            await AddDocumentsAndProject(project, cancellationToken).ConfigureAwait(false);
+            await AddDocumentsAndProjectAsync(project, cancellationToken).ConfigureAwait(false);
 
         return result.ToImmutable();
 
-        async Task AddDocumentsAndProject(Project project, CancellationToken cancellationToken)
+        async Task AddDocumentsAndProjectAsync(Project project, CancellationToken cancellationToken)
         {
             // There are two potential sources for reporting workspace diagnostics:
             //

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -645,7 +645,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // Instead, we invoke this in JTF run which will mitigate deadlocks when the ConfigureAwait(true)
             // tries to switch back to the main thread in the LSP client.
             // Link to LSP client bug for ConfigureAwait(true) - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1216657
-            var mappedChanges = _threadingContext.JoinableTaskFactory.Run(() => GetMappedTextChanges(solutionChanges));
+            var mappedChanges = _threadingContext.JoinableTaskFactory.Run(() => GetMappedTextChangesAsync(solutionChanges));
 
             // Group the mapped text changes by file, then apply all mapped text changes for the file.
             foreach (var changesForFile in mappedChanges)
@@ -660,7 +660,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             return;
 
-            async Task<MultiDictionary<string, (TextChange TextChange, ProjectId ProjectId)>> GetMappedTextChanges(SolutionChanges solutionChanges)
+            async Task<MultiDictionary<string, (TextChange TextChange, ProjectId ProjectId)>> GetMappedTextChangesAsync(SolutionChanges solutionChanges)
             {
                 var filePathToMappedTextChanges = new MultiDictionary<string, (TextChange TextChange, ProjectId ProjectId)>();
                 foreach (var projectChanges in solutionChanges.GetProjectChanges())

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Callers.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Callers.cs
@@ -52,17 +52,17 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             if (directReference != null)
             {
-                await AddReferencingSymbols(directReference, isDirect: true).ConfigureAwait(false);
+                await AddReferencingSymbolsAsync(directReference, isDirect: true).ConfigureAwait(false);
             }
 
             foreach (var indirectReference in indirectReferences)
             {
-                await AddReferencingSymbols(indirectReference, isDirect: false).ConfigureAwait(false);
+                await AddReferencingSymbolsAsync(indirectReference, isDirect: false).ConfigureAwait(false);
             }
 
             return results;
 
-            async Task AddReferencingSymbols(ReferencedSymbol reference, bool isDirect)
+            async Task AddReferencingSymbolsAsync(ReferencedSymbol reference, bool isDirect)
             {
                 var result = await reference.Locations.FindReferencingSymbolsAsync(cancellationToken).ConfigureAwait(false);
                 foreach (var (callingSymbol, locations) in result)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IAsyncEnumerableExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IAsyncEnumerableExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             var tasks = new Task[streams.Length];
             for (var i = 0; i < streams.Length; i++)
-                tasks[i] = Process(streams[i], channel.Writer, cancellationToken);
+                tasks[i] = ProcessAsync(streams[i], channel.Writer, cancellationToken);
 
             // Complete the channel writer with the result of all the tasks.  If nothing failed, t.Exception will be
             // null and this will complete successfully.  If anything failed, the exception will propagate out.
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             return channel.Reader.ReadAllAsync(cancellationToken);
 
-            static async Task Process(IAsyncEnumerable<T> stream, ChannelWriter<T> writer, CancellationToken cancellationToken)
+            static async Task ProcessAsync(IAsyncEnumerable<T> stream, ChannelWriter<T> writer, CancellationToken cancellationToken)
             {
                 await foreach (var value in stream)
                     await writer.WriteAsync(value, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -68,9 +68,9 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             }
 
             // Handle continuation in a local function to avoid capturing arguments when this path is avoided
-            return DelaySlow(delayTask, cancellationTokenSource, cancellationToken);
+            return DelaySlowAsync(delayTask, cancellationTokenSource, cancellationToken);
 
-            static Task<bool> DelaySlow(Task delayTask, CancellationTokenSource cancellationTokenSourceToDispose, CancellationToken cancellationToken)
+            static Task<bool> DelaySlowAsync(Task delayTask, CancellationTokenSource cancellationTokenSourceToDispose, CancellationToken cancellationToken)
             {
                 return delayTask.ContinueWith(
                     task =>

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -163,7 +163,7 @@ namespace Roslyn.Utilities
                     // No in-flight task.  Kick one off to process these messages a second from now.
                     // We always attach the task to the previous one so that notifications to the ui
                     // follow the same order as the notification the OOP server sent to us.
-                    _updateTask = ContinueAfterDelay(_updateTask);
+                    _updateTask = ContinueAfterDelayAsync(_updateTask);
                     _taskInFlight = true;
                 }
             }
@@ -187,7 +187,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            async Task<TResult?> ContinueAfterDelay(Task lastTask)
+            async Task<TResult?> ContinueAfterDelayAsync(Task lastTask)
             {
                 using var _ = _asyncListener.BeginAsyncOperation(nameof(AddWork));
 

--- a/src/Workspaces/Remote/ServiceHub/Services/ClientOptionProviders.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ClientOptionProviders.cs
@@ -34,10 +34,10 @@ internal sealed class RemoteOptionsProviderCache<TOptions>
 
     public async ValueTask<TOptions> GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
     {
-        var lazyOptions = ImmutableInterlocked.GetOrAdd(ref _cache, languageServices.Language, _ => AsyncLazy.Create(GetRemoteOptions));
+        var lazyOptions = ImmutableInterlocked.GetOrAdd(ref _cache, languageServices.Language, _ => AsyncLazy.Create(GetRemoteOptionsAsync));
         return await lazyOptions.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
-        Task<TOptions> GetRemoteOptions(CancellationToken cancellationToken)
+        Task<TOptions> GetRemoteOptionsAsync(CancellationToken cancellationToken)
             => _callback(_callbackId, languageServices.Language, cancellationToken).AsTask();
     }
 }


### PR DESCRIPTION
Observed a few hundred exceptions in a performance trace that were easy to clean up.