### PR TITLE
Do not bail out of unused parameter analysis if encountered a `nameof` expression

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1895,5 +1895,19 @@ class C(int [|a100|]) : Object()
     int M1() => a100;
 }");
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70276")]
+        public async Task TestMethodWithNameOf()
+        {
+            await TestDiagnosticsAsync("""
+                class C
+                {
+                    void M(int [|x|])
+                    {
+                        const string y = nameof(C);
+                    }
+                }
+                """, Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId));
+        }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/70276

The root cause is that when `nameof` is used with a namespace or type name it causes `None` operation kind to appear in the tree. Previously analyzer bailed out as soon as it encountered any `None` operation, so I whitelisted this case as a well-known one.

Note, that since `nameof(parameter)` was correctly working previously we already have a test that verifies a message when parameter is used only in `nameof`:
https://github.com/dotnet/roslyn/blob/2e425a806f07f7f0bfa3fb5bbb3222b13564a538/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs#L1189-L1234
As you can see we report diagnostic with `Parameter '{0}' can be removed; its initial value is never used` message, which makes a lot of sense to me. So I neither changed behavior around it nor added any additional tests in this area.