### PR TITLE
Link to topic about choosing diagnostic IDs

### DIFF
--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// An unique identifier for the diagnostic.
         /// </summary>
+        /// <remarks>
+        /// <a href="/dotnet/csharp/roslyn-sdk/choosing-diagnostic-ids">Choose an appropriate diagnostic ID</a> such that it is unique.
+        /// </remarks>
         public string Id { get; }
 
         /// <summary>
@@ -87,6 +90,9 @@ namespace Microsoft.CodeAnalysis
         /// <param name="description">An optional longer description of the diagnostic.</param>
         /// <param name="helpLinkUri">An optional hyperlink that provides a more detailed description regarding the diagnostic.</param>
         /// <param name="customTags">Optional custom tags for the diagnostic. See <see cref="WellKnownDiagnosticTags"/> for some well known tags.</param>
+        /// <remarks>
+        /// <a href="/dotnet/csharp/roslyn-sdk/choosing-diagnostic-ids">Choose an appropriate diagnostic ID</a> such that it is unique.
+        /// </remarks>
         public DiagnosticDescriptor(
             string id,
             string title,
@@ -114,7 +120,9 @@ namespace Microsoft.CodeAnalysis
         /// <param name="description">An optional longer localizable description of the diagnostic.</param>
         /// <param name="helpLinkUri">An optional hyperlink that provides a more detailed description regarding the diagnostic.</param>
         /// <param name="customTags">Optional custom tags for the diagnostic. See <see cref="WellKnownDiagnosticTags"/> for some well known tags.</param>
-        /// <remarks>Example descriptor for rule CA1001:
+        /// <remarks>
+        /// Example descriptor for rule CA1001:
+        /// <code>
         ///     internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
         ///         new LocalizableResourceString(nameof(FxCopRulesResources.TypesThatOwnDisposableFieldsShouldBeDisposable), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources)),
         ///         new LocalizableResourceString(nameof(FxCopRulesResources.TypeOwnsDisposableFieldButIsNotDisposable), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources)),
@@ -123,6 +131,8 @@ namespace Microsoft.CodeAnalysis
         ///         isEnabledByDefault: true,
         ///         helpLinkUri: "http://msdn.microsoft.com/library/ms182172.aspx",
         ///         customTags: DiagnosticCustomTags.Microsoft);
+        /// </code>
+        /// <a href="/dotnet/csharp/roslyn-sdk/choosing-diagnostic-ids">Choose an appropriate diagnostic ID</a> such that it is unique.
         /// </remarks>
         public DiagnosticDescriptor(
             string id,


### PR DESCRIPTION
This links the newly added topic about choosing [diagnostic IDs](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/choosing-diagnostic-ids).

This is a replacement for https://github.com/dotnet/roslyn-api-docs/pull/120.