### PR TITLE
Align VS workspace diagnostics with public spec by keeping request open until the workspace changes

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptPullDiagnosticHandlerProvider.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptPullDiagnosticHandlerProvider.cs
@@ -26,8 +26,9 @@ internal class VSTypeScriptDocumentPullDiagnosticHandlerFactory(
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal class VSTypeScriptWorkspacePullDiagnosticHandler(
+    LspWorkspaceRegistrationService registrationService,
     IDiagnosticAnalyzerService analyzerService,
     IDiagnosticsRefresher diagnosticsRefresher,
-    IGlobalOptionService globalOptions) : WorkspacePullDiagnosticHandlerFactory(analyzerService, diagnosticsRefresher, globalOptions)
+    IGlobalOptionService globalOptions) : WorkspacePullDiagnosticHandlerFactory(registrationService, analyzerService, diagnosticsRefresher, globalOptions)
 {
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
@@ -18,7 +18,8 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
-internal abstract class AbstractWorkspacePullDiagnosticsHandler<TDiagnosticsParams, TReport, TReturn> : AbstractPullDiagnosticHandler<TDiagnosticsParams, TReport, TReturn>, IDisposable
+internal abstract class AbstractWorkspacePullDiagnosticsHandler<TDiagnosticsParams, TReport, TReturn>
+    : AbstractPullDiagnosticHandler<TDiagnosticsParams, TReport, TReturn>, IDisposable
     where TDiagnosticsParams : IPartialResultParams<TReport>
 {
     private readonly LspWorkspaceRegistrationService _workspaceRegistrationService;

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
@@ -1,0 +1,252 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.SolutionCrawler;
+using Microsoft.CodeAnalysis.TaskList;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
+internal abstract class AbstractWorkspacePullDiagnosticsHandler<TDiagnosticsParams, TReport, TReturn> : AbstractPullDiagnosticHandler<TDiagnosticsParams, TReport, TReturn>, IDisposable
+    where TDiagnosticsParams : IPartialResultParams<TReport>
+{
+    private readonly LspWorkspaceRegistrationService _workspaceRegistrationService;
+    private readonly LspWorkspaceManager _workspaceManager;
+
+    /// <summary>
+    /// Flag that represents whether the LSP view of the world has changed.
+    /// It is totally fine for this to somewhat over-report changes
+    /// as it is an optimization used to delay closing workspace diagnostic requests
+    /// until something has changed.
+    /// </summary>
+    private int _lspChanged = 0;
+
+    protected AbstractWorkspacePullDiagnosticsHandler(
+        LspWorkspaceManager workspaceManager,
+        LspWorkspaceRegistrationService registrationService,
+        IDiagnosticAnalyzerService diagnosticAnalyzerService,
+        IDiagnosticsRefresher diagnosticRefresher,
+        IGlobalOptionService globalOptions) : base(diagnosticAnalyzerService, diagnosticRefresher, globalOptions)
+    {
+        _workspaceManager = workspaceManager;
+        _workspaceRegistrationService = registrationService;
+
+        _workspaceRegistrationService.LspSolutionChanged += OnLspSolutionChanged;
+        _workspaceManager.LspTextChanged += OnLspTextChanged;
+    }
+
+    public void Dispose()
+    {
+        _workspaceManager.LspTextChanged -= OnLspTextChanged;
+        _workspaceRegistrationService.LspSolutionChanged -= OnLspSolutionChanged;
+    }
+
+    protected override async ValueTask<ImmutableArray<IDiagnosticSource>> GetOrderedDiagnosticSourcesAsync(TDiagnosticsParams diagnosticsParams, RequestContext context, CancellationToken cancellationToken)
+    {
+        // If we're being called from razor, we do not support WorkspaceDiagnostics at all.  For razor, workspace
+        // diagnostics will be handled by razor itself, which will operate by calling into Roslyn and asking for
+        // document-diagnostics instead.
+        if (context.ServerKind == WellKnownLspServerKinds.RazorLspServer)
+            return ImmutableArray<IDiagnosticSource>.Empty;
+
+        var category = GetDiagnosticCategory(diagnosticsParams);
+
+        if (category == PullDiagnosticCategories.Task)
+            return GetTaskListDiagnosticSources(context, GlobalOptions);
+
+        // if this request doesn't have a category at all (legacy behavior, assume they're asking about everything).
+        if (category == null || category == PullDiagnosticCategories.WorkspaceDocumentsAndProject)
+            return await GetDiagnosticSourcesAsync(context, GlobalOptions, cancellationToken).ConfigureAwait(false);
+
+        // if it's a category we don't recognize, return nothing.
+        return ImmutableArray<IDiagnosticSource>.Empty;
+    }
+
+    private void OnLspSolutionChanged(object? sender, WorkspaceChangeEventArgs e)
+    {
+        UpdateLspChanged();
+    }
+
+    private void OnLspTextChanged(object? sender, EventArgs e)
+    {
+        UpdateLspChanged();
+    }
+
+    private void UpdateLspChanged()
+    {
+        Interlocked.Exchange(ref _lspChanged, 1);
+    }
+
+    protected override async Task WaitForChangesAsync(RequestContext context, CancellationToken cancellationToken)
+    {
+        // Spin waiting until our LSP change flag has been set.  When the flag is set (meaning LSP has changed),
+        // we reset the flag to false and exit out of the loop allowing the request to close.
+        // The client will automatically trigger a new request as soon as we close it, bringing us up to date on diagnostics.
+        while (Interlocked.CompareExchange(ref _lspChanged, value: 0, comparand: 1) == 0)
+        {
+            // There have been no changes between now and when the last request finished - we will hold the connection open while we poll for changes.
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
+        }
+
+        context.TraceInformation("Closing workspace/diagnostics request");
+        // We've hit a change, so we close the current request to allow the client to open a new one.
+        return;
+    }
+
+    private static ImmutableArray<IDiagnosticSource> GetTaskListDiagnosticSources(
+            RequestContext context, IGlobalOptionService globalOptions)
+    {
+        Contract.ThrowIfNull(context.Solution);
+
+        // Only compute task list items for closed files if the option is on for it.
+        var taskListEnabled = globalOptions.GetTaskListOptions().ComputeForClosedFiles;
+        if (!taskListEnabled)
+            return ImmutableArray<IDiagnosticSource>.Empty;
+
+        using var _ = ArrayBuilder<IDiagnosticSource>.GetInstance(out var result);
+
+        foreach (var project in GetProjectsInPriorityOrder(context.Solution, context.SupportedLanguages))
+        {
+            foreach (var document in project.Documents)
+            {
+                if (!ShouldSkipDocument(context, document))
+                    result.Add(new TaskListDiagnosticSource(document, globalOptions));
+            }
+        }
+
+        return result.ToImmutable();
+    }
+
+    public static async ValueTask<ImmutableArray<IDiagnosticSource>> GetDiagnosticSourcesAsync(
+        RequestContext context, IGlobalOptionService globalOptions, CancellationToken cancellationToken)
+    {
+        Contract.ThrowIfNull(context.Solution);
+
+        using var _ = ArrayBuilder<IDiagnosticSource>.GetInstance(out var result);
+
+        var solution = context.Solution;
+        var enableDiagnosticsInSourceGeneratedFiles = solution.Services.GetService<ISolutionCrawlerOptionsService>()?.EnableDiagnosticsInSourceGeneratedFiles == true;
+        var codeAnalysisService = solution.Workspace.Services.GetRequiredService<ICodeAnalysisDiagnosticAnalyzerService>();
+
+        foreach (var project in GetProjectsInPriorityOrder(solution, context.SupportedLanguages))
+            await AddDocumentsAndProject(project, cancellationToken).ConfigureAwait(false);
+
+        return result.ToImmutable();
+
+        async Task AddDocumentsAndProject(Project project, CancellationToken cancellationToken)
+        {
+            // There are two potential sources for reporting workspace diagnostics:
+            //
+            //  1. Full solution analysis: If the user has enabled Full solution analysis, we always run analysis on the latest
+            //                             project snapshot and return up-to-date diagnostics computed from this analysis.
+            //
+            //  2. Code analysis service: Otherwise, if full solution analysis is disabled, and if we have diagnostics from an explicitly
+            //                            triggered code analysis execution on either the current or a prior project snapshot, we return
+            //                            diagnostics from this execution. These diagnostics may be stale with respect to the current
+            //                            project snapshot, but they match user's intent of not enabling continuous background analysis
+            //                            for always having up-to-date workspace diagnostics, but instead computing them explicitly on
+            //                            specific project snapshots by manually running the "Run Code Analysis" command on a project or solution.
+            //
+            // If full solution analysis is disabled AND code analysis was never executed for the given project,
+            // we have no workspace diagnostics to report and bail out.
+            var fullSolutionAnalysisEnabled = globalOptions.IsFullSolutionAnalysisEnabled(project.Language, out var compilerFullSolutionAnalysisEnabled, out var analyzersFullSolutionAnalysisEnabled);
+            if (!fullSolutionAnalysisEnabled && !codeAnalysisService.HasProjectBeenAnalyzed(project.Id))
+                return;
+
+            var documents = ImmutableArray<TextDocument>.Empty.AddRange(project.Documents).AddRange(project.AdditionalDocuments);
+
+            // If all features are enabled for source generated documents, then compute todo-comments/diagnostics for them.
+            if (enableDiagnosticsInSourceGeneratedFiles)
+            {
+                var sourceGeneratedDocuments = await project.GetSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false);
+                documents = documents.AddRange(sourceGeneratedDocuments);
+            }
+
+            Func<DiagnosticAnalyzer, bool>? shouldIncludeAnalyzer = !compilerFullSolutionAnalysisEnabled || !analyzersFullSolutionAnalysisEnabled
+                ? ShouldIncludeAnalyzer : null;
+            foreach (var document in documents)
+            {
+                if (!ShouldSkipDocument(context, document))
+                {
+                    // Add the appropriate FSA or CodeAnalysis document source to get document diagnostics.
+                    var documentDiagnosticSource = fullSolutionAnalysisEnabled
+                        ? AbstractWorkspaceDocumentDiagnosticSource.CreateForFullSolutionAnalysisDiagnostics(document, shouldIncludeAnalyzer)
+                        : AbstractWorkspaceDocumentDiagnosticSource.CreateForCodeAnalysisDiagnostics(document, codeAnalysisService);
+                    result.Add(documentDiagnosticSource);
+                }
+            }
+
+            // Finally, add the appropriate FSA or CodeAnalysis project source to get project specific diagnostics, not associated with any document.
+            var projectDiagnosticSource = fullSolutionAnalysisEnabled
+                ? AbstractProjectDiagnosticSource.CreateForFullSolutionAnalysisDiagnostics(project, shouldIncludeAnalyzer)
+                : AbstractProjectDiagnosticSource.CreateForCodeAnalysisDiagnostics(project, codeAnalysisService);
+            result.Add(projectDiagnosticSource);
+
+            bool ShouldIncludeAnalyzer(DiagnosticAnalyzer analyzer)
+            {
+                return analyzer.IsCompilerAnalyzer() ? compilerFullSolutionAnalysisEnabled : analyzersFullSolutionAnalysisEnabled;
+            }
+        }
+    }
+
+    private static IEnumerable<Project> GetProjectsInPriorityOrder(
+            Solution solution, ImmutableArray<string> supportedLanguages)
+    {
+        return GetProjectsInPriorityOrderWorker(solution)
+            .WhereNotNull()
+            .Distinct()
+            .Where(p => supportedLanguages.Contains(p.Language));
+
+        static IEnumerable<Project?> GetProjectsInPriorityOrderWorker(Solution solution)
+        {
+            var documentTrackingService = solution.Services.GetRequiredService<IDocumentTrackingService>();
+
+            // Collect all the documents from the solution in the order we'd like to get diagnostics for.  This will
+            // prioritize the files from currently active projects, but then also include all other docs in all projects
+            // (depending on current FSA settings).
+
+            var activeDocument = documentTrackingService.GetActiveDocument(solution);
+            var visibleDocuments = documentTrackingService.GetVisibleDocuments(solution);
+
+            yield return activeDocument?.Project;
+            foreach (var doc in visibleDocuments)
+                yield return doc.Project;
+
+            foreach (var project in solution.Projects)
+                yield return project;
+        }
+    }
+
+    private static bool ShouldSkipDocument(RequestContext context, TextDocument document)
+    {
+        // Only consider closed documents here (and only open ones in the DocumentPullDiagnosticHandler).
+        // Each handler treats those as separate worlds that they are responsible for.
+        if (context.IsTracking(document.GetURI()))
+        {
+            context.TraceInformation($"Skipping tracked document: {document.GetURI()}");
+            return true;
+        }
+
+        // Do not attempt to get workspace diagnostics for Razor files, Razor will directly ask us for document diagnostics
+        // for any razor file they are interested in.
+        return document.IsRazorDocument();
+    }
+
+    internal abstract TestAccessor GetTestAccessor();
+
+    internal readonly struct TestAccessor(AbstractWorkspacePullDiagnosticsHandler<TDiagnosticsParams, TReport, TReturn> handler)
+    {
+        public void TriggerConnectionClose() => handler.UpdateLspChanged();
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticHandlerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticHandlerFactory.cs
@@ -5,37 +5,23 @@
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.Public;
 
 [ExportCSharpVisualBasicLspServiceFactory(typeof(PublicWorkspacePullDiagnosticsHandler)), Shared]
-internal sealed class PublicWorkspacePullDiagnosticHandlerFactory : ILspServiceFactory
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class PublicWorkspacePullDiagnosticHandlerFactory(
+    LspWorkspaceRegistrationService registrationService,
+    IDiagnosticAnalyzerService analyzerService,
+    IDiagnosticsRefresher diagnosticsRefresher,
+    IGlobalOptionService globalOptions) : ILspServiceFactory
 {
-    private readonly LspWorkspaceRegistrationService _registrationService;
-    private readonly IDiagnosticAnalyzerService _analyzerService;
-    private readonly IDiagnosticsRefresher _diagnosticsRefresher;
-    private readonly IGlobalOptionService _globalOptions;
-
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public PublicWorkspacePullDiagnosticHandlerFactory(
-        LspWorkspaceRegistrationService registrationService,
-        IDiagnosticAnalyzerService analyzerService,
-        IDiagnosticsRefresher diagnosticsRefresher,
-        IGlobalOptionService globalOptions)
-    {
-        _registrationService = registrationService;
-        _analyzerService = analyzerService;
-        _diagnosticsRefresher = diagnosticsRefresher;
-        _globalOptions = globalOptions;
-    }
-
     public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
     {
         var workspaceManager = lspServices.GetRequiredService<LspWorkspaceManager>();
-        return new PublicWorkspacePullDiagnosticsHandler(workspaceManager, _registrationService, _analyzerService, _diagnosticsRefresher, _globalOptions);
+        return new PublicWorkspacePullDiagnosticsHandler(workspaceManager, registrationService, analyzerService, diagnosticsRefresher, globalOptions);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
@@ -5,11 +5,8 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Utilities;
@@ -22,39 +19,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.Public;
 using WorkspaceDiagnosticPartialReport = SumType<WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult>;
 
 [Method(Methods.WorkspaceDiagnosticName)]
-internal sealed class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHandler<WorkspaceDiagnosticParams, WorkspaceDiagnosticPartialReport, WorkspaceDiagnosticReport?>, IDisposable
+internal sealed class PublicWorkspacePullDiagnosticsHandler(
+    LspWorkspaceManager workspaceManager,
+    LspWorkspaceRegistrationService registrationService,
+    IDiagnosticAnalyzerService analyzerService,
+    IDiagnosticsRefresher diagnosticRefresher,
+    IGlobalOptionService globalOptions)
+    : AbstractWorkspacePullDiagnosticsHandler<WorkspaceDiagnosticParams, WorkspaceDiagnosticPartialReport, WorkspaceDiagnosticReport?>(
+        workspaceManager, registrationService, analyzerService, diagnosticRefresher, globalOptions), IDisposable
 {
-    private readonly LspWorkspaceRegistrationService _workspaceRegistrationService;
-    private readonly LspWorkspaceManager _workspaceManager;
-
-    /// <summary>
-    /// Flag that represents whether the LSP view of the world has changed.
-    /// It is totally fine for this to somewhat over-report changes
-    /// as it is an optimization used to delay closing workspace diagnostic requests
-    /// until something has changed.
-    /// </summary>
-    private int _lspChanged = 0;
-
-    public PublicWorkspacePullDiagnosticsHandler(
-        LspWorkspaceManager workspaceManager,
-        LspWorkspaceRegistrationService registrationService,
-        IDiagnosticAnalyzerService analyzerService,
-        IDiagnosticsRefresher diagnosticRefresher,
-        IGlobalOptionService globalOptions)
-        : base(analyzerService, diagnosticRefresher, globalOptions)
-    {
-        _workspaceManager = workspaceManager;
-        _workspaceRegistrationService = registrationService;
-
-        _workspaceRegistrationService.LspSolutionChanged += OnLspSolutionChanged;
-        _workspaceManager.LspTextChanged += OnLspTextChanged;
-    }
-
-    public void Dispose()
-    {
-        _workspaceManager.LspTextChanged -= OnLspTextChanged;
-        _workspaceRegistrationService.LspSolutionChanged -= OnLspSolutionChanged;
-    }
 
     /// <summary>
     /// Public API doesn't support categories (yet).
@@ -123,13 +96,6 @@ internal sealed class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagno
         };
     }
 
-    protected override ValueTask<ImmutableArray<IDiagnosticSource>> GetOrderedDiagnosticSourcesAsync(
-        WorkspaceDiagnosticParams diagnosticParams, RequestContext context, CancellationToken cancellationToken)
-    {
-        // Task list items are not reported through the public LSP diagnostic API.
-        return WorkspacePullDiagnosticHandler.GetDiagnosticSourcesAsync(context, GlobalOptions, cancellationToken);
-    }
-
     protected override ImmutableArray<PreviousPullResult>? GetPreviousResults(WorkspaceDiagnosticParams diagnosticsParams)
     {
         return diagnosticsParams.PreviousResultId.Select(id => new PreviousPullResult
@@ -142,48 +108,5 @@ internal sealed class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagno
         }).ToImmutableArray();
     }
 
-    private void OnLspSolutionChanged(object? sender, WorkspaceChangeEventArgs e)
-    {
-        UpdateLspChanged();
-    }
-
-    private void OnLspTextChanged(object? sender, EventArgs e)
-    {
-        UpdateLspChanged();
-    }
-
-    private void UpdateLspChanged()
-    {
-        Interlocked.Exchange(ref _lspChanged, 1);
-    }
-
-    protected override async Task WaitForChangesAsync(RequestContext context, CancellationToken cancellationToken)
-    {
-        // Spin waiting until our LSP change flag has been set.  When the flag is set (meaning LSP has changed),
-        // we reset the flag to false and exit out of the loop allowing the request to close.
-        // The client will automatically trigger a new request as soon as we close it, bringing us up to date on diagnostics.
-        while (Interlocked.CompareExchange(ref _lspChanged, value: 0, comparand: 1) == 0)
-        {
-            // There have been no changes between now and when the last request finished - we will hold the connection open while we poll for changes.
-            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
-        }
-
-        context.TraceInformation("Closing workspace/diagnostics request");
-        // We've hit a change, so we close the current request to allow the client to open a new one.
-        return;
-    }
-
-    internal TestAccessor GetTestAccessor() => new(this);
-
-    internal readonly struct TestAccessor
-    {
-        private readonly PublicWorkspacePullDiagnosticsHandler _handler;
-
-        public TestAccessor(PublicWorkspacePullDiagnosticsHandler handler)
-        {
-            _handler = handler;
-        }
-
-        public void TriggerConnectionClose() => _handler.UpdateLspChanged();
-    }
+    internal override TestAccessor GetTestAccessor() => new(this);
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandlerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandlerFactory.cs
@@ -11,25 +11,18 @@ using Microsoft.CodeAnalysis.Options;
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 {
     [ExportCSharpVisualBasicLspServiceFactory(typeof(WorkspacePullDiagnosticHandler)), Shared]
-    internal class WorkspacePullDiagnosticHandlerFactory : ILspServiceFactory
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal class WorkspacePullDiagnosticHandlerFactory(
+        LspWorkspaceRegistrationService registrationService,
+        IDiagnosticAnalyzerService analyzerService,
+        IDiagnosticsRefresher diagnosticsRefresher,
+        IGlobalOptionService globalOptions) : ILspServiceFactory
     {
-        private readonly IDiagnosticAnalyzerService _analyzerService;
-        private readonly IDiagnosticsRefresher _diagnosticsRefresher;
-        private readonly IGlobalOptionService _globalOptions;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public WorkspacePullDiagnosticHandlerFactory(
-            IDiagnosticAnalyzerService analyzerService,
-            IDiagnosticsRefresher diagnosticsRefresher,
-            IGlobalOptionService globalOptions)
-        {
-            _analyzerService = analyzerService;
-            _diagnosticsRefresher = diagnosticsRefresher;
-            _globalOptions = globalOptions;
-        }
-
         public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
-            => new WorkspacePullDiagnosticHandler(_analyzerService, _diagnosticsRefresher, _globalOptions);
+        {
+            var workspaceManager = lspServices.GetRequiredService<LspWorkspaceManager>();
+            return new WorkspacePullDiagnosticHandler(workspaceManager, registrationService, analyzerService, diagnosticsRefresher, globalOptions);
+        }
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -1911,15 +1911,15 @@ class A {";
         }
 
         [Theory, CombinatorialData]
-        public async Task TestPublicWorkspaceDiagnosticsWaitsForLspTextChanges(bool mutatingLspWorkspace)
+        public async Task TestWorkspaceDiagnosticsWaitsForLspTextChanges(bool useVSDiagnostics, bool mutatingLspWorkspace)
         {
             var markup1 =
 @"class A {";
             var markup2 = "";
             await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(
-                new[] { markup1, markup2 }, mutatingLspWorkspace, BackgroundAnalysisScope.FullSolution, useVSDiagnostics: false);
+                new[] { markup1, markup2 }, mutatingLspWorkspace, BackgroundAnalysisScope.FullSolution, useVSDiagnostics);
 
-            var resultTask = RunPublicGetWorkspacePullDiagnosticsAsync(testLspServer, useProgress: true, triggerConnectionClose: false);
+            var resultTask = RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, useProgress: true, triggerConnectionClose: false);
 
             // Assert that the connection isn't closed and task doesn't complete even after some delay.
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -1935,15 +1935,15 @@ class A {";
         }
 
         [Theory, CombinatorialData]
-        public async Task TestPublicWorkspaceDiagnosticsWaitsForLspSolutionChanges(bool mutatingLspWorkspace)
+        public async Task TestWorkspaceDiagnosticsWaitsForLspSolutionChanges(bool useVSDiagnostics, bool mutatingLspWorkspace)
         {
             var markup1 =
 @"class A {";
             var markup2 = "";
             await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(
-                new[] { markup1, markup2 }, mutatingLspWorkspace, BackgroundAnalysisScope.FullSolution, useVSDiagnostics: false);
+                new[] { markup1, markup2 }, mutatingLspWorkspace, BackgroundAnalysisScope.FullSolution, useVSDiagnostics);
 
-            var resultTask = RunPublicGetWorkspacePullDiagnosticsAsync(testLspServer, useProgress: true, triggerConnectionClose: false);
+            var resultTask = RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, useProgress: true, triggerConnectionClose: false);
 
             // Assert that the connection isn't closed and task doesn't complete even after some delay.
             await Task.Delay(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
Public LSP spec diagnostics for the workspace typically poll immediately and expect servers to keep the request open as long as they need it.

Our public spec implementation works by keeping the request open until we notice that the workspace changes.  Then we close the request, allowing the client to ask us again for diagnostics.

This updates the VS implementation to do the same now that they function the same way.

Resolves https://github.com/dotnet/roslyn/issues/70703