### PR TITLE
Update CodeStyle analyzer and MicrosoftNetCompilersToolset packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -149,8 +149,7 @@ dotnet_public_api_analyzer.require_api_files = true
 
 # IDE0055: Fix formatting
 # Workaround for https://github.com/dotnet/roslyn/issues/70570
-# Disabled because the current SDK warns on collection expressions
-dotnet_diagnostic.IDE0055.severity = none
+dotnet_diagnostic.IDE0055.severity = warning
 
 # CSharp code style settings:
 [*.cs]

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
       Keep the setting conditional. The toolset sets the assembly version to 42.42.42.42 if not set explicitly.
     -->
     <AssemblyVersion Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.8.0-1.23419.1</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.8.0-3.final</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->
@@ -24,7 +24,7 @@
     <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23411.1</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.149-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
     <!-- CodeStyleAnalyzerVersion should we updated together with version of dotnet-format in dotnet-tools.json -->
-    <CodeStyleAnalyzerVersion>4.6.0</CodeStyleAnalyzerVersion>
+    <CodeStyleAnalyzerVersion>4.8.0-3.final</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>17.7.188</VisualStudioEditorPackagesVersion>
     <ILAsmPackageVersion>6.0.0-rtm.21518.12</ILAsmPackageVersion>
     <ILDAsmPackageVersion>6.0.0-rtm.21518.12</ILDAsmPackageVersion>

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -45,7 +45,7 @@
       impact the correctness of the output, so we avoid the performance overhead where it's easy to do so.
     -->
     <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND '$(DisableNullableWarnings)' == 'true'">false</RoslynCheckCodeStyle>
-    <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND ('$(ContinuousIntegrationBuild)' != 'true' OR '$(RoslynEnforceCodeStyle)' == 'true')">true</RoslynCheckCodeStyle>
+    <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND ('$(ContinuousIntegrationBuild)' != 'true' OR '$(RoslynEnforceCodeStyle)' == 'true' OR '$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true')">true</RoslynCheckCodeStyle>
   </PropertyGroup>
 
   <!--

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -43,6 +43,7 @@
     <!--
       Disable code style analyzers in "older" targets for a multi-targeted project. These analyzers don't
       impact the correctness of the output, so we avoid the performance overhead where it's easy to do so.
+      Enable code style analyzers for design time builds for live background analysis while typing (see https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build).
     -->
     <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND '$(DisableNullableWarnings)' == 'true'">false</RoslynCheckCodeStyle>
     <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND ('$(ContinuousIntegrationBuild)' != 'true' OR '$(RoslynEnforceCodeStyle)' == 'true' OR '$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true')">true</RoslynCheckCodeStyle>

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -43,10 +43,9 @@
     <!--
       Disable code style analyzers in "older" targets for a multi-targeted project. These analyzers don't
       impact the correctness of the output, so we avoid the performance overhead where it's easy to do so.
-      Enable code style analyzers for design time builds for live background analysis while typing (see https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build).
     -->
     <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND '$(DisableNullableWarnings)' == 'true'">false</RoslynCheckCodeStyle>
-    <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND ('$(ContinuousIntegrationBuild)' != 'true' OR '$(RoslynEnforceCodeStyle)' == 'true' OR '$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true')">true</RoslynCheckCodeStyle>
+    <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND ('$(ContinuousIntegrationBuild)' != 'true' OR '$(RoslynEnforceCodeStyle)' == 'true')">true</RoslynCheckCodeStyle>
   </PropertyGroup>
 
   <!--

--- a/src/Analyzers/CSharp/Analyzers/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationDiagnosticAnalyzer.cs
@@ -106,7 +106,7 @@ internal class CSharpUseImplicitObjectCreationDiagnosticAnalyzer : AbstractBuilt
                 ConversionOperatorDeclarationSyntax conversion => conversion.Type,
                 OperatorDeclarationSyntax op => op.ReturnType,
                 BasePropertyDeclarationSyntax property => property.Type,
-                AccessorDeclarationSyntax(SyntaxKind.GetAccessorDeclaration) { Parent: AccessorListSyntax { Parent: BasePropertyDeclarationSyntax baseProperty } } accessor => baseProperty.Type,
+                AccessorDeclarationSyntax(SyntaxKind.GetAccessorDeclaration) { Parent: AccessorListSyntax { Parent: BasePropertyDeclarationSyntax baseProperty } } => baseProperty.Type,
                 _ => null,
             };
         }

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
@@ -59,9 +59,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
 
                 await _languageClientBroker.Value.LoadAsync(new LanguageClientMetadata(
                 [
-                        ContentTypeNames.CSharpContentType,
-                        ContentTypeNames.VisualBasicContentType,
-                        ContentTypeNames.FSharpContentType
+                    ContentTypeNames.CSharpContentType,
+                    ContentTypeNames.VisualBasicContentType,
+                    ContentTypeNames.FSharpContentType
                 ]), _languageClient).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatch(e))

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerVisualizerAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerVisualizerAttributeTests.cs
@@ -54,20 +54,32 @@ class Q
 
             DkmCustomUIVisualizerInfo[] customUIVisualizerInfo =
             [
-                new DkmCustomUIVisualizerInfo { Id = 0, Description = "P", MenuName = "P", Metric = "ClrCustomVisualizerVSHost",
+                new DkmCustomUIVisualizerInfo
+                {
+                    Id = 0,
+                    Description = "P",
+                    MenuName = "P",
+                    Metric = "ClrCustomVisualizerVSHost",
                     UISideVisualizerTypeName = typeP.FullName,
                     UISideVisualizerAssemblyName = typeP.Assembly.FullName,
                     UISideVisualizerAssemblyLocation = DkmClrCustomVisualizerAssemblyLocation.Unknown,
                     DebuggeeSideVisualizerTypeName = defaultDebuggeeSideVisualizerTypeName,
                     DebuggeeSideVisualizerAssemblyName = defaultDebuggeeSideVisualizerAssemblyName,
-                    ExtensionPartId = Guid.Empty},
-                new DkmCustomUIVisualizerInfo { Id = 1, Description = "Q Visualizer", MenuName = "Q Visualizer",  Metric = "ClrCustomVisualizerVSHost",
+                    ExtensionPartId = Guid.Empty
+                },
+                new DkmCustomUIVisualizerInfo
+                {
+                    Id = 1,
+                    Description = "Q Visualizer",
+                    MenuName = "Q Visualizer",
+                    Metric = "ClrCustomVisualizerVSHost",
                     UISideVisualizerTypeName = typeQ.FullName,
                     UISideVisualizerAssemblyName = typeQ.Assembly.FullName,
                     UISideVisualizerAssemblyLocation = DkmClrCustomVisualizerAssemblyLocation.Unknown,
                     DebuggeeSideVisualizerTypeName = defaultDebuggeeSideVisualizerTypeName,
                     DebuggeeSideVisualizerAssemblyName = defaultDebuggeeSideVisualizerAssemblyName,
-                    ExtensionPartId = Guid.Empty}
+                    ExtensionPartId = Guid.Empty
+                }
             ];
 
             Verify(evalResult,

--- a/src/Features/CSharp/Portable/CodeRefactorings/UseRecursivePatterns/UseRecursivePatternsCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/UseRecursivePatterns/UseRecursivePatternsCodeRefactoringProvider.cs
@@ -85,8 +85,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseRecursivePatterns
             => node switch
             {
                 BinaryExpressionSyntax(LogicalAndExpression) => true,
-                CasePatternSwitchLabelSyntax { WhenClause: { } whenClause } => true,
-                SwitchExpressionArmSyntax { WhenClause: { } whenClause } => true,
+                CasePatternSwitchLabelSyntax { WhenClause: { } } => true,
+                SwitchExpressionArmSyntax { WhenClause: { } } => true,
                 WhenClauseSyntax { Parent: CasePatternSwitchLabelSyntax } => true,
                 WhenClauseSyntax { Parent: SwitchExpressionArmSyntax } => true,
                 _ => false

--- a/src/Features/CSharp/Portable/ConvertLinq/ConvertForEachToLinqQuery/YieldReturnConverter.cs
+++ b/src/Features/CSharp/Portable/ConvertLinq/ConvertForEachToLinqQuery/YieldReturnConverter.cs
@@ -26,10 +26,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertLinq.ConvertForEachToLinqQuery
                selectExpression: _yieldReturnStatement.Expression,
                leadingTokensForSelect: new[] { _yieldReturnStatement.YieldKeyword, _yieldReturnStatement.ReturnOrBreakKeyword },
                trailingTokensForSelect: _yieldBreakStatement != null
-                                        ? [ _yieldReturnStatement.SemicolonToken,
-                                                _yieldBreakStatement.YieldKeyword,
-                                                _yieldBreakStatement.ReturnOrBreakKeyword,
-                                                _yieldBreakStatement.SemicolonToken ]
+                                        ? [_yieldReturnStatement.SemicolonToken,
+                                            _yieldBreakStatement.YieldKeyword,
+                                            _yieldBreakStatement.ReturnOrBreakKeyword,
+                                            _yieldBreakStatement.SemicolonToken]
                                         : [_yieldReturnStatement.SemicolonToken],
                convertToQuery: convertToQuery);
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractContextVariableArgumentProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractContextVariableArgumentProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Completion
             if (IsInstanceContext(tree, targetToken, context.SemanticModel, context.CancellationToken))
             {
                 var enclosingSymbol = context.SemanticModel.GetEnclosingSymbol(targetToken.SpanStart, context.CancellationToken);
-                while (enclosingSymbol is IMethodSymbol { MethodKind: MethodKind.LocalFunction or MethodKind.AnonymousFunction } method)
+                while (enclosingSymbol is IMethodSymbol { MethodKind: MethodKind.LocalFunction or MethodKind.AnonymousFunction })
                 {
                     // It is allowed to reference the instance (`this`) within a local function or anonymous function,
                     // as long as the containing method allows it

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
         {
             if (symbol == null)
                 return false;
+
             if (symbol is IPropertySymbol { SetMethod: { } setMethod } &&
                 !IsSymbolAccessible(compilation, setMethod))
             {

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
@@ -43,8 +43,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
         {
             if (symbol == null)
                 return false;
-
-            if (symbol is IPropertySymbol { SetMethod: { } setMethod } property &&
+            if (symbol is IPropertySymbol { SetMethod: { } setMethod } &&
                 !IsSymbolAccessible(compilation, setMethod))
             {
                 return false;

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/VsReferenceHashingAlgorithm.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/VsReferenceHashingAlgorithm.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
 internal static class VsReferenceHashingAlgorithm
 {
     private static readonly ulong[] s_hashText =
+#pragma warning disable format // https://github.com/dotnet/roslyn/issues/70711 tracks removing this suppression.
     [
         0x0000000000000000, 0x0809e8a2969451e9, 0x1013d1452d28a3d2, 0x181a39e7bbbcf23b,
         0x2027a28a5a5147a4, 0x282e4a28ccc5164d, 0x303473cf7779e476, 0x383d9b6de1edb59f,
@@ -80,6 +81,7 @@ internal static class VsReferenceHashingAlgorithm
         0x3fc53cf3939e7ac7, 0x37ccd451050a2b2e, 0x2fd6edb6beb6d915, 0x27df0514282288fc,
         0x1fe29e79c9cf3d63, 0x17eb76db5f5b6c8a, 0x0ff14f3ce4e79eb1, 0x07f8a79e7273cf58,
     ];
+#pragma warning restore format
 
     /// <summary>
     /// The format in which the input stream should be read.abstract Ulong bitmask

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/VsTfmAndFileExtHashingAlgorithm.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/VsTfmAndFileExtHashingAlgorithm.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
 internal static class VsTfmAndFileExtHashingAlgorithm
 {
     private static readonly long[] s_cr3tab =  /* CRC polynomial 0xedb88320 */
+#pragma warning disable format // https://github.com/dotnet/roslyn/issues/70711 tracks removing this suppression.
     [
         0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L, 0x706af48fL, 0xe963a535L, 0x9e6495a3L,
         0x0edb8832L, 0x79dcb8a4L, 0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L, 0x90bf1d91L,
@@ -52,6 +53,7 @@ internal static class VsTfmAndFileExtHashingAlgorithm
         0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L, 0xcdd70693L, 0x54de5729L, 0x23d967bfL,
         0xb3667a2eL, 0xc4614ab8L, 0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL, 0x2d02ef8dL
     ];
+#pragma warning restore format
 
     public static string HashInput(string cleartext)
     {

--- a/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveHandler.cs
@@ -72,8 +72,8 @@ internal sealed class CodeLensResolveHandler : ILspServiceDocumentRequestHandler
                 Arguments =
                 [
                     resolveData.TextDocument.Uri,
-                    request.Range.Start
-                ]
+                    request.Range.Start,
+                ],
             };
 
         }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveHandler.cs
@@ -71,8 +71,8 @@ internal sealed class CodeLensResolveHandler : ILspServiceDocumentRequestHandler
                 CommandIdentifier = ClientReferencesCommand,
                 Arguments =
                 [
-                        resolveData.TextDocument.Uri,
-                        request.Range.Start
+                    resolveData.TextDocument.Uri,
+                    request.Range.Start
                 ]
             };
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/MapCode/MapCodeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/MapCode/MapCodeTests.cs
@@ -101,8 +101,8 @@ public class MapCodeTests : AbstractLanguageServerProtocolTests
                     new MapCodeMapping
                     (
                         TextDocument: CreateTextDocumentIdentifier(documentUri),
-                        Contents:[codeBlock],
-                        FocusLocations:[ranges]
+                        Contents: [codeBlock],
+                        FocusLocations: [ranges]
                     )
                 ],
                 Updates: null

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
@@ -15,6 +15,8 @@ using Xunit;
 using Xunit.Abstractions;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
+#pragma warning disable format // We want to force explicit column spacing within the collection literals in this file, so we disable formatting.
+
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.SemanticTokens
 {
     public class SemanticTokensRangeTests : AbstractSemanticTokensTests

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangesTests.cs
@@ -40,6 +40,7 @@ static class C { }
             if (isVS)
             {
                 expectedResults.Data =
+#pragma warning disable format // Force explicit column spacing.
                 [
                     // Line | Char | Len | Token type                                                               | Modifier
                        0,     0,     10,   tokenTypeToIndex[SemanticTokenTypes.Comment],      0, // '// Comment'
@@ -63,6 +64,7 @@ static class C { }
                        0,     2,     1,    tokenTypeToIndex[ClassificationTypeNames.Punctuation], 0, // '}'
                 ];
             }
+#pragma warning restore format
 
             await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results.Data).ConfigureAwait(false);
             AssertEx.Equal(ConvertToReadableFormat(testLspServer.ClientCapabilities, expectedResults.Data), ConvertToReadableFormat(testLspServer.ClientCapabilities, results.Data));

--- a/src/Test/PdbUtilities/Reader/Token2SourceLineExporter.cs
+++ b/src/Test/PdbUtilities/Reader/Token2SourceLineExporter.cs
@@ -344,12 +344,14 @@ namespace Roslyn.Test.PdbUtilities
 
         private class IntHashTable
         {
+#pragma warning disable format // https://github.com/dotnet/roslyn/issues/70711 tracks removing this suppression.
             private static readonly int[] s_primes = [
                 3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
                 1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
                 17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
                 187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
                 1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369];
+#pragma warning restore format
 
             private static int GetPrime(int minSize)
             {

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -1475,7 +1475,7 @@ class Customer2
 }}
 ";
 
-        private static readonly string[] s_usingDirectivePlacement = [ $@"
+        private static readonly string[] s_usingDirectivePlacement = [$@"
 //[
     namespace Namespace
     {{
@@ -1500,7 +1500,7 @@ class Customer2
         }}
     }}
 //]
-" ];
+"];
 
         private static readonly string s_preferReadOnlyStruct = $@"
 //[

--- a/src/VisualStudio/Core/Def/GenerateType/GenerateTypeDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/GenerateType/GenerateTypeDialogViewModel.cs
@@ -46,11 +46,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
 
         // reserved names that cannot be a folder name or filename
         private readonly string[] _reservedKeywords =
+#pragma warning disable format // https://github.com/dotnet/roslyn/issues/70711 tracks removing this suppression.
                                                 [
                                                     "con", "prn", "aux", "nul",
                                                     "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
                                                     "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9", "clock$"
                                                 ];
+#pragma warning restore format
 
         // Below code details with the Access List and the manipulation
         public List<string> AccessList { get; }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpErrorListWeb.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpErrorListWeb.cs
@@ -45,9 +45,9 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
 
             string[] expectedContents =
             [
-                    "(Compiler) Index.razor(3, 20): error CS1002: ; expected",
-                    "(Compiler) Index.razor(3, 9): warning CS0219: The variable 'x' is assigned but its value is never used",
-                    "(Csc) Index.razor(1, 6): error RZ1016: The 'page' directive expects a string surrounded by double quotes.",
+                "(Compiler) Index.razor(3, 20): error CS1002: ; expected",
+                "(Compiler) Index.razor(3, 9): warning CS0219: The variable 'x' is assigned but its value is never used",
+                "(Csc) Index.razor(1, 6): error RZ1016: The 'page' directive expects a string surrounded by double quotes.",
             ];
 
             AssertEx.EqualOrDiff(

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpIntelliSense.cs
@@ -383,8 +383,8 @@ class Class1
 
             await TestServices.Input.SendAsync(
                 [
-                        'M',
-                        (VirtualKeyCode.RETURN, VirtualKeyCode.SHIFT),
+                    'M',
+                    (VirtualKeyCode.RETURN, VirtualKeyCode.SHIFT),
                 ],
                 HangMitigatingCancellationToken);
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpReferenceHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpReferenceHighlighting.cs
@@ -150,11 +150,11 @@ class C
             await TestServices.Editor.PlaceCaretAsync(marker, charsOffset: -1, cancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
                 [
-                FeatureAttribute.Workspace,
-                FeatureAttribute.SolutionCrawlerLegacy,
-                FeatureAttribute.DiagnosticService,
-                FeatureAttribute.Classification,
-                FeatureAttribute.ReferenceHighlighting,
+                    FeatureAttribute.Workspace,
+                    FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.DiagnosticService,
+                    FeatureAttribute.Classification,
+                    FeatureAttribute.ReferenceHighlighting,
                 ],
                 cancellationToken);
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/AddParameterDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/AddParameterDialogInProcess.cs
@@ -66,8 +66,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            if (await TryGetDialogAsync(cancellationToken) is not { } dialog)
+            if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 
             await ClickCancelAsync(cancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/AddParameterDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/AddParameterDialogInProcess.cs
@@ -66,6 +66,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
             if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ChangeSignatureDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ChangeSignatureDialogInProcess.cs
@@ -68,6 +68,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
             if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ChangeSignatureDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ChangeSignatureDialogInProcess.cs
@@ -68,8 +68,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            if (await TryGetDialogAsync(cancellationToken) is not { } dialog)
+            if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 
             await ClickCancelAsync(cancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ExtractInterfaceDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ExtractInterfaceDialogInProcess.cs
@@ -71,6 +71,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
             if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ExtractInterfaceDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ExtractInterfaceDialogInProcess.cs
@@ -71,8 +71,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            if (await TryGetDialogAsync(cancellationToken) is not { } dialog)
+            if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 
             await ClickCancelAsync(cancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/GenerateTypeDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/GenerateTypeDialogInProcess.cs
@@ -68,6 +68,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
             if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/GenerateTypeDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/GenerateTypeDialogInProcess.cs
@@ -68,8 +68,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            if (await TryGetDialogAsync(cancellationToken) is not { } dialog)
+            if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 
             await ClickCancelAsync(cancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MoveToNamespaceDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MoveToNamespaceDialogInProcess.cs
@@ -67,6 +67,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
             if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MoveToNamespaceDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MoveToNamespaceDialogInProcess.cs
@@ -67,8 +67,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            if (await TryGetDialogAsync(cancellationToken) is not { } dialog)
+            if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 
             await ClickCancelAsync(cancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/PickMembersDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/PickMembersDialogInProcess.cs
@@ -68,6 +68,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
             if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/PickMembersDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/PickMembersDialogInProcess.cs
@@ -68,8 +68,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         public async Task<bool> CloseWindowAsync(CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            if (await TryGetDialogAsync(cancellationToken) is not { } dialog)
+            if (await TryGetDialogAsync(cancellationToken) is not { })
                 return false;
 
             await ClickCancelAsync(cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
@@ -166,6 +166,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             for (var current = parameterNode; current != null; current = current.Parent)
             {
                 var declaredSymbol = semanticModel.GetDeclaredSymbol(current);
+
                 if (declaredSymbol is IMethodSymbol { MethodKind: not MethodKind.AnonymousFunction })
                     return current;
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
@@ -166,8 +166,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             for (var current = parameterNode; current != null; current = current.Parent)
             {
                 var declaredSymbol = semanticModel.GetDeclaredSymbol(current);
-
-                if (declaredSymbol is IMethodSymbol { MethodKind: not MethodKind.AnonymousFunction } method)
+                if (declaredSymbol is IMethodSymbol { MethodKind: not MethodKind.AnonymousFunction })
                     return current;
             }
 

--- a/src/Workspaces/CoreTest/UtilityTest/BKTreeTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/BKTreeTests.cs
@@ -134,12 +134,15 @@ namespace Microsoft.CodeAnalysis.UnitTests.UtilityTest
         [Fact]
         public void TestSpillover()
         {
+#pragma warning disable format // https://github.com/dotnet/roslyn/issues/70711 tracks removing this suppression.
             string[] testValues = [
                 /*root:*/ "Four",
                 /*d=1*/ "Fou", "For", "Fur", "Our", "FourA", "FouAr", "FoAur", "FAour", "AFour", "Tour",
                 /*d=2*/ "Fo", "Fu", "Fr", "or", "ur", "ou", "FourAb", "FouAbr", "FoAbur", "FAbour", "AbFour", "oFour", "Fuor", "Foru", "ours",
                 /*d=3*/ "F", "o", "u", "r", "Fob", "Fox", "bur", "urn", "hur", "foraa", "found"
             ];
+#pragma warning restore format
+
             TestTreeInvariants(testValues);
         }
 

--- a/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
@@ -135,6 +135,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         public static readonly string[] Top1000 =
+#pragma warning disable format // https://github.com/dotnet/roslyn/issues/70711 tracks removing this suppression.
             [
                 "a","able","about","above","act","add","afraid","after","again","against","age","ago","agree","air","all",
                 "allow","also","always","am","among","an","and","anger","animal","answer","any","appear","apple","are",
@@ -212,6 +213,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 "wish","with","woman","women","wonder","wont","wood","word","work","world","would","write","written",
                 "wrong","wrote","yard","year","yellow","yes","yet","you","young","your",
             ];
+#pragma warning restore format
 
         [Fact]
         public void Top1000Test()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return false;
 
             var exprSymbol = semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol;
-            if (exprSymbol is not IFieldSymbol { IsConst: true } field)
+            if (exprSymbol is not IFieldSymbol { IsConst: true })
                 return false;
 
             // See if interpreting the same expression as a type in this location binds.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1511,7 +1511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
             => ((TypePatternSyntax)node).Type;
 
         public bool IsVerbatimInterpolatedStringExpression([NotNullWhen(true)] SyntaxNode? node)
-            => node is InterpolatedStringExpressionSyntax { StringStartToken: (kind: SyntaxKind.InterpolatedVerbatimStringStartToken) } interpolatedString;
+            => node is InterpolatedStringExpressionSyntax { StringStartToken: (kind: SyntaxKind.InterpolatedVerbatimStringStartToken) };
 
         public bool IsInInactiveRegion(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             }
 
             var parent = castNode.WalkUpParentheses().GetRequiredParent();
-            if (parent is not PrefixUnaryExpressionSyntax(SyntaxKind.BitwiseNotExpression) originalBitwiseNotExpression)
+            if (parent is not PrefixUnaryExpressionSyntax(SyntaxKind.BitwiseNotExpression))
                 return false;
 
             // If we were parented by a bitwise negation before, we must also be afterwards.
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             Debug.Assert(rewrittenBitwiseNotExpression.Kind() == SyntaxKind.BitwiseNotExpression);
 
             var rewrittenOperation = rewrittenSemanticModel.GetOperation(rewrittenBitwiseNotExpression, cancellationToken);
-            if (rewrittenOperation is not IUnaryOperation { OperatorKind: UnaryOperatorKind.BitwiseNegation } unaryOperation)
+            if (rewrittenOperation is not IUnaryOperation { OperatorKind: UnaryOperatorKind.BitwiseNegation })
                 return false;
 
             // Post rewrite we need to have the same conversion outside that `~` that we had inside.


### PR DESCRIPTION
Resolves #70705 - [IDE0055](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) has now been re-enabled and valid formatting violations have been fixed. There are a few more formatting false positives within collection literals that are not part of `4.8.0-3.final` CodeStyle package - these have been suppressed with #70711 filed as a tracking issue to revert these suppressions once VS2022 17.9 Preview1 is released publicly.

This PR also fixes the [IDE0059](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059) violations from the new package.

Additionally, https://github.com/dotnet/roslyn/commit/aef5ae2caf59da00f8b2be5d0caa5c1d7d0b83e9 updates the repo such that we use identical version of CodeStyle package in CI and IDE live analysis during typing. Prior to this change we would use the built-in IDE analyzers/fixers from VS during IDE live analysis and a specific version of CodeStyle package specified in Versions.props in CI, which caused mismatch between IDExxxx diagnostics in live analysis and in CI. 