### PR TITLE
Fix for source generator diagnostics not showing up as part of live analysis when generators run in OOP

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -7,22 +7,18 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessarySuppressions;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics.EngineV2;
 using Microsoft.CodeAnalysis.Editor.Test;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote.Diagnostics;
+using Microsoft.CodeAnalysis.Remote.Testing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Simplification;
@@ -1239,11 +1235,11 @@ class A
             Assert.Equal(CancellationTestAnalyzer.DiagnosticId, diagnostic.Id);
         }
 
-        [Theory]
+        [Theory, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1909806")]
         [CombinatorialData]
-        internal async Task TestGeneratorProducedDiagnostics(bool fullSolutionAnalysis)
+        internal async Task TestGeneratorProducedDiagnostics(bool fullSolutionAnalysis, bool analyzeProject, TestHost testHost)
         {
-            using var workspace = TestWorkspace.CreateCSharp("// This file will get a diagnostic", composition: s_featuresCompositionWithMockDiagnosticUpdateSourceRegistrationService);
+            using var workspace = TestWorkspace.CreateCSharp("// This file will get a diagnostic", composition: s_featuresCompositionWithMockDiagnosticUpdateSourceRegistrationService.WithTestHostParts(testHost));
             var globalOptions = workspace.GetService<IGlobalOptionService>();
 
             var generator = new DiagnosticProducingGenerator(c => Location.Create(c.Compilation.SyntaxTrees.Single(), new TextSpan(0, 10)));
@@ -1252,13 +1248,12 @@ class A
             var project = workspace.CurrentSolution.Projects.Single();
             var document = project.Documents.Single();
 
-            if (fullSolutionAnalysis)
+            globalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp,
+                fullSolutionAnalysis ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.OpenFiles);
+
+            // If we aren't testing FSA or analyzing document diagnostics, then open the file.
+            if (!fullSolutionAnalysis || !analyzeProject)
             {
-                globalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution);
-            }
-            else
-            {
-                // If we aren't testing FSA, then open the file.
                 workspace.OpenDocument(document.Id);
             }
 
@@ -1280,7 +1275,10 @@ class A
             };
 
             var incrementalAnalyzer = (DiagnosticIncrementalAnalyzer)service.CreateIncrementalAnalyzer(workspace);
-            await incrementalAnalyzer.AnalyzeProjectAsync(project, semanticsChanged: true, InvocationReasons.Reanalyze, CancellationToken.None);
+            if (analyzeProject)
+                await incrementalAnalyzer.AnalyzeProjectAsync(project, semanticsChanged: true, InvocationReasons.Reanalyze, CancellationToken.None);
+            else
+                await incrementalAnalyzer.AnalyzeDocumentAsync(document, bodyOpt: null, InvocationReasons.SemanticChanged, CancellationToken.None);
 
             await ((AsynchronousOperationListener)service.Listener).ExpeditedWaitAsync();
 

--- a/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal interface IRemoteDiagnosticAnalyzerService
     {
         ValueTask<SerializableDiagnosticAnalysisResults> CalculateDiagnosticsAsync(Checksum solutionChecksum, DiagnosticArguments arguments, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<DiagnosticData>> GetSourceGeneratorDiagnosticsAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken);
         ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis, CancellationToken cancellationToken);
         ValueTask StartSolutionCrawlerAsync(CancellationToken cancellationToken);
     }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -542,7 +542,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     others: ImmutableArray<DiagnosticData>.Empty,
                     documentIds: null));
 
-            var generatorDiagnostics = await project.GetSourceGeneratorDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
+            var generatorDiagnostics = await InProcOrRemoteHostAnalyzerRunner.GetSourceGeneratorDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
             var diagnosticResultBuilder = new DiagnosticAnalysisResultBuilder(project, version);
             foreach (var generatorDiagnostic in generatorDiagnostics)
             {

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         project.Solution,
                         invocation: (service, solutionInfo, cancellationToken) => service.GetSourceGeneratorDiagnosticsAsync(solutionInfo, project.Id, cancellationToken),
                         cancellationToken).ConfigureAwait(false);
-                    
+
                     if (!result.HasValue)
                         return ImmutableArray<Diagnostic>.Empty;
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Diagnostics.EngineV2;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -84,6 +85,29 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return await AnalyzeInProcAsync(documentAnalysisScope, project, compilationWithAnalyzers,
                     client: null, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        public static async Task<ImmutableArray<Diagnostic>> GetSourceGeneratorDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            var options = project.Solution.Services.GetRequiredService<IWorkspaceConfigurationService>().Options;
+            if (!options.RunSourceGeneratorsInSameProcessOnly)
+            {
+                var remoteHostClient = await RemoteHostClient.TryGetClientAsync(project, cancellationToken).ConfigureAwait(false);
+                if (remoteHostClient != null)
+                {
+                    var result = await remoteHostClient.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, ImmutableArray<DiagnosticData>>(
+                        project.Solution,
+                        invocation: (service, solutionInfo, cancellationToken) => service.GetSourceGeneratorDiagnosticsAsync(solutionInfo, project.Id, cancellationToken),
+                        cancellationToken).ConfigureAwait(false);
+                    
+                    if (!result.HasValue || result.Value.IsEmpty)
+                        return ImmutableArray<Diagnostic>.Empty;
+
+                    return await result.Value.ToDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return await project.GetSourceGeneratorDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeInProcAsync(

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         invocation: (service, solutionInfo, cancellationToken) => service.GetSourceGeneratorDiagnosticsAsync(solutionInfo, project.Id, cancellationToken),
                         cancellationToken).ConfigureAwait(false);
                     
-                    if (!result.HasValue || result.Value.IsEmpty)
+                    if (!result.HasValue)
                         return ImmutableArray<Diagnostic>.Empty;
 
                     return await result.Value.ToDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -48,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         /// <summary>
-        /// Calculate dignostics. this works differently than other ones such as todo comments or designer attribute scanner
+        /// Calculate diagnostics. this works differently than other ones such as todo comments or designer attribute scanner
         /// since in proc and out of proc runs quite differently due to concurrency and due to possible amount of data
         /// that needs to pass through between processes
         /// </summary>
@@ -94,6 +95,31 @@ namespace Microsoft.CodeAnalysis.Remote
                         return result;
                     }, cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        public async ValueTask<ImmutableArray<DiagnosticData>> GetSourceGeneratorDiagnosticsAsync(Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken)
+        {
+            return await RunWithSolutionAsync(
+                solutionChecksum,
+                async solution =>
+                {
+                    var project = solution.GetRequiredProject(projectId);
+                    var diagnostics = await project.GetSourceGeneratorDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
+                    if (diagnostics.IsEmpty)
+                        return ImmutableArray<DiagnosticData>.Empty;
+
+                    using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var builder);
+                    foreach (var diagnostic in diagnostics)
+                    {
+                        var document = solution.GetDocument(diagnostic.Location.SourceTree);
+                        var data = document != null
+                            ? DiagnosticData.Create(diagnostic, document)
+                            : DiagnosticData.Create(solution, diagnostic, project);
+                        builder.Add(data);
+                    }
+
+                    return builder.ToImmutable();
+                }, cancellationToken).ConfigureAwait(false);
         }
 
         public ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Telemetry;
@@ -105,10 +106,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     var project = solution.GetRequiredProject(projectId);
                     var diagnostics = await project.GetSourceGeneratorDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
-                    if (diagnostics.IsEmpty)
-                        return ImmutableArray<DiagnosticData>.Empty;
-
-                    using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var builder);
+                    using var builder = TemporaryArray<DiagnosticData>.Empty;
                     foreach (var diagnostic in diagnostics)
                     {
                         var document = solution.GetDocument(diagnostic.Location.SourceTree);
@@ -118,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         builder.Add(data);
                     }
 
-                    return builder.ToImmutable();
+                    return builder.ToImmutableAndClear();
                 }, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Ensure that we fetch the source generator diagnostics using the IRemoteDiagnosticAnalyzerService when generators are executed in OOP test host

Fixes [AB#1909806](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1909806)

Verified that the repro scenario mentioned in the above bug is fixed after this change. Also verified that the added unit test in the first commit fails without the product changes for OOP test host.

FYI: This is a potential candidate to backport to 17.9 P1