### PR TITLE
Fix crash in 'Use primary constructor'

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
@@ -348,7 +348,7 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider() : CodeFixPro
             {
                 // Validated by analyzer.
                 await ProcessConstructorAssignmentAsync(
-                    semanticModel, (AssignmentExpressionSyntax)constructorDeclaration.ExpressionBody.Expression, expressionStatement: null).ConfigureAwait(false);
+                    (AssignmentExpressionSyntax)constructorDeclaration.ExpressionBody.Expression, expressionStatement: null).ConfigureAwait(false);
             }
             else
             {
@@ -358,13 +358,13 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider() : CodeFixPro
                     // Validated by analyzer.
                     var expressionStatement = (ExpressionStatementSyntax)statement;
                     await ProcessConstructorAssignmentAsync(
-                        semanticModel, (AssignmentExpressionSyntax)expressionStatement.Expression, expressionStatement).ConfigureAwait(false);
+                        (AssignmentExpressionSyntax)expressionStatement.Expression, expressionStatement).ConfigureAwait(false);
                 }
             }
         }
 
         async ValueTask ProcessConstructorAssignmentAsync(
-            SemanticModel semanticModel, AssignmentExpressionSyntax assignmentExpression, ExpressionStatementSyntax? expressionStatement)
+            AssignmentExpressionSyntax assignmentExpression, ExpressionStatementSyntax? expressionStatement)
         {
             // We can use constructorDeclarationSemanticModel because we're only processing the assignments in the
             // constructor itself.

--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
@@ -216,12 +216,9 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider() : CodeFixPro
                     if (nameSyntax.Parent is not QualifiedNameSyntax qualifiedNameSyntax || qualifiedNameSyntax.Right != nameSyntax)
                     {
                         var symbol = semanticModel.GetSymbolInfo(nameSyntax, cancellationToken).GetAnySymbol();
-                        if (symbol is INamedTypeSymbol { ContainingType: not null } &&
-                            namedType.Equals(symbol.ContainingType.OriginalDefinition))
-                        {
-                            // reference to a nested type in an unqualified fashion.  Have to qualify this.
-                            return QualifiedName(namedType.GenerateNameSyntax(), currentNameSyntax);
-                        }
+                        // reference to a nested type in an unqualified fashion.  Have to qualify this.
+                        if (symbol is INamedTypeSymbol { ContainingType: { } containingType })
+                            return QualifiedName(containingType.GenerateNameSyntax(), currentNameSyntax);
                     }
 
                     if (nameSyntax.Parent is not MemberAccessExpressionSyntax memberAccessExpression || memberAccessExpression.Name != nameSyntax)

--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
@@ -366,8 +366,6 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider() : CodeFixPro
         async ValueTask ProcessConstructorAssignmentAsync(
             AssignmentExpressionSyntax assignmentExpression, ExpressionStatementSyntax? expressionStatement)
         {
-            // We can use constructorDeclarationSemanticModel because we're only processing the assignments in the
-            // constructor itself.
             var member = semanticModel.GetSymbolInfo(assignmentExpression.Left, cancellationToken).GetAnySymbol()?.OriginalDefinition;
 
             // Validated by analyzer.

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -2535,6 +2535,36 @@ public partial class UsePrimaryConstructorTests
         }.RunAsync();
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70586")]
+    public async Task TestReferenceToNestedType5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                public class B(B.A a)
+                {
+                    public class A { }
+                }
+
+                public class C : B
+                {
+                    public [|C|](A a) : base(a) { }
+                }
+                """,
+            FixedCode = """
+                public class B(B.A a)
+                {
+                    public class A { }
+                }
+                
+                public class C(B.A a) : B(a)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
     [Fact]
     public async Task TestNotWithNonAutoProperty()
     {

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UsePrimaryConstructor;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -3106,9 +3105,8 @@ public partial class UsePrimaryConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
-                class Base
+                class Base(int i)
                 {
-                    public Base(int i) { }
                 }
 
                 partial class C
@@ -3123,9 +3121,8 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             FixedCode = """
-                class Base
+                class Base(int i)
                 {
-                    public Base(int i) { }
                 }
                 
                 partial class C(int i) : Base(i)
@@ -3148,9 +3145,8 @@ public partial class UsePrimaryConstructorTests
             TestCode = """
                 using System;
 
-                class Base
+                class Base(int i)
                 {
-                    public Base(int i) { }
                 }
 
                 partial class C : IDisposable
@@ -3167,9 +3163,10 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             FixedCode = """
-                class Base
+                using System;
+                
+                class Base(int i)
                 {
-                    public Base(int i) { }
                 }
                 
                 partial class C(int i) : Base(i), IDisposable
@@ -3178,6 +3175,86 @@ public partial class UsePrimaryConstructorTests
                 }
                 
                 partial class C : Base
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70658")]
+    public async Task TestPartialType3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class Base(int i)
+                {
+                }
+
+                partial class C<T>
+                {
+                    public [|C|](int i) : base(i)
+                    {
+                    }
+                }
+
+                partial class C<T> : Base
+                {
+                }
+                """,
+            FixedCode = """
+                class Base(int i)
+                {
+                }
+                
+                partial class C<T>(int i) : Base(i)
+                {
+                }
+                
+                partial class C<T> : Base
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70658")]
+    public async Task TestPartialType4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class Base(int i)
+                {
+                }
+
+                partial class C<T> where T : IDisposable
+                {
+                    public [|C|](int i) : base(i)
+                    {
+                    }
+                }
+
+                partial class C<T> : Base
+                {
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class Base(int i)
+                {
+                }
+                
+                partial class C<T>(int i) : Base(i) where T : IDisposable
+                {
+                }
+                
+                partial class C<T> : Base
                 {
                 }
                 """,

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -3101,7 +3101,7 @@ public partial class UsePrimaryConstructorTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70658")]
-    public async Task TestPartialType()
+    public async Task TestPartialType1()
     {
         await new VerifyCS.Test
         {
@@ -3130,6 +3130,51 @@ public partial class UsePrimaryConstructorTests
                 
                 partial class C(int i) : Base(i)
                 {
+                }
+                
+                partial class C : Base
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70658")]
+    public async Task TestPartialType2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class Base
+                {
+                    public Base(int i) { }
+                }
+
+                partial class C : IDisposable
+                {
+                    public [|C|](int i) : base(i)
+                    {
+                    }
+
+                    public void Dispose() { }
+                }
+
+                partial class C : Base
+                {
+                }
+                """,
+            FixedCode = """
+                class Base
+                {
+                    public Base(int i) { }
+                }
+                
+                partial class C(int i) : Base(i), IDisposable
+                {
+                    public void Dispose() { }
                 }
                 
                 partial class C : Base

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UsePrimaryConstructor;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.UsePrimaryConstructor;
@@ -3093,6 +3094,46 @@ public partial class UsePrimaryConstructorTests
                         /// </summary>
                         public int ILOffset { get; } = ilOffset;
                     }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70658")]
+    public async Task TestPartialType()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class Base
+                {
+                    public Base(int i) { }
+                }
+
+                partial class C
+                {
+                    public [|C|](int i) : base(i)
+                    {
+                    }
+                }
+
+                partial class C : Base
+                {
+                }
+                """,
+            FixedCode = """
+                class Base
+                {
+                    public Base(int i) { }
+                }
+                
+                partial class C(int i) : Base(i)
+                {
+                }
+                
+                partial class C : Base
+                {
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70658.
Fixes https://github.com/dotnet/roslyn/issues/70586.

Original fix errantly thought that that the primary constructor parameters (PCPs) coudl be passed to the base type, regardless of which partial part the base type was listed on.  This is incorrect.  The PCPs must be passed on the same type-decl that the primary constructor is declared on.  

The original logic was both incorrect, and it was crashed due to misuse of a semantic model for one file for nodes for another.  This fixes both issues.  We use the correct semantic model now (since we're only looking at the starting type decl), and we properly only pass parameters along on the same type decl we're starting at.