### PR TITLE
Implement textDocument/prepareRename for better rename experience

### DIFF
--- a/src/Features/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
+++ b/src/Features/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
@@ -54,7 +54,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
             capabilities.DefinitionProvider = true;
             capabilities.DocumentHighlightProvider = true;
-            capabilities.RenameProvider = true;
+            capabilities.RenameProvider = new RenameOptions
+            {
+                PrepareProvider = true,
+            };
             capabilities.ImplementationProvider = true;
             capabilities.CodeActionProvider = new CodeActionOptions { CodeActionKinds = [CodeActionKind.QuickFix, CodeActionKind.Refactor], ResolveProvider = true };
             capabilities.CompletionProvider = new VisualStudio.LanguageServer.Protocol.CompletionOptions

--- a/src/Features/LanguageServer/Protocol/Handler/Rename/PrepareRenameHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Rename/PrepareRenameHandler.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Rename;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+[ExportCSharpVisualBasicStatelessLspService(typeof(PrepareRenameHandler)), Shared]
+[Method(Methods.TextDocumentPrepareRenameName)]
+internal class PrepareRenameHandler : ILspServiceDocumentRequestHandler<PrepareRenameParams, DefaultBehaviorPrepareRename?>
+{
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public PrepareRenameHandler()
+    {
+    }
+
+    public bool MutatesSolutionState => false;
+    public bool RequiresLSPSolution => true;
+
+    public TextDocumentIdentifier GetTextDocumentIdentifier(PrepareRenameParams request) => request.TextDocument;
+
+    public async Task<DefaultBehaviorPrepareRename?> HandleRequestAsync(PrepareRenameParams request, RequestContext context, CancellationToken cancellationToken)
+    {
+        var document = context.Document;
+        Contract.ThrowIfNull(document);
+
+        var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+
+        var symbolicRenameInfo = await SymbolicRenameInfo.GetRenameInfoAsync(
+            document, position, cancellationToken).ConfigureAwait(false);
+        if (symbolicRenameInfo.IsError)
+            return null;
+
+        return new DefaultBehaviorPrepareRename
+        {
+            DefaultBehavior = true,
+        };
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/Rename/PrepareRenameHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Rename/PrepareRenameHandler.cs
@@ -15,18 +15,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 [ExportCSharpVisualBasicStatelessLspService(typeof(PrepareRenameHandler)), Shared]
 [Method(Methods.TextDocumentPrepareRenameName)]
-internal class PrepareRenameHandler : ILspServiceDocumentRequestHandler<PrepareRenameParams, DefaultBehaviorPrepareRename?>
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class PrepareRenameHandler() : ILspServiceDocumentRequestHandler<PrepareRenameParams, DefaultBehaviorPrepareRename?>
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public PrepareRenameHandler()
-    {
-    }
-
     public bool MutatesSolutionState => false;
     public bool RequiresLSPSolution => true;
 
-    public TextDocumentIdentifier GetTextDocumentIdentifier(PrepareRenameParams request) => request.TextDocument;
+    public TextDocumentIdentifier GetTextDocumentIdentifier(PrepareRenameParams request)
+        => request.TextDocument;
 
     public async Task<DefaultBehaviorPrepareRename?> HandleRequestAsync(PrepareRenameParams request, RequestContext context, CancellationToken cancellationToken)
     {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Rename/PrepareRenameTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Rename/PrepareRenameTests.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Rename
+{
+    public class PrepareRenameTests : AbstractLanguageServerProtocolTests
+    {
+        public PrepareRenameTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestPrepareRenameValidLocationAsync(bool mutatingLspWorkspace)
+        {
+            var markup =
+@"class A
+{
+    void {|caret:|}M()
+    {
+    }
+}";
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+            var renameLocation = testLspServer.GetLocations("caret").First();
+
+            var results = await RunPrepareRenameAsync(testLspServer, CreatePrepareRenameParams(renameLocation));
+            Assert.True(results?.DefaultBehavior);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestPrepareRenameInvalidLocationAsync(bool mutatingLspWorkspace)
+        {
+            var markup =
+@"class A
+{
+    // Cannot rename {|caret:|}inside a comment.
+    void M()
+    {
+    }
+}";
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+            var renameLocation = testLspServer.GetLocations("caret").First();
+
+            var results = await RunPrepareRenameAsync(testLspServer, CreatePrepareRenameParams(renameLocation));
+            Assert.Null(results);
+        }
+
+        private static LSP.PrepareRenameParams CreatePrepareRenameParams(LSP.Location location)
+            => new LSP.PrepareRenameParams()
+            {
+                Position = location.Range.Start,
+                TextDocument = CreateTextDocumentIdentifier(location.Uri)
+            };
+
+        private static async Task<LSP.DefaultBehaviorPrepareRename?> RunPrepareRenameAsync(TestLspServer testLspServer, LSP.PrepareRenameParams prepareRenameParams)
+        {
+            return await testLspServer.ExecuteRequestAsync<LSP.PrepareRenameParams, LSP.DefaultBehaviorPrepareRename?>(LSP.Methods.TextDocumentPrepareRenameName, prepareRenameParams, CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6643

### Why
Two benefits of implementing prepare rename
1.  The UX is better when an item cannot be renamed (see gifs below)
2.  It allows us to play nicer with other extensions that implement rename in different contexts.

### Before this change - rename on invalid identifier
![rename_fail](https://github.com/dotnet/roslyn/assets/5749229/e54447b6-5c75-4c6d-b20d-f866d94fa5d8)

### After this change - rename on invalid identifier
![prepare_rename](https://github.com/dotnet/roslyn/assets/5749229/5d4f8340-5f2e-465d-99d1-6263984273ad)
