### PR TITLE
[POC - Do not merge] Add target for handling a new MSBuild property 'EnforceCodeStyleSeverityInBuild'

### DIFF
--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -210,6 +210,22 @@ $@"<Project>{GetTargetContents(language)}
             {
                 return $"""
 
+                      <!-- Handle 'EnforceCodeStyleSeverityInBuild' - this property determines if code style severity set in 'option_name = option_value:severity' is respected on build. -->
+                      <Target Name="HandleEnforceCodeStyleSeverityInBuild"
+                              BeforeTargets="GenerateMSBuildEditorConfigFileCore;CoreCompile">
+                        <!-- Set default value for 'EnforceCodeStyleSeverityInBuild'. -->
+                        <PropertyGroup Condition="'$(EnforceCodeStyleSeverityInBuild)' == ''">
+                          <!-- Enable 'EnforceCodeStyleSeverityInBuild' by default for AnalysisLevel greater than or equals '9.0'. Otherwise, disable it by default. -->
+                          <EnforceCodeStyleSeverityInBuild Condition="'$(EffectiveAnalysisLevel)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '9.0'))">true</EnforceCodeStyleSeverityInBuild>
+                          <EnforceCodeStyleSeverityInBuild Condition="'$(EnforceCodeStyleSeverityInBuild)' == ''">false</EnforceCodeStyleSeverityInBuild>
+                        </PropertyGroup>
+
+                        <!-- Pass the MSBuild property value for 'EnforceCodeStyleSeverityInBuild' to the analyzers via analyzer config options. -->
+                        <ItemGroup>
+                          <CompilerVisibleProperty Include="EnforceCodeStyleSeverityInBuild" />
+                        </ItemGroup>
+                      </Target>
+
                       <Target Name="AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysis{language}CodeStyle" BeforeTargets="CoreCompile" Condition="'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'">
                         <!-- PropertyGroup to compute global analyzer config file to be used -->
                         <PropertyGroup>

--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -208,46 +208,48 @@ $@"<Project>{GetTargetContents(language)}
 
             static string GetTargetContents(string language)
             {
-                return $@"
-  <Target Name=""AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysis{language}CodeStyle"" BeforeTargets=""CoreCompile"" Condition=""'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'"">
-    <!-- PropertyGroup to compute global analyzer config file to be used -->
-    <PropertyGroup>
-      <!-- Default 'AnalysisLevelStyle' to the core 'AnalysisLevel' -->
-      <AnalysisLevelStyle Condition=""'$(AnalysisLevelStyle)' == ''"">$(AnalysisLevel)</AnalysisLevelStyle>
-      
-      <!-- AnalysisLevelStyle can also contain compound values with a prefix and suffix separated by a '-' character.
-           The prefix indicates the core AnalysisLevel for CA analyzers, which we ignore for IDE style analyzers.
-           The suffix indicates the bucket of rules to enable for 'Style' rules by default. It is used to map to the correct global config.
-      -->
-      <AnalysisLevelPrefixStyle Condition=""$(AnalysisLevelStyle.Contains('-'))"">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '-(.)*', ''))</AnalysisLevelPrefixStyle>
-      <AnalysisLevelSuffixStyle Condition=""'$(AnalysisLevelPrefixStyle)' != ''"">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '$(AnalysisLevelPrefixStyle)-', ''))</AnalysisLevelSuffixStyle>
-      
-      <!-- Default 'AnalysisLevelSuffixStyle' to the core 'AnalysisLevelSuffix' -->
-      <AnalysisLevelSuffixStyle Condition=""'$(AnalysisLevelSuffixStyle)' == ''"">$(AnalysisLevelSuffix)</AnalysisLevelSuffixStyle>
-      <!-- Default 'AnalysisModeStyle' to the core 'AnalysisMode' -->
-      <AnalysisModeStyle Condition=""'$(AnalysisModeStyle)' == ''"">$(AnalysisMode)</AnalysisModeStyle>
+                return $"""
 
-      <!-- Set the default analysis mode, if not set by the user -->
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>$(AnalysisLevelSuffixStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''"">$(AnalysisModeStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == 'AllEnabledByDefault'"">{nameof(AnalysisMode.All)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == 'AllDisabledByDefault'"">{nameof(AnalysisMode.None)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''"">{nameof(AnalysisMode.Default)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                      <Target Name="AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysis{language}CodeStyle" BeforeTargets="CoreCompile" Condition="'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'">
+                        <!-- PropertyGroup to compute global analyzer config file to be used -->
+                        <PropertyGroup>
+                          <!-- Default 'AnalysisLevelStyle' to the core 'AnalysisLevel' -->
+                          <AnalysisLevelStyle Condition="'$(AnalysisLevelStyle)' == ''">$(AnalysisLevel)</AnalysisLevelStyle>
 
-      <_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>AnalysisLevelStyle_$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle).editorconfig</_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle.ToLowerInvariant())</_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>
-      
-      <_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)' == ''"">$(MSBuildThisFileDirectory)config</_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)' != ''"">$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)\$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)</_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle>
-    </PropertyGroup>
+                          <!-- AnalysisLevelStyle can also contain compound values with a prefix and suffix separated by a '-' character.
+                               The prefix indicates the core AnalysisLevel for CA analyzers, which we ignore for IDE style analyzers.
+                               The suffix indicates the bucket of rules to enable for 'Style' rules by default. It is used to map to the correct global config.
+                          -->
+                          <AnalysisLevelPrefixStyle Condition="$(AnalysisLevelStyle.Contains('-'))">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '-(.)*', ''))</AnalysisLevelPrefixStyle>
+                          <AnalysisLevelSuffixStyle Condition="'$(AnalysisLevelPrefixStyle)' != ''">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '$(AnalysisLevelPrefixStyle)-', ''))</AnalysisLevelSuffixStyle>
 
-    <!-- Add the global config, if required. -->
-    <ItemGroup Condition=""Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and
-                           ('$(AnalysisLevelStyle)' != '$(AnalysisLevel)' or '$(AnalysisModeStyle)' != '$(AnalysisMode)')"">
-      <EditorConfigFiles Include=""$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)"" />
-    </ItemGroup>
-  </Target>
-";
+                          <!-- Default 'AnalysisLevelSuffixStyle' to the core 'AnalysisLevelSuffix' -->
+                          <AnalysisLevelSuffixStyle Condition="'$(AnalysisLevelSuffixStyle)' == ''">$(AnalysisLevelSuffix)</AnalysisLevelSuffixStyle>
+                          <!-- Default 'AnalysisModeStyle' to the core 'AnalysisMode' -->
+                          <AnalysisModeStyle Condition="'$(AnalysisModeStyle)' == ''">$(AnalysisMode)</AnalysisModeStyle>
+
+                          <!-- Set the default analysis mode, if not set by the user -->
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>$(AnalysisLevelSuffixStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''">$(AnalysisModeStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == 'AllEnabledByDefault'">{nameof(AnalysisMode.All)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == 'AllDisabledByDefault'">{nameof(AnalysisMode.None)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''">{nameof(AnalysisMode.Default)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+
+                          <_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>AnalysisLevelStyle_$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle).editorconfig</_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle.ToLowerInvariant())</_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>
+
+                          <_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)' == ''">$(MSBuildThisFileDirectory)config</_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)' != ''">$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)\$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)</_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle>
+                        </PropertyGroup>
+
+                        <!-- Add the global config, if required. -->
+                        <ItemGroup Condition="Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and
+                                               ('$(AnalysisLevelStyle)' != '$(AnalysisLevel)' or '$(AnalysisModeStyle)' != '$(AnalysisMode)')">
+                          <EditorConfigFiles Include="$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)" />
+                        </ItemGroup>
+                      </Target>
+
+                    """;
             }
         }
 


### PR DESCRIPTION
**Recommend to review commit-by-commit (first commit just converts existing string to a raw string literal)**

Proof of concept PR to address the concern raised in https://github.com/dotnet/roslyn/issues/52991#issuecomment-1788123932

'EnforceCodeStyleSeverityInBuild' property will determine if code style severity set in editorconfig entry `option_name = option_value:severity` is respected on build or not. We add this new property as a `CompilerVisibileProperty` to pass it to the analyzers via analyzer config options.

Note that this Target will get added to C# and VB CodeStyle targets file that is imported here: https://github.com/dotnet/sdk/blob/f52240f11ad291e6ee3cff86e83c0f7a21b60370/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets#L117-L120. I verified locally that `<%ProjectName%>.GeneratedMSBuildEditorConfig.editorconfig` generated by our tooling contains an entry with key `build_property.EnforceCodeStyleSeverityInBuild`, whose value is `true` or `false` based on the analysis level being greater than or equals 9.0
