### PR TITLE
Fix contract assertion firing with SG OOP syncing.

### DIFF
--- a/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
@@ -36,11 +36,14 @@ internal interface IRemoteSourceGenerationService
 /// Information that uniquely identifies the content of a source-generated document and ensures the remote and local
 /// hosts are in agreement on them.
 /// </summary>
-/// <param name="Checksum">Checksum produced from <see cref="SourceText.GetChecksum"/>.</param>
+/// <param name="OriginalSourceTextChecksum">Checksum originally produced from <see cref="SourceText.GetChecksum"/> on
+/// the server side.  This may technically not be the same checksum that is produced on the client side once the
+/// SourceText is hydrated there.  See comments on <see
+/// cref="SourceGeneratedDocumentState.GetOriginalSourceTextChecksum"/> for more details on when this happens.</param>
 /// <param name="EncodingName">Result of <see cref="SourceText.Encoding"/>'s <see cref="Encoding.WebName"/>.</param>
 /// <param name="ChecksumAlgorithm">Result of <see cref="SourceText.ChecksumAlgorithm"/>.</param>
 [DataContract]
 internal readonly record struct SourceGeneratedDocumentContentIdentity(
-    [property: DataMember(Order = 0)] Checksum Checksum,
+    [property: DataMember(Order = 0)] Checksum OriginalSourceTextChecksum,
     [property: DataMember(Order = 1)] string? EncodingName,
     [property: DataMember(Order = 2)] SourceHashAlgorithm ChecksumAlgorithm);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker_Generators.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker_Generators.cs
@@ -178,25 +178,24 @@ internal partial class SolutionState
                         documentIdentity,
                         sourceText,
                         ProjectState.ParseOptions!,
-                        ProjectState.LanguageServices);
-                    Contract.ThrowIfTrue(generatedDocument.GetTextChecksum() != contentIdentity.Checksum, "Checksums must match!");
+                        ProjectState.LanguageServices,
+                        // Server provided us the checksum, so we just pass that along.  Note: it is critical that we do
+                        // this as it may not be possible to reconstruct the same checksum the server produced due to
+                        // the lossy nature of source texts.  See comment on GetOriginalSourceTextChecksum for more detail.
+                        contentIdentity.OriginalSourceTextChecksum);
+                    Contract.ThrowIfTrue(generatedDocument.GetOriginalSourceTextChecksum() != contentIdentity.OriginalSourceTextChecksum, "Checksums must match!");
                     generatedDocumentsBuilder.Add(generatedDocument);
                 }
                 else
                 {
                     // a document that already matched something locally.
                     var existingDocument = generatorInfo.Documents.GetRequiredState(documentId);
-                    Contract.ThrowIfTrue(existingDocument.Identity != documentIdentity, "Identies must match!");
-                    Contract.ThrowIfTrue(existingDocument.GetTextChecksum() != contentIdentity.Checksum, "Checksums must match!");
+                    Contract.ThrowIfTrue(existingDocument.Identity != documentIdentity, "Identities must match!");
+                    Contract.ThrowIfTrue(existingDocument.GetOriginalSourceTextChecksum() != contentIdentity.OriginalSourceTextChecksum, "Checksums must match!");
 
-                    if (existingDocument.ParseOptions.Equals(this.ProjectState.ParseOptions))
-                    {
-                        generatedDocumentsBuilder.Add(existingDocument);
-                    }
-                    else
-                    {
-                        generatedDocumentsBuilder.Add(existingDocument.WithUpdatedGeneratedContent(existingDocument.SourceText, this.ProjectState.ParseOptions!));
-                    }
+                    // ParseOptions may have changed between last generation and this one.  Ensure that they are
+                    // properly propagated to the generated doc.
+                    generatedDocumentsBuilder.Add(existingDocument.WithParseOptions(this.ProjectState.ParseOptions!));
                 }
             }
 
@@ -305,9 +304,9 @@ internal partial class SolutionState
 
                     if (existing != null)
                     {
-                        var newDocument = existing.WithUpdatedGeneratedContent(
-                            generatedSource.SourceText,
-                            this.ProjectState.ParseOptions!);
+                        var newDocument = existing
+                            .WithText(generatedSource.SourceText)
+                            .WithParseOptions(this.ProjectState.ParseOptions!);
 
                         generatedDocumentsBuilder.Add(newDocument);
 
@@ -330,7 +329,9 @@ internal partial class SolutionState
                                 identity,
                                 generatedSource.SourceText,
                                 generatedSource.SyntaxTree.Options,
-                                ProjectState.LanguageServices));
+                                ProjectState.LanguageServices,
+                                // Compute the checksum on demand from the given source text.
+                                originalSourceTextChecksum: null));
 
                         // The count of trees was the same, but something didn't match up. Since we're here, at least one tree
                         // was added, and an equal number must have been removed. Rather than trying to incrementally update

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1881,7 +1881,9 @@ namespace Microsoft.CodeAnalysis
 
             if (existingGeneratedState != null)
             {
-                newGeneratedState = existingGeneratedState.WithUpdatedGeneratedContent(sourceText, existingGeneratedState.ParseOptions);
+                newGeneratedState = existingGeneratedState
+                    .WithText(sourceText)
+                    .WithParseOptions(existingGeneratedState.ParseOptions);
 
                 // If the content already matched, we can just reuse the existing state
                 if (newGeneratedState == existingGeneratedState)
@@ -1896,7 +1898,9 @@ namespace Microsoft.CodeAnalysis
                     documentIdentity,
                     sourceText,
                     projectState.ParseOptions!,
-                    projectState.LanguageServices);
+                    projectState.LanguageServices,
+                    // Just compute the checksum from the source text passed in.
+                    originalSourceTextChecksum: null);
             }
 
             var projectId = documentIdentity.DocumentId.ProjectId;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -7,12 +7,14 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.SourceGeneration;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Microsoft.CodeAnalysis;
 
 internal sealed class SourceGeneratedDocumentState : DocumentState
 {
+    /// <summary>
+    /// Backing store for <see cref="GetOriginalSourceTextChecksum"/>.
+    /// </summary>
     private readonly Lazy<Checksum> _lazyTextChecksum;
 
     public SourceGeneratedDocumentIdentity Identity { get; }
@@ -25,11 +27,39 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
     /// </summary>
     public SourceText SourceText { get; }
 
+    /// <summary>
+    /// Checksum of <see cref="SourceText"/> when it was <em>originally</em> created.  This is subtly, but importantly
+    /// different from the checksum acquired from <see cref="SourceText.GetChecksum"/>.  Specifically, the original
+    /// source text may have been created from a <see cref="System.IO.Stream"/> in a lossy fashion (for example,
+    /// removing BOM marks and the like) on the OOP side. As such, its checksum might not be reconstructible from the
+    /// actual text and hash algorithm that were used to create the SourceText on the host side.  To ensure both the
+    /// host and OOP are in agreement about the true content checksum, we store this separately.
+    /// </summary>
+    public Checksum GetOriginalSourceTextChecksum()
+        => _lazyTextChecksum.Value;
+
     public static SourceGeneratedDocumentState Create(
         SourceGeneratedDocumentIdentity documentIdentity,
         SourceText generatedSourceText,
         ParseOptions parseOptions,
-        LanguageServices languageServices)
+        LanguageServices languageServices,
+        Checksum? originalSourceTextChecksum)
+    {
+        // If the caller explicitly provided us with the checksum for the source text, then we always defer to that.
+        // This happens on the host side, when we are give the data computed by the OOP side.
+        //
+        // If the caller didn't provide us with the checksum, then we'll compute it on demand.  This happens on the OOP
+        // side when we're actually producing the SG doc in the first place.
+        var lazyTextChecksum = new Lazy<Checksum>(() => originalSourceTextChecksum ?? ComputeChecksum(generatedSourceText));
+        return Create(documentIdentity, generatedSourceText, parseOptions, languageServices, lazyTextChecksum);
+    }
+
+    private static SourceGeneratedDocumentState Create(
+        SourceGeneratedDocumentIdentity documentIdentity,
+        SourceText generatedSourceText,
+        ParseOptions parseOptions,
+        LanguageServices languageServices,
+        Lazy<Checksum> lazyTextChecksum)
     {
         var loadTextOptions = new LoadTextOptions(generatedSourceText.ChecksumAlgorithm);
         var textAndVersion = TextAndVersion.Create(generatedSourceText, VersionStamp.Create());
@@ -57,7 +87,8 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
             textSource,
             generatedSourceText,
             loadTextOptions,
-            treeSource);
+            treeSource,
+            lazyTextChecksum);
     }
 
     private SourceGeneratedDocumentState(
@@ -69,42 +100,57 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         ConstantTextAndVersionSource textSource,
         SourceText text,
         LoadTextOptions loadTextOptions,
-        AsyncLazy<TreeAndVersion> treeSource)
+        AsyncLazy<TreeAndVersion> treeSource,
+        Lazy<Checksum> lazyTextChecksum)
         : base(languageServices, documentServiceProvider, attributes, options, textSource, loadTextOptions, treeSource)
     {
         Identity = documentIdentity;
 
         SourceText = text;
-
-        _lazyTextChecksum = new Lazy<Checksum>(() => Checksum.From(SourceText.GetChecksum()));
+        _lazyTextChecksum = lazyTextChecksum;
     }
+
+    private static Checksum ComputeChecksum(SourceText text)
+        => Checksum.From(text.GetChecksum());
 
     // The base allows for parse options to be null for non-C#/VB languages, but we'll always have parse options
     public new ParseOptions ParseOptions => base.ParseOptions!;
 
-    public Checksum GetTextChecksum()
-        => _lazyTextChecksum.Value;
-
     public SourceGeneratedDocumentContentIdentity GetContentIdentity()
-        => new(this.GetTextChecksum(), this.SourceText.Encoding?.WebName, this.SourceText.ChecksumAlgorithm);
+        => new(this.GetOriginalSourceTextChecksum(), this.SourceText.Encoding?.WebName, this.SourceText.ChecksumAlgorithm);
 
     protected override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
         => throw new NotSupportedException(WorkspacesResources.The_contents_of_a_SourceGeneratedDocument_may_not_be_changed);
 
-    public SourceGeneratedDocumentState WithUpdatedGeneratedContent(SourceText sourceText, ParseOptions parseOptions)
+    public SourceGeneratedDocumentState WithText(SourceText sourceText)
     {
-        if (GetTextChecksum() == Checksum.From(sourceText.GetChecksum()) &&
-            ParseOptions.Equals(parseOptions))
-        {
-            // We can reuse this instance directly
+        // See if we can reuse this instance directly
+        var newSourceTextChecksum = ComputeChecksum(sourceText);
+        if (this.GetOriginalSourceTextChecksum() == newSourceTextChecksum)
             return this;
-        }
 
         return Create(
             Identity,
             sourceText,
+            ParseOptions,
+            LanguageServices,
+            // Just pass along the checksum for the new source text since we've already computed it.
+            newSourceTextChecksum);
+    }
+
+    public SourceGeneratedDocumentState WithParseOptions(ParseOptions parseOptions)
+    {
+        // See if we can reuse this instance directly
+        if (ParseOptions.Equals(parseOptions))
+            return this;
+
+        return Create(
+            Identity,
+            SourceText,
             parseOptions,
-            LanguageServices);
+            LanguageServices,
+            // We're just changing the parse options.  So the checksum will remain as is.
+            _lazyTextChecksum);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes [1916082](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1916082)

This was a very subtle issue.  It was found thanks to some paranoid asserts added when doing the "perform SG generation in OOP process" work. 

First, some background.  We have a type called SourceText which represents the string-oriented (not byte-oriented) contents of a file.  That type also exposes a concept of the "content checksum".  This content checksum corresponds to the *original bytes* the source-text was created from, and not necessarily the current 'string-oriented view' the SourceText represents.

In other words, the following axiom does NOT hold:

`sourceText.GetChecksum() == SourceText.From(sourceText.ToString(), sourceText.Encoding, sourceText.HashAlgorithm).GetChecksum()`

As an example of when this might happen, consider that the bytes of a file may or may not include the BOM for utf8.  So you might have two files with different byte contents that end up representing the same *char* contents.  

Unfortunately, the SG OOP syncing code assumed the above was true.  If would sync over file contents, then assert that the checksum we then produced on the host side matched what was on the OOP side.  This assertion was not valid given the above, and our connection would die.

The fix is *not* to just to remove the assertion though.  If we did that, we'd end up in a bad state where the host and the OOP side would *always* disagree on the content checksum of these SG files, causing them to resync on each solution fork.  That would be very bad for perf (Esp. as SG files can be enormous).  The fix instead is to understand that the checksum on the OOP side may not be computable on the host side, and instead just trust and use that server-side-computed checksum locally for all checksum related questions we have. 

Note: A cleaner fix will be possible if/when we get approval on the following API suggestion: https://github.com/dotnet/roslyn/issues/70752.  With that API we would be able to produce a SourceText locally with the exact same checksum as what was on the OOP side.  This would be nice to have in the long term so that if we have any other code that ends up looking directly at the SourceText for its checksum, it doesn't get confused as to why the host and OOP disagree on it.