### PR TITLE
[Performance]: Cache last PENamespaceSymbol.GetMembers result when the result is a namespace

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -43,6 +43,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         private Dictionary<string, TypeDefinitionHandle> _lazyNoPiaLocalTypes;
 
         /// <summary>
+        /// Caches the last call to GetMembers(string) when the call returns a single element that is a namespace. Multiple types
+        /// within the same namespace are often requested in sequence, so this allows the second and
+        /// subsequent request for members with the same name to share a result without looking up the
+        /// values or allocating.
+        /// For example, if we ask for two different types `System.Collections.Generic` in sequence,
+        /// The symbol representing 'System' namespace will have cached the symbol representing 'System.Collections',
+        /// And the symbol representing 'System.Collections' will have cached the symbol representing 'System.Collections.Generic'
+        /// So, the second time we request a nested namespace, it will be zero cost as the result is already cached.
+        /// </summary>
+        private ImmutableArray<Symbol> _lastNestedNamespaceResult;
+
+        /// <summary>
         /// All type members in a flat array
         /// </summary>
         private ImmutableArray<PENamedTypeSymbol> _lazyFlattenedTypes;
@@ -89,12 +101,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public sealed override ImmutableArray<Symbol> GetMembers(ReadOnlyMemory<char> name)
         {
+            var lastResult = _lastNestedNamespaceResult;
+
+            // The only code path where we cache is creating a single-element array.
+            Debug.Assert(lastResult.IsDefault || lastResult.Length == 1);
+
+            if (!lastResult.IsDefault && name.Span.SequenceEqual(lastResult[0].Name.AsSpan()))
+            {
+                return lastResult;
+            }
+
             EnsureAllMembersLoaded();
 
-            PENestedNamespaceSymbol ns = null;
             ImmutableArray<PENamedTypeSymbol> t;
 
-            if (lazyNamespaces.TryGetValue(name, out ns))
+            if (lazyNamespaces.TryGetValue(name, out PENestedNamespaceSymbol ns))
             {
                 if (lazyTypes.TryGetValue(name, out t))
                 {
@@ -103,7 +124,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
                 else
                 {
-                    return ImmutableArray.Create<Symbol>(ns);
+                    // This is intentionally the only path being cached.
+                    // Measurements show this path as the problematic non-performant path.
+                    // Caching other paths will make the cache less beneficial.
+                    var result = ImmutableArray.Create<Symbol>(ns);
+                    _lastNestedNamespaceResult = result;
+                    return result;
                 }
             }
             else if (lazyTypes.TryGetValue(name, out t))


### PR DESCRIPTION
Basically, it's a common pattern to call `GetTypeByMetadataName` for many types that are in the same namespace.

For example:

```csharp
DoSomething(compilation.GetTypeByMetadataName("NS1.NS2.NS3.Type1"));
DoSomething(compilation.GetTypeByMetadataName("NS1.NS2.NS3.Type2"));
DoSomething(compilation.GetTypeByMetadataName("NS1.NS2.NS3.Type3"));
DoSomething(compilation.GetTypeByMetadataName("NS1.NS2.NS3.Type4"));
```

Every single call involves getting namespace segments and keep calling GetMembers. So, every call of these call will repeat this work:

```csharp
namespaceSymbolRepresentingNS1.GetMembers("NS2");
namespaceSymbolRepresentingNS2.GetMembers("NS3");
```

By caching the last result when `PENamespaceSymbol.GetMembers` would be returning a namespace, there is a high likelihood of having a cache hit and saving dictionary lookups and allocations.