### PR TITLE
Disabling roll forward

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "8.0.100-rc.1.23463.5",
     "allowPrerelease": false,
-    "rollForward": "latestPatch"
+    "rollForward": "disable"
   },
   "tools": {
     "dotnet": "8.0.100-rc.1.23463.5",


### PR DESCRIPTION
This breaks restore on latest intpreview builds.  