### PR TITLE
Handle satellite assembly loading in .NET Core

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -367,23 +367,7 @@ Delta: Gamma: Beta: Test B
 
                 if (path.EndsWith(".resources.dll", StringComparison.Ordinal))
                 {
-                    // This is a satellite assembly, need to find the mapped path of the real assembly, then 
-                    // adjust that mapped path for the suffix of the satellite assembly
-                    //
-                    // Example of dll and it's corresponding satellite assembly
-                    //
-                    //  c:\some\path\en-GB\util.resources.dll
-                    //  c:\some\path\util.dll
-                    var assemblyFileName = Path.ChangeExtension(Path.GetFileNameWithoutExtension(path), ".dll");
-                    // Real assembly is located in the directory above this one
-                    var assemblyDir = Path.GetDirectoryName(Path.GetDirectoryName(path))!;
-                    var assemblyPath = Path.Combine(assemblyDir, assemblyFileName);
-
-                    var loadPath = loader.GetRealAnalyzerLoadPath(assemblyPath);
-                    var loadSatellitePath = Path.Combine(
-                        Path.GetDirectoryName(loadPath)!,
-                        path.Substring(assemblyDir.Length + 1));
-                    return loadSatellitePath;
+                    return loader.GetRealSatelliteLoadPath(path) ?? "";
                 }
                 return loader.GetRealAnalyzerLoadPath(path ?? "");
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -137,8 +137,29 @@ namespace Microsoft.CodeAnalysis
                 var assemblyPath = Path.Combine(Directory, simpleName + ".dll");
                 if (_loader.IsAnalyzerDependencyPath(assemblyPath))
                 {
-                    (_, var loadPath) = _loader.GetAssemblyInfoForPath(assemblyPath);
+                    (_, var loadPath, _) = _loader.GetAssemblyInfoForPath(assemblyPath);
                     return loadCore(loadPath);
+                }
+
+                // Next if this is a resource assembly for a known assembly then load it from the 
+                // appropriate sub directory if it exists
+                //
+                // Note: when loading from disk the .NET runtime has a fallback step that will handle
+                // satellite assembly loading if the call to Load(satelliteAssemblyName) fails. This
+                // loader has a mode where it loads from Stream though and the runtime will not handle
+                // that automatically. Rather than bifurate our loading behavior between Disk and
+                // Stream both modes just handle satellite loading directly
+                if (!string.IsNullOrEmpty(assemblyName.CultureName) && simpleName.EndsWith(".resources", StringComparison.Ordinal))
+                {
+                    var analyzerFileName = Path.ChangeExtension(simpleName, ".dll");
+                    var analyzerFilePath = Path.Combine(Directory, analyzerFileName);
+                    var satelliteLoadPath = _loader.GetSatelliteInfoForPath(analyzerFilePath, assemblyName.CultureName);
+                    if (satelliteLoadPath is not null)
+                    {
+                        return loadCore(satelliteLoadPath);
+                    }
+
+                    return null;
                 }
 
                 // Next prefer registered dependencies from other directories. Ideally this would not
@@ -172,7 +193,7 @@ namespace Microsoft.CodeAnalysis
                 var assemblyPath = Path.Combine(Directory, unmanagedDllName + ".dll");
                 if (_loader.IsAnalyzerDependencyPath(assemblyPath))
                 {
-                    (_, var loadPath) = _loader.GetAssemblyInfoForPath(assemblyPath);
+                    (_, var loadPath, _) = _loader.GetAssemblyInfoForPath(assemblyPath);
                     return LoadUnmanagedDllFromPath(loadPath);
                 }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis
         /// When <see cref="PreparePathToLoad(string, ImmutableHashSet{string})"/> is overriden this returns the most recent
         /// real path for the given analyzer satellite assembly path
         /// </summary>
-        internal string GetRealSatelliteLoadPath(string originalSatelliteFullPath, string cultureName)
+        internal string? GetRealSatelliteLoadPath(string originalSatelliteFullPath)
         {
             // This is a satellite assembly, need to find the mapped path of the real assembly, then 
             // adjust that mapped path for the suffix of the satellite assembly
@@ -309,8 +309,11 @@ namespace Microsoft.CodeAnalysis
             //  c:\some\path\util.dll
             var assemblyFileName = Path.ChangeExtension(Path.GetFileNameWithoutExtension(originalSatelliteFullPath), ".dll");
 
+            var assemblyDir = Path.GetDirectoryName(originalSatelliteFullPath)!;
+            var cultureName = Path.GetFileName(assemblyDir);
+            assemblyDir = Path.GetDirectoryName(assemblyDir)!;
+
             // Real assembly is located in the directory above this one
-            var assemblyDir = Path.GetDirectoryName(Path.GetDirectoryName(originalSatelliteFullPath))!;
             var assemblyPath = Path.Combine(assemblyDir, assemblyFileName);
             return GetSatelliteInfoForPath(assemblyPath, cultureName);
         }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis
             return (assemblyName, realPath, resourceAssemblyCultureNames);
 
             // Discover the culture names for any satellite dlls related to this analyzer. These 
-            // need to be understood when handling the resource loading in ceratin cases.
+            // need to be understood when handling the resource loading in certain cases.
             static ImmutableHashSet<string> getResourceAssemblyCultureNames(string originalAnalyzerPath)
             {
                 var path = Path.GetDirectoryName(originalAnalyzerPath)!;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis
                     return ImmutableHashSet<string>.Empty;
                 }
 
-                var resourceFileName = Path.ChangeExtension(Path.GetFileName(originalAnalyzerPath), ".resources.dll");
+                var resourceFileName = GetSatelliteFileName(Path.GetFileName(originalAnalyzerPath));
                 var builder = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
                 do
                 {
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Get the real load paths the satellite assembly given the original path to the analyzer 
+        /// Get the real load path of the satellite assembly given the original path to the analyzer 
         /// and the desired culture name.
         /// </summary>
         protected string? GetSatelliteInfoForPath(string originalAnalyzerPath, string cultureName)
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis
         protected abstract string PreparePathToLoad(string assemblyFilePath, ImmutableHashSet<string> resourceAssemblyCultureNames);
 
         /// <summary>
-        /// When <see cref="PreparePathToLoad(string, ImmutableHashSet{string})"/> is overriden this returns the most recent
+        /// When <see cref="PreparePathToLoad(string, ImmutableHashSet{string})"/> is overridden this returns the most recent
         /// real path calculated for the <paramref name="originalFullPath"/>
         /// </summary>
         internal string GetRealAnalyzerLoadPath(string originalFullPath)
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// When <see cref="PreparePathToLoad(string, ImmutableHashSet{string})"/> is overriden this returns the most recent
+        /// When <see cref="PreparePathToLoad(string, ImmutableHashSet{string})"/> is overridden this returns the most recent
         /// real path for the given analyzer satellite assembly path
         /// </summary>
         internal string? GetRealSatelliteLoadPath(string originalSatelliteFullPath)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -32,9 +32,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The default implementation is to simply load in place.
         /// </summary>
-        /// <param name="fullPath"></param>
-        /// <returns></returns>
-        protected override string PreparePathToLoad(string fullPath) => fullPath;
+        protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> satelliteCultureNames) => fullPath;
 
         /// <summary>
         /// Return an <see cref="IAnalyzerAssemblyLoader"/> which does not lock assemblies on disk that is

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Immutable;
 
 #if NETCOREAPP
 using System.Runtime.Loader;
@@ -128,59 +129,41 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        protected override string PreparePathToLoad(string originalFullPath)
+        protected override string PreparePathToLoad(string originalAnalyzerPath, ImmutableHashSet<string> cultureNames)
         {
-            string assemblyDirectory = CreateUniqueDirectoryForAssembly();
-            string shadowCopyPath = CopyFileAndResources(originalFullPath, assemblyDirectory);
-            return shadowCopyPath;
-        }
+            var analyzerFileName = Path.GetFileName(originalAnalyzerPath);
+            var shadowDirectory = CreateUniqueDirectoryForAssembly();
+            var shadowAnalyzerPath = Path.Combine(shadowDirectory, analyzerFileName);
+            copyFile(originalAnalyzerPath, shadowAnalyzerPath);
 
-        private static string CopyFileAndResources(string fullPath, string assemblyDirectory)
-        {
-            string fileNameWithExtension = Path.GetFileName(fullPath);
-            string shadowCopyPath = Path.Combine(assemblyDirectory, fileNameWithExtension);
-
-            CopyFile(fullPath, shadowCopyPath);
-
-            string originalDirectory = Path.GetDirectoryName(fullPath)!;
-            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileNameWithExtension);
-            string resourcesNameWithoutExtension = fileNameWithoutExtension + ".resources";
-            string resourcesNameWithExtension = resourcesNameWithoutExtension + ".dll";
-
-            foreach (var directory in Directory.EnumerateDirectories(originalDirectory))
+            if (cultureNames.IsEmpty)
             {
-                string directoryName = Path.GetFileName(directory);
-
-                string resourcesPath = Path.Combine(directory, resourcesNameWithExtension);
-                if (File.Exists(resourcesPath))
-                {
-                    string resourcesShadowCopyPath = Path.Combine(assemblyDirectory, directoryName, resourcesNameWithExtension);
-                    CopyFile(resourcesPath, resourcesShadowCopyPath);
-                }
-
-                resourcesPath = Path.Combine(directory, resourcesNameWithoutExtension, resourcesNameWithExtension);
-                if (File.Exists(resourcesPath))
-                {
-                    string resourcesShadowCopyPath = Path.Combine(assemblyDirectory, directoryName, resourcesNameWithoutExtension, resourcesNameWithExtension);
-                    CopyFile(resourcesPath, resourcesShadowCopyPath);
-                }
+                return shadowAnalyzerPath;
             }
 
-            return shadowCopyPath;
-        }
-
-        private static void CopyFile(string originalPath, string shadowCopyPath)
-        {
-            var directory = Path.GetDirectoryName(shadowCopyPath);
-            if (directory is null)
+            var originalDirectory = Path.GetDirectoryName(originalAnalyzerPath)!;
+            var satelliteFileName = GetSatelliteFileName(analyzerFileName);
+            foreach (var cultureName in cultureNames)
             {
-                throw new ArgumentException($"Shadow copy path '{shadowCopyPath}' must not be the root directory");
+                var originalSatellitePath = Path.Combine(originalDirectory, cultureName, satelliteFileName);
+                var shadowSatellitePath = Path.Combine(shadowDirectory, cultureName, satelliteFileName);
+                copyFile(originalSatellitePath, shadowSatellitePath);
             }
-            Directory.CreateDirectory(directory);
 
-            File.Copy(originalPath, shadowCopyPath);
+            return shadowAnalyzerPath;
 
-            ClearReadOnlyFlagOnFile(new FileInfo(shadowCopyPath));
+            static void copyFile(string originalPath, string shadowCopyPath)
+            {
+                var directory = Path.GetDirectoryName(shadowCopyPath);
+                if (directory is null)
+                {
+                    throw new ArgumentException($"Shadow copy path '{shadowCopyPath}' must not be the root directory");
+                }
+
+                _ = Directory.CreateDirectory(directory);
+                File.Copy(originalPath, shadowCopyPath);
+                ClearReadOnlyFlagOnFile(new FileInfo(shadowCopyPath));
+            }
         }
 
         private static void ClearReadOnlyFlagOnFiles(string directoryPath)

--- a/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
+++ b/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
@@ -143,7 +143,7 @@ namespace AnalyzerWithLoc
         {
             try
             {
-                var ci = new CultureInfo("en-GB");
+                var ci = new CultureInfo(culture);
                 var rm = new ResourceManager("rmc", typeof(Util).Assembly);
                 _ = rm.GetString("hello", ci);
             }

--- a/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
+++ b/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
@@ -110,10 +110,64 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public string AnalyzerWithLaterFakeCompilerDependency { get; }
 
+        /// <summary>
+        /// An analyzer that can be used to load a resource
+        /// </summary>
+        public string AnalyzerWithLoc { get; }
+
+        /// <summary>
+        /// An analyzer that can be used to load a resource
+        /// </summary>
+        public string AnalyzerWithLocResourceEnGB { get; }
+
         public AssemblyLoadTestFixture()
         {
             _temp = new TempRoot();
             _directory = _temp.CreateDirectory();
+
+            const string AnalyzerWithLocSource = """
+using System;
+using System.Resources;
+using System.Reflection;
+using System.Threading;
+using System.Globalization;
+
+[assembly: System.Reflection.AssemblyTitle("AnalyzerWithLoc")]
+[assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
+
+namespace AnalyzerWithLoc
+{
+    public static class Util
+    {
+        public static void Exec(string culture)
+        {
+            try
+            {
+                var ci = new CultureInfo("en-GB");
+                var rm = new ResourceManager("rmc", typeof(Util).Assembly);
+                _ = rm.GetString("hello", ci);
+            }
+            catch (Exception ex)
+            {
+
+            }
+        }
+    }
+}
+""";
+
+            AnalyzerWithLoc = GenerateDll("AnalyzerWithLoc", _directory, AnalyzerWithLocSource);
+
+            const string AnalyzerWithLocResourceEnGBSource = @"
+using System.Text;
+
+[assembly: System.Reflection.AssemblyTitle(""AnalyzerWithLoc"")]
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+[assembly: System.Reflection.AssemblyCulture(""en-GB"")]
+";
+
+            AnalyzerWithLocResourceEnGB = GenerateDll("AnalyzerWithLoc.resources", _directory.CreateDirectory("en-GB"), AnalyzerWithLocResourceEnGBSource);
+
 
             const string Delta1Source = @"
 using System.Text;
@@ -134,6 +188,7 @@ namespace Delta
 ";
 
             Delta1 = GenerateDll("Delta", _directory, Delta1Source);
+
             var delta1Reference = MetadataReference.CreateFromFile(Delta1);
             DeltaPublicSigned1 = GenerateDll("DeltaPublicSigned", _directory.CreateDirectory("Delta1PublicSigned"), Delta1Source, publicKeyOpt: SigningTestHelpers.PublicKey);
 

--- a/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
+++ b/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
@@ -159,8 +159,6 @@ namespace AnalyzerWithLoc
             AnalyzerWithLoc = GenerateDll("AnalyzerWithLoc", _directory, AnalyzerWithLocSource);
 
             const string AnalyzerWithLocResourceEnGBSource = @"
-using System.Text;
-
 [assembly: System.Reflection.AssemblyTitle(""AnalyzerWithLoc"")]
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 [assembly: System.Reflection.AssemblyCulture(""en-GB"")]

--- a/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
+++ b/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
@@ -168,7 +168,6 @@ using System.Text;
 
             AnalyzerWithLocResourceEnGB = GenerateDll("AnalyzerWithLoc.resources", _directory.CreateDirectory("en-GB"), AnalyzerWithLocResourceEnGBSource);
 
-
             const string Delta1Source = @"
 using System.Text;
 

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -691,7 +691,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
         private class MissingAnalyzerLoader : AnalyzerAssemblyLoader
         {
-            protected override string PreparePathToLoad(string fullPath)
+            protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> cultureNames)
                 => throw new FileNotFoundException(fullPath);
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             _baseDirectory = baseDirectory;
         }
 
-        protected override string PreparePathToLoad(string fullPath)
+        protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> cultureNames)
         {
             var fixedPath = Path.GetFullPath(Path.Combine(_baseDirectory, Path.GetFileName(fullPath)));
             return File.Exists(fixedPath) ? fixedPath : fullPath;


### PR DESCRIPTION
This fixes a bug where-by the compiler did not load satellite assemblies properly on Unix and Linux. The compiler recently changed (#69406) our loading strategy there to use `AssemblyLoadContext.LoadFromStream`. The runtime fallback logic for loading satellite assemblies is effectively the following:

1. Call `AssemblyLoadContext.Load(satelliteAssemblyName)`
2. If that fails call `AssemblyLoadContext.Load(realAssemblyName)` for the real assembly
3. Look at `Assembly.Location` on the return and change it to have the appropriate satellite path.
4. Call `AssemblyLoadContext.LoadFromPath(...)` on the result of (3)

That logic breaks when assemblies are loaded via `LoadFromStream` as there is no location information.

This changes our `AssemblyLoadContext` implementation to just handle satellite loads in step (1). This is done irrespective of whether the loader is loading via path or via stream. The loader has the information already so simpler to just handle it the same way every time.

closes #56708

Note: these are [the docs](https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/loading-resources) describing satellite assembly loading.