### PR TITLE
Attempt to simplify SyntacticChangeRangeComputer

### DIFF
--- a/src/Tools/IdeCoreBenchmarks/SyntacticChangeRangeBenchmark.cs
+++ b/src/Tools/IdeCoreBenchmarks/SyntacticChangeRangeBenchmark.cs
@@ -66,6 +66,23 @@ namespace IdeCoreBenchmarks
             return newRoot;
         }
 
+        private SyntaxNode WithSimpleEditAtBeginning()
+        {
+            var addedText = "using System.IO;";
+            var newText = _text.WithChanges(new TextChange(new TextSpan(0, addedText.Length), addedText));
+            var newTree = _tree.WithChangedText(newText);
+            var newRoot = newTree.GetRoot();
+            return newRoot;
+        }
+        private SyntaxNode WithSimpleEditInTheEnd()
+        {
+            var addedText = "class HelloWorld { }";
+            var newText = _text.WithChanges(new TextChange(new TextSpan(_text.Length - addedText.Length, addedText.Length), addedText));
+            var newTree = _tree.WithChangedText(newText);
+            var newRoot = newTree.GetRoot();
+            return newRoot;
+        }
+
         [Benchmark]
         public void SimpleEditAtMiddle()
         {
@@ -90,6 +107,20 @@ namespace IdeCoreBenchmarks
         public void DestabalizingEditAtMiddle_NoParse()
         {
             SyntacticChangeRangeComputer.ComputeSyntacticChangeRange(_root, _rootWithComplexEdit, TimeSpan.MaxValue, CancellationToken.None);
+        }
+
+        [Benchmark]
+        public void SimpleEditAtTheBeginning()
+        {
+            var newRoot = WithSimpleEditAtBeginning();
+            SyntacticChangeRangeComputer.ComputeSyntacticChangeRange(_root, newRoot, TimeSpan.MaxValue, CancellationToken.None);
+        }
+
+        [Benchmark]
+        public void SimpleEditorInTheEnd()
+        {
+            var newRoot = WithSimpleEditInTheEnd();
+            SyntacticChangeRangeComputer.ComputeSyntacticChangeRange(_root, newRoot, TimeSpan.MaxValue, CancellationToken.None);
         }
     }
 }


### PR DESCRIPTION
Exploring alternative to https://github.com/dotnet/roslyn/pull/70772

Unit tests passed. Not sure whether this code didn't previously just recurse because of concerns over stack depth.

Before:
![image](https://github.com/dotnet/roslyn/assets/6785178/b1ad9334-17b5-4b46-9a15-24315926c31b)

After:
![image](https://github.com/dotnet/roslyn/assets/6785178/79403dd9-2680-48a4-9b0b-d9c7f9899d91)
