### PR TITLE
Fix 'make member readonly' with mutation of primary constructor parameters

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -223,7 +223,7 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
     {
         // We only care if the parameter is a value type when looking at if it is somehow mutated with the
         // operations that follow.
-        if (originalOperation is IParameterReferenceOperation { Parameter.Type.IsReferenceType: true })
+        if (originalOperation is IParameterReferenceOperation && !IsPotentiallyValueType(originalOperation))
             return false;
 
         // Now walk up the instance-operation and see if any operation actually or potentially mutates this value.

--- a/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
@@ -2035,4 +2035,75 @@ public sealed class MakeStructMemberReadOnlyTests
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70780")]
+    public async Task TestPrimaryConstructorParameterReference11()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+
+            struct Cell<T>(T t) where T : class, IDisposable
+            {
+                public void [|RemoveBit|](int candidate)
+                {
+                    t.Dispose();
+                }
+            }
+            """,
+            FixedCode = """
+            using System;
+            
+            struct Cell<T>(T t) where T : class, IDisposable
+            {
+                public readonly void RemoveBit(int candidate)
+                {
+                    t.Dispose();
+                }
+            }
+            """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70780")]
+    public async Task TestPrimaryConstructorParameterReference12()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+
+            struct Cell<T>(T t) where T : struct, IDisposable
+            {
+                public void RemoveBit(int candidate)
+                {
+                    t.Dispose();
+                }
+            }
+            """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70780")]
+    public async Task TestPrimaryConstructorParameterReference13()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+
+            struct Cell<T>(T t) where T : IDisposable
+            {
+                public void RemoveBit(int candidate)
+                {
+                    t.Dispose();
+                }
+            }
+            """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70780