### PR TITLE
Make eng/build.sh --test run more unit tests

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -337,6 +337,6 @@ if [[ "$test_core_clr" == true ]]; then
   if [[ "$ci" != true ]]; then
     runtests_args="$runtests_args --html"
   fi
-  dotnet exec "$scriptroot/../artifacts/bin/RunTests/${configuration}/net7.0/RunTests.dll" --tfm net7.0 --configuration ${configuration} --logs ${log_dir} --dotnet ${_InitializeDotNetCli}/dotnet $runtests_args
+  dotnet exec "$scriptroot/../artifacts/bin/RunTests/${configuration}/net7.0/RunTests.dll" --tfm net7.0 --tfm net8.0 --configuration ${configuration} --logs ${log_dir} --dotnet ${_InitializeDotNetCli}/dotnet $runtests_args
 fi
 ExitWithExitCode 0


### PR DESCRIPTION
A few months ago, I could use the following to build roslyn on Linux and run (many of?) its unit tests:

    $ ./eng/build.sh --restore --build --pack --test

Unfortunately, PR #69669 (commit
4d8f34750e4b1af8452ef5ce520dcbd372b81510) changed how that works. That PR changed the default build target of many projects to net8.0, and the test runner seems to be running only 7.0 projects. After that commit, the above command shows only one set of unit tests running:

    Running tests in 1 partitions
      1 running,  0 queued,  0 completed
      0 running,  0 queued,  1 completed
    ================
    Microsoft.CodeAnalysis.UnitTests_0 PASSED 00:00:45.4625833
    ================

Adding the net8.0 as a tfm target in the eng/build.sh makes us run more tests again:

    ================
    Microsoft.CodeAnalysis.Scripting.UnitTests_12                     PASSED 00:00:03.9577625
    Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.UnitTests_10  PASSED 00:00:04.9223846
    VBCSCompiler.UnitTests_20                                         PASSED 00:00:23.7411654
    Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests_4                PASSED 00:00:27.8150736
    Microsoft.Build.Tasks.CodeAnalysis.UnitTests_0                    PASSED 00:00:31.9628642
    Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests_6               PASSED 00:00:33.1929440
    Microsoft.CodeAnalysis.VisualBasic.Syntax.UnitTests_18            PASSED 00:00:33.5702799
    Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests_1             PASSED 00:00:39.4990867
    Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests_5              PASSED 00:00:52.4321826
    Microsoft.CodeAnalysis.UnitTests_13                               PASSED 00:00:53.3982241
    Roslyn.Compilers.VisualBasic.IOperation.UnitTests_19              PASSED 00:00:53.7378359
    Microsoft.CodeAnalysis.UnitTests_14                               PASSED 00:00:54.3801182
    Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests_9                  PASSED 00:01:17.6610151
    Microsoft.CodeAnalysis.Rebuild.UnitTests_11                       PASSED 00:01:22.3798957
    Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests_17            PASSED 00:01:29.8493252
    Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests_16          FAILED 00:01:50.8836743
    Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests_15              FAILED 00:03:35.7901555
    Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests_8                  FAILED 00:04:06.2959522
    Microsoft.CodeAnalysis.CSharp.Emit.UnitTests_2                    FAILED 00:05:27.2969811
    Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests_3                   FAILED 00:06:26.4284098
    Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests_7                FAILED 00:08:06.2821945
    ================