### PR TITLE
Thread in a new MSBuild property `EffectiveAnalysisLevelStyle` to IDE code style analyzers

### DIFF
--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -210,15 +210,19 @@ $@"<Project>{GetTargetContents(language)}
             {
                 return $"""
 
-                      <Target Name="AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysis{language}CodeStyle" BeforeTargets="CoreCompile" Condition="'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'">
+                      <Target Name="AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysis{language}CodeStyle" BeforeTargets="GenerateMSBuildEditorConfigFileCore;CoreCompile" Condition="'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'">
                         <!-- PropertyGroup to compute global analyzer config file to be used -->
                         <PropertyGroup>
                           <!-- Default 'AnalysisLevelStyle' to the core 'AnalysisLevel' -->
                           <AnalysisLevelStyle Condition="'$(AnalysisLevelStyle)' == ''">$(AnalysisLevel)</AnalysisLevelStyle>
 
                           <!-- AnalysisLevelStyle can also contain compound values with a prefix and suffix separated by a '-' character.
-                               The prefix indicates the core AnalysisLevel for CA analyzers, which we ignore for IDE style analyzers.
-                               The suffix indicates the bucket of rules to enable for 'Style' rules by default. It is used to map to the correct global config.
+                               The prefix indicates the core AnalysisLevel for 'Style' rules and the suffix indicates the bucket of
+                               rules to enable for 'Style' rules by default. For example, some valid compound values for AnalysisLevelStyle are:
+                                 1. '5-all' - Indicates core AnalysisLevelStyle = '5' with 'all' the 'Style' rules enabled by default.
+                                 2. 'latest-none' - Indicates core AnalysisLevelStyle = 'latest' with 'none' of the 'Style' rules enabled by default.
+                               AnalysisLevelPrefixStyle is used to set the EffectiveAnalysisLevelStyle below.
+                               AnalysisLevelSuffixStyle is used to map to the correct global config.
                           -->
                           <AnalysisLevelPrefixStyle Condition="$(AnalysisLevelStyle.Contains('-'))">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '-(.)*', ''))</AnalysisLevelPrefixStyle>
                           <AnalysisLevelSuffixStyle Condition="'$(AnalysisLevelPrefixStyle)' != ''">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '$(AnalysisLevelPrefixStyle)-', ''))</AnalysisLevelSuffixStyle>
@@ -227,6 +231,18 @@ $@"<Project>{GetTargetContents(language)}
                           <AnalysisLevelSuffixStyle Condition="'$(AnalysisLevelSuffixStyle)' == ''">$(AnalysisLevelSuffix)</AnalysisLevelSuffixStyle>
                           <!-- Default 'AnalysisModeStyle' to the core 'AnalysisMode' -->
                           <AnalysisModeStyle Condition="'$(AnalysisModeStyle)' == ''">$(AnalysisMode)</AnalysisModeStyle>
+
+                          <!-- EffectiveAnalysisLevelStyle is used to differentiate from user specified strings (such as 'none')
+                               and an implied numerical option (such as '4') -->
+                          <EffectiveAnalysisLevelStyle Condition="'$(AnalysisLevelStyle)' == 'none' or '$(AnalysisLevelPrefixStyle)' == 'none'">$(_NoneAnalysisLevel)</EffectiveAnalysisLevelStyle>
+                          <EffectiveAnalysisLevelStyle Condition="'$(AnalysisLevelStyle)' == 'latest' or '$(AnalysisLevelPrefixStyle)' == 'latest'">$(_LatestAnalysisLevel)</EffectiveAnalysisLevelStyle>
+                          <EffectiveAnalysisLevelStyle Condition="'$(AnalysisLevelStyle)' == 'preview' or '$(AnalysisLevelPrefixStyle)' == 'preview'">$(_PreviewAnalysisLevel)</EffectiveAnalysisLevelStyle>
+
+                          <!-- Set EffectiveAnalysisLevelStyle to the value of AnalysisLevelStyle if it is a version number -->
+                          <EffectiveAnalysisLevelStyle Condition="'$(EffectiveAnalysisLevelStyle)' == '' And
+                                                              '$(AnalysisLevelPrefixStyle)' != ''">$(AnalysisLevelPrefixStyle)</EffectiveAnalysisLevelStyle>
+                          <EffectiveAnalysisLevelStyle Condition="'$(EffectiveAnalysisLevelStyle)' == '' And
+                                                              '$(AnalysisLevelStyle)' != ''">$(AnalysisLevelStyle)</EffectiveAnalysisLevelStyle>
 
                           <!-- Set the default analysis mode, if not set by the user -->
                           <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>$(AnalysisLevelSuffixStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
@@ -246,6 +262,11 @@ $@"<Project>{GetTargetContents(language)}
                         <ItemGroup Condition="Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and
                                                ('$(AnalysisLevelStyle)' != '$(AnalysisLevel)' or '$(AnalysisModeStyle)' != '$(AnalysisMode)')">
                           <EditorConfigFiles Include="$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)" />
+                        </ItemGroup>
+
+                        <!-- Pass the MSBuild property value for 'EffectiveAnalysisLevelStyle' to the analyzers via analyzer config options. -->
+                        <ItemGroup>
+                          <CompilerVisibleProperty Include="EffectiveAnalysisLevelStyle" />
                         </ItemGroup>
                       </Target>
 

--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -208,46 +208,48 @@ $@"<Project>{GetTargetContents(language)}
 
             static string GetTargetContents(string language)
             {
-                return $@"
-  <Target Name=""AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysis{language}CodeStyle"" BeforeTargets=""CoreCompile"" Condition=""'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'"">
-    <!-- PropertyGroup to compute global analyzer config file to be used -->
-    <PropertyGroup>
-      <!-- Default 'AnalysisLevelStyle' to the core 'AnalysisLevel' -->
-      <AnalysisLevelStyle Condition=""'$(AnalysisLevelStyle)' == ''"">$(AnalysisLevel)</AnalysisLevelStyle>
-      
-      <!-- AnalysisLevelStyle can also contain compound values with a prefix and suffix separated by a '-' character.
-           The prefix indicates the core AnalysisLevel for CA analyzers, which we ignore for IDE style analyzers.
-           The suffix indicates the bucket of rules to enable for 'Style' rules by default. It is used to map to the correct global config.
-      -->
-      <AnalysisLevelPrefixStyle Condition=""$(AnalysisLevelStyle.Contains('-'))"">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '-(.)*', ''))</AnalysisLevelPrefixStyle>
-      <AnalysisLevelSuffixStyle Condition=""'$(AnalysisLevelPrefixStyle)' != ''"">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '$(AnalysisLevelPrefixStyle)-', ''))</AnalysisLevelSuffixStyle>
-      
-      <!-- Default 'AnalysisLevelSuffixStyle' to the core 'AnalysisLevelSuffix' -->
-      <AnalysisLevelSuffixStyle Condition=""'$(AnalysisLevelSuffixStyle)' == ''"">$(AnalysisLevelSuffix)</AnalysisLevelSuffixStyle>
-      <!-- Default 'AnalysisModeStyle' to the core 'AnalysisMode' -->
-      <AnalysisModeStyle Condition=""'$(AnalysisModeStyle)' == ''"">$(AnalysisMode)</AnalysisModeStyle>
+                return $"""
 
-      <!-- Set the default analysis mode, if not set by the user -->
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>$(AnalysisLevelSuffixStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''"">$(AnalysisModeStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == 'AllEnabledByDefault'"">{nameof(AnalysisMode.All)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == 'AllDisabledByDefault'"">{nameof(AnalysisMode.None)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''"">{nameof(AnalysisMode.Default)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                      <Target Name="AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysis{language}CodeStyle" BeforeTargets="CoreCompile" Condition="'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'">
+                        <!-- PropertyGroup to compute global analyzer config file to be used -->
+                        <PropertyGroup>
+                          <!-- Default 'AnalysisLevelStyle' to the core 'AnalysisLevel' -->
+                          <AnalysisLevelStyle Condition="'$(AnalysisLevelStyle)' == ''">$(AnalysisLevel)</AnalysisLevelStyle>
 
-      <_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>AnalysisLevelStyle_$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle).editorconfig</_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle.ToLowerInvariant())</_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>
-      
-      <_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)' == ''"">$(MSBuildThisFileDirectory)config</_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle>
-      <_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle Condition=""'$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)' != ''"">$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)\$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)</_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle>
-    </PropertyGroup>
+                          <!-- AnalysisLevelStyle can also contain compound values with a prefix and suffix separated by a '-' character.
+                               The prefix indicates the core AnalysisLevel for CA analyzers, which we ignore for IDE style analyzers.
+                               The suffix indicates the bucket of rules to enable for 'Style' rules by default. It is used to map to the correct global config.
+                          -->
+                          <AnalysisLevelPrefixStyle Condition="$(AnalysisLevelStyle.Contains('-'))">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '-(.)*', ''))</AnalysisLevelPrefixStyle>
+                          <AnalysisLevelSuffixStyle Condition="'$(AnalysisLevelPrefixStyle)' != ''">$([System.Text.RegularExpressions.Regex]::Replace($(AnalysisLevelStyle), '$(AnalysisLevelPrefixStyle)-', ''))</AnalysisLevelSuffixStyle>
 
-    <!-- Add the global config, if required. -->
-    <ItemGroup Condition=""Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and
-                           ('$(AnalysisLevelStyle)' != '$(AnalysisLevel)' or '$(AnalysisModeStyle)' != '$(AnalysisMode)')"">
-      <EditorConfigFiles Include=""$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)"" />
-    </ItemGroup>
-  </Target>
-";
+                          <!-- Default 'AnalysisLevelSuffixStyle' to the core 'AnalysisLevelSuffix' -->
+                          <AnalysisLevelSuffixStyle Condition="'$(AnalysisLevelSuffixStyle)' == ''">$(AnalysisLevelSuffix)</AnalysisLevelSuffixStyle>
+                          <!-- Default 'AnalysisModeStyle' to the core 'AnalysisMode' -->
+                          <AnalysisModeStyle Condition="'$(AnalysisModeStyle)' == ''">$(AnalysisMode)</AnalysisModeStyle>
+
+                          <!-- Set the default analysis mode, if not set by the user -->
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>$(AnalysisLevelSuffixStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''">$(AnalysisModeStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == 'AllEnabledByDefault'">{nameof(AnalysisMode.All)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == 'AllDisabledByDefault'">{nameof(AnalysisMode.None)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''">{nameof(AnalysisMode.Default)}</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
+
+                          <_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>AnalysisLevelStyle_$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle).editorconfig</_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle.ToLowerInvariant())</_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle>
+
+                          <_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)' == ''">$(MSBuildThisFileDirectory)config</_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle>
+                          <_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)' != ''">$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)\$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)</_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle>
+                        </PropertyGroup>
+
+                        <!-- Add the global config, if required. -->
+                        <ItemGroup Condition="Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and
+                                               ('$(AnalysisLevelStyle)' != '$(AnalysisLevel)' or '$(AnalysisModeStyle)' != '$(AnalysisMode)')">
+                          <EditorConfigFiles Include="$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)" />
+                        </ItemGroup>
+                      </Target>
+
+                    """;
             }
         }
 


### PR DESCRIPTION
**Recommend to review commit-by-commit (first commit https://github.com/dotnet/roslyn/commit/591d47ec0fea0f3764d9ccdad3ebd0f61519baf1 just converts existing string to a raw string literal)**

Addresses the concern raised in https://github.com/dotnet/roslyn/issues/52991#issuecomment-1788123932

The core idea is to define and thread in a new numeric `AnalysisLevel` value specific to IDE Code style, that gets passed to the analyzers to conditionally enable any new breaking change features, such as the one proposed in https://github.com/dotnet/roslyn/issues/52991.

Currently, we support `AnalysisLevel` and per-category `AnalysisLevel{Category}` properties to determine the set of first party CA and IDE rules to enable by default: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#analysislevelcategory. This also includes `AnalysisLevelStyle` property for IDE CodeStyle analyzers, which already defaults to `AnalysisLevel`. However, this property can hold well-known non-numeric values such as `none`, `preview`, `latest` or compound values in the form `<version>-<mode>` (documented [here](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#analysislevel)). This PR adds the below additional logic:

1. Add a new MSBuild 'EffectiveAnalysisLevelStyle' property, that contains a numeric value derived from the existing `AnalysisLevelStyle` property, similar to the way we have `EffectiveAnalysisLevel` derived from `AnalysisLevel` property (see https://github.com/dotnet/sdk/blob/fcc367b2164e4b41b8fb6622110aeb9f3247dd92/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets#L35-L56). Note that the category specific logic added here (for 'Style' category) is identical to the existing logic in `Microsoft.CodeAnalysis.NetAnalyzers.targets` file for different CA analyzer categories that is generated by tooling and inserted into the .NET SDK: https://github.com/dotnet/roslyn-analyzers/blob/b924542a1b526322929725a1aaa9586c21b1b231/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs#L1528C62-L1553.

2. Mark this new 'EffectiveAnalysisLevelStyle' property as a `CompilerVisibileProperty` to pass it to the analyzers via analyzer config options.

Note that this Target gets added to C# and VB CodeStyle targets file that is imported here: https://github.com/dotnet/sdk/blob/f52240f11ad291e6ee3cff86e83c0f7a21b60370/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets#L117-L120. I verified locally that `<%ProjectName%>.GeneratedMSBuildEditorConfig.editorconfig` generated by our tooling contains an entry with key `build_property.EffectiveAnalysisLevelStyle`.