### PR TITLE
Fix captured variables analysis

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -2686,8 +2686,8 @@ class C
                 { int x3 = 0, y3 = 0;      // Group #2 
                                            
                     G(a => x3 + x1);       
-                    G(a => x0 + y0 + x2);
-                    G(a => x);
+                    G(b => x0 + y0 + x2);
+                    G(c => x);
                 }
             }
         }
@@ -2714,15 +2714,15 @@ class C
                 { int x3 = 0, y3 = 0;       // Group #2 
                                             
                     G(a => x3 + x1);        
-                    G(a => x0 + y0 + x2);
-                    G(a => x);
+                    G(b => x0 + y0 + x2);
+                    G(c => x);
 
-                    G(a => x);              // OK
-                    G(a => x0 + y0);        // OK
-                    G(a => x1 + y0);        // error - connecting Group #1 and Group #2
-                    G(a => x3 + x1);        // error - multi-scope (conservative)
-                    G(a => x + y0);         // error - connecting Group #0 and Group #1
-                    G(a => x + x3);         // error - connecting Group #0 and Group #2
+                    G(d => x);              // OK
+                    G(e => x0 + y0);        // OK
+                    G(f => x1 + y0);        // error - connecting Group #1 and Group #2
+                    G(g => x3 + x1);        // error - multi-scope (conservative)
+                    G(h => x + y0);         // error - connecting Group #0 and Group #1
+                    G(i => x + x3);         // error - connecting Group #0 and Group #2
                 }
             }
         }
@@ -2732,18 +2732,18 @@ class C
             var insert = GetTopEdits(src1, src2);
 
             insert.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x1", CSharpFeaturesResources.lambda, "y0", "x1"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "y0", CSharpFeaturesResources.lambda, "x1", "y0"),
                 Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x3", CSharpFeaturesResources.lambda, "x1", "x3"),
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "y0", CSharpFeaturesResources.lambda, "this", "y0"),
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x3", CSharpFeaturesResources.lambda, "this", "x3"));
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "h", CSharpFeaturesResources.lambda, "y0", "this"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "i", CSharpFeaturesResources.lambda, "x3", "this"));
 
             var delete = GetTopEdits(src2, src1);
 
             delete.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x1", CSharpFeaturesResources.lambda, "y0", "x1"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", CSharpFeaturesResources.lambda, "x1", "x3"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "y0", CSharpFeaturesResources.lambda, "this", "y0"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", CSharpFeaturesResources.lambda, "this", "x3"));
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "y0", GetResource("lambda"), "x1", "y0"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", GetResource("lambda"), "x1", "x3"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "F", GetResource("lambda"), "y0", "this"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "F", GetResource("lambda"), "x3", "this"));
         }
 
         [Fact]
@@ -5302,7 +5302,7 @@ class C
                 SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.M"), preserveLocalVariables: true));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/69152")]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/69152")]
         public void Lambdas_Update_PrimaryParameterOutsideOfLambda()
         {
@@ -5411,7 +5411,7 @@ partial class C
                 Diagnostic(RudeEditKind.CapturingVariable, "F", "this").WithFirstLine("partial void F()  // impl"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/69152")]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/69152")]
         public void Lambdas_Update_StaticToPrimaryParameterOnly_Partial()
         {
@@ -5490,7 +5490,7 @@ class C
                 Diagnostic(RudeEditKind.AccessingCapturedVariableInLambda, "a1", "this", CSharpFeaturesResources.lambda));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/69152")]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/69152")]
         public void Lambdas_Update_StaticToPrimaryParameterOnly3()
         {
@@ -5521,7 +5521,7 @@ class C(int x)
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.AccessingCapturedVariableInLambda, "x", "x", CSharpFeaturesResources.lambda));
+                Diagnostic(RudeEditKind.AccessingCapturedVariableInLambda, "a1", "x", CSharpFeaturesResources.lambda));
         }
 
         [Fact]
@@ -7004,18 +7004,18 @@ class C
             var insert = GetTopEdits(src1, src2);
 
             insert.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x1", CSharpFeaturesResources.local_function, "y0", "x1"),
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x3", CSharpFeaturesResources.local_function, "x1", "x3"),
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "y0", CSharpFeaturesResources.local_function, "this", "y0"),
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x3", CSharpFeaturesResources.local_function, "this", "x3"));
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "y0", GetResource("local function"), "x1", "y0"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x3", GetResource("local function"), "x1", "x3"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "f8", GetResource("local function"), "y0", "this"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "f9", GetResource("local function"), "x3", "this"));
 
             var delete = GetTopEdits(src2, src1);
 
             delete.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x1", CSharpFeaturesResources.local_function, "y0", "x1"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", CSharpFeaturesResources.local_function, "x1", "x3"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "y0", CSharpFeaturesResources.local_function, "this", "y0"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", CSharpFeaturesResources.local_function, "this", "x3"));
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "y0", GetResource("local function"), "x1", "y0"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", GetResource("local function"), "x1", "x3"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "F", GetResource("local function"), "y0", "this"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "F", GetResource("local function"), "x3", "this"));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21499")]

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/StatementEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/StatementEditingTests.vb
@@ -1234,17 +1234,17 @@ End Class"
 
             Dim insert = GetTopEdits(src1, src2)
             insert.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x1", VBFeaturesResources.Lambda, "y0", "x1"),
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x3", VBFeaturesResources.Lambda, "x1", "x3"),
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "y0", VBFeaturesResources.Lambda, "Me", "y0"),
-                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x3", VBFeaturesResources.Lambda, "Me", "x3"))
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "y0", GetResource("Lambda"), "x1", "y0"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "x3", GetResource("Lambda"), "x1", "x3"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "Function(a)", GetResource("Lambda"), "y0", "Me"),
+                Diagnostic(RudeEditKind.InsertLambdaWithMultiScopeCapture, "Function(a)", GetResource("Lambda"), "x3", "Me"))
 
             Dim delete = GetTopEdits(src2, src1)
             delete.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x1", VBFeaturesResources.Lambda, "y0", "x1"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", VBFeaturesResources.Lambda, "x1", "x3"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "y0", VBFeaturesResources.Lambda, "Me", "y0"),
-                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", VBFeaturesResources.Lambda, "Me", "x3"))
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "y0", GetResource("Lambda"), "x1", "y0"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "x3", GetResource("Lambda"), "x1", "x3"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "F", GetResource("Lambda"), "y0", "Me"),
+                Diagnostic(RudeEditKind.DeleteLambdaWithMultiScopeCapture, "F", GetResource("Lambda"), "x3", "Me"))
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1290")>

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/CSharpLambdaBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/CSharpLambdaBody.cs
@@ -33,7 +33,7 @@ internal sealed class CSharpLambdaBody(SyntaxNode node) : LambdaBody
             HasSuspensionPoints: SyntaxUtilities.GetSuspensionPoints(node).Any());
 
     public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
-        => model.AnalyzeDataFlow(node).Captured;
+        => model.AnalyzeDataFlow(node).CapturedInside;
 
     public override Match<SyntaxNode>? ComputeSingleRootMatch(DeclarationBody newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
         => CSharpEditAndContinueAnalyzer.ComputeBodyMatch(node, ((CSharpLambdaBody)newBody).Node, knownMatches);

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/FieldWithInitializerDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/FieldWithInitializerDeclarationBody.cs
@@ -31,7 +31,7 @@ internal sealed class FieldWithInitializerDeclarationBody(VariableDeclaratorSynt
         => variableDeclarator.SyntaxTree;
 
     public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
-        => model.AnalyzeDataFlow(InitializerExpression)!.Captured;
+        => model.AnalyzeDataFlow(InitializerExpression)!.CapturedInside;
 
     public override TextSpan Envelope
     {

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/OrdinaryInstanceConstructorWithExplicitInitializerDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/OrdinaryInstanceConstructorWithExplicitInitializerDeclarationBody.cs
@@ -28,7 +28,7 @@ internal sealed class OrdinaryInstanceConstructorWithExplicitInitializerDeclarat
         => BreakpointSpans.CreateSpanForExplicitConstructorInitializer(Initializer);
 
     public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
-        => model.AnalyzeDataFlow(Initializer)!.Captured.AddRange(model.AnalyzeDataFlow(Body).Captured).Distinct();
+        => model.AnalyzeDataFlow(Initializer)!.CapturedInside.AddRange(model.AnalyzeDataFlow(Body).CapturedInside).Distinct();
 
     public override TextSpan Envelope
         => TextSpan.FromBounds(InitializerActiveStatementSpan.Start, Body.Span.End);

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/OrdinaryInstanceConstructorWithImplicitInitializerDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/OrdinaryInstanceConstructorWithImplicitInitializerDeclarationBody.cs
@@ -25,7 +25,7 @@ internal sealed class OrdinaryInstanceConstructorWithImplicitInitializerDeclarat
         => BreakpointSpans.CreateSpanForImplicitConstructorInitializer(Constructor);
 
     public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
-        => model.AnalyzeDataFlow(Body).Captured;
+        => model.AnalyzeDataFlow(Body).CapturedInside;
 
     public override TextSpan Envelope
         => TextSpan.FromBounds(InitializerActiveStatementSpan.Start, Body.Span.End);

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/PrimaryConstructorWithExplicitInitializerDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/PrimaryConstructorWithExplicitInitializerDeclarationBody.cs
@@ -39,5 +39,5 @@ internal sealed class PrimaryConstructorWithExplicitInitializerDeclarationBody(T
         => Initializer;
 
     public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
-        => model.AnalyzeDataFlow(Initializer)!.Captured;
+        => model.AnalyzeDataFlow(Initializer)!.CapturedInside;
 }

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/PropertyOrIndexerAccessorDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/PropertyOrIndexerAccessorDeclarationBody.cs
@@ -74,7 +74,7 @@ internal abstract class PropertyOrIndexerAccessorDeclarationBody : MemberBody
         => StateMachineInfo.None;
 
     public sealed override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
-        => (ExplicitBody != null) ? model.AnalyzeDataFlow(ExplicitBody).Captured : ImmutableArray<ISymbol>.Empty;
+        => (ExplicitBody != null) ? model.AnalyzeDataFlow(ExplicitBody).CapturedInside : ImmutableArray<ISymbol>.Empty;
 
     public sealed override SyntaxNode FindStatementAndPartner(TextSpan span, MemberBody? partnerDeclarationBody, out SyntaxNode? partnerStatement, out int statementPart)
     {

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/TopLevelCodeDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/TopLevelCodeDeclarationBody.cs
@@ -27,7 +27,7 @@ internal sealed class TopLevelCodeDeclarationBody(CompilationUnitSyntax unit) : 
         => unit.SyntaxTree;
 
     public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
-        => model.AnalyzeDataFlow(((GlobalStatementSyntax)unit.Members[0]).Statement, GlobalStatements.Last().Statement)!.Captured;
+        => model.AnalyzeDataFlow(((GlobalStatementSyntax)unit.Members[0]).Statement, GlobalStatements.Last().Statement)!.CapturedInside;
 
     public override TextSpan Envelope
         => TextSpan.FromBounds(unit.Members[0].SpanStart, GlobalStatements.Last().Span.End);

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -6257,6 +6257,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             ISymbol? oldCapturedThisParameter = null;
             ISymbol? newCapturedThisParameter = null;
+            var oldThisCaptureIndex = -1;
 
             for (var oldCaptureIndex = 0; oldCaptureIndex < oldCaptures.Length; oldCaptureIndex++)
             {
@@ -6264,7 +6265,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (oldCapture.IsThis)
                 {
-                    oldCapturedThisParameter ??= oldCapture.Symbol;
+                    // captures are unique, so we can only have one that represents this pointer:
+                    Debug.Assert(oldCapturedThisParameter == null);
+                    Debug.Assert(oldThisCaptureIndex == -1);
+
+                    oldCapturedThisParameter = oldCapture.Symbol;
+                    oldThisCaptureIndex = oldCaptureIndex;
                 }
                 else if (oldCapture.Symbol is IParameterSymbol oldParameterCapture)
                 {
@@ -6283,7 +6289,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (newCapture.IsThis)
                 {
-                    newCapturedThisParameter ??= newCapture.Symbol;
+                    // captures are unique, so we can only have one that represents this pointer:
+                    Debug.Assert(newCapturedThisParameter == null);
+
+                    newCapturedThisParameter = newCapture.Symbol;
+                    reverseCapturesMap[newCaptureIndex] = oldThisCaptureIndex;
                     continue;
                 }
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractSimpleMemberBody.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractSimpleMemberBody.cs
@@ -30,5 +30,5 @@ internal abstract class AbstractSimpleMemberBody(SyntaxNode node) : MemberBody
         => node.DescendantTokens();
 
     public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
-        => model.AnalyzeDataFlow(Node).Captured;
+        => model.AnalyzeDataFlow(Node).CapturedInside;
 }

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldOrPropertyDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldOrPropertyDeclarationBody.vb
@@ -128,7 +128,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         End Function
 
         Public Overrides Function GetCapturedVariables(model As SemanticModel) As ImmutableArray(Of ISymbol)
-            Return model.AnalyzeDataFlow(OtherActiveStatementContainer).Captured
+            Return model.AnalyzeDataFlow(OtherActiveStatementContainer).CapturedInside
         End Function
 
         Public NotOverridable Overrides Function GetStateMachineInfo() As StateMachineInfo

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/MethodBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/MethodBody.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Return ImmutableArray(Of ISymbol).Empty
             End If
 
-            Return model.AnalyzeDataFlow(methodBlock.Statements.First, methodBlock.Statements.Last).Captured
+            Return model.AnalyzeDataFlow(methodBlock.Statements.First, methodBlock.Statements.Last).CapturedInside
         End Function
 
         Public Overrides Function GetStateMachineInfo() As StateMachineInfo

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/VisualBasicLambdaBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/VisualBasicLambdaBody.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         End Function
 
         Public Overrides Function GetCapturedVariables(model As SemanticModel) As ImmutableArray(Of ISymbol)
-            Return model.AnalyzeDataFlow(If(TryCast(_node.Parent, LambdaExpressionSyntax), _node)).Captured
+            Return model.AnalyzeDataFlow(If(TryCast(_node.Parent, LambdaExpressionSyntax), _node)).CapturedInside
         End Function
 
         Public Overrides Function TryGetPartnerLambdaBody(newLambda As SyntaxNode) As LambdaBody

--- a/src/Features/VisualBasic/Portable/EditAndContinue/SyntaxUtilities.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/SyntaxUtilities.vb
@@ -120,7 +120,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return ImmutableArray.CreateRange(
                     arrayBounds.Arguments.
                         SelectMany(AddressOf GetArgumentExpressions).
-                        SelectMany(Function(expr) model.AnalyzeDataFlow(expr).Captured).
+                        SelectMany(Function(expr) model.AnalyzeDataFlow(expr).CapturedInside).
                         Distinct())
         End Function
 


### PR DESCRIPTION
Use `CapturedInside` instead of `Captured`. 

Fixes https://github.com/dotnet/roslyn/issues/69152