### PR TITLE
Create real `NamedTypeSymbol` for private implementation type and use it as a parent for `SynthesizedGlobalMethodSymbol`.

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -1467,7 +1467,7 @@ oneMoreTime:
             // Condition is necessary, but not sufficient (e.g. might be missing a special or well-known member).
             if (SwitchStringJumpTableEmitter.ShouldGenerateHashTableSwitch(switchCaseLabels.Length))
             {
-                var privateImplClass = _module.GetPrivateImplClass(syntaxNode, _diagnostics.DiagnosticBag);
+                var privateImplClass = _module.GetPrivateImplClass(syntaxNode, _diagnostics.DiagnosticBag).PrivateImplementationDetails;
                 Cci.IReference stringHashMethodRef = privateImplClass.GetMethod(
                     isSpanOrReadOnlySpan
                         ? isReadOnlySpan

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -530,16 +530,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             private Symbol? VisitNamedTypeMember<T>(T member, Func<T, T, bool> predicate)
                 where T : Symbol
             {
-                if (member.ContainingType is null)
-                {
-                    // ContainingType is null for synthesized PrivateImplementationDetails helpers.
-                    // For simplicity, these helpers are not reused across generations.
-                    // Instead new ones are regenerated as needed.
-                    Debug.Assert(member is ISynthesizedGlobalMethodSymbol);
-
-                    return null;
-                }
-
                 var otherType = (NamedTypeSymbol?)Visit(member.ContainingType);
 
                 // Containing type may be null for synthesized

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -908,6 +908,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal new NamedTypeSymbolAdapter GetCciAdapter()
         {
+            Debug.Assert(this is not SynthesizedPrivateImplementationDetailsType);
+
             if (_lazyAdapter is null)
             {
                 return InterlockedOperations.Initialize(ref _lazyAdapter, new NamedTypeSymbolAdapter(this));

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedPrivateImplementationDetailsStaticConstructor : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedPrivateImplementationDetailsStaticConstructor(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplementationType, NamedTypeSymbol voidType)
-            : base(containingModule, privateImplementationType, voidType, WellKnownMemberNames.StaticConstructorName)
+        internal SynthesizedPrivateImplementationDetailsStaticConstructor(SynthesizedPrivateImplementationDetailsType privateImplementationType, NamedTypeSymbol voidType)
+            : base(privateImplementationType, voidType, WellKnownMemberNames.StaticConstructorName)
         {
             this.SetParameters(ImmutableArray<ParameterSymbol>.Empty);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
@@ -921,7 +921,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // If we have already generated the helper, possibly for another switch
                 // or on another thread, we don't need to regenerate it.
                 var privateImplClass = module.GetPrivateImplClass(syntaxNode, _localRewriter._diagnostics.DiagnosticBag);
-                if (privateImplClass.GetMethod(stringPatternInput switch
+                if (privateImplClass.PrivateImplementationDetails.GetMethod(stringPatternInput switch
                 {
                     StringPatternInput.String => CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedStringHashFunctionName,
                     StringPatternInput.SpanChar => CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedReadOnlySpanHashFunctionName,
@@ -958,12 +958,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 SynthesizedGlobalMethodSymbol method = stringPatternInput switch
                 {
-                    StringPatternInput.String => new SynthesizedStringSwitchHashMethod(module.SourceModule, privateImplClass, returnType, paramType),
-                    StringPatternInput.SpanChar => new SynthesizedSpanSwitchHashMethod(module.SourceModule, privateImplClass, returnType, paramType, isReadOnlySpan: false),
-                    StringPatternInput.ReadOnlySpanChar => new SynthesizedSpanSwitchHashMethod(module.SourceModule, privateImplClass, returnType, paramType, isReadOnlySpan: true),
+                    StringPatternInput.String => new SynthesizedStringSwitchHashMethod(privateImplClass, returnType, paramType),
+                    StringPatternInput.SpanChar => new SynthesizedSpanSwitchHashMethod(privateImplClass, returnType, paramType, isReadOnlySpan: false),
+                    StringPatternInput.ReadOnlySpanChar => new SynthesizedSpanSwitchHashMethod(privateImplClass, returnType, paramType, isReadOnlySpan: true),
                     _ => throw ExceptionUtilities.UnexpectedValue(stringPatternInput),
                 };
-                privateImplClass.TryAddSynthesizedMethod(method.GetCciAdapter());
+                privateImplClass.PrivateImplementationDetails.TryAddSynthesizedMethod(method.GetCciAdapter());
             }
 
 #nullable enable

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -612,12 +612,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            if (method.ContainingType is null)
-            {
-                Debug.Assert(method.OriginalDefinition is SynthesizedGlobalMethodSymbol);
-                return method.OriginalDefinition.ConstructIfGeneric(TypeMap.SubstituteTypes(method.TypeArgumentsWithAnnotations));
-            }
-            else if (method.ContainingType.IsAnonymousType)
+            if (method.ContainingType.IsAnonymousType)
             {
                 //  Method of an anonymous type
                 var newType = (NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly();

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -362,22 +362,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int code = this.OriginalDefinition.GetHashCode();
             int containingHashCode;
 
-            if (OriginalDefinition is SynthesizedGlobalMethodSymbol global)
+            // If the containing type of the original definition is the same as our containing type
+            // it's possible that we will compare equal to the original definition under certain conditions 
+            // (e.g, ignoring nullability) and want to retain the same hashcode. As such, consider only
+            // the original definition for the hashcode when we know equality is possible
+            containingHashCode = _containingType.GetHashCode();
+            if (containingHashCode == this.OriginalDefinition.ContainingType.GetHashCode() &&
+                wasConstructedForAnnotations(this))
             {
-                containingHashCode = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(global.ContainingPrivateImplementationDetailsType);
-            }
-            else
-            {
-                // If the containing type of the original definition is the same as our containing type
-                // it's possible that we will compare equal to the original definition under certain conditions 
-                // (e.g, ignoring nullability) and want to retain the same hashcode. As such, consider only
-                // the original definition for the hashcode when we know equality is possible
-                containingHashCode = _containingType.GetHashCode();
-                if (containingHashCode == this.OriginalDefinition.ContainingType.GetHashCode() &&
-                    wasConstructedForAnnotations(this))
-                {
-                    return code;
-                }
+                return code;
             }
 
             code = Hash.Combine(containingHashCode, code);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -20,26 +20,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal abstract class SynthesizedGlobalMethodSymbol : MethodSymbol, ISynthesizedGlobalMethodSymbol
     {
-        private readonly ModuleSymbol _containingModule;
-        private readonly PrivateImplementationDetails _privateImplType;
+        private readonly SynthesizedPrivateImplementationDetailsType _privateImplType;
         private TypeSymbol _returnType;
         private ImmutableArray<ParameterSymbol> _parameters;
         private ImmutableArray<TypeParameterSymbol> _typeParameters;
         private readonly string _name;
 
-        internal SynthesizedGlobalMethodSymbol(ModuleSymbol containingModule, PrivateImplementationDetails privateImplType, string name)
+        internal SynthesizedGlobalMethodSymbol(SynthesizedPrivateImplementationDetailsType privateImplType, string name)
         {
-            Debug.Assert((object)containingModule != null);
-            Debug.Assert(privateImplType != null);
+            Debug.Assert(privateImplType is not null);
             Debug.Assert(name != null);
 
-            _containingModule = containingModule;
             _privateImplType = privateImplType;
             _name = name;
         }
 
-        internal SynthesizedGlobalMethodSymbol(ModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, string name)
-            : this(containingModule, privateImplType, name)
+        internal SynthesizedGlobalMethodSymbol(SynthesizedPrivateImplementationDetailsType privateImplType, TypeSymbol returnType, string name)
+            : this(privateImplType, name)
         {
             Debug.Assert((object)returnType != null);
             _returnType = returnType;
@@ -77,42 +74,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        internal sealed override ModuleSymbol ContainingModule
-        {
-            get
-            {
-                return _containingModule;
-            }
-        }
-
-        public sealed override AssemblySymbol ContainingAssembly
-        {
-            get
-            {
-                return _containingModule.ContainingAssembly;
-            }
-        }
-
-        /// <summary>
-        /// Synthesized methods that must be emitted in the compiler generated
-        /// PrivateImplementationDetails class have null containing type symbol.
-        /// </summary>
         public sealed override Symbol ContainingSymbol
         {
-            get { return null; }
+            get { return _privateImplType; }
         }
 
         public sealed override NamedTypeSymbol ContainingType
         {
             get
             {
-                return null;
+                return _privateImplType;
             }
         }
 
         public PrivateImplementationDetails ContainingPrivateImplementationDetailsType
         {
-            get { return _privateImplType; }
+            get { return _privateImplType.PrivateImplementationDetails; }
         }
 
         public override string Name
@@ -377,7 +354,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override bool HasUnscopedRefAttribute => false;
 
-        internal sealed override bool UseUpdatedEscapeRules => _containingModule.UseUpdatedEscapeRules;
+        internal sealed override bool UseUpdatedEscapeRules => ContainingModule.UseUpdatedEscapeRules;
 
         internal sealed override bool HasAsyncMethodBuilderAttribute(out TypeSymbol builderArgument)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayAsReadOnlySpanMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayAsReadOnlySpanMethod.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedInlineArrayAsReadOnlySpanMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedInlineArrayAsReadOnlySpanMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, string synthesizedMethodName, NamedTypeSymbol spanType, NamedTypeSymbol intType)
-            : base(containingModule, privateImplType, synthesizedMethodName)
+        internal SynthesizedInlineArrayAsReadOnlySpanMethod(SynthesizedPrivateImplementationDetailsType privateImplType, string synthesizedMethodName, NamedTypeSymbol spanType, NamedTypeSymbol intType)
+            : base(privateImplType, synthesizedMethodName)
         {
             this.SetTypeParameters(ImmutableArray.Create<TypeParameterSymbol>(new SynthesizedSimpleMethodTypeParameterSymbol(this, 0, "TBuffer"), new SynthesizedSimpleMethodTypeParameterSymbol(this, 1, "TElement")));
             this.SetReturnType(spanType.Construct(TypeParameters[1]));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayAsSpanMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayAsSpanMethod.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedInlineArrayAsSpanMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedInlineArrayAsSpanMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, string synthesizedMethodName, NamedTypeSymbol spanType, NamedTypeSymbol intType)
-            : base(containingModule, privateImplType, synthesizedMethodName)
+        internal SynthesizedInlineArrayAsSpanMethod(SynthesizedPrivateImplementationDetailsType privateImplType, string synthesizedMethodName, NamedTypeSymbol spanType, NamedTypeSymbol intType)
+            : base(privateImplType, synthesizedMethodName)
         {
             this.SetTypeParameters(ImmutableArray.Create<TypeParameterSymbol>(new SynthesizedSimpleMethodTypeParameterSymbol(this, 0, "TBuffer"), new SynthesizedSimpleMethodTypeParameterSymbol(this, 1, "TElement")));
             this.SetReturnType(spanType.Construct(TypeParameters[1]));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayElementRefMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayElementRefMethod.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedInlineArrayElementRefMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedInlineArrayElementRefMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, string synthesizedMethodName, NamedTypeSymbol intType)
-            : base(containingModule, privateImplType, synthesizedMethodName)
+        internal SynthesizedInlineArrayElementRefMethod(SynthesizedPrivateImplementationDetailsType privateImplType, string synthesizedMethodName, NamedTypeSymbol intType)
+            : base(privateImplType, synthesizedMethodName)
         {
             this.SetTypeParameters(ImmutableArray.Create<TypeParameterSymbol>(new SynthesizedSimpleMethodTypeParameterSymbol(this, 0, "TBuffer"), new SynthesizedSimpleMethodTypeParameterSymbol(this, 1, "TElement")));
             this.SetReturnType(TypeParameters[1]);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayElementRefReadOnlyMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayElementRefReadOnlyMethod.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedInlineArrayElementRefReadOnlyMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedInlineArrayElementRefReadOnlyMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, string synthesizedMethodName, NamedTypeSymbol intType)
-            : base(containingModule, privateImplType, synthesizedMethodName)
+        internal SynthesizedInlineArrayElementRefReadOnlyMethod(SynthesizedPrivateImplementationDetailsType privateImplType, string synthesizedMethodName, NamedTypeSymbol intType)
+            : base(privateImplType, synthesizedMethodName)
         {
             this.SetTypeParameters(ImmutableArray.Create<TypeParameterSymbol>(new SynthesizedSimpleMethodTypeParameterSymbol(this, 0, "TBuffer"), new SynthesizedSimpleMethodTypeParameterSymbol(this, 1, "TElement")));
             this.SetReturnType(TypeParameters[1]);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayFirstElementRefMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayFirstElementRefMethod.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedInlineArrayFirstElementRefMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedInlineArrayFirstElementRefMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, string synthesizedMethodName)
-            : base(containingModule, privateImplType, synthesizedMethodName)
+        internal SynthesizedInlineArrayFirstElementRefMethod(SynthesizedPrivateImplementationDetailsType privateImplType, string synthesizedMethodName)
+            : base(privateImplType, synthesizedMethodName)
         {
             this.SetTypeParameters(ImmutableArray.Create<TypeParameterSymbol>(new SynthesizedSimpleMethodTypeParameterSymbol(this, 0, "TBuffer"), new SynthesizedSimpleMethodTypeParameterSymbol(this, 1, "TElement")));
             this.SetReturnType(TypeParameters[1]);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayFirstElementRefReadOnlyMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayFirstElementRefReadOnlyMethod.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class SynthesizedInlineArrayFirstElementRefReadOnlyMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedInlineArrayFirstElementRefReadOnlyMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, string synthesizedMethodName)
-            : base(containingModule, privateImplType, synthesizedMethodName)
+        internal SynthesizedInlineArrayFirstElementRefReadOnlyMethod(SynthesizedPrivateImplementationDetailsType privateImplType, string synthesizedMethodName)
+            : base(privateImplType, synthesizedMethodName)
         {
             this.SetTypeParameters(ImmutableArray.Create<TypeParameterSymbol>(new SynthesizedSimpleMethodTypeParameterSymbol(this, 0, "TBuffer"), new SynthesizedSimpleMethodTypeParameterSymbol(this, 1, "TElement")));
             this.SetReturnType(TypeParameters[1]);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterlessThrowMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterlessThrowMethod.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly MethodSymbol _exceptionConstructor;
 
-        internal SynthesizedParameterlessThrowMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, string synthesizedMethodName, MethodSymbol exceptionConstructor)
-            : base(containingModule, privateImplType, returnType, synthesizedMethodName)
+        internal SynthesizedParameterlessThrowMethod(SynthesizedPrivateImplementationDetailsType privateImplType, TypeSymbol returnType, string synthesizedMethodName, MethodSymbol exceptionConstructor)
+            : base(privateImplType, returnType, synthesizedMethodName)
         {
             _exceptionConstructor = exceptionConstructor;
             this.SetParameters(ImmutableArray<ParameterSymbol>.Empty);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
@@ -1,0 +1,189 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed partial class SynthesizedPrivateImplementationDetailsType : NamedTypeSymbol
+    {
+        private readonly PrivateImplementationDetails _privateImplementationDetails;
+        private readonly NamespaceSymbol _globalNamespace;
+        private readonly NamedTypeSymbol _objectType;
+
+        public SynthesizedPrivateImplementationDetailsType(PrivateImplementationDetails privateImplementationDetails, NamespaceSymbol globalNamespace, NamedTypeSymbol objectType)
+        {
+            Debug.Assert(globalNamespace.IsGlobalNamespace);
+            Debug.Assert(objectType.IsObjectType());
+
+            _privateImplementationDetails = privateImplementationDetails;
+            _globalNamespace = globalNamespace;
+            _objectType = objectType;
+        }
+
+        public PrivateImplementationDetails PrivateImplementationDetails => _privateImplementationDetails;
+
+        public override bool IsImplicitlyDeclared => true;
+
+        public override int Arity => 0;
+
+        public override ImmutableArray<TypeParameterSymbol> TypeParameters => ImmutableArray<TypeParameterSymbol>.Empty;
+
+        public override NamedTypeSymbol ConstructedFrom => this;
+
+        public override bool MightContainExtensionMethods => false;
+
+        public override string Name => _privateImplementationDetails.Name!;
+
+        public override IEnumerable<string> MemberNames => SpecializedCollections.EmptyEnumerable<string>();
+
+        public override Accessibility DeclaredAccessibility => Accessibility.Internal;
+
+        public override bool IsSerializable => false;
+
+        public override bool AreLocalsZeroed => false;
+
+        public override TypeKind TypeKind => TypeKind.Class;
+
+        public override bool IsRefLikeType => false;
+
+        public override bool IsReadOnly => false;
+
+        public override Symbol ContainingSymbol => _globalNamespace;
+
+        public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
+
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
+
+        public override bool IsStatic => _privateImplementationDetails.IsSealed && _privateImplementationDetails.IsAbstract;
+
+        public override bool IsAbstract => _privateImplementationDetails.IsAbstract && !_privateImplementationDetails.IsSealed;
+
+        public override bool IsSealed => _privateImplementationDetails.IsSealed && !_privateImplementationDetails.IsAbstract;
+
+        internal override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotationsNoUseSiteDiagnostics => ImmutableArray<TypeWithAnnotations>.Empty;
+
+        internal override bool IsFileLocal => false;
+
+        internal override FileIdentifier? AssociatedFileIdentifier => null;
+
+        internal override bool MangleName => false;
+
+        internal override bool HasDeclaredRequiredMembers => false;
+
+        internal override bool HasCodeAnalysisEmbeddedAttribute => false;
+
+        internal override bool IsInterpolatedStringHandlerType => false;
+
+        internal override bool HasSpecialName => _privateImplementationDetails.IsSpecialName;
+
+        internal override bool IsComImport => false;
+
+        internal override bool IsWindowsRuntimeImport => false;
+
+        internal override bool ShouldAddWinRTMembers => false;
+
+        internal override TypeLayout Layout => new TypeLayout(_privateImplementationDetails.Layout, (int)_privateImplementationDetails.SizeOf, (byte)_privateImplementationDetails.Alignment);
+
+        internal override CharSet MarshallingCharSet => _privateImplementationDetails.StringFormat;
+
+        internal override bool HasDeclarativeSecurity => false;
+
+        internal override bool IsInterface => false;
+
+        internal override NamedTypeSymbol? NativeIntegerUnderlyingType => null;
+
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => _objectType;
+
+        internal override bool IsRecord => false;
+
+        internal override bool IsRecordStruct => false;
+
+        internal override ObsoleteAttributeData? ObsoleteAttributeData => null;
+
+        public override ImmutableArray<Symbol> GetMembers() => ImmutableArray<Symbol>.Empty;
+
+        public override ImmutableArray<Symbol> GetMembers(string name) => ImmutableArray<Symbol>.Empty;
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => ImmutableArray<NamedTypeSymbol>.Empty;
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name, int arity) => ImmutableArray<NamedTypeSymbol>.Empty;
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name) => ImmutableArray<NamedTypeSymbol>.Empty;
+
+        protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData)
+        {
+            throw ExceptionUtilities.Unreachable();
+        }
+
+        internal override NamedTypeSymbol AsNativeInteger()
+        {
+            throw ExceptionUtilities.Unreachable();
+        }
+
+        internal override ImmutableArray<string> GetAppliedConditionalSymbols() => ImmutableArray<string>.Empty;
+
+        internal override AttributeUsageInfo GetAttributeUsageInfo()
+        {
+            throw ExceptionUtilities.Unreachable();
+        }
+
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved) => _objectType;
+
+        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<TypeSymbol> basesBeingResolved) => ImmutableArray<NamedTypeSymbol>.Empty;
+
+        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers() => ImmutableArray<Symbol>.Empty;
+
+        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name) => ImmutableArray<Symbol>.Empty;
+
+        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => SpecializedCollections.EmptyEnumerable<FieldSymbol>();
+
+        internal override bool GetGuidString(out string? guidString)
+        {
+            guidString = null;
+            return false;
+        }
+
+        internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit() => ImmutableArray<NamedTypeSymbol>.Empty;
+
+        internal override IEnumerable<SecurityAttribute> GetSecurityInformation() => SpecializedCollections.EmptyEnumerable<SecurityAttribute>();
+
+        internal override bool HasAsyncMethodBuilderAttribute(out TypeSymbol? builderArgument)
+        {
+            builderArgument = null;
+            return false;
+        }
+
+        internal override bool HasCollectionBuilderAttribute(out TypeSymbol? builderType, out string? methodName)
+        {
+            builderType = null;
+            methodName = null;
+            return false;
+        }
+
+        internal override bool HasInlineArrayAttribute(out int length)
+        {
+            length = 0;
+            return false;
+        }
+
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
+
+        internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved = null) => ImmutableArray<NamedTypeSymbol>.Empty;
+
+        internal override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
+        {
+            return SpecializedCollections.EmptyEnumerable<(MethodSymbol Body, MethodSymbol Implemented)>();
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool MightContainExtensionMethods => false;
 
-        public override string Name => _privateImplementationDetails.Name!;
+        public override string Name => _privateImplementationDetails.Name;
 
         public override IEnumerable<string> MemberNames => SpecializedCollections.EmptyEnumerable<string>();
 
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name) => ImmutableArray<Symbol>.Empty;
 
-        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => SpecializedCollections.EmptyEnumerable<FieldSymbol>();
+        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => throw ExceptionUtilities.Unreachable();
 
         internal override bool GetGuidString(out string? guidString)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStringHashFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStringHashFunctionSymbol.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed partial class SynthesizedStringSwitchHashMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedStringSwitchHashMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, TypeSymbol paramType)
-            : base(containingModule, privateImplType, returnType, PrivateImplementationDetails.SynthesizedStringHashFunctionName)
+        internal SynthesizedStringSwitchHashMethod(SynthesizedPrivateImplementationDetailsType privateImplType, TypeSymbol returnType, TypeSymbol paramType)
+            : base(privateImplType, returnType, PrivateImplementationDetails.SynthesizedStringHashFunctionName)
         {
             this.SetParameters(ImmutableArray.Create<ParameterSymbol>(SynthesizedParameterSymbol.Create(this, TypeWithAnnotations.Create(paramType), 0, RefKind.None, "s")));
         }
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
     internal sealed partial class SynthesizedSpanSwitchHashMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedSpanSwitchHashMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, TypeSymbol paramType, bool isReadOnlySpan)
-            : base(containingModule, privateImplType, returnType, isReadOnlySpan ? PrivateImplementationDetails.SynthesizedReadOnlySpanHashFunctionName : PrivateImplementationDetails.SynthesizedSpanHashFunctionName)
+        internal SynthesizedSpanSwitchHashMethod(SynthesizedPrivateImplementationDetailsType privateImplType, TypeSymbol returnType, TypeSymbol paramType, bool isReadOnlySpan)
+            : base(privateImplType, returnType, isReadOnlySpan ? PrivateImplementationDetails.SynthesizedReadOnlySpanHashFunctionName : PrivateImplementationDetails.SynthesizedSpanHashFunctionName)
         {
             _isReadOnlySpan = isReadOnlySpan;
             this.SetParameters(ImmutableArray.Create<ParameterSymbol>(SynthesizedParameterSymbol.Create(this, TypeWithAnnotations.Create(paramType), 0, RefKind.None, "s")));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class SynthesizedThrowSwitchExpressionExceptionMethod : SynthesizedGlobalMethodSymbol
     {
-        internal SynthesizedThrowSwitchExpressionExceptionMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, TypeSymbol paramType)
-            : base(containingModule, privateImplType, returnType, PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName)
+        internal SynthesizedThrowSwitchExpressionExceptionMethod(SynthesizedPrivateImplementationDetailsType privateImplType, TypeSymbol returnType, TypeSymbol paramType)
+            : base(privateImplType, returnType, PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName)
         {
             this.SetParameters(ImmutableArray.Create(SynthesizedParameterSymbol.Create(this, TypeWithAnnotations.Create(paramType), 0, RefKind.None, "unmatchedValue")));
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -2922,7 +2922,7 @@ class Test
   IL_0021:  ldarg.0
   IL_0022:  brfalse    IL_012b
   IL_0027:  ldarg.0
-  IL_0028:  call       ""ComputeStringHash(string)""
+  IL_0028:  call       ""uint <PrivateImplementationDetails>.ComputeStringHash(string)""
   IL_002d:  stloc.1
   IL_002e:  ldloc.1
   IL_002f:  ldc.i4     0xc70bfb85
@@ -3367,7 +3367,7 @@ class Test
   IL_0017:  callvirt   ""string string.Remove(int, int)""
   IL_001c:  starg.s    V_0
   IL_001e:  ldarg.0
-  IL_001f:  call       ""ComputeStringHash(string)""
+  IL_001f:  call       ""uint <PrivateImplementationDetails>.ComputeStringHash(string)""
   IL_0024:  stloc.1
   IL_0025:  ldloc.1
   IL_0026:  ldc.i4     0xb2f29419
@@ -4039,11 +4039,11 @@ class Goo
 
         private static void VerifySynthesizedStringHashMethod(CompilationVerifier compVerifier, bool expected)
         {
-            compVerifier.VerifyMemberInIL(PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected);
+            compVerifier.VerifyMemberInIL("<PrivateImplementationDetails>." + PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected);
 
             if (expected)
             {
-                compVerifier.VerifyIL(PrivateImplementationDetails.SynthesizedStringHashFunctionName,
+                compVerifier.VerifyIL("<PrivateImplementationDetails>." + PrivateImplementationDetails.SynthesizedStringHashFunctionName,
                     @"
 {
   // Code size       44 (0x2c)
@@ -7165,7 +7165,7 @@ public class Test
   .maxstack  2
   .locals init (uint V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       ""ComputeStringHash(string)""
+  IL_0001:  call       ""uint <PrivateImplementationDetails>.ComputeStringHash(string)""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  ldc.i4     0x6ceb2d06
@@ -7870,7 +7870,7 @@ public class Test
   IL_0017:  ldelem.ref
   IL_0018:  stloc.0
   IL_0019:  ldloc.0
-  IL_001a:  call       ""ComputeStringHash(string)""
+  IL_001a:  call       ""uint <PrivateImplementationDetails>.ComputeStringHash(string)""
   IL_001f:  stloc.1
   IL_0020:  ldloc.1
   IL_0021:  ldc.i4     0xc30bf539
@@ -8104,7 +8104,7 @@ public class Test
   IL_0002:  ldelem.ref
   IL_0003:  stloc.0
   IL_0004:  ldloc.0
-  IL_0005:  call       ""ComputeStringHash(string)""
+  IL_0005:  call       ""uint <PrivateImplementationDetails>.ComputeStringHash(string)""
   IL_000a:  stloc.1
   IL_000b:  ldloc.1
   IL_000c:  ldc.i4     0xc30bf539

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -470,7 +470,7 @@ True
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
             verifier.VerifyIL("Program.Barney", expectedBarneyIL);
-            verifier.VerifyIL(".cctor", expectedPIDStaticConstructorIL);
+            verifier.VerifyIL("<PrivateImplementationDetails>..cctor", expectedPIDStaticConstructorIL);
             verifier.VerifyDiagnostics(Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(16, 9));
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenLengthBasedSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenLengthBasedSwitchTests.cs
@@ -267,7 +267,7 @@ public class C
         comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDisableLengthBasedSwitch());
         comp.VerifyDiagnostics();
         verifier = CompileAndVerify(comp, expectedOutput: "RAN");
-        verifier.VerifyMemberInIL(PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected: true);
+        verifier.VerifyMemberInIL("<PrivateImplementationDetails>." + PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected: true);
 
         verifier.VerifyIL("C.M", """
 {
@@ -276,7 +276,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x62366ffa
@@ -517,7 +517,7 @@ public class C
   IL_0002:  brtrue.s   IL_0005
   IL_0004:  nop
   IL_0005:  ldarg.0
-  IL_0006:  call       "ComputeStringHash(string)"
+  IL_0006:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_000b:  stloc.1
   IL_000c:  ldloc.1
   IL_000d:  ldc.i4     0x62366ffa
@@ -1035,7 +1035,7 @@ public class C
         comp.VerifyDiagnostics();
         verifier = CompileAndVerify(comp, expectedOutput: "RAN");
         var helper = useReadonly ? "ComputeReadOnlySpanHash(System.ReadOnlySpan<char>)" : "ComputeSpanHash(System.Span<char>)";
-        verifier.VerifyMemberInIL(helper, expected: true);
+        verifier.VerifyMemberInIL("<PrivateImplementationDetails>." + helper, expected: true);
         verifier.VerifyIL("C.M", $$"""
 {
   // Code size      861 (0x35d)
@@ -1043,7 +1043,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "{{helper}}"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.{{helper}}"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x62366ffa
@@ -1472,7 +1472,7 @@ public class C
         comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDisableLengthBasedSwitch());
         comp.VerifyDiagnostics();
         verifier = CompileAndVerify(comp, expectedOutput: "RAN");
-        verifier.VerifyMemberInIL(PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected: true);
+        verifier.VerifyMemberInIL("<PrivateImplementationDetails>." + PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected: true);
         verifier.VerifyIL("C.M", """
 {
   // Code size      335 (0x14f)
@@ -1486,7 +1486,7 @@ public class C
   IL_0007:  ldloc.1
   IL_0008:  brfalse    IL_0147
   IL_000d:  ldloc.1
-  IL_000e:  call       "ComputeStringHash(string)"
+  IL_000e:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0013:  stloc.2
   IL_0014:  ldloc.2
   IL_0015:  ldc.i4     0x749bcf08
@@ -2430,7 +2430,7 @@ public class C
         comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDisableLengthBasedSwitch());
         comp.VerifyDiagnostics();
         verifier = CompileAndVerify(comp, expectedOutput: "RAN");
-        verifier.VerifyMemberInIL(PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected: true);
+        verifier.VerifyMemberInIL("<PrivateImplementationDetails>." + PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected: true);
         verifier.VerifyIL("C.M", """
 {
   // Code size      357 (0x165)
@@ -2444,7 +2444,7 @@ public class C
   IL_0007:  ldloc.1
   IL_0008:  brfalse    IL_0110
   IL_000d:  ldloc.1
-  IL_000e:  call       "ComputeStringHash(string)"
+  IL_000e:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0013:  stloc.2
   IL_0014:  ldloc.2
   IL_0015:  ldc.i4     0x749bcf08
@@ -2870,7 +2870,7 @@ public class C
   .maxstack  2
   .locals init (uint V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  ldc.i4     0xad238cee
@@ -3175,7 +3175,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x87f05176
@@ -4390,7 +4390,7 @@ public class C
   .maxstack  2
   .locals init (uint V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  ldc.i4     0x93254270
@@ -7768,7 +7768,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x77c08b8d
@@ -9191,7 +9191,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x8979e177
@@ -9588,7 +9588,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x2607050f
@@ -10349,7 +10349,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x6ccaf138
@@ -11649,7 +11649,7 @@ public class C
   .maxstack  2
   .locals init (uint V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  ldc.i4     0xb508d68f
@@ -12654,7 +12654,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x76692b6a
@@ -13115,7 +13115,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x62fa988f
@@ -13592,7 +13592,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x5ef81c51
@@ -14027,7 +14027,7 @@ public class C
   .locals init (string V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       "ComputeStringHash(string)"
+  IL_0001:  call       "uint <PrivateImplementationDetails>.ComputeStringHash(string)"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x4569f715

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -9874,7 +9874,7 @@ partial class Program
   IL_0002:  initobj    "<>y__InlineArray2<MyCollection<int>?>"
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.0
-  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray2<MyCollection<int>?>, MyCollection<int>?>(ref <>y__InlineArray2<MyCollection<int>?>, int)"
+  IL_000b:  call       "ref MyCollection<int>? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<MyCollection<int>?>, MyCollection<int>?>(ref <>y__InlineArray2<MyCollection<int>?>, int)"
   IL_0010:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=4_Align=4 <PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA4504"
   IL_0015:  call       "System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)"
   IL_001a:  call       "MyCollection<int> MyCollectionBuilder.Create<int>(System.ReadOnlySpan<int>)"
@@ -9882,7 +9882,7 @@ partial class Program
   IL_0024:  stobj      "MyCollection<int>?"
   IL_0029:  ldloca.s   V_0
   IL_002b:  ldc.i4.1
-  IL_002c:  call       "InlineArrayElementRef<<>y__InlineArray2<MyCollection<int>?>, MyCollection<int>?>(ref <>y__InlineArray2<MyCollection<int>?>, int)"
+  IL_002c:  call       "ref MyCollection<int>? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<MyCollection<int>?>, MyCollection<int>?>(ref <>y__InlineArray2<MyCollection<int>?>, int)"
   IL_0031:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=4_Align=4 <PrivateImplementationDetails>.26B25D457597A7B0463F9620F666DD10AA2C4373A505967C7C8D70922A2D6ECE4"
   IL_0036:  call       "System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)"
   IL_003b:  call       "MyCollection<int> MyCollectionBuilder.Create<int>(System.ReadOnlySpan<int>)"
@@ -9890,7 +9890,7 @@ partial class Program
   IL_0045:  stobj      "MyCollection<int>?"
   IL_004a:  ldloca.s   V_0
   IL_004c:  ldc.i4.2
-  IL_004d:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray2<MyCollection<int>?>, MyCollection<int>?>(in <>y__InlineArray2<MyCollection<int>?>, int)"
+  IL_004d:  call       "System.ReadOnlySpan<MyCollection<int>?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray2<MyCollection<int>?>, MyCollection<int>?>(in <>y__InlineArray2<MyCollection<int>?>, int)"
   IL_0052:  call       "MyCollection<MyCollection<int>?> MyCollectionBuilder.Create<MyCollection<int>?>(System.ReadOnlySpan<MyCollection<int>?>)"
   IL_0057:  ret
 }
@@ -10355,23 +10355,23 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray3<object>"
                   IL_0008:  ldloca.s   V_0
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_0010:  ldarg.0
                   IL_0011:  box        "int"
                   IL_0016:  stind.ref
                   IL_0017:  ldloca.s   V_0
                   IL_0019:  ldc.i4.1
-                  IL_001a:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_001a:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_001f:  ldarg.1
                   IL_0020:  stind.ref
                   IL_0021:  ldloca.s   V_0
                   IL_0023:  ldc.i4.2
-                  IL_0024:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_0024:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_0029:  ldnull
                   IL_002a:  stind.ref
                   IL_002b:  ldloca.s   V_0
                   IL_002d:  ldc.i4.3
-                  IL_002e:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
+                  IL_002e:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
                   IL_0033:  call       "MyCollection<object> MyCollectionBuilder.Create<object>(System.ReadOnlySpan<object>)"
                   IL_0038:  ret
                 }
@@ -10524,23 +10524,23 @@ partial class Program
                       IL_0002:  initobj    "<>y__InlineArray3<int?>"
                       IL_0008:  ldloca.s   V_0
                       IL_000a:  ldc.i4.0
-                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<int?>, int?>(ref <>y__InlineArray3<int?>, int)"
+                      IL_000b:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int?>, int?>(ref <>y__InlineArray3<int?>, int)"
                       IL_0010:  ldc.i4.1
                       IL_0011:  newobj     "int?..ctor(int)"
                       IL_0016:  stobj      "int?"
                       IL_001b:  ldloca.s   V_0
                       IL_001d:  ldc.i4.1
-                      IL_001e:  call       "InlineArrayElementRef<<>y__InlineArray3<int?>, int?>(ref <>y__InlineArray3<int?>, int)"
+                      IL_001e:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int?>, int?>(ref <>y__InlineArray3<int?>, int)"
                       IL_0023:  ldc.i4.2
                       IL_0024:  newobj     "int?..ctor(int)"
                       IL_0029:  stobj      "int?"
                       IL_002e:  ldloca.s   V_0
                       IL_0030:  ldc.i4.2
-                      IL_0031:  call       "InlineArrayElementRef<<>y__InlineArray3<int?>, int?>(ref <>y__InlineArray3<int?>, int)"
+                      IL_0031:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int?>, int?>(ref <>y__InlineArray3<int?>, int)"
                       IL_0036:  initobj    "int?"
                       IL_003c:  ldloca.s   V_0
                       IL_003e:  ldc.i4.3
-                      IL_003f:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<int?>, int?>(in <>y__InlineArray3<int?>, int)"
+                      IL_003f:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<int?>, int?>(in <>y__InlineArray3<int?>, int)"
                       IL_0044:  call       "MyCollection<int?> MyCollectionBuilder.Create<int?>(System.ReadOnlySpan<int?>)"
                       IL_0049:  ret
                     }
@@ -10821,25 +10821,25 @@ partial class Program
                     IL_0002:  initobj    "<>y__InlineArray3<object>"
                     IL_0008:  ldloca.s   V_1
                     IL_000a:  ldc.i4.0
-                    IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                    IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                     IL_0010:  ldc.i4.1
                     IL_0011:  box        "int"
                     IL_0016:  stind.ref
                     IL_0017:  ldloca.s   V_1
                     IL_0019:  ldc.i4.1
-                    IL_001a:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                    IL_001a:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                     IL_001f:  ldc.i4.2
                     IL_0020:  box        "int"
                     IL_0025:  stind.ref
                     IL_0026:  ldloca.s   V_1
                     IL_0028:  ldc.i4.2
-                    IL_0029:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                    IL_0029:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                     IL_002e:  ldc.i4.3
                     IL_002f:  box        "int"
                     IL_0034:  stind.ref
                     IL_0035:  ldloca.s   V_1
                     IL_0037:  ldc.i4.3
-                    IL_0038:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
+                    IL_0038:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
                     IL_003d:  call       "MyCollection<object> MyCollectionBuilder.Create<object>({{qualifier}}System.ReadOnlySpan<object>)"
                     IL_0042:  stloc.0
                     IL_0043:  ldloca.s   V_0
@@ -14972,13 +14972,13 @@ partial class Program
                     IL_007c:  ldarg.0
                     IL_007d:  ldflda     "<>y__InlineArray3<int> Program.<CreateCollection>d__1.<>7__wrap1"
                     IL_0082:  ldc.i4.0
-                    IL_0083:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                    IL_0083:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                     IL_0088:  ldloc.2
                     IL_0089:  stind.i4
                     IL_008a:  ldarg.0
                     IL_008b:  ldflda     "<>y__InlineArray3<int> Program.<CreateCollection>d__1.<>7__wrap1"
                     IL_0090:  ldc.i4.1
-                    IL_0091:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                    IL_0091:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                     IL_0096:  ldc.i4.2
                     IL_0097:  stind.i4
                     IL_0098:  ldc.i4.3
@@ -15019,13 +15019,13 @@ partial class Program
                     IL_00f4:  ldarg.0
                     IL_00f5:  ldflda     "<>y__InlineArray3<int> Program.<CreateCollection>d__1.<>7__wrap1"
                     IL_00fa:  ldc.i4.2
-                    IL_00fb:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                    IL_00fb:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                     IL_0100:  ldloc.3
                     IL_0101:  stind.i4
                     IL_0102:  ldarg.0
                     IL_0103:  ldflda     "<>y__InlineArray3<int> Program.<CreateCollection>d__1.<>7__wrap1"
                     IL_0108:  ldc.i4.3
-                    IL_0109:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<int>, int>(in <>y__InlineArray3<int>, int)"
+                    IL_0109:  call       "System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<int>, int>(in <>y__InlineArray3<int>, int)"
                     IL_010e:  call       "MyCollection<int> MyCollectionBuilder.Create<int>(System.ReadOnlySpan<int>)"
                     IL_0113:  stloc.1
                     IL_0114:  leave.s    IL_012f
@@ -16540,22 +16540,22 @@ partial class Program
                           IL_0002:  initobj    "<>y__InlineArray3<T>"
                           IL_0008:  ldloca.s   V_0
                           IL_000a:  ldc.i4.0
-                          IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                          IL_000b:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                           IL_0010:  ldarg.0
                           IL_0011:  stobj      "T"
                           IL_0016:  ldloca.s   V_0
                           IL_0018:  ldc.i4.1
-                          IL_0019:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                          IL_0019:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                           IL_001e:  ldarg.1
                           IL_001f:  stobj      "T"
                           IL_0024:  ldloca.s   V_0
                           IL_0026:  ldc.i4.2
-                          IL_0027:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                          IL_0027:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                           IL_002c:  ldarg.2
                           IL_002d:  stobj      "T"
                           IL_0032:  ldloca.s   V_0
                           IL_0034:  ldc.i4.3
-                          IL_0035:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<T>, T>(in <>y__InlineArray3<T>, int)"
+                          IL_0035:  call       "System.ReadOnlySpan<T> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<T>, T>(in <>y__InlineArray3<T>, int)"
                           IL_003a:  call       "MyCollection<T> MyCollectionBuilder.Create<T>(scoped System.ReadOnlySpan<T>)"
                           IL_003f:  ret
                         }
@@ -16697,37 +16697,37 @@ partial class Program
                       IL_0002:  initobj    "<>y__InlineArray1<object>"
                       IL_0008:  ldloca.s   V_0
                       IL_000a:  ldc.i4.0
-                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_0010:  ldc.i4.1
                       IL_0011:  box        "int"
                       IL_0016:  stind.ref
                       IL_0017:  ldloca.s   V_0
                       IL_0019:  ldc.i4.1
-                      IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_001a:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_001f:  call       "void Program.F1<object>(System.Span<object>)"
                       IL_0024:  ldloca.s   V_1
                       IL_0026:  initobj    "<>y__InlineArray1<int?>"
                       IL_002c:  ldloca.s   V_1
                       IL_002e:  ldc.i4.0
-                      IL_002f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_002f:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                       IL_0034:  ldc.i4.2
                       IL_0035:  newobj     "int?..ctor(int)"
                       IL_003a:  stobj      "int?"
                       IL_003f:  ldloca.s   V_1
                       IL_0041:  ldc.i4.1
-                      IL_0042:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_0042:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                       IL_0047:  call       "void Program.F2<int?>(System.ReadOnlySpan<int?>)"
                       IL_004c:  ldloca.s   V_2
                       IL_004e:  initobj    "<>y__InlineArray1<int?>"
                       IL_0054:  ldloca.s   V_2
                       IL_0056:  ldc.i4.0
-                      IL_0057:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_0057:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                       IL_005c:  ldc.i4.3
                       IL_005d:  newobj     "int?..ctor(int)"
                       IL_0062:  stobj      "int?"
                       IL_0067:  ldloca.s   V_2
                       IL_0069:  ldc.i4.1
-                      IL_006a:  call       "InlineArrayAsSpan<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_006a:  call       "System.Span<int?> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                       IL_006f:  stloc.s    V_4
                       IL_0071:  ldloca.s   V_4
                       IL_0073:  call       "void Program.F3<int?>(in System.Span<int?>)"
@@ -16735,13 +16735,13 @@ partial class Program
                       IL_007a:  initobj    "<>y__InlineArray1<object>"
                       IL_0080:  ldloca.s   V_3
                       IL_0082:  ldc.i4.0
-                      IL_0083:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0083:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_0088:  ldc.i4.4
                       IL_0089:  box        "int"
                       IL_008e:  stind.ref
                       IL_008f:  ldloca.s   V_3
                       IL_0091:  ldc.i4.1
-                      IL_0092:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                      IL_0092:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                       IL_0097:  stloc.s    V_5
                       IL_0099:  ldloca.s   V_5
                       IL_009b:  call       "void Program.F4<object>(in System.ReadOnlySpan<object>)"
@@ -16833,65 +16833,65 @@ partial class Program
                 expectedOutput: IncludeExpectedOutput("[1], [2], [3], [4], "));
             verifier.VerifyIL("Program.Main", """
                 {
-                    // Code size      149 (0x95)
-                    .maxstack  2
-                    .locals init (<>y__InlineArray1<object> V_0,
-                                <>y__InlineArray1<object> V_1,
-                                <>y__InlineArray1<object> V_2,
-                                <>y__InlineArray1<object> V_3)
-                    IL_0000:  ldloca.s   V_0
-                    IL_0002:  initobj    "<>y__InlineArray1<object>"
-                    IL_0008:  ldloca.s   V_0
-                    IL_000a:  ldc.i4.0
-                    IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_0010:  ldc.i4.1
-                    IL_0011:  box        "int"
-                    IL_0016:  stind.ref
-                    IL_0017:  ldloca.s   V_0
-                    IL_0019:  ldc.i4.1
-                    IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_001f:  call       "S Program.ReturnsStruct<object>(System.Span<object>)"
-                    IL_0024:  pop
-                    IL_0025:  ldloca.s   V_1
-                    IL_0027:  initobj    "<>y__InlineArray1<object>"
-                    IL_002d:  ldloca.s   V_1
-                    IL_002f:  ldc.i4.0
-                    IL_0030:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_0035:  ldc.i4.2
-                    IL_0036:  box        "int"
-                    IL_003b:  stind.ref
-                    IL_003c:  ldloca.s   V_1
-                    IL_003e:  ldc.i4.1
-                    IL_003f:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_0044:  call       "R Program.ReturnsRefStruct<object>(System.Span<object>)"
-                    IL_0049:  pop
-                    IL_004a:  ldloca.s   V_2
-                    IL_004c:  initobj    "<>y__InlineArray1<object>"
-                    IL_0052:  ldloca.s   V_2
-                    IL_0054:  ldc.i4.0
-                    IL_0055:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_005a:  ldc.i4.3
-                    IL_005b:  box        "int"
-                    IL_0060:  stind.ref
-                    IL_0061:  ldloca.s   V_2
-                    IL_0063:  ldc.i4.1
-                    IL_0064:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_0069:  call       "ref int Program.ReturnsRef<object>(System.Span<object>)"
-                    IL_006e:  pop
-                    IL_006f:  ldloca.s   V_3
-                    IL_0071:  initobj    "<>y__InlineArray1<object>"
-                    IL_0077:  ldloca.s   V_3
-                    IL_0079:  ldc.i4.0
-                    IL_007a:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_007f:  ldc.i4.4
-                    IL_0080:  box        "int"
-                    IL_0085:  stind.ref
-                    IL_0086:  ldloca.s   V_3
-                    IL_0088:  ldc.i4.1
-                    IL_0089:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_008e:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(System.Span<object>)"
-                    IL_0093:  pop
-                    IL_0094:  ret
+                  // Code size      149 (0x95)
+                  .maxstack  2
+                  .locals init (<>y__InlineArray1<object> V_0,
+                              <>y__InlineArray1<object> V_1,
+                              <>y__InlineArray1<object> V_2,
+                              <>y__InlineArray1<object> V_3)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "<>y__InlineArray1<object>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0010:  ldc.i4.1
+                  IL_0011:  box        "int"
+                  IL_0016:  stind.ref
+                  IL_0017:  ldloca.s   V_0
+                  IL_0019:  ldc.i4.1
+                  IL_001a:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_001f:  call       "S Program.ReturnsStruct<object>(System.Span<object>)"
+                  IL_0024:  pop
+                  IL_0025:  ldloca.s   V_1
+                  IL_0027:  initobj    "<>y__InlineArray1<object>"
+                  IL_002d:  ldloca.s   V_1
+                  IL_002f:  ldc.i4.0
+                  IL_0030:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0035:  ldc.i4.2
+                  IL_0036:  box        "int"
+                  IL_003b:  stind.ref
+                  IL_003c:  ldloca.s   V_1
+                  IL_003e:  ldc.i4.1
+                  IL_003f:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0044:  call       "R Program.ReturnsRefStruct<object>(System.Span<object>)"
+                  IL_0049:  pop
+                  IL_004a:  ldloca.s   V_2
+                  IL_004c:  initobj    "<>y__InlineArray1<object>"
+                  IL_0052:  ldloca.s   V_2
+                  IL_0054:  ldc.i4.0
+                  IL_0055:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_005a:  ldc.i4.3
+                  IL_005b:  box        "int"
+                  IL_0060:  stind.ref
+                  IL_0061:  ldloca.s   V_2
+                  IL_0063:  ldc.i4.1
+                  IL_0064:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0069:  call       "ref int Program.ReturnsRef<object>(System.Span<object>)"
+                  IL_006e:  pop
+                  IL_006f:  ldloca.s   V_3
+                  IL_0071:  initobj    "<>y__InlineArray1<object>"
+                  IL_0077:  ldloca.s   V_3
+                  IL_0079:  ldc.i4.0
+                  IL_007a:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_007f:  ldc.i4.4
+                  IL_0080:  box        "int"
+                  IL_0085:  stind.ref
+                  IL_0086:  ldloca.s   V_3
+                  IL_0088:  ldc.i4.1
+                  IL_0089:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_008e:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(System.Span<object>)"
+                  IL_0093:  pop
+                  IL_0094:  ret
                 }
                 """);
         }
@@ -16933,39 +16933,39 @@ partial class Program
                     IL_0002:  initobj    "<>y__InlineArray1<object>"
                     IL_0008:  ldloca.s   V_0
                     IL_000a:  ldc.i4.0
-                    IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_0010:  ldc.i4.2
                     IL_0011:  box        "int"
                     IL_0016:  stind.ref
                     IL_0017:  ldloca.s   V_0
                     IL_0019:  ldc.i4.1
-                    IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_001a:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_001f:  call       "R Program.ReturnsRefStruct<object>(scoped System.Span<object>)"
                     IL_0024:  pop
                     IL_0025:  ldloca.s   V_1
                     IL_0027:  initobj    "<>y__InlineArray1<object>"
                     IL_002d:  ldloca.s   V_1
                     IL_002f:  ldc.i4.0
-                    IL_0030:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_0030:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_0035:  ldc.i4.3
                     IL_0036:  box        "int"
                     IL_003b:  stind.ref
                     IL_003c:  ldloca.s   V_1
                     IL_003e:  ldc.i4.1
-                    IL_003f:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_003f:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_0044:  call       "ref int Program.ReturnsRef<object>(scoped System.Span<object>)"
                     IL_0049:  pop
                     IL_004a:  ldloca.s   V_2
                     IL_004c:  initobj    "<>y__InlineArray1<object>"
                     IL_0052:  ldloca.s   V_2
                     IL_0054:  ldc.i4.0
-                    IL_0055:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_0055:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_005a:  ldc.i4.4
                     IL_005b:  box        "int"
                     IL_0060:  stind.ref
                     IL_0061:  ldloca.s   V_2
                     IL_0063:  ldc.i4.1
-                    IL_0064:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_0064:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_0069:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(scoped System.Span<object>)"
                     IL_006e:  pop
                     IL_006f:  ret
@@ -17071,26 +17071,26 @@ partial class Program
                   IL_000c:  initobj    "<>y__InlineArray1<int?>"
                   IL_0012:  ldloca.s   V_3
                   IL_0014:  ldc.i4.0
-                  IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_0015:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_001a:  ldc.i4.1
                   IL_001b:  newobj     "int?..ctor(int)"
                   IL_0020:  stobj      "int?"
                   IL_0025:  ldloca.s   V_3
                   IL_0027:  ldc.i4.1
-                  IL_0028:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_0028:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_002d:  call       "void S.M(System.ReadOnlySpan<int?>)"
                   IL_0032:  ldloca.s   V_0
                   IL_0034:  ldloca.s   V_4
                   IL_0036:  initobj    "<>y__InlineArray1<int?>"
                   IL_003c:  ldloca.s   V_4
                   IL_003e:  ldc.i4.0
-                  IL_003f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_003f:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_0044:  ldc.i4.2
                   IL_0045:  newobj     "int?..ctor(int)"
                   IL_004a:  stobj      "int?"
                   IL_004f:  ldloca.s   V_4
                   IL_0051:  ldc.i4.1
-                  IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_0052:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_0057:  ldnull
                   IL_0058:  call       "void S.this[System.ReadOnlySpan<int?>].set"
                   IL_005d:  ldloca.s   V_1
@@ -17100,26 +17100,26 @@ partial class Program
                   IL_0069:  initobj    "<>y__InlineArray1<int?>"
                   IL_006f:  ldloca.s   V_5
                   IL_0071:  ldc.i4.0
-                  IL_0072:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_0072:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_0077:  ldc.i4.3
                   IL_0078:  newobj     "int?..ctor(int)"
                   IL_007d:  stobj      "int?"
                   IL_0082:  ldloca.s   V_5
                   IL_0084:  ldc.i4.1
-                  IL_0085:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_0085:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_008a:  call       "void R1.M(System.ReadOnlySpan<int?>)"
                   IL_008f:  ldloca.s   V_1
                   IL_0091:  ldloca.s   V_6
                   IL_0093:  initobj    "<>y__InlineArray1<int?>"
                   IL_0099:  ldloca.s   V_6
                   IL_009b:  ldc.i4.0
-                  IL_009c:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_009c:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_00a1:  ldc.i4.4
                   IL_00a2:  newobj     "int?..ctor(int)"
                   IL_00a7:  stobj      "int?"
                   IL_00ac:  ldloca.s   V_6
                   IL_00ae:  ldc.i4.1
-                  IL_00af:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_00af:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_00b4:  ldnull
                   IL_00b5:  call       "void R1.this[System.ReadOnlySpan<int?>].set"
                   IL_00ba:  ldloca.s   V_2
@@ -17129,26 +17129,26 @@ partial class Program
                   IL_00c6:  initobj    "<>y__InlineArray1<int?>"
                   IL_00cc:  ldloca.s   V_7
                   IL_00ce:  ldc.i4.0
-                  IL_00cf:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_00cf:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_00d4:  ldc.i4.5
                   IL_00d5:  newobj     "int?..ctor(int)"
                   IL_00da:  stobj      "int?"
                   IL_00df:  ldloca.s   V_7
                   IL_00e1:  ldc.i4.1
-                  IL_00e2:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_00e2:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_00e7:  call       "void R2.M(scoped System.ReadOnlySpan<int?>)"
                   IL_00ec:  ldloca.s   V_2
                   IL_00ee:  ldloca.s   V_8
                   IL_00f0:  initobj    "<>y__InlineArray1<int?>"
                   IL_00f6:  ldloca.s   V_8
                   IL_00f8:  ldc.i4.0
-                  IL_00f9:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_00f9:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_00fe:  ldc.i4.6
                   IL_00ff:  newobj     "int?..ctor(int)"
                   IL_0104:  stobj      "int?"
                   IL_0109:  ldloca.s   V_8
                   IL_010b:  ldc.i4.1
-                  IL_010c:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_010c:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_0111:  ldnull
                   IL_0112:  call       "void R2.this[scoped System.ReadOnlySpan<int?>].set"
                   IL_0117:  ret
@@ -17206,26 +17206,26 @@ partial class Program
                   IL_000c:  initobj    "<>y__InlineArray1<int?>"
                   IL_0012:  ldloca.s   V_2
                   IL_0014:  ldc.i4.0
-                  IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_0015:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_001a:  ldc.i4.3
                   IL_001b:  newobj     "int?..ctor(int)"
                   IL_0020:  stobj      "int?"
                   IL_0025:  ldloca.s   V_2
                   IL_0027:  ldc.i4.1
-                  IL_0028:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_0028:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_002d:  call       "void R1.M(System.ReadOnlySpan<int?>)"
                   IL_0032:  ldloca.s   V_0
                   IL_0034:  ldloca.s   V_3
                   IL_0036:  initobj    "<>y__InlineArray1<int?>"
                   IL_003c:  ldloca.s   V_3
                   IL_003e:  ldc.i4.0
-                  IL_003f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_003f:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_0044:  ldc.i4.4
                   IL_0045:  newobj     "int?..ctor(int)"
                   IL_004a:  stobj      "int?"
                   IL_004f:  ldloca.s   V_3
                   IL_0051:  ldc.i4.1
-                  IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_0052:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_0057:  call       "object R1.this[System.ReadOnlySpan<int?>].get"
                   IL_005c:  pop
                   IL_005d:  ldloca.s   V_1
@@ -17235,26 +17235,26 @@ partial class Program
                   IL_0069:  initobj    "<>y__InlineArray1<int?>"
                   IL_006f:  ldloca.s   V_4
                   IL_0071:  ldc.i4.0
-                  IL_0072:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_0072:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_0077:  ldc.i4.5
                   IL_0078:  newobj     "int?..ctor(int)"
                   IL_007d:  stobj      "int?"
                   IL_0082:  ldloca.s   V_4
                   IL_0084:  ldc.i4.1
-                  IL_0085:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_0085:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_008a:  call       "readonly void R2.M(System.ReadOnlySpan<int?>)"
                   IL_008f:  ldloca.s   V_1
                   IL_0091:  ldloca.s   V_5
                   IL_0093:  initobj    "<>y__InlineArray1<int?>"
                   IL_0099:  ldloca.s   V_5
                   IL_009b:  ldc.i4.0
-                  IL_009c:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                  IL_009c:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
                   IL_00a1:  ldc.i4.6
                   IL_00a2:  newobj     "int?..ctor(int)"
                   IL_00a7:  stobj      "int?"
                   IL_00ac:  ldloca.s   V_5
                   IL_00ae:  ldc.i4.1
-                  IL_00af:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                  IL_00af:  call       "System.ReadOnlySpan<int?> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
                   IL_00b4:  call       "readonly object R2.this[System.ReadOnlySpan<int?>].get"
                   IL_00b9:  pop
                   IL_00ba:  ret
@@ -17294,31 +17294,31 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray1<int>"
                   IL_0008:  ldloca.s   V_0
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
+                  IL_000b:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
                   IL_0010:  ldloca.s   V_1
                   IL_0012:  initobj    "<>y__InlineArray1<int>"
                   IL_0018:  ldloca.s   V_1
                   IL_001a:  ldc.i4.0
-                  IL_001b:  call       "InlineArrayElementRef<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
+                  IL_001b:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
                   IL_0020:  ldc.i4.1
                   IL_0021:  stind.i4
                   IL_0022:  ldloca.s   V_1
                   IL_0024:  ldc.i4.1
-                  IL_0025:  call       "InlineArrayAsSpan<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
+                  IL_0025:  call       "System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
                   IL_002a:  call       "int Program.F1<int>(System.Span<int>)"
                   IL_002f:  ldc.i4.2
                   IL_0030:  add
                   IL_0031:  stind.i4
                   IL_0032:  ldloca.s   V_0
                   IL_0034:  ldc.i4.1
-                  IL_0035:  call       "InlineArrayAsSpan<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
+                  IL_0035:  call       "System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
                   IL_003a:  call       "int Program.F1<int>(System.Span<int>)"
                   IL_003f:  pop
                   IL_0040:  ldloca.s   V_2
                   IL_0042:  initobj    "<>y__InlineArray1<int>"
                   IL_0048:  ldloca.s   V_2
                   IL_004a:  ldc.i4.0
-                  IL_004b:  call       "InlineArrayElementRef<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
+                  IL_004b:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
                   IL_0050:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=4_Align=4 <PrivateImplementationDetails>.26B25D457597A7B0463F9620F666DD10AA2C4373A505967C7C8D70922A2D6ECE4"
                   IL_0055:  call       "System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)"
                   IL_005a:  call       "int Program.F2<int>(System.ReadOnlySpan<int>)"
@@ -17327,7 +17327,7 @@ partial class Program
                   IL_0061:  stind.i4
                   IL_0062:  ldloca.s   V_2
                   IL_0064:  ldc.i4.1
-                  IL_0065:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int>, int>(in <>y__InlineArray1<int>, int)"
+                  IL_0065:  call       "System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<int>, int>(in <>y__InlineArray1<int>, int)"
                   IL_006a:  call       "int Program.F2<int>(System.ReadOnlySpan<int>)"
                   IL_006f:  pop
                   IL_0070:  ret
@@ -17380,25 +17380,25 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray1<object>"
                   IL_0008:  ldloca.s   V_0
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_0010:  ldc.i4.1
                   IL_0011:  box        "int"
                   IL_0016:  stind.ref
                   IL_0017:  ldloca.s   V_0
                   IL_0019:  ldc.i4.1
-                  IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_001a:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_001f:  stloc.s    V_4
                   IL_0021:  ldloca.s   V_1
                   IL_0023:  initobj    "<>y__InlineArray1<object>"
                   IL_0029:  ldloca.s   V_1
                   IL_002b:  ldc.i4.0
-                  IL_002c:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_002c:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_0031:  ldc.i4.2
                   IL_0032:  box        "int"
                   IL_0037:  stind.ref
                   IL_0038:  ldloca.s   V_1
                   IL_003a:  ldc.i4.1
-                  IL_003b:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_003b:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_0040:  ldloc.s    V_4
                   IL_0042:  call       "System.Span<object> Program.F1<object>(System.Span<object>, scoped System.Span<object>)"
                   IL_0047:  pop
@@ -17406,25 +17406,25 @@ partial class Program
                   IL_004a:  initobj    "<>y__InlineArray1<object>"
                   IL_0050:  ldloca.s   V_2
                   IL_0052:  ldc.i4.0
-                  IL_0053:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0053:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_0058:  ldc.i4.3
                   IL_0059:  box        "int"
                   IL_005e:  stind.ref
                   IL_005f:  ldloca.s   V_2
                   IL_0061:  ldc.i4.1
-                  IL_0062:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                  IL_0062:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                   IL_0067:  stloc.s    V_5
                   IL_0069:  ldloca.s   V_3
                   IL_006b:  initobj    "<>y__InlineArray1<object>"
                   IL_0071:  ldloca.s   V_3
                   IL_0073:  ldc.i4.0
-                  IL_0074:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0074:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_0079:  ldc.i4.4
                   IL_007a:  box        "int"
                   IL_007f:  stind.ref
                   IL_0080:  ldloca.s   V_3
                   IL_0082:  ldc.i4.1
-                  IL_0083:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                  IL_0083:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                   IL_0088:  ldloc.s    V_5
                   IL_008a:  call       "System.ReadOnlySpan<object> Program.F2<object>(scoped System.ReadOnlySpan<object>, System.ReadOnlySpan<object>)"
                   IL_008f:  pop
@@ -17502,22 +17502,22 @@ partial class Program
                       IL_0003:  initobj    "<>y__InlineArray3<T>"
                       IL_0009:  ldloca.s   V_0
                       IL_000b:  ldc.i4.0
-                      IL_000c:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                      IL_000c:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                       IL_0011:  ldarg.1
                       IL_0012:  stobj      "T"
                       IL_0017:  ldloca.s   V_0
                       IL_0019:  ldc.i4.1
-                      IL_001a:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                      IL_001a:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                       IL_001f:  ldarg.2
                       IL_0020:  stobj      "T"
                       IL_0025:  ldloca.s   V_0
                       IL_0027:  ldc.i4.2
-                      IL_0028:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                      IL_0028:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                       IL_002d:  ldarg.3
                       IL_002e:  stobj      "T"
                       IL_0033:  ldloca.s   V_0
                       IL_0035:  ldc.i4.3
-                      IL_0036:  call       "InlineArrayAsSpan<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                      IL_0036:  call       "System.Span<T> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                       IL_003b:  call       "R<T>..ctor(scoped System.Span<T>)"
                       IL_0040:  ret
                     }
@@ -17622,22 +17622,22 @@ partial class Program
                   IL_0018:  initobj    "<>y__InlineArray3<T>"
                   IL_001e:  ldloca.s   V_0
                   IL_0020:  ldc.i4.0
-                  IL_0021:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0021:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0026:  ldarg.1
                   IL_0027:  stobj      "T"
                   IL_002c:  ldloca.s   V_0
                   IL_002e:  ldc.i4.1
-                  IL_002f:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_002f:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0034:  ldarg.2
                   IL_0035:  stobj      "T"
                   IL_003a:  ldloca.s   V_0
                   IL_003c:  ldc.i4.2
-                  IL_003d:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_003d:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0042:  ldarg.3
                   IL_0043:  stobj      "T"
                   IL_0048:  ldloca.s   V_0
                   IL_004a:  ldc.i4.3
-                  IL_004b:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<T>, T>(in <>y__InlineArray3<T>, int)"
+                  IL_004b:  call       "System.ReadOnlySpan<T> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<T>, T>(in <>y__InlineArray3<T>, int)"
                   IL_0050:  call       "T[] A<T>.ToArray(System.ReadOnlySpan<T>)"
                   IL_0055:  call       "A<T>..ctor(T[])"
                   IL_005a:  ret
@@ -17722,13 +17722,13 @@ partial class Program
                     IL_0002:  initobj    "<>y__InlineArray1<object>"
                     IL_0008:  ldloca.s   V_1
                     IL_000a:  ldc.i4.0
-                    IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_0010:  ldc.i4.1
                     IL_0011:  box        "int"
                     IL_0016:  stind.ref
                     IL_0017:  ldloca.s   V_1
                     IL_0019:  ldc.i4.1
-                    IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_001a:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_001f:  stloc.0
                     IL_0020:  ldloca.s   V_0
                     IL_0022:  call       "object[] System.Span<object>.ToArray()"
@@ -17745,13 +17745,13 @@ partial class Program
                     IL_0002:  initobj    "<>y__InlineArray1<object>"
                     IL_0008:  ldloca.s   V_1
                     IL_000a:  ldc.i4.0
-                    IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_0010:  ldc.i4.2
                     IL_0011:  box        "int"
                     IL_0016:  stind.ref
                     IL_0017:  ldloca.s   V_1
                     IL_0019:  ldc.i4.1
-                    IL_001a:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                    IL_001a:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                     IL_001f:  stloc.0
                     IL_0020:  ldloca.s   V_0
                     IL_0022:  call       "object[] System.ReadOnlySpan<object>.ToArray()"
@@ -17798,25 +17798,25 @@ partial class Program
                       IL_0002:  initobj    "<>y__InlineArray1<object>"
                       IL_0008:  ldloca.s   V_2
                       IL_000a:  ldc.i4.0
-                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_0010:  ldc.i4.1
                       IL_0011:  box        "int"
                       IL_0016:  stind.ref
                       IL_0017:  ldloca.s   V_2
                       IL_0019:  ldc.i4.1
-                      IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_001a:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_001f:  stloc.0
                       IL_0020:  ldloca.s   V_3
                       IL_0022:  initobj    "<>y__InlineArray1<object>"
                       IL_0028:  ldloca.s   V_3
                       IL_002a:  ldc.i4.0
-                      IL_002b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_002b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_0030:  ldc.i4.2
                       IL_0031:  box        "int"
                       IL_0036:  stind.ref
                       IL_0037:  ldloca.s   V_3
                       IL_0039:  ldc.i4.1
-                      IL_003a:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                      IL_003a:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                       IL_003f:  stloc.1
                       IL_0040:  ldloca.s   V_0
                       IL_0042:  call       "void CollectionExtensions.Report<object>(in System.Span<object>)"
@@ -17931,26 +17931,26 @@ partial class Program
                   IL_0014:  initobj    "<>y__InlineArray1<object>"
                   IL_001a:  ldloca.s   V_2
                   IL_001c:  ldc.i4.0
-                  IL_001d:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_001d:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_0022:  ldc.i4.1
                   IL_0023:  box        "int"
                   IL_0028:  stind.ref
                   IL_0029:  ldloca.s   V_2
                   IL_002b:  ldc.i4.1
-                  IL_002c:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                  IL_002c:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                   IL_0031:  stfld      "System.ReadOnlySpan<object> R<object>.F"
                   IL_0036:  ldloca.s   V_1
                   IL_0038:  ldloca.s   V_3
                   IL_003a:  initobj    "<>y__InlineArray1<object>"
                   IL_0040:  ldloca.s   V_3
                   IL_0042:  ldc.i4.0
-                  IL_0043:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0043:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_0048:  ldc.i4.2
                   IL_0049:  box        "int"
                   IL_004e:  stind.ref
                   IL_004f:  ldloca.s   V_3
                   IL_0051:  ldc.i4.1
-                  IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                  IL_0052:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                   IL_0057:  stfld      "System.ReadOnlySpan<object> R<object>.F"
                   IL_005c:  ldloca.s   V_0
                   IL_005e:  ldflda     "System.ReadOnlySpan<object> R<object>.F"
@@ -18010,22 +18010,22 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray3<int>"
                   IL_0008:  ldloca.s   V_0
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_000b:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_0010:  ldc.i4.1
                   IL_0011:  stind.i4
                   IL_0012:  ldloca.s   V_0
                   IL_0014:  ldc.i4.1
-                  IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_0015:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_001a:  ldc.i4.2
                   IL_001b:  stind.i4
                   IL_001c:  ldloca.s   V_0
                   IL_001e:  ldc.i4.2
-                  IL_001f:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_001f:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_0024:  ldc.i4.3
                   IL_0025:  stind.i4
                   IL_0026:  ldloca.s   V_0
                   IL_0028:  ldc.i4.3
-                  IL_0029:  call       "InlineArrayAsSpan<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_0029:  call       "System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_002e:  call       "int[] Program.FromSpan<int>(System.Span<int>)"
                   IL_0033:  stsfld     "int[] Program.F"
                   IL_0038:  ret
@@ -18066,25 +18066,25 @@ partial class Program
                   IL_0003:  initobj    "<>y__InlineArray3<object>"
                   IL_0009:  ldloca.s   V_0
                   IL_000b:  ldc.i4.0
-                  IL_000c:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_000c:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_0011:  ldc.i4.1
                   IL_0012:  box        "int"
                   IL_0017:  stind.ref
                   IL_0018:  ldloca.s   V_0
                   IL_001a:  ldc.i4.1
-                  IL_001b:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_001b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_0020:  ldc.i4.2
                   IL_0021:  box        "int"
                   IL_0026:  stind.ref
                   IL_0027:  ldloca.s   V_0
                   IL_0029:  ldc.i4.2
-                  IL_002a:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_002a:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_002f:  ldc.i4.3
                   IL_0030:  box        "int"
                   IL_0035:  stind.ref
                   IL_0036:  ldloca.s   V_0
                   IL_0038:  ldc.i4.3
-                  IL_0039:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
+                  IL_0039:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
                   IL_003e:  call       "object[] C.FromSpan<object>(System.ReadOnlySpan<object>)"
                   IL_0043:  stfld      "object[] C.F"
                   IL_0048:  ldarg.0
@@ -18128,25 +18128,25 @@ partial class Program
                   IL_0003:  initobj    "<>y__InlineArray3<object>"
                   IL_0009:  ldloca.s   V_0
                   IL_000b:  ldc.i4.0
-                  IL_000c:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_000c:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_0011:  ldc.i4.1
                   IL_0012:  box        "int"
                   IL_0017:  stind.ref
                   IL_0018:  ldloca.s   V_0
                   IL_001a:  ldc.i4.1
-                  IL_001b:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_001b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_0020:  ldc.i4.2
                   IL_0021:  box        "int"
                   IL_0026:  stind.ref
                   IL_0027:  ldloca.s   V_0
                   IL_0029:  ldc.i4.2
-                  IL_002a:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_002a:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_002f:  ldc.i4.3
                   IL_0030:  box        "int"
                   IL_0035:  stind.ref
                   IL_0036:  ldloca.s   V_0
                   IL_0038:  ldc.i4.3
-                  IL_0039:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
+                  IL_0039:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
                   IL_003e:  call       "object[] S.FromSpan<object>(System.ReadOnlySpan<object>)"
                   IL_0043:  stfld      "object[] S.F"
                   IL_0048:  ret
@@ -18228,13 +18228,13 @@ partial class Program
                       IL_0002:  initobj    "<>y__InlineArray1<object>"
                       IL_0008:  ldloca.s   V_0
                       IL_000a:  ldc.i4.0
-                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_0010:  ldc.i4.1
                       IL_0011:  box        "int"
                       IL_0016:  stind.ref
                       IL_0017:  ldloca.s   V_0
                       IL_0019:  ldc.i4.1
-                      IL_001a:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                      IL_001a:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                       IL_001f:  pop
                       IL_0020:  ldarg.0
                       IL_0021:  brfalse.s  IL_0045
@@ -18242,38 +18242,38 @@ partial class Program
                       IL_0025:  initobj    "<>y__InlineArray1<object>"
                       IL_002b:  ldloca.s   V_1
                       IL_002d:  ldc.i4.0
-                      IL_002e:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_002e:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_0033:  ldc.i4.2
                       IL_0034:  box        "int"
                       IL_0039:  stind.ref
                       IL_003a:  ldloca.s   V_1
                       IL_003c:  ldc.i4.1
-                      IL_003d:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                      IL_003d:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                       IL_0042:  pop
                       IL_0043:  br.s       IL_0065
                       IL_0045:  ldloca.s   V_2
                       IL_0047:  initobj    "<>y__InlineArray1<object>"
                       IL_004d:  ldloca.s   V_2
                       IL_004f:  ldc.i4.0
-                      IL_0050:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0050:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_0055:  ldc.i4.3
                       IL_0056:  box        "int"
                       IL_005b:  stind.ref
                       IL_005c:  ldloca.s   V_2
                       IL_005e:  ldc.i4.1
-                      IL_005f:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                      IL_005f:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                       IL_0064:  pop
                       IL_0065:  ldloca.s   V_3
                       IL_0067:  initobj    "<>y__InlineArray1<object>"
                       IL_006d:  ldloca.s   V_3
                       IL_006f:  ldc.i4.0
-                      IL_0070:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0070:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                       IL_0075:  ldc.i4.4
                       IL_0076:  box        "int"
                       IL_007b:  stind.ref
                       IL_007c:  ldloca.s   V_3
                       IL_007e:  ldc.i4.1
-                      IL_007f:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                      IL_007f:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                       IL_0084:  pop
                       IL_0085:  ret
                     }
@@ -18327,22 +18327,22 @@ partial class Program
                   IL_000d:  initobj    "<>y__InlineArray3<T>"
                   IL_0013:  ldloca.s   V_1
                   IL_0015:  ldc.i4.0
-                  IL_0016:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0016:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_001b:  ldarg.1
                   IL_001c:  stobj      "T"
                   IL_0021:  ldloca.s   V_1
                   IL_0023:  ldc.i4.1
-                  IL_0024:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0024:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0029:  ldarg.2
                   IL_002a:  stobj      "T"
                   IL_002f:  ldloca.s   V_1
                   IL_0031:  ldc.i4.2
-                  IL_0032:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0032:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0037:  ldarg.3
                   IL_0038:  stobj      "T"
                   IL_003d:  ldloca.s   V_1
                   IL_003f:  ldc.i4.3
-                  IL_0040:  call       "InlineArrayAsSpan<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0040:  call       "System.Span<T> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0045:  stloc.0
                   IL_0046:  ldarg.0
                   IL_0047:  brfalse.s  IL_0077
@@ -18350,17 +18350,17 @@ partial class Program
                   IL_004b:  initobj    "<>y__InlineArray2<T>"
                   IL_0051:  ldloca.s   V_2
                   IL_0053:  ldc.i4.0
-                  IL_0054:  call       "InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_0054:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
                   IL_0059:  ldarg.3
                   IL_005a:  stobj      "T"
                   IL_005f:  ldloca.s   V_2
                   IL_0061:  ldc.i4.1
-                  IL_0062:  call       "InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_0062:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
                   IL_0067:  ldarg.s    V_4
                   IL_0069:  stobj      "T"
                   IL_006e:  ldloca.s   V_2
                   IL_0070:  ldc.i4.2
-                  IL_0071:  call       "InlineArrayAsSpan<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_0071:  call       "System.Span<T> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
                   IL_0076:  stloc.0
                   IL_0077:  ldloca.s   V_0
                   IL_0079:  call       "void CollectionExtensions.Report<T>(in System.Span<T>)"
@@ -18498,22 +18498,22 @@ partial class Program
                   IL_000d:  initobj    "<>y__InlineArray3<T>"
                   IL_0013:  ldloca.s   V_1
                   IL_0015:  ldc.i4.0
-                  IL_0016:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0016:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_001b:  ldarg.2
                   IL_001c:  stobj      "T"
                   IL_0021:  ldloca.s   V_1
                   IL_0023:  ldc.i4.1
-                  IL_0024:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0024:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0029:  ldarg.3
                   IL_002a:  stobj      "T"
                   IL_002f:  ldloca.s   V_1
                   IL_0031:  ldc.i4.2
-                  IL_0032:  call       "InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0032:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0037:  ldarg.s    V_4
                   IL_0039:  stobj      "T"
                   IL_003e:  ldloca.s   V_1
                   IL_0040:  ldc.i4.3
-                  IL_0041:  call       "InlineArrayAsSpan<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
+                  IL_0041:  call       "System.Span<T> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray3<T>, T>(ref <>y__InlineArray3<T>, int)"
                   IL_0046:  stloc.0
                   IL_0047:  ldloca.s   V_0
                   IL_0049:  call       "void CollectionExtensions.Report<T>(in System.Span<T>)"
@@ -18574,13 +18574,13 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray1<T>"
                   IL_0008:  ldloca.s   V_1
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<T>, T>(ref <>y__InlineArray1<T>, int)"
+                  IL_000b:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<T>, T>(ref <>y__InlineArray1<T>, int)"
                   IL_0010:  ldarg.0
                   IL_0011:  ldfld      "T Program.<>c__DisplayClass1_0<T>.z"
                   IL_0016:  stobj      "T"
                   IL_001b:  ldloca.s   V_1
                   IL_001d:  ldc.i4.1
-                  IL_001e:  call       "InlineArrayAsSpan<<>y__InlineArray1<T>, T>(ref <>y__InlineArray1<T>, int)"
+                  IL_001e:  call       "System.Span<T> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<T>, T>(ref <>y__InlineArray1<T>, int)"
                   IL_0023:  stloc.0
                   IL_0024:  ldloca.s   V_0
                   IL_0026:  call       "void CollectionExtensions.Report<T>(in System.Span<T>)"
@@ -18645,12 +18645,12 @@ partial class Program
                   IL_0027:  initobj    "<>y__InlineArray1<T>"
                   IL_002d:  ldloca.s   V_1
                   IL_002f:  ldc.i4.0
-                  IL_0030:  call       "InlineArrayElementRef<<>y__InlineArray1<T>, T>(ref <>y__InlineArray1<T>, int)"
+                  IL_0030:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<T>, T>(ref <>y__InlineArray1<T>, int)"
                   IL_0035:  ldarg.1
                   IL_0036:  stobj      "T"
                   IL_003b:  ldloca.s   V_1
                   IL_003d:  ldc.i4.1
-                  IL_003e:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<T>, T>(in <>y__InlineArray1<T>, int)"
+                  IL_003e:  call       "System.ReadOnlySpan<T> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<T>, T>(in <>y__InlineArray1<T>, int)"
                   IL_0043:  stloc.0
                   IL_0044:  ldloca.s   V_0
                   IL_0046:  call       "void CollectionExtensions.Report<T>(in System.ReadOnlySpan<T>)"
@@ -18698,13 +18698,13 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray1<object>"
                   IL_0008:  ldloca.s   V_3
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                   IL_0010:  ldc.i4.1
                   IL_0011:  box        "int"
                   IL_0016:  stind.ref
                   IL_0017:  ldloca.s   V_3
                   IL_0019:  ldc.i4.1
-                  IL_001a:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                  IL_001a:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                   IL_001f:  stloc.0
                   IL_0020:  newobj     "Disposable..ctor()"
                   IL_0025:  stloc.1
@@ -18714,13 +18714,13 @@ partial class Program
                     IL_0028:  initobj    "<>y__InlineArray1<object>"
                     IL_002e:  ldloca.s   V_4
                     IL_0030:  ldc.i4.0
-                    IL_0031:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_0031:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
                     IL_0036:  ldc.i4.2
                     IL_0037:  box        "int"
                     IL_003c:  stind.ref
                     IL_003d:  ldloca.s   V_4
                     IL_003f:  ldc.i4.1
-                    IL_0040:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                    IL_0040:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
                     IL_0045:  stloc.2
                     IL_0046:  ldloca.s   V_0
                     IL_0048:  call       "void CollectionExtensions.Report<object>(in System.ReadOnlySpan<object>)"
@@ -18766,61 +18766,61 @@ partial class Program
                 expectedOutput: IncludeExpectedOutput("[null, 2], [3, 5], "));
             verifier.VerifyIL("Program.Main", """
                 {
-                    // Code size      119 (0x77)
-                    .maxstack  2
-                    .locals init (System.Span<object> V_0, //x
-                                System.Span<int> V_1, //y
-                                <>y__InlineArray2<object> V_2,
-                                <>y__InlineArray2<int> V_3)
-                    IL_0000:  ldloca.s   V_2
-                    IL_0002:  initobj    "<>y__InlineArray2<object>"
-                    IL_0008:  ldloca.s   V_2
-                    IL_000a:  ldc.i4.0
-                    IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray2<object>, object>(ref <>y__InlineArray2<object>, int)"
-                    IL_0010:  ldc.i4.1
-                    IL_0011:  box        "int"
-                    IL_0016:  stind.ref
-                    IL_0017:  ldloca.s   V_2
-                    IL_0019:  ldc.i4.1
-                    IL_001a:  call       "InlineArrayElementRef<<>y__InlineArray2<object>, object>(ref <>y__InlineArray2<object>, int)"
-                    IL_001f:  ldc.i4.2
-                    IL_0020:  box        "int"
-                    IL_0025:  stind.ref
-                    IL_0026:  ldloca.s   V_2
-                    IL_0028:  ldc.i4.2
-                    IL_0029:  call       "InlineArrayAsSpan<<>y__InlineArray2<object>, object>(ref <>y__InlineArray2<object>, int)"
-                    IL_002e:  stloc.0
-                    IL_002f:  ldloca.s   V_0
-                    IL_0031:  ldc.i4.0
-                    IL_0032:  call       "ref object System.Span<object>.this[int].get"
-                    IL_0037:  ldnull
-                    IL_0038:  stind.ref
-                    IL_0039:  ldloca.s   V_3
-                    IL_003b:  initobj    "<>y__InlineArray2<int>"
-                    IL_0041:  ldloca.s   V_3
-                    IL_0043:  ldc.i4.0
-                    IL_0044:  call       "InlineArrayElementRef<<>y__InlineArray2<int>, int>(ref <>y__InlineArray2<int>, int)"
-                    IL_0049:  ldc.i4.3
-                    IL_004a:  stind.i4
-                    IL_004b:  ldloca.s   V_3
-                    IL_004d:  ldc.i4.1
-                    IL_004e:  call       "InlineArrayElementRef<<>y__InlineArray2<int>, int>(ref <>y__InlineArray2<int>, int)"
-                    IL_0053:  ldc.i4.4
-                    IL_0054:  stind.i4
-                    IL_0055:  ldloca.s   V_3
-                    IL_0057:  ldc.i4.2
-                    IL_0058:  call       "InlineArrayAsSpan<<>y__InlineArray2<int>, int>(ref <>y__InlineArray2<int>, int)"
-                    IL_005d:  stloc.1
-                    IL_005e:  ldloca.s   V_1
-                    IL_0060:  ldc.i4.1
-                    IL_0061:  call       "ref int System.Span<int>.this[int].get"
-                    IL_0066:  ldc.i4.5
-                    IL_0067:  stind.i4
-                    IL_0068:  ldloca.s   V_0
-                    IL_006a:  call       "void CollectionExtensions.Report<object>(in System.Span<object>)"
-                    IL_006f:  ldloca.s   V_1
-                    IL_0071:  call       "void CollectionExtensions.Report<int>(in System.Span<int>)"
-                    IL_0076:  ret
+                  // Code size      119 (0x77)
+                  .maxstack  2
+                  .locals init (System.Span<object> V_0, //x
+                              System.Span<int> V_1, //y
+                              <>y__InlineArray2<object> V_2,
+                              <>y__InlineArray2<int> V_3)
+                  IL_0000:  ldloca.s   V_2
+                  IL_0002:  initobj    "<>y__InlineArray2<object>"
+                  IL_0008:  ldloca.s   V_2
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<object>, object>(ref <>y__InlineArray2<object>, int)"
+                  IL_0010:  ldc.i4.1
+                  IL_0011:  box        "int"
+                  IL_0016:  stind.ref
+                  IL_0017:  ldloca.s   V_2
+                  IL_0019:  ldc.i4.1
+                  IL_001a:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<object>, object>(ref <>y__InlineArray2<object>, int)"
+                  IL_001f:  ldc.i4.2
+                  IL_0020:  box        "int"
+                  IL_0025:  stind.ref
+                  IL_0026:  ldloca.s   V_2
+                  IL_0028:  ldc.i4.2
+                  IL_0029:  call       "System.Span<object> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray2<object>, object>(ref <>y__InlineArray2<object>, int)"
+                  IL_002e:  stloc.0
+                  IL_002f:  ldloca.s   V_0
+                  IL_0031:  ldc.i4.0
+                  IL_0032:  call       "ref object System.Span<object>.this[int].get"
+                  IL_0037:  ldnull
+                  IL_0038:  stind.ref
+                  IL_0039:  ldloca.s   V_3
+                  IL_003b:  initobj    "<>y__InlineArray2<int>"
+                  IL_0041:  ldloca.s   V_3
+                  IL_0043:  ldc.i4.0
+                  IL_0044:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<int>, int>(ref <>y__InlineArray2<int>, int)"
+                  IL_0049:  ldc.i4.3
+                  IL_004a:  stind.i4
+                  IL_004b:  ldloca.s   V_3
+                  IL_004d:  ldc.i4.1
+                  IL_004e:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<int>, int>(ref <>y__InlineArray2<int>, int)"
+                  IL_0053:  ldc.i4.4
+                  IL_0054:  stind.i4
+                  IL_0055:  ldloca.s   V_3
+                  IL_0057:  ldc.i4.2
+                  IL_0058:  call       "System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray2<int>, int>(ref <>y__InlineArray2<int>, int)"
+                  IL_005d:  stloc.1
+                  IL_005e:  ldloca.s   V_1
+                  IL_0060:  ldc.i4.1
+                  IL_0061:  call       "ref int System.Span<int>.this[int].get"
+                  IL_0066:  ldc.i4.5
+                  IL_0067:  stind.i4
+                  IL_0068:  ldloca.s   V_0
+                  IL_006a:  call       "void CollectionExtensions.Report<object>(in System.Span<object>)"
+                  IL_006f:  ldloca.s   V_1
+                  IL_0071:  call       "void CollectionExtensions.Report<int>(in System.Span<int>)"
+                  IL_0076:  ret
                 }
                 """);
         }
@@ -18855,17 +18855,17 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray2<int?>"
                   IL_0008:  ldloca.s   V_1
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray2<int?>, int?>(ref <>y__InlineArray2<int?>, int)"
+                  IL_000b:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<int?>, int?>(ref <>y__InlineArray2<int?>, int)"
                   IL_0010:  ldc.i4.1
                   IL_0011:  newobj     "int?..ctor(int)"
                   IL_0016:  stobj      "int?"
                   IL_001b:  ldloca.s   V_1
                   IL_001d:  ldc.i4.1
-                  IL_001e:  call       "InlineArrayElementRef<<>y__InlineArray2<int?>, int?>(ref <>y__InlineArray2<int?>, int)"
+                  IL_001e:  call       "ref int? <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<int?>, int?>(ref <>y__InlineArray2<int?>, int)"
                   IL_0023:  initobj    "int?"
                   IL_0029:  ldloca.s   V_1
                   IL_002b:  ldc.i4.2
-                  IL_002c:  call       "InlineArrayAsSpan<<>y__InlineArray2<int?>, int?>(ref <>y__InlineArray2<int?>, int)"
+                  IL_002c:  call       "System.Span<int?> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray2<int?>, int?>(ref <>y__InlineArray2<int?>, int)"
                   IL_0031:  stloc.2
                   IL_0032:  ldc.i4.0
                   IL_0033:  stloc.3
@@ -19072,59 +19072,59 @@ partial class Program
                     """));
             verifier.VerifyIL("Program.Main", """
                 {
-                    // Code size      135 (0x87)
-                    .maxstack  2
-                    .locals init (<>y__InlineArray1<object> V_0,
-                                <>y__InlineArray1<string> V_1,
-                                <>y__InlineArray1<nint> V_2,
-                                <>y__InlineArray1<nuint> V_3)
-                    IL_0000:  ldloca.s   V_0
-                    IL_0002:  initobj    "<>y__InlineArray1<object>"
-                    IL_0008:  ldloca.s   V_0
-                    IL_000a:  ldc.i4.0
-                    IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
-                    IL_0010:  ldstr      "1"
-                    IL_0015:  stind.ref
-                    IL_0016:  ldloca.s   V_0
-                    IL_0018:  ldc.i4.1
-                    IL_0019:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
-                    IL_001e:  call       "void Program.Report<object>(System.ReadOnlySpan<object>)"
-                    IL_0023:  ldloca.s   V_1
-                    IL_0025:  initobj    "<>y__InlineArray1<string>"
-                    IL_002b:  ldloca.s   V_1
-                    IL_002d:  ldc.i4.0
-                    IL_002e:  call       "InlineArrayElementRef<<>y__InlineArray1<string>, string>(ref <>y__InlineArray1<string>, int)"
-                    IL_0033:  ldstr      "2"
-                    IL_0038:  stind.ref
-                    IL_0039:  ldloca.s   V_1
-                    IL_003b:  ldc.i4.1
-                    IL_003c:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<string>, string>(in <>y__InlineArray1<string>, int)"
-                    IL_0041:  call       "void Program.Report<string>(System.ReadOnlySpan<string>)"
-                    IL_0046:  ldloca.s   V_2
-                    IL_0048:  initobj    "<>y__InlineArray1<nint>"
-                    IL_004e:  ldloca.s   V_2
-                    IL_0050:  ldc.i4.0
-                    IL_0051:  call       "InlineArrayElementRef<<>y__InlineArray1<nint>, nint>(ref <>y__InlineArray1<nint>, int)"
-                    IL_0056:  ldc.i4.3
-                    IL_0057:  conv.i
-                    IL_0058:  stind.i
-                    IL_0059:  ldloca.s   V_2
-                    IL_005b:  ldc.i4.1
-                    IL_005c:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<nint>, nint>(in <>y__InlineArray1<nint>, int)"
-                    IL_0061:  call       "void Program.Report<nint>(System.ReadOnlySpan<nint>)"
-                    IL_0066:  ldloca.s   V_3
-                    IL_0068:  initobj    "<>y__InlineArray1<nuint>"
-                    IL_006e:  ldloca.s   V_3
-                    IL_0070:  ldc.i4.0
-                    IL_0071:  call       "InlineArrayElementRef<<>y__InlineArray1<nuint>, nuint>(ref <>y__InlineArray1<nuint>, int)"
-                    IL_0076:  ldc.i4.4
-                    IL_0077:  conv.i
-                    IL_0078:  stind.i
-                    IL_0079:  ldloca.s   V_3
-                    IL_007b:  ldc.i4.1
-                    IL_007c:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<nuint>, nuint>(in <>y__InlineArray1<nuint>, int)"
-                    IL_0081:  call       "void Program.Report<nuint>(System.ReadOnlySpan<nuint>)"
-                    IL_0086:  ret
+                  // Code size      135 (0x87)
+                  .maxstack  2
+                  .locals init (<>y__InlineArray1<object> V_0,
+                              <>y__InlineArray1<string> V_1,
+                              <>y__InlineArray1<nint> V_2,
+                              <>y__InlineArray1<nuint> V_3)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "<>y__InlineArray1<object>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0010:  ldstr      "1"
+                  IL_0015:  stind.ref
+                  IL_0016:  ldloca.s   V_0
+                  IL_0018:  ldc.i4.1
+                  IL_0019:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                  IL_001e:  call       "void Program.Report<object>(System.ReadOnlySpan<object>)"
+                  IL_0023:  ldloca.s   V_1
+                  IL_0025:  initobj    "<>y__InlineArray1<string>"
+                  IL_002b:  ldloca.s   V_1
+                  IL_002d:  ldc.i4.0
+                  IL_002e:  call       "ref string <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<string>, string>(ref <>y__InlineArray1<string>, int)"
+                  IL_0033:  ldstr      "2"
+                  IL_0038:  stind.ref
+                  IL_0039:  ldloca.s   V_1
+                  IL_003b:  ldc.i4.1
+                  IL_003c:  call       "System.ReadOnlySpan<string> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<string>, string>(in <>y__InlineArray1<string>, int)"
+                  IL_0041:  call       "void Program.Report<string>(System.ReadOnlySpan<string>)"
+                  IL_0046:  ldloca.s   V_2
+                  IL_0048:  initobj    "<>y__InlineArray1<nint>"
+                  IL_004e:  ldloca.s   V_2
+                  IL_0050:  ldc.i4.0
+                  IL_0051:  call       "ref nint <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<nint>, nint>(ref <>y__InlineArray1<nint>, int)"
+                  IL_0056:  ldc.i4.3
+                  IL_0057:  conv.i
+                  IL_0058:  stind.i
+                  IL_0059:  ldloca.s   V_2
+                  IL_005b:  ldc.i4.1
+                  IL_005c:  call       "System.ReadOnlySpan<nint> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<nint>, nint>(in <>y__InlineArray1<nint>, int)"
+                  IL_0061:  call       "void Program.Report<nint>(System.ReadOnlySpan<nint>)"
+                  IL_0066:  ldloca.s   V_3
+                  IL_0068:  initobj    "<>y__InlineArray1<nuint>"
+                  IL_006e:  ldloca.s   V_3
+                  IL_0070:  ldc.i4.0
+                  IL_0071:  call       "ref nuint <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<nuint>, nuint>(ref <>y__InlineArray1<nuint>, int)"
+                  IL_0076:  ldc.i4.4
+                  IL_0077:  conv.i
+                  IL_0078:  stind.i
+                  IL_0079:  ldloca.s   V_3
+                  IL_007b:  ldc.i4.1
+                  IL_007c:  call       "System.ReadOnlySpan<nuint> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray1<nuint>, nuint>(in <>y__InlineArray1<nuint>, int)"
+                  IL_0081:  call       "void Program.Report<nuint>(System.ReadOnlySpan<nuint>)"
+                  IL_0086:  ret
                 }
                 """);
         }
@@ -19375,22 +19375,22 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray3<int>"
                   IL_0008:  ldloca.s   V_1
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_000b:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_0010:  ldc.i4.1
                   IL_0011:  stind.i4
                   IL_0012:  ldloca.s   V_1
                   IL_0014:  ldc.i4.1
-                  IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_0015:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_001a:  ldc.i4.2
                   IL_001b:  stind.i4
                   IL_001c:  ldloca.s   V_1
                   IL_001e:  ldc.i4.2
-                  IL_001f:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_001f:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_0024:  ldc.i4.3
                   IL_0025:  stind.i4
                   IL_0026:  ldloca.s   V_1
                   IL_0028:  ldc.i4.3
-                  IL_0029:  call       "InlineArrayAsSpan<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_0029:  call       "System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_002e:  stloc.0
                   IL_002f:  ldloca.s   V_0
                   IL_0031:  call       "void CollectionExtensions.Report<int>(in System.Span<int>)"
@@ -19407,22 +19407,22 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray3<int>"
                   IL_0008:  ldloca.s   V_1
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_000b:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_0010:  ldc.i4.1
                   IL_0011:  stind.i4
                   IL_0012:  ldloca.s   V_1
                   IL_0014:  ldc.i4.1
-                  IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_0015:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_001a:  ldc.i4.2
                   IL_001b:  stind.i4
                   IL_001c:  ldloca.s   V_1
                   IL_001e:  ldc.i4.2
-                  IL_001f:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_001f:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_0024:  ldarg.0
                   IL_0025:  stind.i4
                   IL_0026:  ldloca.s   V_1
                   IL_0028:  ldc.i4.3
-                  IL_0029:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<int>, int>(in <>y__InlineArray3<int>, int)"
+                  IL_0029:  call       "System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<int>, int>(in <>y__InlineArray3<int>, int)"
                   IL_002e:  stloc.0
                   IL_002f:  ldloca.s   V_0
                   IL_0031:  call       "void CollectionExtensions.Report<int>(in System.ReadOnlySpan<int>)"
@@ -19623,22 +19623,22 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray3<string>"
                   IL_0008:  ldloca.s   V_0
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<string>, string>(ref <>y__InlineArray3<string>, int)"
+                  IL_000b:  call       "ref string <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<string>, string>(ref <>y__InlineArray3<string>, int)"
                   IL_0010:  ldnull
                   IL_0011:  stind.ref
                   IL_0012:  ldloca.s   V_0
                   IL_0014:  ldc.i4.1
-                  IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray3<string>, string>(ref <>y__InlineArray3<string>, int)"
+                  IL_0015:  call       "ref string <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<string>, string>(ref <>y__InlineArray3<string>, int)"
                   IL_001a:  ldnull
                   IL_001b:  stind.ref
                   IL_001c:  ldloca.s   V_0
                   IL_001e:  ldc.i4.2
-                  IL_001f:  call       "InlineArrayElementRef<<>y__InlineArray3<string>, string>(ref <>y__InlineArray3<string>, int)"
+                  IL_001f:  call       "ref string <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<string>, string>(ref <>y__InlineArray3<string>, int)"
                   IL_0024:  ldstr      "ab"
                   IL_0029:  stind.ref
                   IL_002a:  ldloca.s   V_0
                   IL_002c:  ldc.i4.3
-                  IL_002d:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<string>, string>(in <>y__InlineArray3<string>, int)"
+                  IL_002d:  call       "System.ReadOnlySpan<string> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<string>, string>(in <>y__InlineArray3<string>, int)"
                   IL_0032:  call       "void Program.Report<string>(System.ReadOnlySpan<string>)"
                   IL_0037:  ret
                 }
@@ -21612,25 +21612,25 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray3<object>"
                   IL_0008:  ldloca.s   V_0
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_000b:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_0010:  ldc.i4.1
                   IL_0011:  box        "int"
                   IL_0016:  stind.ref
                   IL_0017:  ldloca.s   V_0
                   IL_0019:  ldc.i4.1
-                  IL_001a:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_001a:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_001f:  ldc.i4.2
                   IL_0020:  box        "int"
                   IL_0025:  stind.ref
                   IL_0026:  ldloca.s   V_0
                   IL_0028:  ldc.i4.2
-                  IL_0029:  call       "InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
+                  IL_0029:  call       "ref object <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<object>, object>(ref <>y__InlineArray3<object>, int)"
                   IL_002e:  ldc.i4.3
                   IL_002f:  box        "int"
                   IL_0034:  stind.ref
                   IL_0035:  ldloca.s   V_0
                   IL_0037:  ldc.i4.3
-                  IL_0038:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
+                  IL_0038:  call       "System.ReadOnlySpan<object> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<object>, object>(in <>y__InlineArray3<object>, int)"
                   IL_003d:  call       "MyCollection<object> MyCollectionBuilder.Create<object>(System.ReadOnlySpan<object>)"
                   IL_0042:  ret
                 }
@@ -22259,22 +22259,22 @@ partial class Program
                   IL_0009:  initobj    "<>y__InlineArray3<int>"
                   IL_000f:  ldloca.s   V_4
                   IL_0011:  ldc.i4.0
-                  IL_0012:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_0012:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_0017:  ldloc.0
                   IL_0018:  stind.i4
                   IL_0019:  ldloca.s   V_4
                   IL_001b:  ldc.i4.1
-                  IL_001c:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_001c:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_0021:  ldloc.1
                   IL_0022:  stind.i4
                   IL_0023:  ldloca.s   V_4
                   IL_0025:  ldc.i4.2
-                  IL_0026:  call       "InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
+                  IL_0026:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray3<int>, int>(ref <>y__InlineArray3<int>, int)"
                   IL_002b:  ldloc.2
                   IL_002c:  stind.i4
                   IL_002d:  ldloca.s   V_4
                   IL_002f:  ldc.i4.3
-                  IL_0030:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray3<int>, int>(in <>y__InlineArray3<int>, int)"
+                  IL_0030:  call       "System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray3<int>, int>(in <>y__InlineArray3<int>, int)"
                   IL_0035:  call       "System.Collections.Immutable.ImmutableArray<int> System.Collections.Immutable.ImmutableArray.Create<int>(System.ReadOnlySpan<int>)"
                   IL_003a:  stloc.3
                   IL_003b:  ldloc.3
@@ -22705,12 +22705,12 @@ partial class Program
                   IL_0002:  initobj    "<>y__InlineArray1<int>"
                   IL_0008:  ldloca.s   V_0
                   IL_000a:  ldc.i4.0
-                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
+                  IL_000b:  call       "ref int <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
                   IL_0010:  ldc.i4.1
                   IL_0011:  stind.i4
                   IL_0012:  ldloca.s   V_0
                   IL_0014:  ldc.i4.1
-                  IL_0015:  call       "InlineArrayAsSpan<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
+                  IL_0015:  call       "System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray1<int>, int>(ref <>y__InlineArray1<int>, int)"
                   IL_001a:  pop
                   IL_001b:  ldc.i4.1
                   IL_001c:  newarr     "int"

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -2278,7 +2278,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -2291,7 +2291,7 @@ class Program
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ldc.i4.s   111
   IL_000d:  stind.i4
   IL_000e:  ret
@@ -2369,7 +2369,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -2406,7 +2406,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -2519,7 +2519,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -2557,7 +2557,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -2598,7 +2598,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -2640,7 +2640,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -2951,7 +2951,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.1
-  IL_0007:  call       ""InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ldind.i4
   IL_000d:  ret
 }
@@ -2965,7 +2965,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.1
-  IL_0007:  call       ""InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ldc.i4.s   111
   IL_000e:  stind.i4
   IL_000f:  ret
@@ -3014,7 +3014,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   9
-  IL_0008:  call       ""InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ldind.i4
   IL_000e:  ret
 }
@@ -3028,7 +3028,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   9
-  IL_0008:  call       ""InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ldc.i4.s   111
   IL_000f:  stind.i4
   IL_0010:  ret
@@ -3078,7 +3078,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  stloc.0
   IL_000e:  ldloca.s   V_0
   IL_0010:  ldarg.1
@@ -3097,7 +3097,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  stloc.0
   IL_000e:  ldloca.s   V_0
   IL_0010:  ldarg.1
@@ -3206,7 +3206,7 @@ class Program
     IL_0070:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
     IL_007a:  ldc.i4.s   10
-    IL_007c:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_007c:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0081:  stloc.s    V_4
     IL_0083:  ldloca.s   V_4
     IL_0085:  ldloc.2
@@ -3298,7 +3298,7 @@ class Program
     IL_0070:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
     IL_007a:  ldc.i4.s   10
-    IL_007c:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_007c:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0081:  stloc.3
     IL_0082:  ldloca.s   V_3
     IL_0084:  ldloc.1
@@ -3432,7 +3432,7 @@ class Program
     IL_0077:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_007c:  ldflda     ""Buffer10<int> C.F""
     IL_0081:  ldc.i4.s   10
-    IL_0083:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_0083:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0088:  stloc.s    V_4
     IL_008a:  ldloca.s   V_4
     IL_008c:  ldloca.s   V_2
@@ -3528,7 +3528,7 @@ class Program
     IL_0077:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_007c:  ldflda     ""Buffer10<int> C.F""
     IL_0081:  ldc.i4.s   10
-    IL_0083:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_0083:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0088:  stloc.3
     IL_0089:  ldloca.s   V_3
     IL_008b:  ldloca.s   V_1
@@ -3662,7 +3662,7 @@ class Program
     IL_0071:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0076:  ldflda     ""Buffer10<int> C.F""
     IL_007b:  ldc.i4.s   10
-    IL_007d:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_007d:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0082:  stloc.s    V_4
     IL_0084:  ldloca.s   V_4
     IL_0086:  ldc.i4.s   10
@@ -3756,7 +3756,7 @@ class Program
     IL_0071:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_0076:  ldflda     ""Buffer10<int> C.F""
     IL_007b:  ldc.i4.s   10
-    IL_007d:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_007d:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0082:  stloc.3
     IL_0083:  ldloca.s   V_3
     IL_0085:  ldc.i4.s   10
@@ -3885,7 +3885,7 @@ class Program
     IL_006e:  ldarg.0
     IL_006f:  ldflda     ""Buffer10<int> Program.<M2>d__1.<>7__wrap1""
     IL_0074:  ldc.i4.s   10
-    IL_0076:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+    IL_0076:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
     IL_007b:  stloc.s    V_4
     IL_007d:  ldloca.s   V_4
     IL_007f:  ldloc.2
@@ -4012,7 +4012,7 @@ class Program
     IL_0075:  ldarg.0
     IL_0076:  ldflda     ""Buffer10<int> Program.<M2>d__1.<>7__wrap1""
     IL_007b:  ldc.i4.s   10
-    IL_007d:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+    IL_007d:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
     IL_0082:  stloc.s    V_4
     IL_0084:  ldloca.s   V_4
     IL_0086:  ldloca.s   V_2
@@ -4139,7 +4139,7 @@ class Program
     IL_006f:  ldarg.0
     IL_0070:  ldflda     ""Buffer10<int> Program.<M2>d__1.<>7__wrap1""
     IL_0075:  ldc.i4.s   10
-    IL_0077:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+    IL_0077:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
     IL_007c:  stloc.s    V_4
     IL_007e:  ldloca.s   V_4
     IL_0080:  ldc.i4.s   10
@@ -4272,7 +4272,7 @@ class Program
     IL_0070:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
     IL_007a:  ldc.i4.s   10
-    IL_007c:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+    IL_007c:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
     IL_0081:  stloc.s    V_4
     IL_0083:  ldloca.s   V_4
     IL_0085:  ldloc.2
@@ -4411,7 +4411,7 @@ class Program
     IL_00a2:  ldfld      ""int Program.<M2>d__1.<>7__wrap3""
     IL_00a7:  ldelema    ""Buffer10<int>""
     IL_00ac:  ldc.i4.s   10
-    IL_00ae:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_00ae:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_00b3:  stloc.3
     IL_00b4:  ldloca.s   V_3
     IL_00b6:  ldarg.0
@@ -4555,14 +4555,14 @@ class Program
     IL_008d:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0092:  ldflda     ""Buffer10<Buffer10<int>> C.F""
     IL_0097:  ldc.i4.s   10
-    IL_0099:  call       ""InlineArrayAsReadOnlySpan<Buffer10<Buffer10<int>>, Buffer10<int>>(in Buffer10<Buffer10<int>>, int)""
+    IL_0099:  call       ""System.ReadOnlySpan<Buffer10<int>> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<Buffer10<int>>, Buffer10<int>>(in Buffer10<Buffer10<int>>, int)""
     IL_009e:  stloc.s    V_4
     IL_00a0:  ldloca.s   V_4
     IL_00a2:  ldarg.0
     IL_00a3:  ldfld      ""int Program.<M1>d__1.<>7__wrap2""
     IL_00a8:  call       ""ref readonly Buffer10<int> System.ReadOnlySpan<Buffer10<int>>.this[int].get""
     IL_00ad:  ldc.i4.s   10
-    IL_00af:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+    IL_00af:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
     IL_00b4:  stloc.s    V_5
     IL_00b6:  ldloca.s   V_5
     IL_00b8:  ldloc.2
@@ -4922,7 +4922,7 @@ class Program
     IL_0077:  ldfld      ""C<T> Program.<M1>d__1<T>.<>7__wrap1""
     IL_007c:  ldflda     ""Buffer10<T> C<T>.F""
     IL_0081:  ldc.i4.s   10
-    IL_0083:  call       ""InlineArrayAsSpan<Buffer10<T>, T>(ref Buffer10<T>, int)""
+    IL_0083:  call       ""System.Span<T> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<T>, T>(ref Buffer10<T>, int)""
     IL_0088:  stloc.s    V_4
     IL_008a:  ldloca.s   V_4
     IL_008c:  ldloca.s   V_2
@@ -5018,7 +5018,7 @@ class Program
     IL_007a:  ldfld      ""C<T> Program.<M2>d__2<T>.<>7__wrap1""
     IL_007f:  ldflda     ""Buffer10<T> C<T>.F""
     IL_0084:  ldc.i4.s   10
-    IL_0086:  call       ""InlineArrayAsSpan<Buffer10<T>, T>(ref Buffer10<T>, int)""
+    IL_0086:  call       ""System.Span<T> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<T>, T>(ref Buffer10<T>, int)""
     IL_008b:  stloc.3
     IL_008c:  ldloca.s   V_3
     IL_008e:  ldloca.s   V_1
@@ -5154,7 +5154,7 @@ class Program
     IL_0070:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
     IL_007a:  ldc.i4.1
-    IL_007b:  call       ""InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_007b:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0080:  ldloc.2
     IL_0081:  call       ""int Program.GetInt(ref int, int)""
     IL_0086:  stloc.1
@@ -5242,7 +5242,7 @@ class Program
     IL_0071:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_0076:  ldflda     ""Buffer10<int> C.F""
     IL_007b:  ldc.i4.1
-    IL_007c:  call       ""InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_007c:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0081:  ldloc.1
     IL_0082:  stind.i4
     IL_0083:  ldarg.0
@@ -5372,7 +5372,7 @@ class Program
     IL_0070:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
     IL_007a:  ldc.i4.1
-    IL_007b:  call       ""InlineArrayElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>, int)""
+    IL_007b:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>, int)""
     IL_0080:  ldloc.2
     IL_0081:  call       ""int Program.GetInt(in int, int)""
     IL_0086:  stloc.1
@@ -5499,7 +5499,7 @@ class Program
     IL_006f:  ldarg.0
     IL_0070:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
-    IL_007a:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+    IL_007a:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
     IL_007f:  ldloc.2
     IL_0080:  call       ""int Program.GetInt(ref int, int)""
     IL_0085:  stloc.1
@@ -5586,7 +5586,7 @@ class Program
     IL_0070:  ldarg.0
     IL_0071:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_0076:  ldflda     ""Buffer10<int> C.F""
-    IL_007b:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+    IL_007b:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
     IL_0080:  ldloc.1
     IL_0081:  stind.i4
     IL_0082:  ldarg.0
@@ -5715,7 +5715,7 @@ class Program
     IL_006f:  ldarg.0
     IL_0070:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
-    IL_007a:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+    IL_007a:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
     IL_007f:  ldloc.2
     IL_0080:  call       ""int Program.GetInt(in int, int)""
     IL_0085:  stloc.1
@@ -5780,7 +5780,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -5793,7 +5793,7 @@ class Program
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ldc.i4.s   111
   IL_000d:  stind.i4
   IL_000e:  ret
@@ -5867,7 +5867,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  stloc.0
   IL_000e:  ldloca.s   V_0
   IL_0010:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> Program.<>o__2.<>p__0""
@@ -5960,7 +5960,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -6040,7 +6040,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -6155,7 +6155,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -6194,7 +6194,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -6237,7 +6237,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -6280,7 +6280,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -6606,7 +6606,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.0
-  IL_0007:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -6651,7 +6651,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  stloc.0
   IL_000e:  ldloca.s   V_0
   IL_0010:  ldc.i4.1
@@ -6701,7 +6701,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  stloc.0
   IL_000e:  ldloca.s   V_0
   IL_0010:  ldc.i4.0
@@ -6754,7 +6754,7 @@ class Program
   IL_0006:  ldarg.1
   IL_0007:  stloc.0
   IL_0008:  ldc.i4.s   10
-  IL_000a:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_000a:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000f:  stloc.1
   IL_0010:  ldloca.s   V_1
   IL_0012:  ldloc.0
@@ -6807,7 +6807,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  stloc.0
   IL_000e:  ldloca.s   V_0
   IL_0010:  ldc.i4.1
@@ -6860,7 +6860,7 @@ class Program
   IL_0006:  ldarg.1
   IL_0007:  stloc.0
   IL_0008:  ldc.i4.s   10
-  IL_000a:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_000a:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000f:  stloc.1
   IL_0010:  ldloca.s   V_1
   IL_0012:  ldloc.0
@@ -6911,7 +6911,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   9
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -7004,7 +7004,7 @@ class Program
   IL_0031:  sub
   IL_0032:  stloc.2
   IL_0033:  ldc.i4.s   10
-  IL_0035:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0035:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_003a:  stloc.s    V_4
   IL_003c:  ldloca.s   V_4
   IL_003e:  ldloc.1
@@ -7074,7 +7074,7 @@ class Program
   IL_0031:  sub
   IL_0032:  stloc.2
   IL_0033:  ldc.i4.s   10
-  IL_0035:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0035:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_003a:  stloc.s    V_4
   IL_003c:  ldloca.s   V_4
   IL_003e:  ldloc.1
@@ -7181,7 +7181,7 @@ class Program
     IL_0073:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_0078:  ldflda     ""Buffer10<int> C.F""
     IL_007d:  ldc.i4.s   10
-    IL_007f:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_007f:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0084:  stloc.3
     IL_0085:  ldloca.s   V_3
     IL_0087:  ldc.i4.0
@@ -7324,7 +7324,7 @@ class Program
     IL_0081:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_0086:  ldflda     ""Buffer10<int> C.F""
     IL_008b:  ldc.i4.s   10
-    IL_008d:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_008d:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0092:  stloc.s    V_4
     IL_0094:  ldloca.s   V_4
     IL_0096:  ldloc.2
@@ -7490,7 +7490,7 @@ class Program
     IL_00b7:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_00bc:  ldflda     ""Buffer10<int> C.F""
     IL_00c1:  ldc.i4.s   10
-    IL_00c3:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_00c3:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_00c8:  stloc.s    V_7
     IL_00ca:  ldloca.s   V_7
     IL_00cc:  ldloc.3
@@ -7649,7 +7649,7 @@ class Program
     IL_00aa:  ldfld      ""C Program.<M2>d__2.<>7__wrap4""
     IL_00af:  ldflda     ""Buffer10<int> C.F""
     IL_00b4:  ldc.i4.s   10
-    IL_00b6:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_00b6:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_00bb:  stloc.s    V_4
     IL_00bd:  ldloca.s   V_4
     IL_00bf:  ldarg.0
@@ -7828,7 +7828,7 @@ class Program
     IL_00d3:  ldfld      ""C Program.<M1>d__1.<>7__wrap3""
     IL_00d8:  ldflda     ""Buffer10<int> C.F""
     IL_00dd:  ldc.i4.s   10
-    IL_00df:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+    IL_00df:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
     IL_00e4:  stloc.s    V_8
     IL_00e6:  ldloca.s   V_8
     IL_00e8:  ldarg.0
@@ -8114,7 +8114,7 @@ class Program
   IL_000c:  ret
   IL_000d:  ldarg.0
   IL_000e:  ldflda     ""Buffer10<int> C.F""
-  IL_0013:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0013:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_0018:  ldind.i4
   IL_0019:  newobj     ""int?..ctor(int)""
   IL_001e:  ret
@@ -8175,7 +8175,7 @@ class Program
   IL_000d:  ldarg.0
   IL_000e:  ldflda     ""Buffer10<int> C.F""
   IL_0013:  ldc.i4.5
-  IL_0014:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0014:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_0019:  stloc.1
   IL_001a:  ldloca.s   V_1
   IL_001c:  ldc.i4.0
@@ -8232,7 +8232,7 @@ class Program
   IL_0019:  call       ""readonly Buffer10<int> Buffer10<int>?.GetValueOrDefault()""
   IL_001e:  stloc.1
   IL_001f:  ldloca.s   V_1
-  IL_0021:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0021:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_0026:  ldind.i4
   IL_0027:  newobj     ""int?..ctor(int)""
   IL_002c:  ret
@@ -8290,7 +8290,7 @@ class Program
   IL_001e:  stloc.1
   IL_001f:  ldloca.s   V_1
   IL_0021:  ldc.i4.s   10
-  IL_0023:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0023:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_0028:  stloc.2
   IL_0029:  ldloca.s   V_2
   IL_002b:  ldloca.s   V_3
@@ -8349,7 +8349,7 @@ class Program
   IL_001a:  ldfld      ""Buffer10<int> C.F""
   IL_001f:  stloc.1
   IL_0020:  ldloca.s   V_1
-  IL_0022:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0022:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_0027:  ldind.i4
   IL_0028:  newobj     ""int?..ctor(int)""
   IL_002d:  ret
@@ -8406,7 +8406,7 @@ class Program
   IL_001f:  stloc.1
   IL_0020:  ldloca.s   V_1
   IL_0022:  ldc.i4.s   10
-  IL_0024:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0024:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_0029:  stloc.2
   IL_002a:  ldloca.s   V_2
   IL_002c:  ldloca.s   V_3
@@ -8604,7 +8604,7 @@ class Program
   IL_0000:  call       ""Buffer10<int> Program.M3()""
   IL_0005:  stloc.0
   IL_0006:  ldloca.s   V_0
-  IL_0008:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0008:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000d:  ldind.i4
   IL_000e:  stloc.1
   IL_000f:  ldloca.s   V_1
@@ -8684,7 +8684,7 @@ class Program
   IL_0005:  stloc.0
   IL_0006:  ldloca.s   V_0
   IL_0008:  ldc.i4.s   10
-  IL_000a:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_000a:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000f:  stloc.1
   IL_0010:  ldloca.s   V_1
   IL_0012:  ldloca.s   V_2
@@ -8850,7 +8850,7 @@ class Program
   IL_0000:  call       ""Buffer10<int> Program.M3()""
   IL_0005:  stloc.0
   IL_0006:  ldloca.s   V_0
-  IL_0008:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0008:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000d:  ldind.i4
   IL_000e:  stloc.1
   IL_000f:  ldloca.s   V_1
@@ -9036,7 +9036,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -9083,7 +9083,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -9134,7 +9134,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  call       ""int Program.M4(in int)""
   IL_0010:  ret
 }
@@ -9224,7 +9224,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -9269,7 +9269,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -9387,7 +9387,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -9435,7 +9435,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -9487,7 +9487,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  call       ""int C.M4(in int)""
   IL_0010:  ret
 }
@@ -9619,7 +9619,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -9704,7 +9704,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -9808,7 +9808,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0007:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -9855,7 +9855,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0007:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -10140,7 +10140,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0007:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -10185,7 +10185,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0007:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -10322,7 +10322,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -10396,7 +10396,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -10448,7 +10448,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  call       ""int Program.M4(in int)""
   IL_0010:  ret
 }
@@ -10540,7 +10540,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -10586,7 +10586,7 @@ class Program
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
+  IL_0006:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayFirstElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>)""
   IL_000b:  ret
 }
 ");
@@ -10925,7 +10925,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.1
-  IL_0007:  call       ""InlineArrayElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0007:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000c:  ldind.i4
   IL_000d:  ret
 }
@@ -10971,7 +10971,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   9
-  IL_0008:  call       ""InlineArrayElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ldind.i4
   IL_000e:  ret
 }
@@ -11018,7 +11018,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  stloc.0
   IL_000e:  ldloca.s   V_0
   IL_0010:  ldarg.1
@@ -11067,7 +11067,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0007:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -11141,7 +11141,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0007:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -11268,7 +11268,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  stloc.0
   IL_000e:  ldloca.s   V_0
   IL_0010:  ldc.i4.0
@@ -11797,7 +11797,7 @@ class Program
   IL_0006:  initobj    ""Buffer10<int>""
   IL_000c:  ldarg.0
   IL_000d:  ldflda     ""Buffer10<int> C.F""
-  IL_0012:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0012:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_0017:  ldc.i4.1
   IL_0018:  stind.i4
   IL_0019:  ret
@@ -11998,13 +11998,13 @@ public struct Buffer2<T>
   IL_0013:  stfld      ""int Buffer2<int>._element0""
   IL_0018:  ldarg.0
   IL_0019:  ldflda     ""Buffer2<int> C.F""
-  IL_001e:  call       ""InlineArrayFirstElementRef<Buffer2<int>, int>(ref Buffer2<int>)""
+  IL_001e:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer2<int>, int>(ref Buffer2<int>)""
   IL_0023:  ldc.i4.1
   IL_0024:  stind.i4
   IL_0025:  ldarg.0
   IL_0026:  ldflda     ""Buffer2<int> C.F""
   IL_002b:  ldc.i4.1
-  IL_002c:  call       ""InlineArrayElementRef<Buffer2<int>, int>(ref Buffer2<int>, int)""
+  IL_002c:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer2<int>, int>(ref Buffer2<int>, int)""
   IL_0031:  ldc.i4.2
   IL_0032:  stind.i4
   IL_0033:  ret
@@ -12062,7 +12062,7 @@ public struct Buffer2<T>
   IL_0018:  ldarg.0
   IL_0019:  ldflda     ""Buffer2<int> C.F""
   IL_001e:  ldc.i4.1
-  IL_001f:  call       ""InlineArrayElementRef<Buffer2<int>, int>(ref Buffer2<int>, int)""
+  IL_001f:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer2<int>, int>(ref Buffer2<int>, int)""
   IL_0024:  ldc.i4.2
   IL_0025:  stind.i4
   IL_0026:  ret
@@ -12585,7 +12585,7 @@ public struct Buffer10
   IL_0000:  ldarg.0
   IL_0001:  initobj    ""Buffer10""
   IL_0007:  ldarg.0
-  IL_0008:  call       ""InlineArrayFirstElementRef<Buffer10, int>(ref Buffer10)""
+  IL_0008:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10, int>(ref Buffer10)""
   IL_000d:  ldc.i4.1
   IL_000e:  stind.i4
   IL_000f:  ret
@@ -12712,12 +12712,12 @@ public struct Buffer2
   IL_0008:  ldc.i4.0
   IL_0009:  stfld      ""int Buffer2._element0""
   IL_000e:  ldarg.0
-  IL_000f:  call       ""InlineArrayFirstElementRef<Buffer2, int>(ref Buffer2)""
+  IL_000f:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer2, int>(ref Buffer2)""
   IL_0014:  ldc.i4.1
   IL_0015:  stind.i4
   IL_0016:  ldarg.0
   IL_0017:  ldc.i4.1
-  IL_0018:  call       ""InlineArrayElementRef<Buffer2, int>(ref Buffer2, int)""
+  IL_0018:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer2, int>(ref Buffer2, int)""
   IL_001d:  ldc.i4.2
   IL_001e:  stind.i4
   IL_001f:  ret
@@ -12767,7 +12767,7 @@ public struct Buffer2
   IL_0009:  stfld      ""int Buffer2._element0""
   IL_000e:  ldarg.0
   IL_000f:  ldc.i4.1
-  IL_0010:  call       ""InlineArrayElementRef<Buffer2, int>(ref Buffer2, int)""
+  IL_0010:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer2, int>(ref Buffer2, int)""
   IL_0015:  ldc.i4.2
   IL_0016:  stind.i4
   IL_0017:  ret
@@ -13230,7 +13230,7 @@ public ref struct Buffer2Ref
   IL_0008:  ldc.i4.1
   IL_0009:  stfld      ""int Buffer2._element0""
   IL_000e:  ldarg.0
-  IL_000f:  call       ""InlineArrayFirstElementRef<Buffer2, int>(ref Buffer2)""
+  IL_000f:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer2, int>(ref Buffer2)""
   IL_0014:  pop
   IL_0015:  ret
 }
@@ -13320,7 +13320,7 @@ public struct Buffer1
   IL_0001:  ldc.i4.1
   IL_0002:  stfld      ""int Buffer1._element0""
   IL_0007:  ldarg.0
-  IL_0008:  call       ""InlineArrayFirstElementRef<Buffer1, int>(ref Buffer1)""
+  IL_0008:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer1, int>(ref Buffer1)""
   IL_000d:  pop
   IL_000e:  ret
 }
@@ -13381,7 +13381,7 @@ public struct Buffer1
   IL_0001:  ldc.i4.0
   IL_0002:  stfld      ""int Buffer1._element0""
   IL_0007:  ldarg.0
-  IL_0008:  call       ""InlineArrayFirstElementRef<Buffer1, int>(ref Buffer1)""
+  IL_0008:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer1, int>(ref Buffer1)""
   IL_000d:  pop
   IL_000e:  ret
 }
@@ -13446,7 +13446,7 @@ public struct Buffer1
   // Code size        9 (0x9)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  call       ""InlineArrayFirstElementRef<Buffer1, int>(ref Buffer1)""
+  IL_0001:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer1, int>(ref Buffer1)""
   IL_0006:  ldc.i4.1
   IL_0007:  stind.i4
   IL_0008:  ret
@@ -13487,7 +13487,7 @@ public struct Buffer1
   // Code size        9 (0x9)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  call       ""InlineArrayFirstElementRef<Buffer1, int>(ref Buffer1)""
+  IL_0001:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer1, int>(ref Buffer1)""
   IL_0006:  ldc.i4.1
   IL_0007:  stind.i4
   IL_0008:  ret
@@ -13546,7 +13546,7 @@ public struct Buffer2<T>
   IL_000c:  ldarg.0
   IL_000d:  ldflda     ""Buffer2<int> C.F""
   IL_0012:  ldc.i4.2
-  IL_0013:  call       ""InlineArrayAsSpan<Buffer2<int>, int>(ref Buffer2<int>, int)""
+  IL_0013:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer2<int>, int>(ref Buffer2<int>, int)""
   IL_0018:  pop
   IL_0019:  ret
 }
@@ -13604,7 +13604,7 @@ public struct Buffer2<T>
   IL_000c:  ldarg.0
   IL_000d:  ldflda     ""Buffer2<int> C.F""
   IL_0012:  ldc.i4.2
-  IL_0013:  call       ""InlineArrayAsSpan<Buffer2<int>, int>(ref Buffer2<int>, int)""
+  IL_0013:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer2<int>, int>(ref Buffer2<int>, int)""
   IL_0018:  pop
   IL_0019:  ret
 }
@@ -13662,7 +13662,7 @@ public struct Buffer2<T>
   IL_000c:  ldarg.0
   IL_000d:  ldflda     ""Buffer2<int> C.F""
   IL_0012:  ldc.i4.2
-  IL_0013:  call       ""InlineArrayAsReadOnlySpan<Buffer2<int>, int>(in Buffer2<int>, int)""
+  IL_0013:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer2<int>, int>(in Buffer2<int>, int)""
   IL_0018:  pop
   IL_0019:  ret
 }
@@ -13713,7 +13713,7 @@ public struct Buffer2
   IL_0001:  initobj    ""Buffer2""
   IL_0007:  ldarg.0
   IL_0008:  ldc.i4.2
-  IL_0009:  call       ""InlineArrayAsSpan<Buffer2, int>(ref Buffer2, int)""
+  IL_0009:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer2, int>(ref Buffer2, int)""
   IL_000e:  pop
   IL_000f:  ret
 }
@@ -13764,7 +13764,7 @@ public struct Buffer2
   IL_0001:  initobj    ""Buffer2""
   IL_0007:  ldarg.0
   IL_0008:  ldc.i4.2
-  IL_0009:  call       ""InlineArrayAsSpan<Buffer2, int>(ref Buffer2, int)""
+  IL_0009:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer2, int>(ref Buffer2, int)""
   IL_000e:  pop
   IL_000f:  ret
 }
@@ -13815,7 +13815,7 @@ public struct Buffer2
   IL_0001:  initobj    ""Buffer2""
   IL_0007:  ldarg.0
   IL_0008:  ldc.i4.2
-  IL_0009:  call       ""InlineArrayAsReadOnlySpan<Buffer2, int>(in Buffer2, int)""
+  IL_0009:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer2, int>(in Buffer2, int)""
   IL_000e:  pop
   IL_000f:  ret
 }
@@ -14434,7 +14434,7 @@ class Program
                     Assert.Empty(t.GetMembers(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName));
                 }).VerifyDiagnostics();
 
-            verifier.VerifyIL(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayAsSpanName,
+            verifier.VerifyIL("<PrivateImplementationDetails>." + CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayAsSpanName,
 @"
 {
   // Code size       13 (0xd)
@@ -14483,7 +14483,7 @@ class Program
                     Assert.Empty(t.GetMembers(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName));
                 }).VerifyDiagnostics();
 
-            verifier.VerifyIL(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayAsReadOnlySpanName,
+            verifier.VerifyIL("<PrivateImplementationDetails>." + CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayAsReadOnlySpanName,
 @"
 {
   // Code size       18 (0x12)
@@ -14532,7 +14532,7 @@ class Program
                     Assert.Empty(t.GetMembers(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName));
                 }).VerifyDiagnostics();
 
-            verifier.VerifyIL(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayElementRefName,
+            verifier.VerifyIL("<PrivateImplementationDetails>." + CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayElementRefName,
 @"
 {
   // Code size       13 (0xd)
@@ -14580,7 +14580,7 @@ class Program
                     Assert.Empty(t.GetMembers(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName));
                 }).VerifyDiagnostics();
 
-            verifier.VerifyIL(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayElementRefReadOnlyName,
+            verifier.VerifyIL("<PrivateImplementationDetails>." + CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayElementRefReadOnlyName,
 @"
 {
   // Code size       18 (0x12)
@@ -14627,7 +14627,7 @@ class Program
                     Assert.Empty(t.GetMembers(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName));
                 }).VerifyDiagnostics();
 
-            verifier.VerifyIL(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefName,
+            verifier.VerifyIL("<PrivateImplementationDetails>." + CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefName,
 @"
 {
   // Code size        7 (0x7)
@@ -14671,7 +14671,7 @@ class Program
                                  t.GetMember(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName).ToTestDisplayString());
                 }).VerifyDiagnostics();
 
-            verifier.VerifyIL(CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName,
+            verifier.VerifyIL("<PrivateImplementationDetails>." + CodeAnalysis.CodeGen.PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName,
 @"
 {
   // Code size       12 (0xc)
@@ -14911,7 +14911,7 @@ class Program
   .maxstack  3
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  dup
   IL_000c:  ldind.i4
   IL_000d:  ldc.i4.s   111
@@ -14958,7 +14958,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -14971,7 +14971,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15042,7 +15042,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15055,7 +15055,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15179,7 +15179,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15192,7 +15192,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15234,7 +15234,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15247,7 +15247,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15295,7 +15295,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15308,7 +15308,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15358,7 +15358,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15371,7 +15371,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0008:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -15977,7 +15977,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -16025,7 +16025,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -16112,7 +16112,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -16227,7 +16227,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.s   10
-  IL_0008:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+  IL_0008:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
   IL_000d:  ret
 }
 ");
@@ -16518,7 +16518,7 @@ class Program
     IL_0070:  ldfld      ""C Program.<M1>d__1.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
     IL_007a:  ldc.i4.s   10
-    IL_007c:  call       ""InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
+    IL_007c:  call       ""System.ReadOnlySpan<int> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<Buffer10<int>, int>(in Buffer10<int>, int)""
     IL_0081:  stloc.s    V_4
     IL_0083:  ldloca.s   V_4
     IL_0085:  ldloc.2
@@ -16610,7 +16610,7 @@ class Program
     IL_0070:  ldfld      ""C Program.<M2>d__2.<>7__wrap1""
     IL_0075:  ldflda     ""Buffer10<int> C.F""
     IL_007a:  ldc.i4.s   10
-    IL_007c:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+    IL_007c:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
     IL_0081:  stloc.3
     IL_0082:  ldloca.s   V_3
     IL_0084:  ldloc.1
@@ -17313,7 +17313,7 @@ public struct Buffer10<T>
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -17326,7 +17326,7 @@ public struct Buffer10<T>
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ldc.i4.s   111
   IL_000d:  stind.i4
   IL_000e:  ret
@@ -17431,7 +17431,7 @@ public struct Buffer10<T>
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ldind.i4
   IL_000c:  ret
 }
@@ -17444,7 +17444,7 @@ public struct Buffer10<T>
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
-  IL_0006:  call       ""InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
+  IL_0006:  call       ""ref int <PrivateImplementationDetails>.InlineArrayFirstElementRef<Buffer10<int>, int>(ref Buffer10<int>)""
   IL_000b:  ldc.i4.s   111
   IL_000d:  stind.i4
   IL_000e:  ret
@@ -17510,7 +17510,7 @@ public struct Buffer10<T>
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""Buffer10<int> C.F""
   IL_0006:  ldc.i4.5
-  IL_0007:  call       ""InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
+  IL_0007:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer10<int>, int>(ref Buffer10<int>, int)""
   IL_000c:  ret
 }
 ");
@@ -18317,7 +18317,7 @@ class Program
   IL_0009:  br.s       IL_0029
   IL_000b:  ldloc.0
   IL_000c:  ldloc.1
-  IL_000d:  call       ""InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
+  IL_000d:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
   IL_0012:  ldc.i4.s   32
   IL_0014:  call       ""void System.Console.Write(char)""
   IL_0019:  dup
@@ -18415,7 +18415,7 @@ class Program
   IL_0009:  br.s       IL_002e
   IL_000b:  ldloc.0
   IL_000c:  ldloc.1
-  IL_000d:  call       ""InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
+  IL_000d:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
   IL_0012:  ldc.i4.s   32
   IL_0014:  call       ""void System.Console.Write(char)""
   IL_0019:  dup
@@ -18488,7 +18488,7 @@ class Program
   IL_0009:  br.s       IL_0023
   IL_000b:  ldloc.0
   IL_000c:  ldloc.1
-  IL_000d:  call       ""InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
+  IL_000d:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
   IL_0012:  ldind.i4
   IL_0013:  ldc.i4.s   32
   IL_0015:  call       ""void System.Console.Write(char)""
@@ -18642,7 +18642,7 @@ class Program
   IL_0009:  br.s       IL_002e
   IL_000b:  ldloc.0
   IL_000c:  ldloc.1
-  IL_000d:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+  IL_000d:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
   IL_0012:  ldc.i4.s   32
   IL_0014:  call       ""void System.Console.Write(char)""
   IL_0019:  dup
@@ -18777,7 +18777,7 @@ public struct Buffer4<T>
   IL_0009:  br.s       IL_0023
   IL_000b:  ldloc.0
   IL_000c:  ldloc.1
-  IL_000d:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+  IL_000d:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
   IL_0012:  ldind.i4
   IL_0013:  ldc.i4.s   32
   IL_0015:  call       ""void System.Console.Write(char)""
@@ -18980,7 +18980,7 @@ class Program
   IL_000c:  br.s       IL_003b
   IL_000e:  ldloc.1
   IL_000f:  ldloc.2
-  IL_0010:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+  IL_0010:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
   IL_0015:  ldind.i4
   IL_0016:  ldc.i4.s   32
   IL_0018:  call       ""void System.Console.Write(char)""
@@ -19806,7 +19806,7 @@ class Program
     IL_0077:  br.s       IL_0099
     IL_0079:  ldloc.3
     IL_007a:  ldloc.s    V_4
-    IL_007c:  call       ""InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
+    IL_007c:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
     IL_0081:  ldind.i4
     IL_0082:  call       ""void Program.Increment()""
     IL_0087:  ldc.i4.s   32
@@ -19967,7 +19967,7 @@ class Program
     IL_003e:  ldflda     ""Buffer4<int> C.F""
     IL_0043:  ldarg.0
     IL_0044:  ldfld      ""int Program.<Test>d__3.<>7__wrap1""
-    IL_0049:  call       ""InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
+    IL_0049:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
     IL_004e:  ldind.i4
     IL_004f:  call       ""void Program.Increment()""
     IL_0054:  ldc.i4.s   32
@@ -20251,7 +20251,7 @@ class Program
     IL_0077:  br.s       IL_0099
     IL_0079:  ldloc.3
     IL_007a:  ldloc.s    V_4
-    IL_007c:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+    IL_007c:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
     IL_0081:  ldind.i4
     IL_0082:  call       ""void Program.Increment()""
     IL_0087:  ldc.i4.s   32
@@ -20411,7 +20411,7 @@ class Program
     IL_003e:  ldflda     ""Buffer4<int> C.F""
     IL_0043:  ldarg.0
     IL_0044:  ldfld      ""int Program.<Test>d__3.<>7__wrap1""
-    IL_0049:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+    IL_0049:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
     IL_004e:  ldind.i4
     IL_004f:  call       ""void Program.Increment()""
     IL_0054:  ldc.i4.s   32
@@ -20648,7 +20648,7 @@ class Program
     IL_0022:  ldflda     ""Buffer4<int> Program.<Test>d__1.<>7__wrap1""
     IL_0027:  ldarg.0
     IL_0028:  ldfld      ""int Program.<Test>d__1.<>7__wrap2""
-    IL_002d:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+    IL_002d:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
     IL_0032:  ldind.i4
     IL_0033:  ldc.i4.s   32
     IL_0035:  call       ""void System.Console.Write(char)""
@@ -20813,7 +20813,7 @@ class Program
   IL_0041:  br.s       IL_0060
   IL_0043:  ldloc.1
   IL_0044:  ldloc.2
-  IL_0045:  call       ""InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
+  IL_0045:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
   IL_004a:  ldind.i4
   IL_004b:  call       ""void Program.Increment()""
   IL_0050:  ldc.i4.s   32
@@ -20927,7 +20927,7 @@ class Program
   IL_003e:  ldflda     ""Buffer4<int> C.F""
   IL_0043:  ldarg.0
   IL_0044:  ldfld      ""int Program.<Test>d__3.<>7__wrap1""
-  IL_0049:  call       ""InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
+  IL_0049:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer4<int>, int>(ref Buffer4<int>, int)""
   IL_004e:  ldind.i4
   IL_004f:  call       ""void Program.Increment()""
   IL_0054:  ldc.i4.s   32
@@ -21109,7 +21109,7 @@ class Program
   IL_0041:  br.s       IL_0060
   IL_0043:  ldloc.1
   IL_0044:  ldloc.2
-  IL_0045:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+  IL_0045:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
   IL_004a:  ldind.i4
   IL_004b:  call       ""void Program.Increment()""
   IL_0050:  ldc.i4.s   32
@@ -21223,7 +21223,7 @@ class Program
   IL_003e:  ldflda     ""Buffer4<int> C.F""
   IL_0043:  ldarg.0
   IL_0044:  ldfld      ""int Program.<Test>d__3.<>7__wrap1""
-  IL_0049:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+  IL_0049:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
   IL_004e:  ldind.i4
   IL_004f:  call       ""void Program.Increment()""
   IL_0054:  ldc.i4.s   32
@@ -21385,7 +21385,7 @@ class Program
   IL_002c:  ldflda     ""Buffer4<int> Program.<Test>d__1.<>7__wrap1""
   IL_0031:  ldarg.0
   IL_0032:  ldfld      ""int Program.<Test>d__1.<>7__wrap2""
-  IL_0037:  call       ""InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
+  IL_0037:  call       ""ref readonly int <PrivateImplementationDetails>.InlineArrayElementRefReadOnly<Buffer4<int>, int>(in Buffer4<int>, int)""
   IL_003c:  ldind.i4
   IL_003d:  ldc.i4.s   32
   IL_003f:  call       ""void System.Console.Write(char)""
@@ -21857,6 +21857,51 @@ struct Buffer4
                 //     public static implicit operator System.Span<int>() => new [] {1, 2, 3, 4}; 
                 Diagnostic(ErrorCode.ERR_OvlUnaryOperatorExpected, "()").WithLocation(7, 53)
                 );
+        }
+
+        [ConditionalFact(typeof(CoreClrOnly))]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70738")]
+        public void CoalesceForNullableElement()
+        {
+            var src = @"
+class Program
+{
+    static void Main()
+    {
+        MyArray x = default;
+        System.Console.Write(Test(x));
+
+        x[0] = 124;
+        System.Console.Write(Test(x));
+    }
+
+    static int Test(MyArray array)
+    {
+        return array[0] ?? 123;
+    }
+}
+
+[System.Runtime.CompilerServices.InlineArray(1)]
+struct MyArray
+{
+    private int? _value;
+}
+";
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "123124").VerifyDiagnostics();
+
+            verifier.VerifyIL("Program.Test",
+@"
+{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldarga.s   V_0
+  IL_0002:  call       ""ref int? <PrivateImplementationDetails>.InlineArrayFirstElementRef<MyArray, int?>(ref MyArray)""
+  IL_0007:  ldc.i4.s   123
+  IL_0009:  call       ""readonly int int?.GetValueOrDefault(int)""
+  IL_000e:  ret
+}
+");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests.cs
@@ -7684,7 +7684,7 @@ class C
   .locals init (int V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       ""ComputeReadOnlySpanHash(System.ReadOnlySpan<char>)""
+  IL_0001:  call       ""uint <PrivateImplementationDetails>.ComputeReadOnlySpanHash(System.ReadOnlySpan<char>)""
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x75b03721
@@ -8000,7 +8000,7 @@ class C
   .maxstack  2
   .locals init (uint V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       ""ComputeReadOnlySpanHash(System.ReadOnlySpan<char>)""
+  IL_0001:  call       ""uint <PrivateImplementationDetails>.ComputeReadOnlySpanHash(System.ReadOnlySpan<char>)""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  ldc.i4     0x75b03721
@@ -9282,7 +9282,7 @@ class C
   .locals init (int V_0,
                 uint V_1)
   IL_0000:  ldarg.0
-  IL_0001:  call       ""ComputeSpanHash(System.Span<char>)""
+  IL_0001:  call       ""uint <PrivateImplementationDetails>.ComputeSpanHash(System.Span<char>)""
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  ldc.i4     0x75b03721
@@ -9599,7 +9599,7 @@ class C
   .maxstack  2
   .locals init (uint V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       ""ComputeSpanHash(System.Span<char>)""
+  IL_0001:  call       ""uint <PrivateImplementationDetails>.ComputeSpanHash(System.Span<char>)""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  ldc.i4     0x75b03721

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests4.cs
@@ -2135,7 +2135,7 @@ public class C
     // sequence point: switch { (3, 4) => 1 }
     IL_002e:  nop
     // sequence point: <hidden>
-    IL_002f:  call       ""ThrowInvalidOperationException()""
+    IL_002f:  call       ""void <PrivateImplementationDetails>.ThrowInvalidOperationException()""
     IL_0034:  nop
     // sequence point: <hidden>
     IL_0035:  ldc.i4.1
@@ -2165,7 +2165,7 @@ public class C
   // sequence point: }
   IL_0052:  ret
 }
-", sequencePoints: "C.Main", source: source).VerifyIL("ThrowInvalidOperationException", @"
+", sequencePoints: "C.Main", source: source).VerifyIL("<PrivateImplementationDetails>.ThrowInvalidOperationException", @"
 {
   // Code size        6 (0x6)
   .maxstack  1
@@ -2277,7 +2277,7 @@ namespace System.Runtime.CompilerServices
     // sequence point: switch { (3, 4) => 1 }
     IL_002e:  nop
     // sequence point: <hidden>
-    IL_002f:  call       ""ThrowSwitchExpressionExceptionParameterless()""
+    IL_002f:  call       ""void <PrivateImplementationDetails>.ThrowSwitchExpressionExceptionParameterless()""
     IL_0034:  nop
     // sequence point: <hidden>
     IL_0035:  ldc.i4.1
@@ -2327,7 +2327,7 @@ namespace System.Runtime.CompilerServices
   // sequence point: }
   IL_007a:  ret
 }
-", sequencePoints: "C.Main", source: source).VerifyIL("ThrowSwitchExpressionExceptionParameterless", @"
+", sequencePoints: "C.Main", source: source).VerifyIL("<PrivateImplementationDetails>.ThrowSwitchExpressionExceptionParameterless", @"
 {
   // Code size        6 (0x6)
   .maxstack  1
@@ -2471,7 +2471,7 @@ namespace System.Runtime.CompilerServices
     IL_001d:  ldloc.1
     IL_001e:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
     IL_0023:  box        ""System.ValueTuple<int, int>""
-    IL_0028:  call       ""ThrowSwitchExpressionException(object)""
+    IL_0028:  call       ""void <PrivateImplementationDetails>.ThrowSwitchExpressionException(object)""
     IL_002d:  nop
     // sequence point: <hidden>
     IL_002e:  ldc.i4.1
@@ -2521,7 +2521,7 @@ namespace System.Runtime.CompilerServices
   // sequence point: }
   IL_0071:  ret
 }
-", sequencePoints: "C.Main", source: source).VerifyIL("ThrowSwitchExpressionException", @"
+", sequencePoints: "C.Main", source: source).VerifyIL("<PrivateImplementationDetails>.ThrowSwitchExpressionException", @"
 {
   // Code size        7 (0x7)
   .maxstack  1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -3557,7 +3557,7 @@ namespace System.Runtime.CompilerServices
     IL_008a:  br.s       IL_0097
     IL_008c:  ldloc.1
     IL_008d:  box        ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>""
-    IL_0092:  call       ""ThrowSwitchExpressionException(object)""
+    IL_0092:  call       ""void <PrivateImplementationDetails>.ThrowSwitchExpressionException(object)""
     IL_0097:  ldloc.0
     IL_0098:  call       ""void System.Console.WriteLine(int)""
     IL_009d:  leave.s    IL_00ac
@@ -3687,7 +3687,7 @@ namespace System.Runtime.CompilerServices
     IL_009f:  br.s       IL_00ac
     IL_00a1:  ldloc.1
     IL_00a2:  box        ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>""
-    IL_00a7:  call       ""ThrowSwitchExpressionException(object)""
+    IL_00a7:  call       ""void <PrivateImplementationDetails>.ThrowSwitchExpressionException(object)""
     IL_00ac:  ldloc.0
     IL_00ad:  call       ""void System.Console.WriteLine(int)""
     IL_00b2:  leave.s    IL_00c1

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -759,11 +759,14 @@ namespace Microsoft.CodeAnalysis.Emit
         {
             if (details.GetMethod(WellKnownMemberNames.StaticConstructorName) == null)
             {
-                details.TryAddSynthesizedMethod(CreatePrivateImplementationDetailsStaticConstructor(details, syntaxOpt, diagnostics));
+                Cci.IMethodDefinition cctor = CreatePrivateImplementationDetailsStaticConstructor(syntaxOpt, diagnostics);
+                Debug.Assert(((ISynthesizedGlobalMethodSymbol)cctor.GetInternalSymbol()).ContainingPrivateImplementationDetailsType == (object)details);
+
+                details.TryAddSynthesizedMethod(cctor);
             }
         }
 
-        protected abstract Cci.IMethodDefinition CreatePrivateImplementationDetailsStaticConstructor(PrivateImplementationDetails details, TSyntaxNode syntaxOpt, DiagnosticBag diagnostics);
+        protected abstract Cci.IMethodDefinition CreatePrivateImplementationDetailsStaticConstructor(TSyntaxNode syntaxOpt, DiagnosticBag diagnostics);
 
         #region Synthesized Members
 

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -749,8 +749,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return _disableJITOptimization.ContainsKey(methodSymbol)
         End Function
 
-        Protected NotOverridable Overrides Function CreatePrivateImplementationDetailsStaticConstructor(details As PrivateImplementationDetails, syntaxOpt As SyntaxNode, diagnostics As DiagnosticBag) As Cci.IMethodDefinition
-            Return New SynthesizedPrivateImplementationDetailsSharedConstructor(SourceModule, details, GetUntranslatedSpecialType(SpecialType.System_Void, syntaxOpt, diagnostics)).GetCciAdapter()
+        Protected NotOverridable Overrides Function CreatePrivateImplementationDetailsStaticConstructor(syntaxOpt As SyntaxNode, diagnostics As DiagnosticBag) As Cci.IMethodDefinition
+            Return New SynthesizedPrivateImplementationDetailsSharedConstructor(SourceModule, GetPrivateImplClass(syntaxOpt, diagnostics), GetUntranslatedSpecialType(SpecialType.System_Void, syntaxOpt, diagnostics)).GetCciAdapter()
         End Function
 
         Public Overrides Function GetAdditionalTopLevelTypeDefinitions(context As EmitContext) As IEnumerable(Of Cci.INamespaceTypeDefinition)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -11029,7 +11029,7 @@ public struct Buffer4
   .locals init (System.Span<int> V_0)
   IL_0000:  ldarga.s   V_0
   IL_0002:  ldc.i4.1
-  IL_0003:  call       ""InlineArrayElementRef<Buffer4, int>(ref Buffer4, int)""
+  IL_0003:  call       ""ref int <PrivateImplementationDetails>.InlineArrayElementRef<Buffer4, int>(ref Buffer4, int)""
   IL_0008:  ldind.i4
   IL_0009:  ret
 }");
@@ -11079,7 +11079,7 @@ public struct Buffer4
                 System.Span<int> V_1)
   IL_0000:  ldarga.s   V_0
   IL_0002:  ldc.i4.4
-  IL_0003:  call       ""InlineArrayAsSpan<Buffer4, int>(ref Buffer4, int)""
+  IL_0003:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer4, int>(ref Buffer4, int)""
   IL_0008:  stloc.1
   IL_0009:  ldloca.s   V_1
   IL_000b:  ldarg.1
@@ -11137,7 +11137,7 @@ public struct Buffer4
                 System.Span<int> V_5)
   IL_0000:  ldarga.s   V_0
   IL_0002:  ldc.i4.4
-  IL_0003:  call       ""InlineArrayAsSpan<Buffer4, int>(ref Buffer4, int)""
+  IL_0003:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer4, int>(ref Buffer4, int)""
   IL_0008:  stloc.s    V_5
   IL_000a:  ldloca.s   V_5
   IL_000c:  ldc.i4.1
@@ -11217,7 +11217,7 @@ public struct Buffer4
   IL_002b:  sub
   IL_002c:  stloc.s    V_7
   IL_002e:  ldc.i4.4
-  IL_002f:  call       ""InlineArrayAsSpan<Buffer4, int>(ref Buffer4, int)""
+  IL_002f:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer4, int>(ref Buffer4, int)""
   IL_0034:  stloc.s    V_9
   IL_0036:  ldloca.s   V_9
   IL_0038:  ldloc.s    V_6
@@ -11269,7 +11269,7 @@ public struct Buffer4
  .maxstack  2
  IL_0000:  ldarga.s   V_0
  IL_0002:  ldc.i4.4
- IL_0003:  call       ""InlineArrayAsSpan<Buffer4, int>(ref Buffer4, int)""
+ IL_0003:  call       ""System.Span<int> <PrivateImplementationDetails>.InlineArrayAsSpan<Buffer4, int>(ref Buffer4, int)""
  IL_0008:  ret
 }");
         }


### PR DESCRIPTION
Fixes #70738.

Since `SynthesizedGlobalMethodSymbol`s are getting used more often, more components run into them while assuming that all good methods have containing type.