### PR TITLE
Handle deeply nested collection expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -775,6 +776,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol targetType,
             BindingDiagnosticBag diagnostics)
         {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
             var syntax = node.Syntax;
             var builder = ArrayBuilder<BoundNode>.GetInstance(node.Elements.Length);
             foreach (var element in node.Elements)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70381. Instead of failing with a stackoverflow in these cases, we'll now report an ERR_InsufficientStack, cutting off binding when we can't go any further.
