### PR TITLE
Switch to using spans when doing SourceText.ContentEquals

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
         }
 
         [Fact]
-        public void ContentEqualUnaffectedByEncoding()
+        public void ContentEqualUnaffectedByEncoding1()
         {
             var encodings = new[] { null, Encoding.ASCII, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) };
 
@@ -269,6 +269,22 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
                         Assert.True(sourceText1.GetChecksum().SequenceEqual(sourceText2.GetChecksum()));
                 }
             }
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/70752")]
+        public void ContentEqualUnaffectedByEncoding2()
+        {
+            var sourceText1 = new StringText("；", Encoding.ASCII); // chinese semicolon
+            var sourceText2 = new StringText("?", Encoding.ASCII); // what a non-ascii char will map to.
+
+            var checksum1 = sourceText1.GetChecksum();
+            var checksum2 = sourceText2.GetChecksum();
+
+            Assert.True(checksum1.SequenceEqual(checksum2));
+
+            // This should return false, but is thrown off by the calls to GetChecksum above.  This is a bad bug that
+            // will be fixed once we resolve https://github.com/dotnet/roslyn/issues/70752
+            Assert.False(sourceText1.ContentEquals(sourceText2));
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
@@ -260,8 +260,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
 
                 foreach (var encoding2 in encodings)
                 {
-                    var sourceText2 = new StringText(";", encoding2); // normal ascii semicolon
+                    var sourceText2 = new StringText("?", encoding2); // what a non-ascii char will map to.
                     Assert.False(sourceText1.ContentEquals(sourceText2));
+
+                    // Even though the contents are clearly different, they have the same checksum in ascii because of
+                    // the lossy mapping.  This shows how checksums should not be used to validate content equality.
+                    if (encoding1 == Encoding.ASCII && encoding2 == Encoding.ASCII)
+                        Assert.True(sourceText1.GetChecksum().SequenceEqual(sourceText2.GetChecksum()));
                 }
             }
         }

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -1068,13 +1068,13 @@ namespace Microsoft.CodeAnalysis.Text
             var buffer1 = s_charArrayPool.Allocate();
             var buffer2 = s_charArrayPool.Allocate();
             Debug.Assert(buffer1.Length == buffer2.Length);
+            Debug.Assert(buffer1.Length == CharBufferSize);
 
-            var bufferLength = buffer1.Length;
             try
             {
-                for (int position = 0, length = this.Length; position < length; position += bufferLength)
+                for (int position = 0, length = this.Length; position < length; position += CharBufferSize)
                 {
-                    var count = Math.Min(this.Length - position, bufferLength);
+                    var count = Math.Min(this.Length - position, CharBufferSize);
                     this.CopyTo(sourceIndex: position, buffer1, destinationIndex: 0, count);
                     other.CopyTo(sourceIndex: position, buffer2, destinationIndex: 0, count);
 

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -1067,24 +1067,19 @@ namespace Microsoft.CodeAnalysis.Text
 
             var buffer1 = s_charArrayPool.Allocate();
             var buffer2 = s_charArrayPool.Allocate();
+            Debug.Assert(buffer1.Length == buffer2.Length);
+
+            var bufferLength = buffer1.Length;
             try
             {
-                int position = 0;
-                while (position < this.Length)
+                for (int position = 0, length = this.Length; position < length; position += bufferLength)
                 {
-                    int n = Math.Min(this.Length - position, buffer1.Length);
-                    this.CopyTo(position, buffer1, 0, n);
-                    other.CopyTo(position, buffer2, 0, n);
+                    var count = Math.Min(this.Length - position, bufferLength);
+                    this.CopyTo(sourceIndex: position, buffer1, destinationIndex: 0, count);
+                    other.CopyTo(sourceIndex: position, buffer2, destinationIndex: 0, count);
 
-                    for (int i = 0; i < n; i++)
-                    {
-                        if (buffer1[i] != buffer2[i])
-                        {
-                            return false;
-                        }
-                    }
-
-                    position += n;
+                    if (!buffer1.AsSpan(0, count).SequenceEqual(buffer2.AsSpan(0, count)))
+                        return false;
                 }
 
                 return true;


### PR DESCRIPTION
Runtime already optimizes these span sequence equal checks.  This will become vectorized calls that end up calling into: https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs,998a36a55f580ab1

