### PR TITLE
Remove ImmutableDictionary usage when passing telemetry property information.

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Contracts.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -44,13 +45,13 @@ public sealed class TelemetryReporterTests : AbstractLanguageServerHostTests
     {
         var service = await CreateReporterAsync();
         service.LogBlockStart(GetEventName(nameof(TestBlockLogging)), kind: 0, blockId: 0);
-        service.LogBlockEnd(blockId: 0, ImmutableDictionary<string, object?>.Empty, CancellationToken.None);
+        service.LogBlockEnd(blockId: 0, ReadOnlyMemory<Property>.Empty, CancellationToken.None);
     }
 
     [Fact]
     public async Task TestLog()
     {
         var service = await CreateReporterAsync();
-        service.Log(GetEventName(nameof(TestLog)), ImmutableDictionary<string, object?>.Empty);
+        service.Log(GetEventName(nameof(TestLog)), ReadOnlyMemory<Property>.Empty);
     }
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
@@ -45,13 +45,13 @@ public sealed class TelemetryReporterTests : AbstractLanguageServerHostTests
     {
         var service = await CreateReporterAsync();
         service.LogBlockStart(GetEventName(nameof(TestBlockLogging)), kind: 0, blockId: 0);
-        service.LogBlockEnd(blockId: 0, ReadOnlyMemory<Property>.Empty, CancellationToken.None);
+        service.LogBlockEnd(blockId: 0, [], CancellationToken.None);
     }
 
     [Fact]
     public async Task TestLog()
     {
         var service = await CreateReporterAsync();
-        service.Log(GetEventName(nameof(TestLog)), ReadOnlyMemory<Property>.Empty);
+        service.Log(GetEventName(nameof(TestLog)), []);
     }
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/ITelemetryReporter.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/ITelemetryReporter.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.CodeAnalysis.Contracts.Telemetry;
 
 internal interface ITelemetryReporter : IDisposable
 {
     void InitializeSession(string telemetryLevel, string? sessionId, bool isDefaultSession);
-    void Log(string name, ImmutableDictionary<string, object?> properties);
+    void Log(string name, ReadOnlyMemory<Property> properties);
     void LogBlockStart(string eventName, int kind, int blockId);
-    void LogBlockEnd(int blockId, ImmutableDictionary<string, object?> properties, CancellationToken cancellationToken);
+    void LogBlockEnd(int blockId, ReadOnlyMemory<Property> properties, CancellationToken cancellationToken);
     void ReportFault(string eventName, string description, int logLevel, bool forceDump, int processId, Exception exception);
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/ITelemetryReporter.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/ITelemetryReporter.cs
@@ -7,8 +7,8 @@ namespace Microsoft.CodeAnalysis.Contracts.Telemetry;
 internal interface ITelemetryReporter : IDisposable
 {
     void InitializeSession(string telemetryLevel, string? sessionId, bool isDefaultSession);
-    void Log(string name, List<Property> properties);
+    void Log(string name, List<KeyValuePair<string, object?>> properties);
     void LogBlockStart(string eventName, int kind, int blockId);
-    void LogBlockEnd(int blockId, List<Property> properties, CancellationToken cancellationToken);
+    void LogBlockEnd(int blockId, List<KeyValuePair<string, object?>> properties, CancellationToken cancellationToken);
     void ReportFault(string eventName, string description, int logLevel, bool forceDump, int processId, Exception exception);
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/ITelemetryReporter.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/ITelemetryReporter.cs
@@ -7,8 +7,8 @@ namespace Microsoft.CodeAnalysis.Contracts.Telemetry;
 internal interface ITelemetryReporter : IDisposable
 {
     void InitializeSession(string telemetryLevel, string? sessionId, bool isDefaultSession);
-    void Log(string name, ReadOnlyMemory<Property> properties);
+    void Log(string name, List<Property> properties);
     void LogBlockStart(string eventName, int kind, int blockId);
-    void LogBlockEnd(int blockId, ReadOnlyMemory<Property> properties, CancellationToken cancellationToken);
+    void LogBlockEnd(int blockId, List<Property> properties, CancellationToken cancellationToken);
     void ReportFault(string eventName, string description, int logLevel, bool forceDump, int processId, Exception exception);
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/Property.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/Property.cs
@@ -1,7 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-namespace Microsoft.CodeAnalysis.Contracts.Telemetry;
-
-internal readonly record struct Property(string Name, object? Value);

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/Property.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/Property.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Contracts.Telemetry;
+
+internal readonly record struct Property(string Name, object? Value);

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/RoslynLogger.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/RoslynLogger.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Logging
 
         private readonly ConcurrentDictionary<int, object> _pendingScopes = new(concurrencyLevel: 2, capacity: 10);
         private static ITelemetryReporter? _telemetryReporter;
-        private static readonly ObjectPool<List<Property>> s_propertyPool = new(() => new());
+        private static readonly ObjectPool<List<KeyValuePair<string, object?>>> s_propertyPool = new(() => new());
 
         private RoslynLogger()
         {
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Logging
                                         _ => LogType.Trace
                                     };
 
-        private static void AddProperties(List<Property> properties, FunctionId id, LogMessage logMessage, int? delta)
+        private static void AddProperties(List<KeyValuePair<string, object?>> properties, FunctionId id, LogMessage logMessage, int? delta)
         {
             if (logMessage is KeyValueLogMessage kvLogMessage)
             {

--- a/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLog.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLog.cs
@@ -64,10 +64,10 @@ namespace Microsoft.CodeAnalysis.Telemetry
             if (!IsEnabled)
                 return;
 
-            if (!logMessage.TryGetValue(TelemetryLogging.KeyName, out var nameValue) || nameValue is not string metricName)
+            if (!logMessage.Properties.TryGetValue(TelemetryLogging.KeyName, out var nameValue) || nameValue is not string metricName)
                 throw ExceptionUtilities.Unreachable();
 
-            if (!logMessage.TryGetValue(TelemetryLogging.KeyValue, out var valueValue) || valueValue is not int value)
+            if (!logMessage.Properties.TryGetValue(TelemetryLogging.KeyValue, out var valueValue) || valueValue is not int value)
                 throw ExceptionUtilities.Unreachable();
 
             var histogram = ImmutableInterlocked.GetOrAdd(ref _histograms, metricName, metricName => _meter.CreateHistogram<int>(metricName, _histogramConfiguration));
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Telemetry
             if (!IsEnabled)
                 return null;
 
-            if (!logMessage.TryGetValue(TelemetryLogging.KeyName, out var nameValue) || nameValue is not string)
+            if (!logMessage.Properties.TryGetValue(TelemetryLogging.KeyName, out var nameValue) || nameValue is not string)
                 throw ExceptionUtilities.Unreachable();
 
             return new TimedTelemetryLogBlock(logMessage, minThresholdMs, telemetryLog: this);

--- a/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
+++ b/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
@@ -48,7 +48,7 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
         _telemetrySession = session;
     }
 
-    public void Log(string name, List<Property> properties)
+    public void Log(string name, List<KeyValuePair<string, object?>> properties)
     {
         Debug.Assert(_telemetrySession != null);
 
@@ -69,7 +69,7 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
         };
     }
 
-    public void LogBlockEnd(int blockId, List<Property> properties, CancellationToken cancellationToken)
+    public void LogBlockEnd(int blockId, List<KeyValuePair<string, object?>> properties, CancellationToken cancellationToken)
     {
         var found = _pendingScopes.TryRemove(blockId, out var scope);
         Debug.Assert(found);
@@ -183,11 +183,11 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
             _ => throw new InvalidCastException($"Unexpected value for scope: {scope}")
         };
 
-    private static void SetProperties(TelemetryEvent telemetryEvent, List<Property> properties)
+    private static void SetProperties(TelemetryEvent telemetryEvent, List<KeyValuePair<string, object?>> properties)
     {
         foreach (var property in properties)
         {
-            telemetryEvent.Properties.Add(property.Name, property.Value);
+            telemetryEvent.Properties.Add(property);
         }
     }
 }

--- a/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
+++ b/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.Text;
@@ -49,7 +48,7 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
         _telemetrySession = session;
     }
 
-    public void Log(string name, ImmutableDictionary<string, object?> properties)
+    public void Log(string name, ReadOnlyMemory<Property> properties)
     {
         Debug.Assert(_telemetrySession != null);
 
@@ -70,7 +69,7 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
         };
     }
 
-    public void LogBlockEnd(int blockId, ImmutableDictionary<string, object?> properties, CancellationToken cancellationToken)
+    public void LogBlockEnd(int blockId, ReadOnlyMemory<Property> properties, CancellationToken cancellationToken)
     {
         var found = _pendingScopes.TryRemove(blockId, out var scope);
         Debug.Assert(found);
@@ -184,11 +183,11 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
             _ => throw new InvalidCastException($"Unexpected value for scope: {scope}")
         };
 
-    private static void SetProperties(TelemetryEvent telemetryEvent, ImmutableDictionary<string, object?> properties)
+    private static void SetProperties(TelemetryEvent telemetryEvent, ReadOnlyMemory<Property> properties)
     {
-        foreach (var (name, value) in properties)
+        foreach (var property in properties.Span)
         {
-            telemetryEvent.Properties.Add(name, value);
+            telemetryEvent.Properties.Add(property.Name, property.Value);
         }
     }
 }

--- a/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
+++ b/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
@@ -48,7 +48,7 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
         _telemetrySession = session;
     }
 
-    public void Log(string name, ReadOnlyMemory<Property> properties)
+    public void Log(string name, List<Property> properties)
     {
         Debug.Assert(_telemetrySession != null);
 
@@ -69,7 +69,7 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
         };
     }
 
-    public void LogBlockEnd(int blockId, ReadOnlyMemory<Property> properties, CancellationToken cancellationToken)
+    public void LogBlockEnd(int blockId, List<Property> properties, CancellationToken cancellationToken)
     {
         var found = _pendingScopes.TryRemove(blockId, out var scope);
         Debug.Assert(found);
@@ -183,9 +183,9 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
             _ => throw new InvalidCastException($"Unexpected value for scope: {scope}")
         };
 
-    private static void SetProperties(TelemetryEvent telemetryEvent, ReadOnlyMemory<Property> properties)
+    private static void SetProperties(TelemetryEvent telemetryEvent, List<Property> properties)
     {
-        foreach (var property in properties.Span)
+        foreach (var property in properties)
         {
             telemetryEvent.Properties.Add(property.Name, property.Value);
         }

--- a/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
+++ b/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
@@ -72,19 +72,13 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             }
         }
 
-        public IEnumerable<KeyValuePair<string, object?>> Properties
+        public IReadOnlyDictionary<string, object?> Properties
         {
             get
             {
                 EnsureMap();
                 return _lazyMap;
             }
-        }
-
-        public bool TryGetValue(string key, out object? value)
-        {
-            EnsureMap();
-            return _lazyMap.TryGetValue(key, out value);
         }
 
         protected override string CreateMessage()


### PR DESCRIPTION
This should slightly reduce the allocation cost when firing telemetry in vscode.

Pulled out of a larger change I have on my machine for adding telemetry to CLaSP message handling.