### PR TITLE
Fix MSBuildWorkspace test condition

### DIFF
--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
@@ -3257,7 +3257,7 @@ class C { }";
         }
 
         // On .NET Core this tests fails with "CodePage Not Found"
-        [ConditionalFact(typeof(VisualStudioMSBuildInstalled), typeof(CoreClrOnly))]
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled), typeof(DesktopClrOnly))]
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991528")]
         public async Task MSBuildProjectShouldHandleCodePageProperty()
         {


### PR DESCRIPTION
If this fails on .NET Core, it should be conditioned to desktop only. Oops.

Fixes https://github.com/dotnet/roslyn/issues/70809

This isn't caught in CI since we've got a TFM filter on the MSBuildWorkspace integration tests I haven't removed yet. Will do that in [a separate PR](https://github.com/dotnet/roslyn/pull/70849).