### PR TITLE
Automatically detect missing NuGet packages and restore

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -223,6 +223,7 @@
     <RoslynBuildUtilVersion>0.9.8-beta</RoslynBuildUtilVersion>
     <RoslynDependenciesOptimizationDataVersion>3.0.0-beta2-19053-01</RoslynDependenciesOptimizationDataVersion>
     <RoslynDiagnosticsAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</RoslynDiagnosticsAnalyzersVersion>
+    <NuGetProjectModelVersion>6.8.0-rc.112</NuGetProjectModelVersion>
     <RoslynToolsVSIXExpInstallerVersion>1.1.0-beta3.22474.1</RoslynToolsVSIXExpInstallerVersion>
     <RoslynMicrosoftVisualStudioExtensionManagerVersion>0.0.4</RoslynMicrosoftVisualStudioExtensionManagerVersion>
     <SourceBrowserVersion>1.0.21</SourceBrowserVersion>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -77,7 +77,7 @@ internal sealed class LoadedProject : IDisposable
         _projectSystemProject.RemoveFromWorkspace();
     }
 
-    public async ValueTask<(ImmutableArray<CommandLineReference>, OutputKind)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, ILogger logger)
+    public async ValueTask<(ImmutableArray<CommandLineReference>, OutputKind, bool)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, ILogger logger)
     {
         if (_mostRecentFileInfo != null)
         {
@@ -185,11 +185,13 @@ internal sealed class LoadedProject : IDisposable
 
         WatchProjectAssetsFile(newProjectInfo, _fileChangeContext);
 
+        var hasUnresolvedDependencies = ProjectDependencyHelper.HasUnresolvedDependencies(newProjectInfo, _mostRecentFileInfo, logger);
+
         _mostRecentFileInfo = newProjectInfo;
 
         Contract.ThrowIfNull(_projectSystemProject.CompilationOptions, "Compilation options cannot be null for C#/VB project");
         var outputKind = _projectSystemProject.CompilationOptions.OutputKind;
-        return (metadataReferences, outputKind);
+        return (metadataReferences, outputKind, hasUnresolvedDependencies);
 
         // logMessage should be a string with two placeholders; the first is the project name, the second is the number of items.
         void UpdateProjectSystemProjectCollection<T>(IEnumerable<T> loadedCollection, IEnumerable<T>? oldLoadedCollection, IEqualityComparer<T> comparer, Action<T> addItem, Action<T> removeItem, string logMessage)

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Runtime.Serialization;
+using Microsoft.CodeAnalysis.LanguageServer.LanguageServer;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.Extensions.Logging;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+internal static class ProjectDependencyHelper
+{
+    private const string UnresolvedProjectDependenciesName = "workspace/_roslyn_unresolvedProjectDependencies";
+
+    internal static bool HasUnresolvedDependencies(ProjectFileInfo projectFileInfo, ILogger logger)
+    {
+        var projectAssetsPath = projectFileInfo.ProjectAssetsFilePath;
+        if (!File.Exists(projectAssetsPath))
+        {
+            // If the file doesn't exist then all package references are unresolved.
+            logger.LogWarning(string.Format(LanguageServerResources.Project_0_has_unresolved_dependencies, projectFileInfo.FilePath));
+            return true;
+        }
+
+        if (projectFileInfo.PackageReferences.IsEmpty)
+        {
+            // If there are no package references then there are no unresolved dependencies.
+            return false;
+        }
+
+        // Iterate the project's package references and check if there is a package with the same name
+        // and acceptable version in the lock file.
+
+        var lockFileFormat = new LockFileFormat();
+        var lockFile = lockFileFormat.Read(projectAssetsPath);
+        var projectAssetsMap = CreateProjectAssetsMap(lockFile);
+
+        using var _ = PooledHashSet<PackageReference>.GetInstance(out var unresolved);
+
+        foreach (var reference in projectFileInfo.PackageReferences)
+        {
+            if (!projectAssetsMap.TryGetValue(reference.Name, out var projectAssetsVersions))
+            {
+                // If the package name isn't in the lock file then it's unresolved.
+                unresolved.Add(reference);
+                continue;
+            }
+
+            var requestedVersionRange = VersionRange.TryParse(reference.VersionRange, out var versionRange)
+                ? versionRange
+                : VersionRange.All;
+
+            var projectAssetsHasVersion = projectAssetsVersions.Any(projectAssetsVersion => SatisfiesVersion(requestedVersionRange, projectAssetsVersion));
+            if (!projectAssetsHasVersion)
+            {
+                // If the package name is in the lock file but none of the versions satisfy the requested version range then it's unresolved.
+                unresolved.Add(reference);
+            }
+        }
+
+        if (unresolved.Any())
+        {
+            var message = string.Format(LanguageServerResources.Project_0_has_unresolved_dependencies, projectFileInfo.FilePath)
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, unresolved.Select(r => $"{r.Name}-{r.VersionRange}"));
+            logger.LogWarning(message);
+            return true;
+        }
+
+        return false;
+
+        static ImmutableDictionary<string, ImmutableArray<NuGetVersion>> CreateProjectAssetsMap(LockFile lockFile)
+        {
+            // Create a map of package names to all versions in the lock file.
+            var map = lockFile.Libraries
+                .GroupBy(l => l.Name, l => l.Version, StringComparer.OrdinalIgnoreCase)
+                .ToImmutableDictionary(g => g.Key, g => g.ToImmutableArray(), StringComparer.OrdinalIgnoreCase);
+
+            return map;
+        }
+
+        static bool SatisfiesVersion(VersionRange requestedVersionRange, NuGetVersion projectAssetsVersion)
+        {
+            return requestedVersionRange.Satisfies(projectAssetsVersion);
+        }
+    }
+
+    internal static async Task RestoreProjectsAsync(ImmutableHashSet<string> projectPaths, CancellationToken cancellationToken)
+    {
+        if (projectPaths.IsEmpty)
+        {
+            return;
+        }
+
+        Contract.ThrowIfNull(LanguageServerHost.Instance, "We don't have an LSP channel yet to send this request through.");
+        var languageServerManager = LanguageServerHost.Instance.GetRequiredLspService<IClientLanguageServerManager>();
+        var unresolvedParams = new UnresolvedDependenciesParams(projectPaths.ToArray());
+        await languageServerManager.SendRequestAsync(UnresolvedProjectDependenciesName, unresolvedParams, cancellationToken);
+    }
+
+    [DataContract]
+    private record UnresolvedDependenciesParams(
+        [property: DataMember(Name = "projectFilePaths")] string[] ProjectFilePaths);
+}

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
@@ -26,7 +26,7 @@ internal class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory, Server
     /// so that we are able to compare data accurately.
     /// See https://github.com/OmniSharp/omnisharp-roslyn/blob/b2e64c6006beed49460f063117793f42ab2a8a5c/src/OmniSharp.MSBuild/ProjectLoadListener.cs#L36
     /// </summary>
-    public async Task ReportProjectLoadTelemetryAsync(Dictionary<ProjectFileInfo, (ImmutableArray<CommandLineReference> MetadataReferences, OutputKind OutputKind)> projectFileInfos, ProjectToLoad projectToLoad, CancellationToken cancellationToken)
+    public async Task ReportProjectLoadTelemetryAsync(Dictionary<ProjectFileInfo, (ImmutableArray<CommandLineReference> MetadataReferences, OutputKind OutputKind, bool HasUnresolvedDependencies)> projectFileInfos, ProjectToLoad projectToLoad, CancellationToken cancellationToken)
     {
         try
         {
@@ -44,7 +44,7 @@ internal class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory, Server
             // but only the data from one of the sets of possible outputkinds / references / content / etc.
             var firstInfo = projectFileInfos.First();
             var projectFileInfo = firstInfo.Key;
-            var (metadataReferences, outputKind) = firstInfo.Value;
+            var (metadataReferences, outputKind, _) = firstInfo.Value;
 
             // Matches O# behavior to not report this event if no references found.
             if (!metadataReferences.Any())

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreHandler.cs
@@ -85,9 +85,9 @@ internal sealed class RestoreHandler(DotnetCliHelper dotnetCliHelper) : ILspServ
 
     private static ImmutableArray<string> GetRestorePaths(RestoreParams request, Solution solution, RequestContext context)
     {
-        if (request.ProjectFilePath != null)
+        if (request.ProjectFilePaths.Any())
         {
-            return ImmutableArray.Create(request.ProjectFilePath);
+            return request.ProjectFilePaths.ToImmutableArray();
         }
 
         // No file paths were specified - this means we should restore all projects in the solution.

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreParams.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreParams.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 [DataContract]
 internal sealed record RestoreParams(
+    // An empty set of project file paths means restore all projects in the workspace.
     [property: DataMember(Name = "projectFilePaths")] string[] ProjectFilePaths
 ) : IPartialResultParams<RestorePartialResult>
 {

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreParams.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreParams.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 [DataContract]
 internal sealed record RestoreParams(
-    [property: DataMember(Name = "projectFilePath"), JsonProperty(NullValueHandling = NullValueHandling.Ignore)] string? ProjectFilePath
+    [property: DataMember(Name = "projectFilePaths")] string[] ProjectFilePaths
 ) : IPartialResultParams<RestorePartialResult>
 {
     [DataMember(Name = Methods.PartialResultTokenName)]

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -240,4 +240,7 @@
   <data name="Using_runsettings_file_at_0" xml:space="preserve">
     <value>Using .runsettings file at {0}</value>
   </data>
+  <data name="Project_0_has_unresolved_dependencies" xml:space="preserve">
+    <value>Project {0} has unresolved dependencies</value>
+  </data>
 </root>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -79,7 +79,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="$(MicrosoftVisualStudioLanguageServerProtocolVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="$(MicrosoftAspNetCoreRazorExternalAccessRoslynWorkspaceVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -79,6 +79,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="$(MicrosoftVisualStudioLanguageServerProtocolVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="$(MicrosoftAspNetCoreRazorExternalAccessRoslynWorkspaceVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="new">Passed!</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_has_unresolved_dependencies">
+        <source>Project {0} has unresolved dependencies</source>
+        <target state="new">Project {0} has unresolved dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Project_0_loaded_by_CSharp_Dev_Kit">
         <source>Project {0} loaded by C# Dev Kit</source>
         <target state="new">Project {0} loaded by C# Dev Kit</target>

--- a/src/Features/LanguageServer/Protocol/Features/Options/LanguageServerProjectSystemOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/LanguageServerProjectSystemOptionsStorage.cs
@@ -14,5 +14,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace
         /// A folder to log binlogs to when running design-time builds.
         /// </summary>
         public static readonly Option2<string?> BinaryLogPath = new Option2<string?>("dotnet_binary_log_path", defaultValue: null, s_optionGroup);
+
+        /// <summary>
+        /// Whether or not automatic nuget restore is enabled.
+        /// </summary>
+        public static readonly Option2<bool> EnableAutomaticRestore = new Option2<bool>("dotnet_enable_automatic_restore", defaultValue: true, s_optionGroup);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
             LspOptionsStorage.LspEnableReferencesCodeLens,
             LspOptionsStorage.LspEnableTestsCodeLens,
             // Project system
-            LanguageServerProjectSystemOptionsStorage.BinaryLogPath);
+            LanguageServerProjectSystemOptionsStorage.BinaryLogPath,
+            LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore);
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -145,6 +145,7 @@ public class A { }";
                 "code_lens.dotnet_enable_references_code_lens",
                 "code_lens.dotnet_enable_tests_code_lens",
                 "projects.dotnet_binary_log_path",
+                "projects.dotnet_enable_automatic_restore"
             }.OrderBy(name => name);
 
             Assert.Equal(expectedNames, actualNames);

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -226,6 +226,7 @@ public class VisualStudioOptionStorageTests
             "dotnet_style_operator_placement_when_wrapping",                                // Doesn't have VS UI. TODO: https://github.com/dotnet/roslyn/issues/66062
             "dotnet_style_prefer_foreach_explicit_cast_in_source",                          // For a small customer segment, doesn't warrant VS UI.
             "dotnet_binary_log_path",                                                       // VSCode only option for the VS Code project system; does not apply to VS
+            "dotnet_enable_automatic_restore",                                              // VSCode only option for the VS Code project system; does not apply to VS
             "dotnet_lsp_using_devkit",                                                      // VSCode internal only option.  Does not need any UI.
             "dotnet_enable_references_code_lens",                                           // VSCode only option.  Does not apply to VS.
             "dotnet_enable_tests_code_lens",                                                // VSCode only option.  Does not apply to VS.

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/ItemNames.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/ItemNames.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string EditorConfigFiles = nameof(EditorConfigFiles);
         public const string Import = nameof(Import);
         public const string ProjectReference = nameof(ProjectReference);
+        public const string PackageReference = nameof(PackageReference);
         public const string ProjectCapability = nameof(ProjectCapability);
         public const string Reference = nameof(Reference);
         public const string ReferencePath = nameof(ReferencePath);

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/MetadataNames.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/MetadataNames.cs
@@ -12,5 +12,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string Link = nameof(Link);
         public const string Name = nameof(Name);
         public const string ReferenceOutputAssembly = nameof(ReferenceOutputAssembly);
+        public const string Version = nameof(Version);
     }
 }

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/Extensions.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/Extensions.cs
@@ -35,6 +35,27 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 .Where(i => i.ReferenceOutputAssemblyIsTrue())
                 .Select(CreateProjectFileReference);
 
+        public static ImmutableArray<PackageReference> GetPackageReferences(this MSB.Execution.ProjectInstance executedProject)
+        {
+            var packageReferenceItems = executedProject.GetItems(ItemNames.PackageReference);
+            if (packageReferenceItems == null)
+            {
+                return ImmutableArray<PackageReference>.Empty;
+            }
+
+            using var _ = PooledHashSet<PackageReference>.GetInstance(out var references);
+
+            foreach (var item in packageReferenceItems)
+            {
+                var name = item.EvaluatedInclude;
+                var versionRangeValue = item.GetMetadataValue(MetadataNames.Version);
+                var packageReference = new PackageReference(name, versionRangeValue);
+                references.Add(packageReference);
+            }
+
+            return references.ToImmutableArray();
+        }
+
         /// <summary>
         /// Create a <see cref="ProjectFileReference"/> from a ProjectReference node in the MSBuild file.
         /// </summary>

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/PackageReference.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/PackageReference.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.MSBuild;
+
+[DataContract]
+internal record PackageReference(
+    [property: DataMember(Order = 0)] string Name,
+    [property: DataMember(Order = 1)] string VersionRange
+);

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -170,6 +170,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 .Select(MakeNonSourceFileDocumentFileInfo)
                 .ToImmutableArray();
 
+            var packageReferences = project.GetPackageReferences();
+
             var projectCapabilities = project.GetItems(ItemNames.ProjectCapability).SelectAsArray(item => item.ToString());
             var contentFileInfo = GetContentFiles(project);
             var isSdkStyle = IsSdkStyleProject(loadedProject);
@@ -189,6 +191,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 additionalDocs,
                 analyzerConfigDocs,
                 project.GetProjectReferences().ToImmutableArray(),
+                packageReferences,
                 projectCapabilities,
                 contentFileInfo,
                 isSdkStyle);

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -133,6 +133,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         [DataMember(Order = 17)]
         public string? ProjectAssetsFilePath { get; }
 
+        /// <summary>
+        /// Any package references defined on the project.
+        /// </summary>
+        [DataMember(Order = 18)]
+        public ImmutableArray<PackageReference> PackageReferences { get; }
+
         public override string ToString()
             => RoslynString.IsNullOrWhiteSpace(TargetFramework)
                 ? FilePath ?? string.Empty
@@ -154,6 +160,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             ImmutableArray<DocumentFileInfo> additionalDocuments,
             ImmutableArray<DocumentFileInfo> analyzerConfigDocuments,
             ImmutableArray<ProjectFileReference> projectReferences,
+            ImmutableArray<PackageReference> packageReferences,
             ImmutableArray<string> projectCapabilities,
             ImmutableArray<string> contentFilePaths,
             bool isSdkStyle)
@@ -175,6 +182,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             this.AdditionalDocuments = additionalDocuments;
             this.AnalyzerConfigDocuments = analyzerConfigDocuments;
             this.ProjectReferences = projectReferences;
+            this.PackageReferences = packageReferences;
             this.ProjectCapabilities = projectCapabilities;
             this.ContentFilePaths = contentFilePaths;
             this.IsSdkStyle = isSdkStyle;
@@ -195,6 +203,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             ImmutableArray<DocumentFileInfo> additionalDocuments,
             ImmutableArray<DocumentFileInfo> analyzerConfigDocuments,
             ImmutableArray<ProjectFileReference> projectReferences,
+            ImmutableArray<PackageReference> packageReferences,
             ImmutableArray<string> projectCapabilities,
             ImmutableArray<string> contentFilePaths,
             bool isSdkStyle)
@@ -214,6 +223,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 additionalDocuments,
                 analyzerConfigDocuments,
                 projectReferences,
+                packageReferences,
                 projectCapabilities,
                 contentFilePaths,
                 isSdkStyle);
@@ -235,6 +245,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 additionalDocuments: ImmutableArray<DocumentFileInfo>.Empty,
                 analyzerConfigDocuments: ImmutableArray<DocumentFileInfo>.Empty,
                 projectReferences: ImmutableArray<ProjectFileReference>.Empty,
+                packageReferences: ImmutableArray<PackageReference>.Empty,
                 projectCapabilities: ImmutableArray<string>.Empty,
                 contentFilePaths: ImmutableArray<string>.Empty,
                 isSdkStyle: false);


### PR DESCRIPTION
Implements basic support for automatic nuget restore in the C# standalone project system.  This is done by checking the project.assets.json to ensure all project dependencies are present.

Client PR: https://github.com/dotnet/vscode-csharp/pull/6676

Looks like:
![automatic_nuget_restore](https://github.com/dotnet/roslyn/assets/5749229/b20bc78a-9d88-4a4c-8790-18e651593982)
