### PR TITLE
Fix 'make struct member readonly' with init accessors.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -178,7 +178,8 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
             return default;
         }
 
-        // An init accessor in a readonly property is already readonly.  No need to analyze it.
+        // An init accessor in a readonly property is already readonly.  No need to analyze it.  Note: there is no way
+        // to tell this symbolically.  We have to check to the syntax here.
         if (owningMethod.IsInitOnly &&
             owningMethod.AssociatedSymbol is IPropertySymbol { DeclaringSyntaxReferences: [var reference, ..] } &&
             reference.GetSyntax(cancellationToken) is PropertyDeclarationSyntax property &&

--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -103,6 +103,7 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
             {
                 var cancellationToken = context.CancellationToken;
 
+                // No need to lock the dictionary here.  Processing only is called once, after all mutation work is done.
                 foreach (var (method, diagnostic) in methodToDiagnostic)
                 {
                     if (method.IsInitOnly && method.AssociatedSymbol is IPropertySymbol owningProperty)

--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -154,14 +154,15 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
                 return;
         }
 
+        // Called concurrently.  Make sure we write to this dictionary safely.
         lock (methodToDiagnostic)
         {
             methodToDiagnostic[owningMethod] = DiagnosticHelper.Create(
-            Descriptor,
-            location,
-            severity,
-            additionalLocations: ImmutableArray.Create(additionalLocation),
-            properties: null);
+                Descriptor,
+                location,
+                severity,
+                additionalLocations: ImmutableArray.Create(additionalLocation),
+                properties: null);
         }
     }
 

--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -11,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -18,7 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeStructMemberReadOnly;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
-    : AbstractBuiltInCodeStyleDiagnosticAnalyzer(IDEDiagnosticIds.MakeStructMemberReadOnlyDiagnosticId,
+    : AbstractBuiltInCodeStyleDiagnosticAnalyzer(
+        IDEDiagnosticIds.MakeStructMemberReadOnlyDiagnosticId,
         EnforceOnBuildValues.MakeStructMemberReadOnly,
         CSharpCodeStyleOptions.PreferReadOnlyStructMember,
         new LocalizableResourceString(nameof(CSharpAnalyzersResources.Make_member_readonly), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
@@ -39,8 +44,13 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
                 if (!ShouldAnalyze(context, out var option))
                     return;
 
+                var methodToDiagnostic = PooledDictionary<IMethodSymbol, Diagnostic>.GetInstance();
+
                 context.RegisterOperationBlockAction(
-                    context => AnalyzeBlock(context, option.Notification.Severity));
+                    context => AnalyzeBlock(context, option.Notification.Severity, methodToDiagnostic));
+
+                context.RegisterSymbolEndAction(
+                    context => ProcessResults(context, option.Notification.Severity, methodToDiagnostic));
             }, SymbolKind.NamedType);
 
             static bool ShouldAnalyze(SymbolStartAnalysisContext context, [NotNullWhen(true)] out CodeStyleOption2<bool>? option)
@@ -88,11 +98,49 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
 
                 return true;
             }
+
+            void ProcessResults(
+                SymbolAnalysisContext context, ReportDiagnostic severity, PooledDictionary<IMethodSymbol, Diagnostic> methodToDiagnostic)
+            {
+                var cancellationToken = context.CancellationToken;
+
+                // Group accessors to their corresponding property.  If all are going to be marked readonly, then mark
+                // the property instead.
+                foreach (var group in methodToDiagnostic.GroupBy(kvp => kvp.Key.AssociatedSymbol as IPropertySymbol))
+                {
+                    var owningProperty = group.Key;
+                    if (owningProperty is not null)
+                    {
+                        var getMethodIsReadOnly = owningProperty.GetMethod is null || owningProperty.GetMethod.IsReadOnly || group.Contains(kvp => owningProperty.GetMethod.Equals(kvp.Key));
+                        var setMethodIsReadOnly = owningProperty.SetMethod is null || owningProperty.SetMethod.IsReadOnly || group.Contains(kvp => owningProperty.SetMethod.Equals(kvp.Key));
+
+                        if (getMethodIsReadOnly && setMethodIsReadOnly &&
+                            owningProperty.DeclaringSyntaxReferences is [var reference, ..] &&
+                            reference.GetSyntax(cancellationToken) is PropertyDeclarationSyntax propertyDeclaration)
+                        {
+                            context.ReportDiagnostic(DiagnosticHelper.Create(
+                                Descriptor,
+                                propertyDeclaration.Identifier.GetLocation(),
+                                severity,
+                                additionalLocations: ImmutableArray.Create(propertyDeclaration.GetLocation()),
+                                properties: null));
+                            continue;
+                        }
+                    }
+
+                    // Just report for each method distinctly.
+                    foreach (var (_, diagnostic) in group)
+                        context.ReportDiagnostic(diagnostic);
+                }
+
+                methodToDiagnostic.Free();
+            }
         });
 
     private void AnalyzeBlock(
         OperationBlockAnalysisContext context,
-        ReportDiagnostic severity)
+        ReportDiagnostic severity,
+        Dictionary<IMethodSymbol, Diagnostic> methodToDiagnostic)
     {
         var cancellationToken = context.CancellationToken;
 
@@ -115,12 +163,15 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
                 return;
         }
 
-        context.ReportDiagnostic(DiagnosticHelper.Create(
-            Descriptor,
-            location,
-            severity,
-            additionalLocations: ImmutableArray.Create(additionalLocation),
-            properties: null));
+        lock (methodToDiagnostic)
+        {
+            methodToDiagnostic[owningMethod] = DiagnosticHelper.Create(
+                Descriptor,
+                location,
+                severity,
+                additionalLocations: ImmutableArray.Create(additionalLocation),
+                properties: null);
+        }
     }
 
     private static (Location? location, Location? additionalLocation) GetDiagnosticLocation(
@@ -133,8 +184,12 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
             || owningMethod.IsStatic
             || owningMethod.IsImplicitlyDeclared)
         {
-            return (null, null);
+            return default;
         }
+
+        // An init accessor in a readonly property is already readonly.  No need to analyze it.
+        if (owningMethod.IsInitOnly && owningMethod.AssociatedSymbol is IPropertySymbol { IsReadOnly: true })
+            return default;
 
         var methodReference = owningMethod.DeclaringSyntaxReferences[0];
         var declaration = methodReference.GetSyntax(cancellationToken);
@@ -153,7 +208,7 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
             declaration = declaration.GetRequiredParent();
 
         if (nameToken is null)
-            return (null, null);
+            return default;
 
         return (nameToken.Value.GetLocation(), declaration.GetLocation());
     }

--- a/src/Analyzers/CSharp/CodeFixes/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyCodeFixProvider.cs
@@ -20,14 +20,10 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.CSharp.MakeStructMemberReadOnly;
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.MakeStructMemberReadOnly), Shared]
-internal sealed class CSharpMakeStructMemberReadOnlyCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpMakeStructMemberReadOnlyCodeFixProvider() : SyntaxEditorBasedCodeFixProvider
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpMakeStructMemberReadOnlyCodeFixProvider()
-    {
-    }
-
     public override ImmutableArray<string> FixableDiagnosticIds { get; } =
         ImmutableArray.Create(IDEDiagnosticIds.MakeStructMemberReadOnlyDiagnosticId);
 

--- a/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
@@ -2205,4 +2205,44 @@ public sealed class MakeStructMemberReadOnlyTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70864")]
+    public async Task TestInitAccessor4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                public record struct TypeMapCapacity
+                {
+                    private readonly int _MaxSize;
+
+                    public int? MaxSize
+                    {
+                        [|init|]
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                public record struct TypeMapCapacity
+                {
+                    private readonly int _MaxSize;
+
+                    public readonly int? MaxSize
+                    {
+                        init
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
@@ -2106,4 +2106,103 @@ public sealed class MakeStructMemberReadOnlyTests
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70864")]
+    public async Task TestInitAccessor1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                public record struct TypeMapCapacity
+                {
+                    private readonly int _MaxSize;
+
+                    public readonly int? MaxSize
+                    {
+                        get => _MaxSize;
+
+                        // missing, since the property is already readonly
+                        init
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70864")]
+    public async Task TestInitAccessor2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                public record struct TypeMapCapacity
+                {
+                    private readonly int _MaxSize;
+
+                    public int? MaxSize
+                    {
+                        readonly get => _MaxSize;
+
+                        [|init|]
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                public record struct TypeMapCapacity
+                {
+                    private readonly int _MaxSize;
+
+                    public readonly int? MaxSize
+                    {
+                        get => _MaxSize;
+
+                        init
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70864")]
+    public async Task TestInitAccessor3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                public record struct TypeMapCapacity
+                {
+                    private int _MaxSize;
+
+                    public int? MaxSize
+                    {
+                        get => _MaxSize++;
+
+                        init
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70864

Handle the special rules here.