### PR TITLE
Improve formatting when converting to a collection expression

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
@@ -6,12 +6,15 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UseCollectionInitializer;
 using Roslyn.Utilities;
 
@@ -88,7 +91,8 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
             return;
         }
 
-        var analysisResult = AnalyzeInvocation(state, invocation, addMatches: true, cancellationToken);
+        var sourceText = semanticModel.SyntaxTree.GetText(cancellationToken);
+        var analysisResult = AnalyzeInvocation(sourceText, state, invocation, addMatches: true, cancellationToken);
         if (analysisResult is null)
             return;
 
@@ -107,6 +111,7 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
     /// <c>.Add(...)/.AddRange(...)</c> or <c>.ToXXX()</c> calls
     /// </summary>
     public static AnalysisResult? AnalyzeInvocation(
+        SourceText text,
         FluentState state,
         InvocationExpressionSyntax invocation,
         bool addMatches,
@@ -115,7 +120,7 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
         // Because we're recursing from top to bottom in the expression tree, we build up the matches in reverse.  Right
         // before returning them, we'll reverse them again to get the proper order.
         using var _ = ArrayBuilder<CollectionExpressionMatch<ArgumentSyntax>>.GetInstance(out var matchesInReverse);
-        if (!AnalyzeInvocation(state, invocation, addMatches ? matchesInReverse : null, out var existingInitializer, cancellationToken))
+        if (!AnalyzeInvocation(text, state, invocation, addMatches ? matchesInReverse : null, out var existingInitializer, cancellationToken))
             return null;
 
         if (!CanReplaceWithCollectionExpression(state.SemanticModel, invocation, skipVerificationForReplacedNode: true, cancellationToken))
@@ -126,6 +131,7 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
     }
 
     private static bool AnalyzeInvocation(
+        SourceText text,
         FluentState state,
         InvocationExpressionSyntax invocation,
         ArrayBuilder<CollectionExpressionMatch<ArgumentSyntax>>? matchesInReverse,
@@ -247,7 +253,7 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
             // of the ToXXX Methods.  If we just have `x.AddRange(y)` it's preference to keep that, versus `[.. x, ..y]`
             if (!isAdditionMatch && IsIterable(current))
             {
-                matchesInReverse?.Add(new CollectionExpressionMatch<ArgumentSyntax>(SyntaxFactory.Argument(current), UseSpread: true));
+                AddFinalMatch(current);
                 return true;
             }
 
@@ -256,6 +262,41 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
         }
 
         return false;
+
+        void AddFinalMatch(ExpressionSyntax expression)
+        {
+            if (matchesInReverse is null)
+                return;
+
+            // We're only adding one item to the final collection.  So we're ending up with `[.. <expr>]`.  If this
+            // originally was wrapped over multiple lines in a fluent fashion, and we're down to just a single wrapped
+            // line, then unwrap.
+            if (matchesInReverse.Count == 0 &&
+                text.Lines.GetLineFromPosition(expression.SpanStart).LineNumber + 1 == text.Lines.GetLineFromPosition(expression.Span.End).LineNumber &&
+                expression is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax memberAccess } innerInvocation &&
+                !text.AreOnSameLine(memberAccess.Expression.GetLastToken(), memberAccess.Name.GetFirstToken()) &&
+                IsOnlyWhitespaceTrivia(memberAccess.Expression.GetTrailingTrivia()) &&
+                IsOnlyWhitespaceTrivia(memberAccess.OperatorToken.LeadingTrivia) &&
+                IsOnlyWhitespaceTrivia(memberAccess.OperatorToken.TrailingTrivia) &&
+                IsOnlyWhitespaceTrivia(memberAccess.Name.GetLeadingTrivia()))
+            {
+                matchesInReverse.Add(new CollectionExpressionMatch<ArgumentSyntax>(
+                    SyntaxFactory.Argument(innerInvocation.ReplaceSyntax(
+                        [memberAccess.Expression, memberAccess.Name],
+                        (n, _) => n == memberAccess.Expression ? n.WithoutTrailingTrivia() : n.WithoutLeadingTrivia(),
+                        [memberAccess.OperatorToken],
+                        (t, _) => t.WithoutTrivia(),
+                        trivia: null,
+                        computeReplacementTrivia: null)),
+                    UseSpread: true));
+                return;
+            }
+
+            matchesInReverse.Add(new CollectionExpressionMatch<ArgumentSyntax>(SyntaxFactory.Argument(expression), UseSpread: true));
+        }
+
+        bool IsOnlyWhitespaceTrivia(SyntaxTriviaList list)
+            => list.All(static t => t.IsWhitespaceOrEndOfLine());
 
         // We only want to offer this feature when the original collection was list-like (as opposed to being something
         // like a hash-set).  For example: `new List<int> { x, y, z }.ToImmutableArray()` produces different results

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -90,7 +90,7 @@ internal static class CSharpCollectionExpressionRewriter
             // Didn't have an existing initializer (or it was empty).  For both cases, just create an entirely
             // fresh collection expression, and replace the object entirely.
 
-            if (matches is [{ UseSpread: true, Node: ExpressionSyntax expression }])
+            if (matches is [{ Node: ExpressionSyntax expression } match])
             {
                 // Specialize when we're taking some expression (like x.y.ToArray()) and converting to a spreaded
                 // collection expression.  We just want to trivially make that `[.. x.y]` without any specialized
@@ -103,7 +103,9 @@ internal static class CSharpCollectionExpressionRewriter
                 // For that sort of case.  Single element collections should stay closely associated with the original
                 // expression.
                 return CollectionExpression(SingletonSeparatedList<CollectionElementSyntax>(
-                    SpreadElement(expression.WithoutTrivia()))).WithTriviaFrom(expressionToReplace);
+                    match.UseSpread
+                        ? SpreadElement(expression.WithoutTrivia())
+                        : ExpressionElement(expression.WithoutTrivia()))).WithTriviaFrom(expressionToReplace);
             }
             else if (makeMultiLineCollectionExpression)
             {

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -90,7 +90,14 @@ internal static class CSharpCollectionExpressionRewriter
             // Didn't have an existing initializer (or it was empty).  For both cases, just create an entirely
             // fresh collection expression, and replace the object entirely.
 
-            if (makeMultiLineCollectionExpression)
+            if (matches is [{ UseSpread: true, Node: ExpressionSyntax expression }])
+            {
+                // Specialize when we're taking some expression (like x.y.ToArray()) and converting to a spreaded
+                // collection expression.  We just want to trivially make that `[.. x.y]` without any specialized behavior.
+                return CollectionExpression(SingletonSeparatedList<CollectionElementSyntax>(
+                    SpreadElement(expression.WithoutTrivia()))).WithTriviaFrom(expressionToReplace);
+            }
+            else if (makeMultiLineCollectionExpression)
             {
                 // Slightly difficult case.  We're replacing `new List<int>();` with a fresh, multi-line collection
                 // expression.  To figure out what to do here, we need to figure out where the braces *and* elements

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -93,7 +93,15 @@ internal static class CSharpCollectionExpressionRewriter
             if (matches is [{ UseSpread: true, Node: ExpressionSyntax expression }])
             {
                 // Specialize when we're taking some expression (like x.y.ToArray()) and converting to a spreaded
-                // collection expression.  We just want to trivially make that `[.. x.y]` without any specialized behavior.
+                // collection expression.  We just want to trivially make that `[.. x.y]` without any specialized
+                // behavior.  In particular, we do not want to generate something like:
+                //
+                //  [
+                //      .. x.y,
+                //  ]
+                //
+                // For that sort of case.  Single element collections should stay closely associated with the original
+                // expression.
                 return CollectionExpression(SingletonSeparatedList<CollectionElementSyntax>(
                     SpreadElement(expression.WithoutTrivia()))).WithTriviaFrom(expressionToReplace);
             }

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForFluentCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForFluentCodeFixProvider.cs
@@ -54,7 +54,8 @@ internal partial class CSharpUseCollectionExpressionForFluentCodeFixProvider
         var state = new UpdateExpressionState<ExpressionSyntax, StatementSyntax>(
             semanticModel, syntaxFacts, invocationExpression, valuePattern: default, initializedSymbol: null);
 
-        if (AnalyzeInvocation(state, invocationExpression, addMatches: true, cancellationToken) is not { } analysisResult)
+        var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (AnalyzeInvocation(text, state, invocationExpression, addMatches: true, cancellationToken) is not { } analysisResult)
             return;
 
         // We want to replace `new[] { 1, 2, 3 }.Concat(x).Add(y).ToArray()` with the new collection expression.  To do

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
@@ -821,11 +821,8 @@ public class UseCollectionExpressionForCreateTests
             FixedCode = """
                 class C
                 {
-                    MyCollection<int> i =
-                    [
-                        1 +
-                            2,
-                    ];
+                    MyCollection<int> i = [1 +
+                        2];
                 }
                 """ + s_collectionBuilderApi + s_basicCollectionApi,
             LanguageVersion = LanguageVersion.CSharp12,

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForFluentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForFluentTests.cs
@@ -1676,11 +1676,8 @@ public class UseCollectionExpressionForFluentTests
                 {
                     void M()
                     {
-                        List<int> list =
-                        [
-                            1 +
-                                2,
-                        ];
+                        List<int> list = [1 +
+                            2];
                     }
                 }
                 """,

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForFluentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForFluentTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
@@ -2400,6 +2398,218 @@ public class UseCollectionExpressionForFluentTests
                     }
                 }
                 """.ReplaceLineEndings(endOfLine),
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70833")]
+    public async Task SpreadFormatting1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = Enum.GetValues<T>()
+                        .Order()
+                        .[|ToImmutableArray|]();
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+                
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = [.. Enum.GetValues<T>().Order()];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70833")]
+    public async Task SpreadFormatting2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = Enum.GetValues<T>().
+                        Order().
+                        [|ToImmutableArray|]();
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+                
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = [.. Enum.GetValues<T>().Order()];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70833")]
+    public async Task SpreadFormatting3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = Enum.GetValues<T>() // comment
+                        .Order()
+                        .[|ToImmutableArray|]();
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+                
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = [.. Enum.GetValues<T>() // comment
+                        .Order()];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70833")]
+    public async Task SpreadFormatting4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = Enum.GetValues<T>(). // comment
+                        Order().
+                        [|ToImmutableArray|]();
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+                
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = [.. Enum.GetValues<T>(). // comment
+                        Order()];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70833")]
+    public async Task SpreadFormatting5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = Enum.GetValues<T>()
+                        .Order()
+                        .Order()
+                        .[|ToImmutableArray|]();
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+                
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = [.. Enum.GetValues<T>()
+                        .Order()
+                        .Order()];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70833")]
+    public async Task SpreadFormatting6()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = Enum.GetValues<T>().
+                        Order().
+                        Order().
+                        [|ToImmutableArray|]();
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+                
+                static class EnumValueCache<T>
+                    where T : struct, Enum
+                {
+                    public static readonly ImmutableArray<T> SortedValues = [.. Enum.GetValues<T>().
+                        Order().
+                        Order()];
+                }
+                """,
             LanguageVersion = LanguageVersion.CSharp12,
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();


### PR DESCRIPTION
Particularly, if the collection will only have a single element, then don't add lots of superfluous wrapping.  A single element collection should just be the element wrapped tightly with braces, without commas.