### PR TITLE
Pool intermediary collections when performing classification tagging/aggregation.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
@@ -134,9 +134,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
             // Now delete the last character.
             var snapshot = subjectBuffer.Delete(new Span(subjectBuffer.CurrentSnapshot.Length - 1, 1));
 
-            // Try to get the tags prior to TagsChanged firing.  This will force us to use the previous 
-            // data we've cached to produce the new results.
-            tagComputer.GetTags(new NormalizedSnapshotSpanCollection(subjectBuffer.CurrentSnapshot.GetFullSpan()));
+            // Try to get the tags prior to TagsChanged firing.  This will force us to use the previous data we've
+            // cached to produce the new results.  We don't actually care about the tags, so we just pass an empty
+            // buffer for them to go into.
+            tagComputer.AddTags(new NormalizedSnapshotSpanCollection(subjectBuffer.CurrentSnapshot.GetFullSpan()), tags: []);
 
             expectedLength = snapshot.Length;
 

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 }
 
                 using var pooledTags = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var tags);
-                cachedTags.AddIntersectingTagSpans(spans, tags);
+                cachedTags?.AddIntersectingTagSpans(spans, tags);
                 return Classifier.GetFinalList(pooledTags);
             }
 

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Utilities;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Utilities;
@@ -154,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Classification
                     }
                 }
 
-                return Classifier.ComputeList(
+                return SegmentedListPool.ComputeList(
                     static (args, tags) => args.cachedTags?.AddIntersectingTagSpans(args.spans, tags),
                     (cachedTags, spans),
                     _: (ITagSpan<IClassificationTag>?)null);

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 }
 
                 return Classifier.ComputeList(
-                    static (tags, args) => args.cachedTags?.AddIntersectingTagSpans(args.spans, tags),
+                    static (args, tags) => args.cachedTags?.AddIntersectingTagSpans(args.spans, tags),
                     (cachedTags, spans),
                     _: (ITagSpan<IClassificationTag>?)null);
             }

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Classification
                     }
                 }
 
-                using var pooledTags = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var tags);
+                var pooledTags = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var tags);
                 cachedTags?.AddIntersectingTagSpans(spans, tags);
                 return Classifier.GetFinalList(pooledTags);
             }

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -154,9 +154,9 @@ namespace Microsoft.CodeAnalysis.Classification
                     }
                 }
 
-                return cachedTags == null
-                    ? Array.Empty<ITagSpan<IClassificationTag>>()
-                    : cachedTags.GetIntersectingTagSpans(spans);
+                using var pooledTags = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var tags);
+                cachedTags.AddIntersectingTagSpans(spans, tags);
+                return Classifier.GetFinalList(pooledTags);
             }
 
             private Task ProduceTagsAsync(

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -154,9 +154,10 @@ namespace Microsoft.CodeAnalysis.Classification
                     }
                 }
 
-                var pooledTags = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var tags);
-                cachedTags?.AddIntersectingTagSpans(spans, tags);
-                return Classifier.GetFinalList(pooledTags);
+                return Classifier.ComputeList(
+                    static (tags, args) => args.cachedTags?.AddIntersectingTagSpans(args.spans, tags),
+                    (cachedTags, spans),
+                    _: (ITagSpan<IClassificationTag>?)null);
             }
 
             private Task ProduceTagsAsync(

--- a/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
@@ -36,15 +36,6 @@ namespace Microsoft.CodeAnalysis.Classification
                 new ClassificationTag(typeMap.GetClassificationType(classifiedSpan.ClassificationType)));
         }
 
-        public static SegmentedList<ITagSpan<IClassificationTag>> Convert(IClassificationTypeMap typeMap, ITextSnapshot snapshot, SegmentedList<ClassifiedSpan> classifiedSpans)
-        {
-            var result = new SegmentedList<ITagSpan<IClassificationTag>>(capacity: classifiedSpans.Count);
-            foreach (var span in classifiedSpans)
-                result.Add(Convert(typeMap, snapshot, span));
-
-            return result;
-        }
-
         public static async Task ProduceTagsAsync(
             TaggerContext<IClassificationTag> context,
             DocumentSnapshotSpan spanToTag,

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.Tagger.cs
@@ -30,7 +30,7 @@ internal partial class SyntacticClassificationTaggerProvider
             tagComputer.AddTags(spans, tags);
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             if (_tagComputer != null)
             {

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.Tagger.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.VisualStudio.Text;
@@ -13,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Classification;
 
 internal partial class SyntacticClassificationTaggerProvider
 {
-    internal sealed class Tagger : RoslynTagger<IClassificationTag>, IDisposable
+    internal sealed class Tagger : EfficientTagger<IClassificationTag>, IDisposable
     {
         private TagComputer? _tagComputer;
 

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.Tagger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Classification;
 
 internal partial class SyntacticClassificationTaggerProvider
 {
-    internal sealed class Tagger : EfficientTagger<IClassificationTag>, IDisposable
+    private sealed class Tagger : EfficientTagger<IClassificationTag>, IDisposable
     {
         private TagComputer? _tagComputer;
 

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.cs
@@ -18,23 +18,23 @@ internal sealed partial class SyntacticClassificationTaggerProvider(
     IThreadingContext threadingContext,
     ClassificationTypeMap typeMap,
     IGlobalOptionService globalOptions,
-    IAsynchronousOperationListenerProvider listenerProvider) : ITaggerProvider
+    IAsynchronousOperationListenerProvider listenerProvider)
 {
     private readonly IAsynchronousOperationListener _listener = listenerProvider.GetListener(FeatureAttribute.Classification);
     private readonly IThreadingContext _threadingContext = threadingContext;
     private readonly ClassificationTypeMap _typeMap = typeMap;
     private readonly IGlobalOptionService _globalOptions = globalOptions;
 
-    ITagger<T>? ITaggerProvider.CreateTagger<T>(ITextBuffer buffer)
-    {
-        var tagger = CreateTagger(buffer);
-        if (tagger is ITagger<T> typedTagger)
-            return typedTagger;
+    //ITagger<T>? ITaggerProvider.CreateTagger<T>(ITextBuffer buffer)
+    //{
+    //    var tagger = CreateTagger(buffer);
+    //    if (tagger is ITagger<T> typedTagger)
+    //        return typedTagger;
 
-        // Oops, we can't actually return this tagger, so just clean up
-        tagger?.Dispose();
-        return null;
-    }
+    //    // Oops, we can't actually return this tagger, so just clean up
+    //    tagger?.Dispose();
+    //    return null;
+    //}
 
     public Tagger? CreateTagger(ITextBuffer buffer)
     {

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
@@ -25,18 +26,7 @@ internal sealed partial class SyntacticClassificationTaggerProvider(
     private readonly ClassificationTypeMap _typeMap = typeMap;
     private readonly IGlobalOptionService _globalOptions = globalOptions;
 
-    //ITagger<T>? ITaggerProvider.CreateTagger<T>(ITextBuffer buffer)
-    //{
-    //    var tagger = CreateTagger(buffer);
-    //    if (tagger is ITagger<T> typedTagger)
-    //        return typedTagger;
-
-    //    // Oops, we can't actually return this tagger, so just clean up
-    //    tagger?.Dispose();
-    //    return null;
-    //}
-
-    public Tagger? CreateTagger(ITextBuffer buffer)
+    public EfficientTagger<IClassificationTag>? CreateTagger(ITextBuffer buffer)
     {
         _threadingContext.ThrowIfNotOnUIThread();
         if (!_globalOptions.GetOption(SyntacticColorizerOptionsStorage.SyntacticColorizer))

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -187,8 +187,10 @@ internal sealed class TotalClassificationTaggerProvider(
                     return;
 
                 // Only need to ask for the spans that overlapped the string literals.
-                var stringLiteralSpans = new NormalizedSnapshotSpanCollection(stringLiterals.Select(s => s.Span));
                 using var _1 = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var embeddedClassifications);
+
+                var stringLiteralSpans = new NormalizedSnapshotSpanCollection(stringLiterals.Select(s => s.Span));
+                embeddedTagger.AddTags(stringLiteralSpans, embeddedClassifications);
 
                 // Nothing complex to do if we got no embedded classifications back.  Just add in all the string
                 // classifications, untouched.

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -72,7 +72,7 @@ internal sealed class TotalClassificationTaggerProvider(
         SyntacticClassificationTaggerProvider.Tagger syntacticTagger,
         SimpleAggregateTagger<IClassificationTag> semanticTagger,
         SimpleAggregateTagger<IClassificationTag> embeddedTagger)
-        : AbstractAggregateTagger<IClassificationTag>(ImmutableArray.Create<RoslynTagger<IClassificationTag>>(syntacticTagger, semanticTagger, embeddedTagger))
+        : AbstractAggregateTagger<IClassificationTag>(ImmutableArray.Create<EfficientTagger<IClassificationTag>>(syntacticTagger, semanticTagger, embeddedTagger))
     {
         private static readonly Comparison<ITagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start - s2.Span.Start;
 

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -70,8 +70,8 @@ internal sealed class TotalClassificationTaggerProvider(
 
     internal sealed class TotalClassificationAggregateTagger(
         EfficientTagger<IClassificationTag> syntacticTagger,
-        SimpleAggregateTagger<IClassificationTag> semanticTagger,
-        SimpleAggregateTagger<IClassificationTag> embeddedTagger)
+        EfficientTagger<IClassificationTag> semanticTagger,
+        EfficientTagger<IClassificationTag> embeddedTagger)
         : AbstractAggregateTagger<IClassificationTag>(ImmutableArray.Create(syntacticTagger, semanticTagger, embeddedTagger))
     {
         private static readonly Comparison<ITagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start - s2.Span.Start;

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -85,10 +85,12 @@ internal sealed class TotalClassificationTaggerProvider(
 
             var totalTags = new SegmentedList<ITagSpan<IClassificationTag>>();
 
-            using var _ = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var stringLiterals);
+            using var _1 = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var stringLiterals);
+            using var _2 = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var syntacticSpans);
+            // using var _3 = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var semanticSpans);
 
-            var syntacticSpans = syntacticTagger.GetTags(spans);
-            var semanticSpans = semanticTagger.GetTags(spans);
+            syntacticTagger.AddTags(spans, syntacticSpans);
+            var semanticSpans = semanticTagger.GetTags(spans);// .AddTags(spans, semanticSpans);
 
             syntacticSpans.Sort(s_spanComparison);
             semanticSpans.Sort(s_spanComparison);

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -69,10 +69,10 @@ internal sealed class TotalClassificationTaggerProvider(
     }
 
     internal sealed class TotalClassificationAggregateTagger(
-        SyntacticClassificationTaggerProvider.Tagger syntacticTagger,
+        EfficientTagger<IClassificationTag> syntacticTagger,
         SimpleAggregateTagger<IClassificationTag> semanticTagger,
         SimpleAggregateTagger<IClassificationTag> embeddedTagger)
-        : AbstractAggregateTagger<IClassificationTag>(ImmutableArray.Create<EfficientTagger<IClassificationTag>>(syntacticTagger, semanticTagger, embeddedTagger))
+        : AbstractAggregateTagger<IClassificationTag>(ImmutableArray.Create(syntacticTagger, semanticTagger, embeddedTagger))
     {
         private static readonly Comparison<ITagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start - s2.Span.Start;
 

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -88,7 +88,7 @@ internal sealed class TotalClassificationTaggerProvider(
             using var _3 = Classifier.GetPooledList<ITagSpan<IClassificationTag>>(out var semanticSpans);
 
             syntacticTagger.AddTags(spans, syntacticSpans);
-            semanticTagger.AddTags(spans, semanticSpans);// .AddTags(spans, semanticSpans);
+            semanticTagger.AddTags(spans, semanticSpans);
 
             syntacticSpans.Sort(s_spanComparison);
             semanticSpans.Sort(s_spanComparison);

--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -80,7 +80,7 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag> : ITagge
 
     public ITagger<T>? CreateTagger<T>(ITextBuffer buffer) where T : ITag
     {
-        using var taggers = TemporaryArray<RoslynTagger<TTag>>.Empty;
+        using var taggers = TemporaryArray<EfficientTagger<TTag>>.Empty;
         foreach (var taggerProvider in _diagnosticsTaggerProviders)
         {
             var innerTagger = taggerProvider.CreateTagger<TTag>(buffer);

--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -80,7 +80,7 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag> : ITagge
 
     public ITagger<T>? CreateTagger<T>(ITextBuffer buffer) where T : ITag
     {
-        using var taggers = TemporaryArray<ITagger<TTag>>.Empty;
+        using var taggers = TemporaryArray<RoslynTagger<TTag>>.Empty;
         foreach (var taggerProvider in _diagnosticsTaggerProviders)
         {
             var innerTagger = taggerProvider.CreateTagger<TTag>(buffer);

--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -83,7 +83,7 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag> : ITagge
         using var taggers = TemporaryArray<EfficientTagger<TTag>>.Empty;
         foreach (var taggerProvider in _diagnosticsTaggerProviders)
         {
-            var innerTagger = taggerProvider.CreateTagger<TTag>(buffer);
+            var innerTagger = taggerProvider.CreateTagger(buffer);
             if (innerTagger != null)
                 taggers.Add(innerTagger);
         }

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -53,11 +53,10 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         }
 
         public IList<ITagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
-        {
-            var pooledResult = Classifier.GetPooledList<ITagSpan<TTag>>(out var result);
-            AddIntersectingSpans(snapshotSpan, result);
-            return Classifier.GetFinalList(pooledResult);
-        }
+            => Classifier.ComputeList(
+                static (result, args) => args.@this.AddIntersectingSpans(args.snapshotSpan, result),
+                (@this: this, snapshotSpan),
+                _: (ITagSpan<TTag>?)null);
 
         private void AddIntersectingSpans(SnapshotSpan snapshotSpan, SegmentedList<ITagSpan<TTag>> result)
         {

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -78,13 +78,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         public bool IsEmpty()
             => _tree.IsEmpty();
 
-        public IEnumerable<ITagSpan<TTag>> GetIntersectingTagSpans(NormalizedSnapshotSpanCollection requestedSpans)
-        {
-            var pooledResult = Classifier.GetPooledList<ITagSpan<TTag>>(out var result);
-            AddIntersectingTagSpans(requestedSpans, result);
-            return Classifier.GetFinalList(pooledResult);
-        }
-
         public void AddIntersectingTagSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<ITagSpan<TTag>> tags)
         {
             AddIntersectingTagSpansWorker(requestedSpans, tags);

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.Utilities;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Utilities;
@@ -53,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         }
 
         public IList<ITagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
-            => Classifier.ComputeList(
+            => SegmentedListPool.ComputeList(
                 static (args, tags) => args.@this.AddIntersectingSpans(args.snapshotSpan, tags),
                 (@this: this, snapshotSpan),
                 _: (ITagSpan<TTag>?)null);
@@ -133,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             // m == number of requested spans, n = number of returned spans
             var mergedSpan = new SnapshotSpan(requestedSpans[0].Start, requestedSpans[^1].End);
 
-            using var _1 = Classifier.GetPooledList<ITagSpan<TTag>>(out var tempList);
+            using var _1 = SegmentedListPool.GetPooledList<ITagSpan<TTag>>(out var tempList);
 
             AddIntersectingSpans(mergedSpan, tempList);
             if (tempList.Count == 0)

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -56,14 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             var pooledResult = Classifier.GetPooledList<ITagSpan<TTag>>(out var result);
             AddIntersectingSpans(snapshotSpan, result);
-
-            if (result.Count == 0)
-            {
-                pooledResult.Dispose();
-                return Array.Empty<ITagSpan<TTag>>();
-            }
-
-            return result;
+            return Classifier.GetFinalList(pooledResult);
         }
 
         private void AddIntersectingSpans(SnapshotSpan snapshotSpan, SegmentedList<ITagSpan<TTag>> result)
@@ -89,13 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             var pooledResult = Classifier.GetPooledList<ITagSpan<TTag>>(out var result);
             AddIntersectingTagSpans(requestedSpans, result);
-            if (result.Count == 0)
-            {
-                pooledResult.Dispose();
-                return Array.Empty<ITagSpan<TTag>>();
-            }
-
-            return result;
+            return Classifier.GetFinalList(pooledResult);
         }
 
         public void AddIntersectingTagSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<ITagSpan<TTag>> tags)

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
         public IList<ITagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
             => Classifier.ComputeList(
-                static (result, args) => args.@this.AddIntersectingSpans(args.snapshotSpan, result),
+                static (args, tags) => args.@this.AddIntersectingSpans(args.snapshotSpan, tags),
                 (@this: this, snapshotSpan),
                 _: (ITagSpan<TTag>?)null);
 

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -54,9 +54,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
         public IList<ITagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
         {
-            var snapshot = snapshotSpan.Snapshot;
-            Debug.Assert(snapshot.TextBuffer == _textBuffer);
-
             var pooledResult = Classifier.GetPooledList<ITagSpan<TTag>>(out var result);
             AddIntersectingSpans(snapshotSpan, result);
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -571,7 +571,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 return tags;
             }
 
-            public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection requestedSpans)
+            public void AddTags(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<ITagSpan<TTag>> tags)
             {
                 _dataSource.ThreadingContext.ThrowIfNotOnUIThread();
 
@@ -580,14 +580,15 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 ResumeIfVisible();
 
                 if (requestedSpans.Count == 0)
-                    return SpecializedCollections.EmptyEnumerable<ITagSpan<TTag>>();
+                    return;
 
                 var buffer = requestedSpans.First().Snapshot.TextBuffer;
-                var tags = this.TryGetTagIntervalTreeForBuffer(buffer);
+                var tagIntervalTree = this.TryGetTagIntervalTreeForBuffer(buffer);
 
-                return tags == null
-                    ? SpecializedCollections.EmptyEnumerable<ITagSpan<TTag>>()
-                    : tags.GetIntersectingTagSpans(requestedSpans);
+                if (tagIntervalTree is null)
+                    return;
+
+                tags.AddRange(tagIntervalTree.GetIntersectingTagSpans(requestedSpans));
             }
         }
     }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -585,10 +585,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 var buffer = requestedSpans.First().Snapshot.TextBuffer;
                 var tagIntervalTree = this.TryGetTagIntervalTreeForBuffer(buffer);
 
-                if (tagIntervalTree is null)
-                    return;
-
-                tags.AddRange(tagIntervalTree.GetIntersectingTagSpans(requestedSpans));
+                tagIntervalTree?.AddIntersectingTagSpans(requestedSpans, tags);
             }
         }
     }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 remove => _tagSource.TagsChanged -= value;
             }
 
-            public void Dispose()
+            public override void Dispose()
                 => _tagSource.OnTaggerDisposed(this);
 
             public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags)

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -7,36 +7,35 @@ using Microsoft.CodeAnalysis.Collections;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 
-namespace Microsoft.CodeAnalysis.Editor.Tagging
+namespace Microsoft.CodeAnalysis.Editor.Tagging;
+
+internal partial class AbstractAsynchronousTaggerProvider<TTag>
 {
-    internal partial class AbstractAsynchronousTaggerProvider<TTag>
+    /// <summary>
+    /// <see cref="Tagger"/> is a thin wrapper we create around the single shared <see cref="TagSource"/>.
+    /// Clients can request and dispose these at will.  Once the last wrapper is disposed, the underlying
+    /// <see cref="TagSource"/> will finally be disposed as well.
+    /// </summary>
+    private sealed partial class Tagger : EfficientTagger<TTag>, IDisposable
     {
-        /// <summary>
-        /// <see cref="Tagger"/> is a thin wrapper we create around the single shared <see cref="TagSource"/>.
-        /// Clients can request and dispose these at will.  Once the last wrapper is disposed, the underlying
-        /// <see cref="TagSource"/> will finally be disposed as well.
-        /// </summary>
-        private sealed partial class Tagger : EfficientTagger<TTag>, IDisposable
+        private readonly TagSource _tagSource;
+
+        public Tagger(TagSource tagSource)
         {
-            private readonly TagSource _tagSource;
-
-            public Tagger(TagSource tagSource)
-            {
-                _tagSource = tagSource;
-                _tagSource.OnTaggerAdded(this);
-            }
-
-            public override event EventHandler<SnapshotSpanEventArgs>? TagsChanged
-            {
-                add => _tagSource.TagsChanged += value;
-                remove => _tagSource.TagsChanged -= value;
-            }
-
-            public override void Dispose()
-                => _tagSource.OnTaggerDisposed(this);
-
-            public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags)
-                => _tagSource.AddTags(spans, tags);
+            _tagSource = tagSource;
+            _tagSource.OnTaggerAdded(this);
         }
+
+        public override event EventHandler<SnapshotSpanEventArgs>? TagsChanged
+        {
+            add => _tagSource.TagsChanged += value;
+            remove => _tagSource.TagsChanged -= value;
+        }
+
+        public override void Dispose()
+            => _tagSource.OnTaggerDisposed(this);
+
+        public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags)
+            => _tagSource.AddTags(spans, tags);
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// Clients can request and dispose these at will.  Once the last wrapper is disposed, the underlying
         /// <see cref="TagSource"/> will finally be disposed as well.
         /// </summary>
-        private sealed partial class Tagger : RoslynTagger<TTag>, IDisposable
+        private sealed partial class Tagger : EfficientTagger<TTag>, IDisposable
         {
             private readonly TagSource _tagSource;
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// Clients can request and dispose these at will.  Once the last wrapper is disposed, the underlying
         /// <see cref="TagSource"/> will finally be disposed as well.
         /// </summary>
-        private sealed partial class Tagger : ITagger<TTag>, IDisposable
+        private sealed partial class Tagger : RoslynTagger<TTag>, IDisposable
         {
             private readonly TagSource _tagSource;
 
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _tagSource.OnTaggerAdded(this);
             }
 
-            public event EventHandler<SnapshotSpanEventArgs> TagsChanged
+            public override event EventHandler<SnapshotSpanEventArgs>? TagsChanged
             {
                 add => _tagSource.TagsChanged += value;
                 remove => _tagSource.TagsChanged -= value;
@@ -35,8 +35,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             public void Dispose()
                 => _tagSource.OnTaggerDisposed(this);
 
-            public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection requestedSpans)
-                => _tagSource.GetTags(requestedSpans);
+            public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags)
+                => _tagSource.AddTags(spans, tags);
         }
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 #endif
         }
 
-        protected ITagger<T>? CreateTaggerWorker<T>(ITextView? textView, ITextBuffer subjectBuffer) where T : ITag
+        protected RoslynTagger<T>? CreateTaggerWorker<T>(ITextView? textView, ITextBuffer subjectBuffer) where T : ITag
         {
             if (!GlobalOptions.GetOption(EditorComponentOnOffOptions.Tagger))
                 return null;
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             // If we're not able to convert the tagger we instantiated to the type the caller wants, then make sure we
             // dispose of it now.  The tagger will have added a ref to the underlying tagsource, and we have to make
             // sure we return that to the property starting value.
-            if (tagger is not ITagger<T> result)
+            if (tagger is not RoslynTagger<T> result)
             {
                 tagger.Dispose();
                 return null;

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 #endif
         }
 
-        protected RoslynTagger<T>? CreateTaggerWorker<T>(ITextView? textView, ITextBuffer subjectBuffer) where T : ITag
+        protected EfficientTagger<T>? CreateEfficientTagger<T>(ITextView? textView, ITextBuffer subjectBuffer) where T : ITag
         {
             if (!GlobalOptions.GetOption(EditorComponentOnOffOptions.Tagger))
                 return null;
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             // If we're not able to convert the tagger we instantiated to the type the caller wants, then make sure we
             // dispose of it now.  The tagger will have added a ref to the underlying tagsource, and we have to make
             // sure we return that to the property starting value.
-            if (tagger is not RoslynTagger<T> result)
+            if (tagger is not EfficientTagger<T> result)
             {
                 tagger.Dispose();
                 return null;

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 #endif
         }
 
-        protected EfficientTagger<T>? CreateEfficientTagger<T>(ITextView? textView, ITextBuffer subjectBuffer) where T : ITag
+        protected EfficientTagger<TTag>? CreateEfficientTagger(ITextView? textView, ITextBuffer subjectBuffer)
         {
             if (!GlobalOptions.GetOption(EditorComponentOnOffOptions.Tagger))
                 return null;
@@ -142,16 +142,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             var tagSource = GetOrCreateTagSource(textView, subjectBuffer);
             var tagger = new Tagger(tagSource);
 
-            // If we're not able to convert the tagger we instantiated to the type the caller wants, then make sure we
-            // dispose of it now.  The tagger will have added a ref to the underlying tagsource, and we have to make
-            // sure we return that to the property starting value.
-            if (tagger is not EfficientTagger<T> result)
-            {
-                tagger.Dispose();
-                return null;
-            }
-
-            return result;
+            return tagger;
         }
 
         private TagSource GetOrCreateTagSource(ITextView? textView, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/Tagging/AggregateTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AggregateTagger.cs
@@ -31,7 +31,7 @@ internal abstract class RoslynTagger<TTag> : ITagger<TTag> where TTag : ITag
         return tags;
     }
 
-    public virtual event EventHandler<SnapshotSpanEventArgs> TagsChanged;
+    public virtual event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
 
     protected void OnTagsChanged(object? sender, SnapshotSpanEventArgs e)
         => TagsChanged?.Invoke(this, e);

--- a/src/EditorFeatures/Core/Tagging/AggregateTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AggregateTagger.cs
@@ -25,7 +25,7 @@ internal abstract class AbstractAggregateTagger<TTag>(ImmutableArray<EfficientTa
     public override void Dispose()
     {
         foreach (var tagger in this.Taggers)
-            (tagger as IDisposable)?.Dispose();
+            tagger.Dispose();
     }
 
     /// <summary>

--- a/src/EditorFeatures/Core/Tagging/AggregateTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AggregateTagger.cs
@@ -22,7 +22,7 @@ internal abstract class AbstractAggregateTagger<TTag>(ImmutableArray<EfficientTa
     /// <summary>
     /// Disposes all the underlying taggers (if they themselves are <see cref="IDisposable"/>.
     /// </summary>
-    public void Dispose()
+    public override void Dispose()
     {
         foreach (var tagger in this.Taggers)
             (tagger as IDisposable)?.Dispose();

--- a/src/EditorFeatures/Core/Tagging/AsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousTaggerProvider.cs
@@ -10,29 +10,43 @@ using Microsoft.CodeAnalysis.Workspaces;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 
-namespace Microsoft.CodeAnalysis.Editor.Tagging
+namespace Microsoft.CodeAnalysis.Editor.Tagging;
+
+internal abstract class AsynchronousTaggerProvider<TTag> : AbstractAsynchronousTaggerProvider<TTag>, ITaggerProvider
+    where TTag : ITag
 {
-    internal abstract class AsynchronousTaggerProvider<TTag> : AbstractAsynchronousTaggerProvider<TTag>, ITaggerProvider
-        where TTag : ITag
+    protected AsynchronousTaggerProvider(
+        IThreadingContext threadingContext,
+        IGlobalOptionService globalOptions,
+        ITextBufferVisibilityTracker? visibilityTracker,
+        IAsynchronousOperationListener asyncListener)
+        : base(threadingContext, globalOptions, visibilityTracker, asyncListener)
     {
-        protected AsynchronousTaggerProvider(
-            IThreadingContext threadingContext,
-            IGlobalOptionService globalOptions,
-            ITextBufferVisibilityTracker? visibilityTracker,
-            IAsynchronousOperationListener asyncListener)
-            : base(threadingContext, globalOptions, visibilityTracker, asyncListener)
+    }
+
+    public EfficientTagger<TTag>? CreateTagger(ITextBuffer subjectBuffer)
+    {
+        if (subjectBuffer == null)
+            throw new ArgumentNullException(nameof(subjectBuffer));
+
+        return this.CreateEfficientTagger(null, subjectBuffer);
+    }
+
+    ITagger<T>? ITaggerProvider.CreateTagger<T>(ITextBuffer buffer)
+    {
+        var tagger = CreateTagger(buffer);
+        if (tagger is null)
+            return null;
+
+        // If we're not able to convert the tagger we instantiated to the type the caller wants, then make sure we
+        // dispose of it now.  The tagger will have added a ref to the underlying tagsource, and we have to make
+        // sure we return that to the proper starting value.
+        if (tagger is not ITagger<T> typedTagger)
         {
+            tagger.Dispose();
+            return null;
         }
 
-        public EfficientTagger<T>? CreateTagger<T>(ITextBuffer subjectBuffer) where T : ITag
-        {
-            if (subjectBuffer == null)
-                throw new ArgumentNullException(nameof(subjectBuffer));
-
-            return this.CreateEfficientTagger<T>(null, subjectBuffer);
-        }
-
-        ITagger<T>? ITaggerProvider.CreateTagger<T>(ITextBuffer buffer)
-            => CreateTagger<T>(buffer);
+        return typedTagger;
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousTaggerProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         {
         }
 
-        public ITagger<T>? CreateTagger<T>(ITextBuffer subjectBuffer) where T : ITag
+        public RoslynTagger<T>? CreateTagger<T>(ITextBuffer subjectBuffer) where T : ITag
         {
             if (subjectBuffer == null)
                 throw new ArgumentNullException(nameof(subjectBuffer));

--- a/src/EditorFeatures/Core/Tagging/AsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousTaggerProvider.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         {
         }
 
-        public RoslynTagger<T>? CreateTagger<T>(ITextBuffer subjectBuffer) where T : ITag
+        public EfficientTagger<T>? CreateTagger<T>(ITextBuffer subjectBuffer) where T : ITag
         {
             if (subjectBuffer == null)
                 throw new ArgumentNullException(nameof(subjectBuffer));
 
-            return this.CreateTaggerWorker<T>(null, subjectBuffer);
+            return this.CreateEfficientTagger<T>(null, subjectBuffer);
         }
 
         ITagger<T>? ITaggerProvider.CreateTagger<T>(ITextBuffer buffer)

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewTaggerProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         protected abstract override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer);
 #pragma warning restore
 
-        public ITagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer subjectBuffer) where T : ITag
+        public RoslynTagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer subjectBuffer) where T : ITag
         {
             if (textView == null)
                 throw new ArgumentNullException(nameof(subjectBuffer));

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewTaggerProvider.cs
@@ -3,51 +3,63 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Workspaces;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 
-namespace Microsoft.CodeAnalysis.Editor.Tagging
+namespace Microsoft.CodeAnalysis.Editor.Tagging;
+
+/// <summary>
+/// Base type for async taggers that need access to an <see cref="ITextView"/>.  Used when a tagger needs things to
+/// operate like determining what is visible to the user, or where the caret is.
+/// </summary>
+/// <typeparam name="TTag"></typeparam>
+internal abstract class AsynchronousViewTaggerProvider<TTag> : AbstractAsynchronousTaggerProvider<TTag>, IViewTaggerProvider
+    where TTag : ITag
 {
-    /// <summary>
-    /// Base type for async taggers that need access to an <see cref="ITextView"/>.  Used when a tagger needs things to
-    /// operate like determining what is visible to the user, or where the caret is.
-    /// </summary>
-    /// <typeparam name="TTag"></typeparam>
-    internal abstract class AsynchronousViewTaggerProvider<TTag> : AbstractAsynchronousTaggerProvider<TTag>, IViewTaggerProvider
-        where TTag : ITag
+    protected AsynchronousViewTaggerProvider(
+        IThreadingContext threadingContext,
+        IGlobalOptionService globalOptions,
+        ITextBufferVisibilityTracker? visibilityTracker,
+        IAsynchronousOperationListener asyncListener)
+        : base(threadingContext, globalOptions, visibilityTracker, asyncListener)
     {
-        protected AsynchronousViewTaggerProvider(
-            IThreadingContext threadingContext,
-            IGlobalOptionService globalOptions,
-            ITextBufferVisibilityTracker? visibilityTracker,
-            IAsynchronousOperationListener asyncListener)
-            : base(threadingContext, globalOptions, visibilityTracker, asyncListener)
-        {
-        }
+    }
 
 #pragma warning disable CS8765 // Nullability of type of 'textView' doesn't match overridden member (derivations of this type will never receive null in this call)
-        protected abstract override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer);
+    protected abstract override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer);
 #pragma warning restore
 
-        public EfficientTagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer subjectBuffer) where T : ITag
+    public EfficientTagger<TTag>? CreateTagger(ITextView textView, ITextBuffer subjectBuffer)
+    {
+        if (textView == null)
+            throw new ArgumentNullException(nameof(subjectBuffer));
+
+        if (subjectBuffer == null)
+            throw new ArgumentNullException(nameof(subjectBuffer));
+
+        return this.CreateEfficientTagger(textView, subjectBuffer);
+    }
+
+    ITagger<T>? IViewTaggerProvider.CreateTagger<T>(ITextView textView, ITextBuffer buffer)
+    {
+        var tagger = CreateTagger(textView, buffer);
+        if (tagger is null)
+            return null;
+
+        // If we're not able to convert the tagger we instantiated to the type the caller wants, then make sure we
+        // dispose of it now.  The tagger will have added a ref to the underlying tagsource, and we have to make
+        // sure we return that to the proper starting value.
+        if (tagger is not ITagger<T> typedTagger)
         {
-            if (textView == null)
-                throw new ArgumentNullException(nameof(subjectBuffer));
-
-            if (subjectBuffer == null)
-                throw new ArgumentNullException(nameof(subjectBuffer));
-
-            return this.CreateEfficientTagger<T>(textView, subjectBuffer);
+            tagger.Dispose();
+            return null;
         }
 
-        ITagger<T>? IViewTaggerProvider.CreateTagger<T>(ITextView textView, ITextBuffer buffer)
-            => CreateTagger<T>(textView, buffer);
+        return typedTagger;
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewTaggerProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         protected abstract override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer);
 #pragma warning restore
 
-        public RoslynTagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer subjectBuffer) where T : ITag
+        public EfficientTagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer subjectBuffer) where T : ITag
         {
             if (textView == null)
                 throw new ArgumentNullException(nameof(subjectBuffer));
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             if (subjectBuffer == null)
                 throw new ArgumentNullException(nameof(subjectBuffer));
 
-            return this.CreateTaggerWorker<T>(textView, subjectBuffer);
+            return this.CreateEfficientTagger<T>(textView, subjectBuffer);
         }
 
         ITagger<T>? IViewTaggerProvider.CreateTagger<T>(ITextView textView, ITextBuffer buffer)

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
@@ -120,7 +120,7 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> : IView
         using var taggers = TemporaryArray<EfficientTagger<TTag>>.Empty;
         foreach (var taggerProvider in _viewportTaggerProviders)
         {
-            var innerTagger = taggerProvider.CreateTagger<TTag>(textView, buffer);
+            var innerTagger = taggerProvider.CreateTagger(textView, buffer);
             if (innerTagger != null)
                 taggers.Add(innerTagger);
         }

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
@@ -115,7 +115,7 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> : IView
         return genericTagger;
     }
 
-    public SimpleAggregateTagger<TTag> CreateTagger(ITextView textView, ITextBuffer buffer)
+    public EfficientTagger<TTag> CreateTagger(ITextView textView, ITextBuffer buffer)
     {
         using var taggers = TemporaryArray<EfficientTagger<TTag>>.Empty;
         foreach (var taggerProvider in _viewportTaggerProviders)

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
@@ -117,7 +117,7 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> : IView
 
     public SimpleAggregateTagger<TTag> CreateTagger(ITextView textView, ITextBuffer buffer)
     {
-        using var taggers = TemporaryArray<ITagger<TTag>>.Empty;
+        using var taggers = TemporaryArray<RoslynTagger<TTag>>.Empty;
         foreach (var taggerProvider in _viewportTaggerProviders)
         {
             var innerTagger = taggerProvider.CreateTagger<TTag>(textView, buffer);

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
@@ -117,7 +117,7 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> : IView
 
     public SimpleAggregateTagger<TTag> CreateTagger(ITextView textView, ITextBuffer buffer)
     {
-        using var taggers = TemporaryArray<RoslynTagger<TTag>>.Empty;
+        using var taggers = TemporaryArray<EfficientTagger<TTag>>.Empty;
         foreach (var taggerProvider in _viewportTaggerProviders)
         {
             var innerTagger = taggerProvider.CreateTagger<TTag>(textView, buffer);

--- a/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
@@ -33,15 +33,7 @@ internal abstract class EfficientTagger<TTag> : ITagger<TTag>, IDisposable where
     {
         var pooledTags = Classifier.GetPooledList<ITagSpan<TTag>>(out var tags);
         this.AddTags(spans, tags);
-
-        if (tags.Count == 0)
-        {
-            pooledTags.Dispose();
-            return Array.Empty<ITagSpan<TTag>>();
-        }
-
-        // intentionally do not dispose.
-        return tags;
+        return Classifier.GetFinalList(pooledTags);
     }
 
     public virtual event EventHandler<SnapshotSpanEventArgs>? TagsChanged;

--- a/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Tagging;
+
+namespace Microsoft.CodeAnalysis.Editor.Tagging;
+
+/// <summary>
+/// Root type of all roslyn <see cref="ITagger{T}"/> implementations.  This adds specialized hooks that allow for tags
+/// to be added to a preexisting list, rather than generating a fresh list instance.  This can help with avoiding
+/// garbage by allowing us to pool intermediary lists (especially as some high-level aggregating taggers defer to
+/// intermediary taggers).
+/// </summary>
+internal abstract class EfficientTagger<TTag> : ITagger<TTag> where TTag : ITag
+{
+    /// <summary>
+    /// Produce the set of tags with the requested <paramref name="spans"/>, adding those tags to <paramref name="tags"/>.
+    /// </summary>
+    public abstract void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags);
+
+    /// <summary>
+    /// Default impl of the core <see cref="ITagger{T}"/> interface.  Forces an allocation.
+    /// </summary>
+    public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+    {
+        var pooledTags = Classifier.GetPooledList<ITagSpan<TTag>>(out var tags);
+        this.AddTags(spans, tags);
+
+        if (tags.Count == 0)
+        {
+            pooledTags.Dispose();
+            return Array.Empty<ITagSpan<TTag>>();
+        }
+
+        // intentionally do not dispose.
+        return tags;
+    }
+
+    public virtual event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
+
+    protected void OnTagsChanged(object? sender, SnapshotSpanEventArgs e)
+        => TagsChanged?.Invoke(this, e);
+}

--- a/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
@@ -17,12 +17,14 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging;
 /// garbage by allowing us to pool intermediary lists (especially as some high-level aggregating taggers defer to
 /// intermediary taggers).
 /// </summary>
-internal abstract class EfficientTagger<TTag> : ITagger<TTag> where TTag : ITag
+internal abstract class EfficientTagger<TTag> : ITagger<TTag>, IDisposable where TTag : ITag
 {
     /// <summary>
     /// Produce the set of tags with the requested <paramref name="spans"/>, adding those tags to <paramref name="tags"/>.
     /// </summary>
     public abstract void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags);
+
+    public abstract void Dispose();
 
     /// <summary>
     /// Default impl of the core <see cref="ITagger{T}"/> interface.  Forces an allocation.

--- a/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
@@ -30,11 +30,10 @@ internal abstract class EfficientTagger<TTag> : ITagger<TTag>, IDisposable where
     /// Default impl of the core <see cref="ITagger{T}"/> interface.  Forces an allocation.
     /// </summary>
     public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
-    {
-        var pooledTags = Classifier.GetPooledList<ITagSpan<TTag>>(out var tags);
-        this.AddTags(spans, tags);
-        return Classifier.GetFinalList(pooledTags);
-    }
+        => Classifier.ComputeList(
+            static (tags, args) => args.@this.AddTags(args.spans, tags),
+            (@this: this, spans),
+            _: (ITagSpan<TTag>?)null);
 
     public virtual event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
 

--- a/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Utilities;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 
@@ -30,7 +30,7 @@ internal abstract class EfficientTagger<TTag> : ITagger<TTag>, IDisposable where
     /// Default impl of the core <see cref="ITagger{T}"/> interface.  Forces an allocation.
     /// </summary>
     public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
-        => Classifier.ComputeList(
+        => SegmentedListPool.ComputeList(
             static (args, tags) => args.@this.AddTags(args.spans, tags),
             (@this: this, spans),
             _: (ITagSpan<TTag>?)null);

--- a/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
@@ -31,7 +31,7 @@ internal abstract class EfficientTagger<TTag> : ITagger<TTag>, IDisposable where
     /// </summary>
     public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
         => Classifier.ComputeList(
-            static (tags, args) => args.@this.AddTags(args.spans, tags),
+            static (args, tags) => args.@this.AddTags(args.spans, tags),
             (@this: this, spans),
             _: (ITagSpan<TTag>?)null);
 

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -73,10 +73,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
             var document = workspace.Documents.First();
             var textBuffer = document.GetTextBuffer();
             var snapshot = textBuffer.CurrentSnapshot;
-            var tagger = taggerProvider.CreateTagger<TestTag>(textBuffer);
+            using var tagger = taggerProvider.CreateTagger(textBuffer);
             Contract.ThrowIfNull(tagger);
 
-            using var disposable = (IDisposable)tagger;
             var spans = Enumerable.Range(0, 101).Select(i => new Span(i * 4, 1));
             var snapshotSpans = new NormalizedSnapshotSpanCollection(snapshot, spans);
 
@@ -99,10 +98,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
 
             var document = workspace.Documents.First();
             var textBuffer = document.GetTextBuffer();
-            var tagger = tagProvider.CreateTagger<IStructureTag>(textBuffer);
+            using var tagger = tagProvider.CreateTagger(textBuffer);
             Contract.ThrowIfNull(tagger);
 
-            using var disposable = (IDisposable)tagger;
             // The very first all to get tags will not be synchronous as this contains no #region tag
             var tags = tagger.GetTags(new NormalizedSnapshotSpanCollection(textBuffer.CurrentSnapshot.GetFullSpan()));
             Assert.Equal(0, tags.Count());
@@ -125,10 +123,9 @@ class Program
 
             var document = workspace.Documents.First();
             var textBuffer = document.GetTextBuffer();
-            var tagger = tagProvider.CreateTagger<IStructureTag>(textBuffer);
+            using var tagger = tagProvider.CreateTagger(textBuffer);
             Contract.ThrowIfNull(tagger);
 
-            using var disposable = (IDisposable)tagger;
             // The very first all to get tags will be synchronous because of the #region
             var tags = tagger.GetTags(new NormalizedSnapshotSpanCollection(textBuffer.CurrentSnapshot.GetFullSpan()));
             Assert.Equal(2, tags.Count());

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -46,8 +46,16 @@ namespace Microsoft.CodeAnalysis.Classification
             return pooledObject;
         }
 
-        internal static IList<T> GetFinalList<T>(PooledObject<SegmentedList<T>> pooledObject)
+        internal static IList<T> ComputeList<T, TArgs>(
+            Action<SegmentedList<T>, TArgs> compute,
+            TArgs args,
+            // Only used to allow type inference to work at callsite
+            T? _)
         {
+            var pooledObject = GetPooledList<T>(out var list);
+
+            compute(list, args);
+
             // If the result was empty, return it to the pool, and just pass back the empty array singleton.
             if (pooledObject.Object.Count == 0)
             {
@@ -56,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Classification
             }
 
             // Otherwise, do not dispose.  Caller needs this value to stay alive.
-            return pooledObject.Object;
+            return list;
         }
 
         public static async Task<IEnumerable<ClassifiedSpan>> GetClassifiedSpansAsync(

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Classification
@@ -21,57 +22,7 @@ namespace Microsoft.CodeAnalysis.Classification
     public static class Classifier
     {
         internal static PooledObject<SegmentedList<ClassifiedSpan>> GetPooledList(out SegmentedList<ClassifiedSpan> classifiedSpans)
-            => GetPooledList<ClassifiedSpan>(out classifiedSpans);
-
-        internal static PooledObject<SegmentedList<T>> GetPooledList<T>(out SegmentedList<T> classifiedSpans)
-        {
-            var pooledObject = new PooledObject<SegmentedList<T>>(
-                SharedPools.Default<SegmentedList<T>>(),
-                static p =>
-                {
-                    var result = p.Allocate();
-                    result.Clear();
-                    return result;
-                },
-                static (p, list) =>
-                {
-                    // Deliberately do not call ClearAndFree for the set as we can easily have a set that goes past the
-                    // threshold simply with a single classified screen.  This allows reuse of those sets without causing
-                    // lots of **garbage.**
-                    list.Clear();
-                    p.Free(list);
-                });
-
-            classifiedSpans = pooledObject.Object;
-            return pooledObject;
-        }
-
-        /// <summary>
-        /// Computes a list of results based on a provided <paramref name="addItems"/> callback.  The callback is passed
-        /// a <see cref="SegmentedList{T}"/> to add results to, and additional args to assist the process.  If no items
-        /// are added to the list, then the <see cref="Array.Empty{T}"/> singleton will be returned.  Otherwise the 
-        /// <see cref="SegmentedList{T}"/> instance will be returned.
-        /// </summary>
-        internal static IList<T> ComputeList<T, TArgs>(
-            Action<TArgs, SegmentedList<T>> addItems,
-            TArgs args,
-            // Only used to allow type inference to work at callsite
-            T? _)
-        {
-            var pooledObject = GetPooledList<T>(out var list);
-
-            addItems(args, list);
-
-            // If the result was empty, return it to the pool, and just pass back the empty array singleton.
-            if (pooledObject.Object.Count == 0)
-            {
-                pooledObject.Dispose();
-                return Array.Empty<T>();
-            }
-
-            // Otherwise, do not dispose.  Caller needs this value to stay alive.
-            return list;
-        }
+            => SegmentedListPool.GetPooledList<ClassifiedSpan>(out classifiedSpans);
 
         public static async Task<IEnumerable<ClassifiedSpan>> GetClassifiedSpansAsync(
             Document document,

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -46,15 +46,20 @@ namespace Microsoft.CodeAnalysis.Classification
             return pooledObject;
         }
 
+        /// <summary>
+        /// Computes a list of results based on a provided <paramref name="addItems"/> callback.  The callback is passed
+        /// the list to add results to, and additional args to assist the process.  If no items are added to the list,
+        /// then the <see cref="Array.Empty{T}"/> singleton will be returned.
+        /// </summary>
         internal static IList<T> ComputeList<T, TArgs>(
-            Action<SegmentedList<T>, TArgs> compute,
+            Action<TArgs, SegmentedList<T>> addItems,
             TArgs args,
             // Only used to allow type inference to work at callsite
             T? _)
         {
             var pooledObject = GetPooledList<T>(out var list);
 
-            compute(list, args);
+            addItems(args, list);
 
             // If the result was empty, return it to the pool, and just pass back the empty array singleton.
             if (pooledObject.Object.Count == 0)

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Classification
             return pooledObject;
         }
 
-        internal static IList<T> GetFinalList<T>(this PooledObject<SegmentedList<T>> pooledObject)
+        internal static IList<T> GetFinalList<T>(PooledObject<SegmentedList<T>> pooledObject)
         {
             // If the result was empty, retur it to the pool, and just pass back the empty array singleton.
             if (pooledObject.Object.Count == 0)

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Classification
 
         internal static IList<T> GetFinalList<T>(PooledObject<SegmentedList<T>> pooledObject)
         {
-            // If the result was empty, retur it to the pool, and just pass back the empty array singleton.
+            // If the result was empty, return it to the pool, and just pass back the empty array singleton.
             if (pooledObject.Object.Count == 0)
             {
                 pooledObject.Dispose();

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -48,8 +48,9 @@ namespace Microsoft.CodeAnalysis.Classification
 
         /// <summary>
         /// Computes a list of results based on a provided <paramref name="addItems"/> callback.  The callback is passed
-        /// the list to add results to, and additional args to assist the process.  If no items are added to the list,
-        /// then the <see cref="Array.Empty{T}"/> singleton will be returned.
+        /// a <see cref="SegmentedList{T}"/> to add results to, and additional args to assist the process.  If no items
+        /// are added to the list, then the <see cref="Array.Empty{T}"/> singleton will be returned.  Otherwise the 
+        /// <see cref="SegmentedList{T}"/> instance will be returned.
         /// </summary>
         internal static IList<T> ComputeList<T, TArgs>(
             Action<TArgs, SegmentedList<T>> addItems,

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -46,6 +46,19 @@ namespace Microsoft.CodeAnalysis.Classification
             return pooledObject;
         }
 
+        internal static IList<T> GetFinalList<T>(this PooledObject<SegmentedList<T>> pooledObject)
+        {
+            // If the result was empty, retur it to the pool, and just pass back the empty array singleton.
+            if (pooledObject.Object.Count == 0)
+            {
+                pooledObject.Dispose();
+                return Array.Empty<T>();
+            }
+
+            // Otherwise, do not dispose.  Caller needs this value to stay alive.
+            return pooledObject.Object;
+        }
+
         public static async Task<IEnumerable<ClassifiedSpan>> GetClassifiedSpansAsync(
             Document document,
             TextSpan textSpan,

--- a/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/Utilities/SegmentedListPool.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SegmentedListPool.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Collections;
+
+namespace Microsoft.CodeAnalysis.Utilities;
+
+internal static class SegmentedListPool
+{
+    internal static PooledObject<SegmentedList<T>> GetPooledList<T>(out SegmentedList<T> classifiedSpans)
+    {
+        var pooledObject = new PooledObject<SegmentedList<T>>(
+            SharedPools.BigDefault<SegmentedList<T>>(),
+            static p =>
+            {
+                var result = p.Allocate();
+                result.Clear();
+                return result;
+            },
+            static (p, list) =>
+            {
+                // Deliberately do not call pool.ClearAndFree for the set as we can easily have a set that goes past the
+                // threshold simply with a single classified screen.  This allows reuse of those sets without causing
+                // lots of **garbage.**
+                list.Clear();
+                p.Free(list);
+            });
+
+        classifiedSpans = pooledObject.Object;
+        return pooledObject;
+    }
+
+    /// <summary>
+    /// Computes a list of results based on a provided <paramref name="addItems"/> callback.  The callback is passed
+    /// a <see cref="SegmentedList{T}"/> to add results to, and additional args to assist the process.  If no items
+    /// are added to the list, then the <see cref="Array.Empty{T}"/> singleton will be returned.  Otherwise the 
+    /// <see cref="SegmentedList{T}"/> instance will be returned.
+    /// </summary>
+    internal static IList<T> ComputeList<T, TArgs>(
+        Action<TArgs, SegmentedList<T>> addItems,
+        TArgs args,
+        // Only used to allow type inference to work at callsite
+        T? _)
+    {
+        var pooledObject = GetPooledList<T>(out var list);
+
+        addItems(args, list);
+
+        // If the result was empty, return it to the pool, and just pass back the empty array singleton.
+        if (pooledObject.Object.Count == 0)
+        {
+            pooledObject.Dispose();
+            return Array.Empty<T>();
+        }
+
+        // Otherwise, do not dispose.  Caller needs this value to stay alive.
+        return list;
+    }
+}


### PR DESCRIPTION
A recent PR added the "Total Classification Tagger".  This tagger works by calling out to the syntactic, semantic, and embedded classifiers to produce their view of tags, merging those tags appropriately to get the final result (for example, by having syntactic comments override any semantic tags).

The prior approach meant taht we were often creating 3 intermediary lists of tags which were then merged into the final lists we returned.  Those intermediary lists were then garbage.

The new approach updates our tagging infrastructure to allow taggers to add tags to a list they are passed in.  This then allows us to create pooled lists for those purposes, which we return back to the pool once the call to the underlying tagger is done.

Doing this because the typign perf team noticed a spike in allocations in this new system.