### PR TITLE
Move our OOP syncing code off of source-text checksums, onto content hashes.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -402,7 +402,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         if (documentText == lspText)
             return true;
 
-        return lspText.GetChecksum().AsSpan().SequenceEqual(documentText.GetChecksum().AsSpan());
+        return lspText.GetContentHash().AsSpan().SequenceEqual(documentText.GetContentHash().AsSpan());
     }
 
     #endregion

--- a/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
@@ -70,9 +70,9 @@ namespace Microsoft.CodeAnalysis.Serialization
         private SourceText? TryGetText()
             => _text ?? _computedText.GetTarget();
 
-        public ImmutableArray<byte> GetChecksum()
+        public ImmutableArray<byte> GetContentHash()
         {
-            return TryGetText()?.GetChecksum() ?? _storage!.GetChecksum();
+            return TryGetText()?.GetContentHash() ?? _storage!.GetContentHash();
         }
 
         public async ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -84,10 +84,10 @@ internal partial class SerializerService : ISerializerService
                     return CreateChecksum((AnalyzerReference)value, cancellationToken);
 
                 case WellKnownSynchronizationKind.SerializableSourceText:
-                    return Checksum.Create(((SerializableSourceText)value).GetChecksum());
+                    return Checksum.Create(((SerializableSourceText)value).GetContentHash());
 
                 case WellKnownSynchronizationKind.SourceText:
-                    return Checksum.Create(((SourceText)value).GetChecksum());
+                    return Checksum.Create(((SourceText)value).GetContentHash());
 
                 default:
                     // object that is not part of solution is not supported since we don't know what inputs are required to

--- a/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
@@ -36,14 +36,14 @@ internal interface IRemoteSourceGenerationService
 /// Information that uniquely identifies the content of a source-generated document and ensures the remote and local
 /// hosts are in agreement on them.
 /// </summary>
-/// <param name="OriginalSourceTextChecksum">Checksum originally produced from <see cref="SourceText.GetChecksum"/> on
+/// <param name="OriginalSourceTextContentHash">Checksum originally produced from <see cref="SourceText.GetChecksum"/> on
 /// the server side.  This may technically not be the same checksum that is produced on the client side once the
 /// SourceText is hydrated there.  See comments on <see
-/// cref="SourceGeneratedDocumentState.GetOriginalSourceTextChecksum"/> for more details on when this happens.</param>
+/// cref="SourceGeneratedDocumentState.GetOriginalSourceTextContentHash"/> for more details on when this happens.</param>
 /// <param name="EncodingName">Result of <see cref="SourceText.Encoding"/>'s <see cref="Encoding.WebName"/>.</param>
 /// <param name="ChecksumAlgorithm">Result of <see cref="SourceText.ChecksumAlgorithm"/>.</param>
 [DataContract]
 internal readonly record struct SourceGeneratedDocumentContentIdentity(
-    [property: DataMember(Order = 0)] Checksum OriginalSourceTextChecksum,
+    [property: DataMember(Order = 0)] Checksum OriginalSourceTextContentHash,
     [property: DataMember(Order = 1)] string? EncodingName,
     [property: DataMember(Order = 2)] SourceHashAlgorithm ChecksumAlgorithm);

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
@@ -194,11 +194,11 @@ namespace Microsoft.CodeAnalysis.Host
             public SourceHashAlgorithm ChecksumAlgorithm => _checksumAlgorithm;
             public Encoding? Encoding => _encoding;
 
-            public ImmutableArray<byte> GetChecksum()
+            public ImmutableArray<byte> GetContentHash()
             {
                 if (_checksum.IsDefault)
                 {
-                    ImmutableInterlocked.InterlockedInitialize(ref _checksum, ReadText(CancellationToken.None).GetChecksum());
+                    ImmutableInterlocked.InterlockedInitialize(ref _checksum, ReadText(CancellationToken.None).GetContentHash());
                 }
 
                 return _checksum;

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryTextStorageWithName.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryTextStorageWithName.cs
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.Host
 
         /// <summary>
         /// Gets the checksum for the <see cref="SourceText"/> represented by this temporary storage. This is equivalent
-        /// to calling <see cref="SourceText.GetChecksum"/>.
+        /// to calling <see cref="SourceText.GetContentHash"/>.
         /// </summary>
-        ImmutableArray<byte> GetChecksum();
+        ImmutableArray<byte> GetContentHash();
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker_Generators.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker_Generators.cs
@@ -188,8 +188,8 @@ internal partial class SolutionState
                         // Server provided us the checksum, so we just pass that along.  Note: it is critical that we do
                         // this as it may not be possible to reconstruct the same checksum the server produced due to
                         // the lossy nature of source texts.  See comment on GetOriginalSourceTextChecksum for more detail.
-                        contentIdentity.OriginalSourceTextChecksum);
-                    Contract.ThrowIfTrue(generatedDocument.GetOriginalSourceTextChecksum() != contentIdentity.OriginalSourceTextChecksum, "Checksums must match!");
+                        contentIdentity.OriginalSourceTextContentHash);
+                    Contract.ThrowIfTrue(generatedDocument.GetOriginalSourceTextContentHash() != contentIdentity.OriginalSourceTextContentHash, "Checksums must match!");
                     generatedDocumentsBuilder.Add(generatedDocument);
                 }
                 else
@@ -197,7 +197,7 @@ internal partial class SolutionState
                     // a document that already matched something locally.
                     var existingDocument = generatorInfo.Documents.GetRequiredState(documentId);
                     Contract.ThrowIfTrue(existingDocument.Identity != documentIdentity, "Identities must match!");
-                    Contract.ThrowIfTrue(existingDocument.GetOriginalSourceTextChecksum() != contentIdentity.OriginalSourceTextChecksum, "Checksums must match!");
+                    Contract.ThrowIfTrue(existingDocument.GetOriginalSourceTextContentHash() != contentIdentity.OriginalSourceTextContentHash, "Checksums must match!");
 
                     // ParseOptions may have changed between last generation and this one.  Ensure that they are
                     // properly propagated to the generated doc.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -13,9 +13,9 @@ namespace Microsoft.CodeAnalysis;
 internal sealed class SourceGeneratedDocumentState : DocumentState
 {
     /// <summary>
-    /// Backing store for <see cref="GetOriginalSourceTextChecksum"/>.
+    /// Backing store for <see cref="GetOriginalSourceTextContentHash"/>.
     /// </summary>
-    private readonly Lazy<Checksum> _lazyTextChecksum;
+    private readonly Lazy<Checksum> _lazyContentHash;
 
     public SourceGeneratedDocumentIdentity Identity { get; }
 
@@ -35,8 +35,8 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
     /// actual text and hash algorithm that were used to create the SourceText on the host side.  To ensure both the
     /// host and OOP are in agreement about the true content checksum, we store this separately.
     /// </summary>
-    public Checksum GetOriginalSourceTextChecksum()
-        => _lazyTextChecksum.Value;
+    public Checksum GetOriginalSourceTextContentHash()
+        => _lazyContentHash.Value;
 
     public static SourceGeneratedDocumentState Create(
         SourceGeneratedDocumentIdentity documentIdentity,
@@ -50,7 +50,7 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         //
         // If the caller didn't provide us with the checksum, then we'll compute it on demand.  This happens on the OOP
         // side when we're actually producing the SG doc in the first place.
-        var lazyTextChecksum = new Lazy<Checksum>(() => originalSourceTextChecksum ?? ComputeChecksum(generatedSourceText));
+        var lazyTextChecksum = new Lazy<Checksum>(() => originalSourceTextChecksum ?? ComputeContentHash(generatedSourceText));
         return Create(documentIdentity, generatedSourceText, parseOptions, languageServices, lazyTextChecksum);
     }
 
@@ -101,23 +101,23 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         SourceText text,
         LoadTextOptions loadTextOptions,
         AsyncLazy<TreeAndVersion> treeSource,
-        Lazy<Checksum> lazyTextChecksum)
+        Lazy<Checksum> lazyContentHash)
         : base(languageServices, documentServiceProvider, attributes, options, textSource, loadTextOptions, treeSource)
     {
         Identity = documentIdentity;
 
         SourceText = text;
-        _lazyTextChecksum = lazyTextChecksum;
+        _lazyContentHash = lazyContentHash;
     }
 
-    private static Checksum ComputeChecksum(SourceText text)
-        => Checksum.From(text.GetChecksum());
+    private static Checksum ComputeContentHash(SourceText text)
+        => Checksum.From(text.GetContentHash());
 
     // The base allows for parse options to be null for non-C#/VB languages, but we'll always have parse options
     public new ParseOptions ParseOptions => base.ParseOptions!;
 
     public SourceGeneratedDocumentContentIdentity GetContentIdentity()
-        => new(this.GetOriginalSourceTextChecksum(), this.SourceText.Encoding?.WebName, this.SourceText.ChecksumAlgorithm);
+        => new(this.GetOriginalSourceTextContentHash(), this.SourceText.Encoding?.WebName, this.SourceText.ChecksumAlgorithm);
 
     protected override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
         => throw new NotSupportedException(WorkspacesResources.The_contents_of_a_SourceGeneratedDocument_may_not_be_changed);
@@ -125,8 +125,8 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
     public SourceGeneratedDocumentState WithText(SourceText sourceText)
     {
         // See if we can reuse this instance directly
-        var newSourceTextChecksum = ComputeChecksum(sourceText);
-        if (this.GetOriginalSourceTextChecksum() == newSourceTextChecksum)
+        var newSourceTextChecksum = ComputeContentHash(sourceText);
+        if (this.GetOriginalSourceTextContentHash() == newSourceTextChecksum)
             return this;
 
         return Create(
@@ -150,7 +150,7 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
             parseOptions,
             LanguageServices,
             // We're just changing the parse options.  So the checksum will remain as is.
-            _lazyTextChecksum);
+            _lazyContentHash);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1880936
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388754

Followup to https://github.com/dotnet/roslyn/pull/70838