### PR TITLE
Fix override completion with nint/nuint parameters

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -111,6 +111,7 @@ This document provides guidance for thinking about language interactions and tes
 - Definite assignment analysis and auto-default struct fields
 - If you add a place an expression can appear in code, make sure `SpillSequenceSpiller` handles it. Test with a `switch` expression or `stackalloc` in that place.
 - If you add a new expression form that requires spilling, test it in the catch filter.
+- If you add a new expression that can be nested inside itself, test deeply nesting it. Potentially cut off direct nesting.
 - extension based Dispose, DisposeAsync, GetEnumerator, GetAsyncEnumerator, Deconstruct, GetAwaiter etc.
 - UTF8 String Literals (string literals with 'u8' or 'U8' type suffix).
 - Inline array element access and slicing.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23518.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23570.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>3dc05150cf234f76f6936dcb2853d31a0da1f60e</Sha>
+      <Sha>e844aa02a05b90d8cbe499676ec6ee0f19ec4980</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23461.1">

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -384,7 +384,7 @@ namespace Microsoft.CodeAnalysis
                 ImmutableArray<IParameterSymbol> parameters)
                 where TOwningSymbol : ISymbol
             {
-               using var originalParameterTypes = this.ReadSymbolKeyArray<TOwningSymbol, ITypeSymbol>(owningSymbol, getContextualType, out _);
+                using var originalParameterTypes = this.ReadSymbolKeyArray<TOwningSymbol, ITypeSymbol>(owningSymbol, getContextualType, out _);
 
                 if (originalParameterTypes.IsDefault || parameters.Length != originalParameterTypes.Count)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -384,7 +384,7 @@ namespace Microsoft.CodeAnalysis
                 ImmutableArray<IParameterSymbol> parameters)
                 where TOwningSymbol : ISymbol
             {
-                using var originalParameterTypes = this.ReadSymbolKeyArray<TOwningSymbol, ITypeSymbol>(owningSymbol, getContextualType, out _);
+               using var originalParameterTypes = this.ReadSymbolKeyArray<TOwningSymbol, ITypeSymbol>(owningSymbol, getContextualType, out _);
 
                 if (originalParameterTypes.IsDefault || parameters.Length != originalParameterTypes.Count)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis
         /// out a SymbolKey from a previous version of Roslyn and then attempt to use it in a 
         /// newer version where the encoding has changed.
         /// </summary>
-        internal const int FormatVersion = 6;
+        internal const int FormatVersion = 7;
 
         [DataMember(Order = 0)]
         private readonly string _symbolKeyData = data ?? throw new ArgumentNullException(nameof(data));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -322,14 +322,29 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             {
                 Debug.Assert(GetTypeKind(x) == GetTypeKind(y));
 
+                // If one is a tuple, both must be tuples.
                 if (x.IsTupleType != y.IsTupleType)
                     return false;
 
+                // If one is nint/nuint, the other must bas as well.
                 if (x.IsNativeIntegerType != y.IsNativeIntegerType)
                     return false;
 
+                // If one is void, the other must be as well
+                if (x.IsSystemVoid() != y.IsSystemVoid())
+                    return false;
+
+                // If a tuple, make sure the members are equivalent.
                 if (x.IsTupleType)
                     return HandleTupleTypes(x, y, equivalentTypesWithDifferingAssemblies);
+
+                // If a native int, make sure the sign matches.
+                if (x.IsNativeIntegerType)
+                    return x.SpecialType == y.SpecialType;
+
+                // If both are void, they're equivalent.
+                if (x.IsSystemVoid())
+                    return true;
 
                 if (IsConstructedFromSelf(x) != IsConstructedFromSelf(y) ||
                     x.Arity != y.Arity ||


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70782.

Issue was a problem in SymbolKey resolution where we weren't handling nints/nuints properly, leading us to think we hadn't properly resolved the prior symbol for the override int he current compilation.  this, in turn, caused us to bail out.  