### PR TITLE
Make sure document is frozen in semantic snippet provider

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -130,7 +130,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
             var textChange = new TextChange(span, string.Empty);
             originalText = originalText.WithChanges(textChange);
             var newDocument = document.WithText(originalText);
-            return (newDocument, span.Start);
+
+            // It's possible that a full semantic model is passed in. Since we made change to the document,
+            // we need to make sure it's frozen to avoid triggering source generators later on.
+            return (newDocument.WithFrozenPartialSemantics(cancellationToken), span.Start);
         }
     }
 }


### PR DESCRIPTION
Fixing internal bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1884712#3783260

It's possible that full semantic is returned by [this method](https://github.com/dotnet/roslyn/blob/95dcf53dadb5527b8c06c8251747c9a74008e2f1/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs#L30) is one's available. We need to make sure to freeze the modified document in semantic snippet provider.

This approach relies on each individual completion provider to be aware that a full semantic might be passed in, if they need to change the document and get compilation from it again, it might trigger SG. Alternatively, we could always pass in frozen partial for completion. Thoughts? @jasonmalinowski @CyrusNajmabadi 