### PR TITLE
Emit `readonly.` for constrained array access

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundArrayAccess.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundArrayAccess.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+internal partial class BoundArrayAccess
+{
+    public BoundArrayAccess(SyntaxNode syntax, BoundExpression expression, ImmutableArray<BoundExpression> indices, TypeSymbol type, bool hasErrors = false)
+        : this(syntax, expression, indices, inCompoundAssignmentReceiver: false, type, hasErrors)
+    {
+    }
+
+    public BoundArrayAccess Update(BoundExpression expression, ImmutableArray<BoundExpression> indices, TypeSymbol type)
+    {
+        return this.Update(expression, indices, inCompoundAssignmentReceiver: false, type);
+    }
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -658,6 +658,7 @@
 
     <Field Name="Expression" Type="BoundExpression"/>
     <Field Name="Indices" Type="ImmutableArray&lt;BoundExpression&gt;"/>
+    <Field Name="InCompoundAssignmentReceiver" Type="bool" />
   </Node>
 
   <!--

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -417,7 +417,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private bool ShouldEmitReadOnlyPrefix(BoundArrayAccess arrayAccess, AddressKind addressKind)
         {
-            if (addressKind == AddressKind.Constrained)
+            if (addressKind == AddressKind.Constrained ||
+                arrayAccess.InCompoundAssignmentReceiver)
             {
                 Debug.Assert(arrayAccess.Type.TypeKind == TypeKind.TypeParameter, "constrained call should only be used with type parameter types");
                 return true;

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -2041,7 +2041,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundArrayAccess : BoundExpression
     {
-        public BoundArrayAccess(SyntaxNode syntax, BoundExpression expression, ImmutableArray<BoundExpression> indices, TypeSymbol type, bool hasErrors = false)
+        public BoundArrayAccess(SyntaxNode syntax, BoundExpression expression, ImmutableArray<BoundExpression> indices, bool inCompoundAssignmentReceiver, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.ArrayAccess, syntax, type, hasErrors || expression.HasErrors() || indices.HasErrors())
         {
 
@@ -2051,20 +2051,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             this.Expression = expression;
             this.Indices = indices;
+            this.InCompoundAssignmentReceiver = inCompoundAssignmentReceiver;
         }
 
         public new TypeSymbol Type => base.Type!;
         public BoundExpression Expression { get; }
         public ImmutableArray<BoundExpression> Indices { get; }
+        public bool InCompoundAssignmentReceiver { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitArrayAccess(this);
 
-        public BoundArrayAccess Update(BoundExpression expression, ImmutableArray<BoundExpression> indices, TypeSymbol type)
+        public BoundArrayAccess Update(BoundExpression expression, ImmutableArray<BoundExpression> indices, bool inCompoundAssignmentReceiver, TypeSymbol type)
         {
-            if (expression != this.Expression || indices != this.Indices || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (expression != this.Expression || indices != this.Indices || inCompoundAssignmentReceiver != this.InCompoundAssignmentReceiver || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundArrayAccess(this.Syntax, expression, indices, type, this.HasErrors);
+                var result = new BoundArrayAccess(this.Syntax, expression, indices, inCompoundAssignmentReceiver, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -10967,7 +10969,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundExpression> indices = this.VisitList(node.Indices);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(expression, indices, type);
+            return node.Update(expression, indices, node.InCompoundAssignmentReceiver, type);
         }
         public override BoundNode? VisitArrayLength(BoundArrayLength node)
         {
@@ -12756,12 +12758,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(expression, indices, infoAndType.Type!);
+                updatedNode = node.Update(expression, indices, node.InCompoundAssignmentReceiver, infoAndType.Type!);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(expression, indices, node.Type);
+                updatedNode = node.Update(expression, indices, node.InCompoundAssignmentReceiver, node.Type);
             }
             return updatedNode;
         }
@@ -15232,6 +15234,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             new TreeDumperNode("expression", null, new TreeDumperNode[] { Visit(node.Expression, null) }),
             new TreeDumperNode("indices", null, from x in node.Indices select Visit(x, null)),
+            new TreeDumperNode("inCompoundAssignmentReceiver", node.InCompoundAssignmentReceiver, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(receiverOpt.Kind != BoundKind.TypeExpression);
 
-            BoundExpression rewrittenReceiver = VisitExpression(receiverOpt);
+            BoundExpression rewrittenReceiver = VisitCompoundAssignmentReceiver(receiverOpt, isRegularCompoundAssignment);
 
             BoundAssignmentOperator assignmentToTemp;
 
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return receiverTemp;
         }
 
-        private BoundDynamicMemberAccess TransformDynamicMemberAccess(BoundDynamicMemberAccess memberAccess, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
+        private BoundDynamicMemberAccess TransformDynamicMemberAccess(BoundDynamicMemberAccess memberAccess, bool isRegularCompoundAssignment, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
         {
             if (!CanChangeValueBetweenReads(memberAccess.Receiver))
             {
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // store receiver to temp:
-            var rewrittenReceiver = VisitExpression(memberAccess.Receiver);
+            var rewrittenReceiver = VisitCompoundAssignmentReceiver(memberAccess.Receiver, isRegularCompoundAssignment);
             BoundAssignmentOperator assignmentToTemp;
             var receiverTemp = _factory.StoreToTemp(rewrittenReceiver, out assignmentToTemp);
             stores.Add(assignmentToTemp);
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiverOpt = indexerAccess.ReceiverOpt;
             Debug.Assert(receiverOpt != null);
 
-            BoundExpression transformedReceiver = VisitExpression(receiverOpt);
+            BoundExpression transformedReceiver = VisitCompoundAssignmentReceiver(receiverOpt, isRegularCompoundAssignment);
 
             // Dealing with the arguments is a bit tricky because they can be named out-of-order arguments;
             // we have to preserve both the source-code order of the side effects and the side effects
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Returns true if the <paramref name="receiver"/> was lowered and transformed.
         /// The <paramref name="receiver"/> is not changed if this function returns false. 
         /// </summary>
-        private bool TransformCompoundAssignmentFieldOrEventAccessReceiver(Symbol fieldOrEvent, ref BoundExpression? receiver, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
+        private bool TransformCompoundAssignmentFieldOrEventAccessReceiver(Symbol fieldOrEvent, bool isRegularCompoundAssignment, ref BoundExpression? receiver, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
         {
             Debug.Assert(fieldOrEvent.Kind == SymbolKind.Field || fieldOrEvent.Kind == SymbolKind.Event);
 
@@ -476,7 +476,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(receiver.Type.IsReferenceType);
             Debug.Assert(receiver.Kind != BoundKind.TypeExpression);
-            BoundExpression rewrittenReceiver = VisitExpression(receiver);
+            BoundExpression rewrittenReceiver = VisitCompoundAssignmentReceiver(receiver, isRegularCompoundAssignment);
 
             Debug.Assert(rewrittenReceiver.Type is { });
             if (rewrittenReceiver.Type.IsTypeParameter())
@@ -497,13 +497,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
-        private BoundDynamicIndexerAccess TransformDynamicIndexerAccess(BoundDynamicIndexerAccess indexerAccess, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
+        private BoundDynamicIndexerAccess TransformDynamicIndexerAccess(BoundDynamicIndexerAccess indexerAccess, bool isRegularCompoundAssignment, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
         {
             BoundExpression loweredReceiver;
             if (CanChangeValueBetweenReads(indexerAccess.Receiver))
             {
                 BoundAssignmentOperator assignmentToTemp;
-                var temp = _factory.StoreToTemp(VisitExpression(indexerAccess.Receiver), out assignmentToTemp);
+                var temp = _factory.StoreToTemp(VisitCompoundAssignmentReceiver(indexerAccess.Receiver, isRegularCompoundAssignment), out assignmentToTemp);
                 stores.Add(assignmentToTemp);
                 temps.Add(temp.LocalSymbol);
                 loweredReceiver = temp;
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var fieldAccess = (BoundFieldAccess)originalLHS;
                         BoundExpression? receiverOpt = fieldAccess.ReceiverOpt;
 
-                        if (TransformCompoundAssignmentFieldOrEventAccessReceiver(fieldAccess.FieldSymbol, ref receiverOpt, stores, temps))
+                        if (TransformCompoundAssignmentFieldOrEventAccessReceiver(fieldAccess.FieldSymbol, isRegularCompoundAssignment, ref receiverOpt, stores, temps))
                         {
                             return MakeFieldAccess(fieldAccess.Syntax, receiverOpt, fieldAccess.FieldSymbol, fieldAccess.ConstantValueOpt, fieldAccess.ResultKind, fieldAccess.Type, fieldAccess);
                         }
@@ -664,7 +664,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             //   I t_index = index; (possibly more indices)
                             //   T value = t_array[t_index];
                             //   t_array[t_index] = value op R;
-                            var loweredArray = VisitExpression(arrayAccess.Expression);
+
+                            var loweredArray = VisitCompoundAssignmentReceiver(arrayAccess.Expression, isRegularCompoundAssignment);
+
                             var loweredIndices = VisitList(arrayAccess.Indices);
 
                             return SpillArrayElementAccess(loweredArray, loweredIndices, stores, temps);
@@ -677,10 +679,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case BoundKind.DynamicMemberAccess:
-                    return TransformDynamicMemberAccess((BoundDynamicMemberAccess)originalLHS, stores, temps);
+                    return TransformDynamicMemberAccess((BoundDynamicMemberAccess)originalLHS, isRegularCompoundAssignment, stores, temps);
 
                 case BoundKind.DynamicIndexerAccess:
-                    return TransformDynamicIndexerAccess((BoundDynamicIndexerAccess)originalLHS, stores, temps);
+                    return TransformDynamicIndexerAccess((BoundDynamicIndexerAccess)originalLHS, isRegularCompoundAssignment, stores, temps);
 
                 case BoundKind.Local:
                 case BoundKind.Parameter:
@@ -728,7 +730,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                       eventAccess.EventSymbol, eventAccess.IsUsableAsField, eventAccess.ResultKind, eventAccess.Type);
                         }
 
-                        if (TransformCompoundAssignmentFieldOrEventAccessReceiver(eventAccess.EventSymbol, ref receiverOpt, stores, temps))
+                        if (TransformCompoundAssignmentFieldOrEventAccessReceiver(eventAccess.EventSymbol, isRegularCompoundAssignment, ref receiverOpt, stores, temps))
                         {
                             return MakeEventAccess(eventAccess.Syntax, receiverOpt, eventAccess.EventSymbol, eventAccess.ConstantValueOpt, eventAccess.ResultKind, eventAccess.Type);
                         }
@@ -753,6 +755,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             stores.Add(assignmentToTemp2);
             temps.Add(variableTemp.LocalSymbol);
             return variableTemp;
+        }
+
+        private BoundExpression VisitCompoundAssignmentReceiver(BoundExpression receiver, bool isRegularCompoundAssignment)
+        {
+            var previousInCompoundAssignmentReceiver = _inCompoundAssignmentReceiver;
+            _inCompoundAssignmentReceiver |= isRegularCompoundAssignment;
+            var loweredReceiver = VisitExpression(receiver);
+            _inCompoundAssignmentReceiver = previousInCompoundAssignmentReceiver;
+            return loweredReceiver;
         }
 
         private static bool IsInvariantArray(TypeSymbol? type)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -455,7 +455,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var F = _factory;
             BoundExpression makeOffsetInput = DetermineMakePatternIndexOffsetExpressionStrategy(node.Argument, out PatternIndexOffsetLoweringStrategy strategy);
 
-            var receiver = VisitExpression(node.Receiver);
+            var receiver = VisitCompoundAssignmentReceiver(node.Receiver, isRegularAssignmentOrRegularCompoundAssignment);
 
             // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
             // If length access is a local, then we are evaluating a pattern

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenCallTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenCallTests.cs
@@ -9553,14 +9553,13 @@ class Program
     static int GetArrayIndex() => 0;
 }
 ";
-            // Execution fails due to https://github.com/dotnet/roslyn/issues/70267
-            string expectedOutput = null /*@"
+            string expectedOutput = @"
 Position get for item '1'
 Position set for item '1'
 Position get for item '2'
 Position set for item '2'
-"*/;
-            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+";
+            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput, verify: Verification.Fails).VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Shift1<T>",
 @"
@@ -9596,7 +9595,7 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       79 (0x4f)
+  // Code size       81 (0x51)
   .maxstack  4
   .locals init (T& V_0,
                 T V_1,
@@ -9605,38 +9604,39 @@ Position set for item '2'
                 T V_4)
   IL_0000:  ldarg.0
   IL_0001:  call       ""int Program.GetArrayIndex()""
-  IL_0006:  ldelema    ""T""
-  IL_000b:  stloc.2
-  IL_000c:  ldloca.s   V_4
-  IL_000e:  initobj    ""T""
-  IL_0014:  ldloc.s    V_4
-  IL_0016:  box        ""T""
-  IL_001b:  brtrue.s   IL_0028
-  IL_001d:  ldloc.2
-  IL_001e:  ldobj      ""T""
-  IL_0023:  stloc.1
-  IL_0024:  ldloca.s   V_1
-  IL_0026:  br.s       IL_0029
-  IL_0028:  ldloc.2
-  IL_0029:  stloc.0
-  IL_002a:  ldarga.s   V_0
-  IL_002c:  call       ""int Program.GetOffset<T>(ref T[])""
-  IL_0031:  stloc.3
-  IL_0032:  ldloc.0
-  IL_0033:  ldloc.3
+  IL_0006:  readonly.
+  IL_0008:  ldelema    ""T""
+  IL_000d:  stloc.2
+  IL_000e:  ldloca.s   V_4
+  IL_0010:  initobj    ""T""
+  IL_0016:  ldloc.s    V_4
+  IL_0018:  box        ""T""
+  IL_001d:  brtrue.s   IL_002a
+  IL_001f:  ldloc.2
+  IL_0020:  ldobj      ""T""
+  IL_0025:  stloc.1
+  IL_0026:  ldloca.s   V_1
+  IL_0028:  br.s       IL_002b
+  IL_002a:  ldloc.2
+  IL_002b:  stloc.0
+  IL_002c:  ldarga.s   V_0
+  IL_002e:  call       ""int Program.GetOffset<T>(ref T[])""
+  IL_0033:  stloc.3
   IL_0034:  ldloc.0
   IL_0035:  ldloc.3
-  IL_0036:  constrained. ""T""
-  IL_003c:  callvirt   ""int IMoveable.this[int].get""
-  IL_0041:  ldc.i4.1
-  IL_0042:  add
-  IL_0043:  constrained. ""T""
-  IL_0049:  callvirt   ""void IMoveable.this[int].set""
-  IL_004e:  ret
+  IL_0036:  ldloc.0
+  IL_0037:  ldloc.3
+  IL_0038:  constrained. ""T""
+  IL_003e:  callvirt   ""int IMoveable.this[int].get""
+  IL_0043:  ldc.i4.1
+  IL_0044:  add
+  IL_0045:  constrained. ""T""
+  IL_004b:  callvirt   ""void IMoveable.this[int].set""
+  IL_0050:  ret
 }
 ");
 
-            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput, verify: Verification.Fails).VerifyDiagnostics();
         }
 
         [Fact]
@@ -9707,7 +9707,7 @@ Position set for item '-1'
 Position get for item '-2'
 Position set for item '-2'
 ";
-            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput, verify: Verification.Fails).VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Shift1<T>",
 @"
@@ -9737,7 +9737,7 @@ Position set for item '-2'
 }
 ");
 
-            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput, verify: Verification.Fails).VerifyDiagnostics();
         }
 
         [Fact]
@@ -10332,14 +10332,13 @@ class Program
     static int GetArrayIndex() => 0;
 }
 ";
-            // Execution fails due to https://github.com/dotnet/roslyn/issues/70267
-            string expectedOutput = null /*@"
+            string expectedOutput = @"
 Position get for item '1'
 Position set for item '1'
 Position get for item '2'
 Position set for item '2'
-"*/;
-            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+";
+            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput, verify: Verification.Fails).VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Shift1<T>",
 @"
@@ -10375,7 +10374,7 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       79 (0x4f)
+  // Code size       81 (0x51)
   .maxstack  4
   .locals init (T V_0,
                 T& V_1,
@@ -10384,38 +10383,201 @@ Position set for item '2'
                 T V_4)
   IL_0000:  ldarg.0
   IL_0001:  call       ""int Program.GetArrayIndex()""
-  IL_0006:  ldelema    ""T""
-  IL_000b:  stloc.1
-  IL_000c:  ldloca.s   V_4
-  IL_000e:  initobj    ""T""
-  IL_0014:  ldloc.s    V_4
-  IL_0016:  box        ""T""
-  IL_001b:  brtrue.s   IL_0028
-  IL_001d:  ldloc.1
-  IL_001e:  ldobj      ""T""
-  IL_0023:  stloc.0
-  IL_0024:  ldloca.s   V_0
-  IL_0026:  br.s       IL_0029
-  IL_0028:  ldloc.1
-  IL_0029:  ldarga.s   V_0
-  IL_002b:  call       ""int Program.GetOffset<T>(ref T[])""
-  IL_0030:  stloc.2
-  IL_0031:  dup
-  IL_0032:  ldloc.2
-  IL_0033:  constrained. ""T""
-  IL_0039:  callvirt   ""int IMoveable.this[int].get""
-  IL_003e:  stloc.3
-  IL_003f:  ldloc.2
-  IL_0040:  ldloc.3
-  IL_0041:  ldc.i4.1
-  IL_0042:  add
-  IL_0043:  constrained. ""T""
-  IL_0049:  callvirt   ""void IMoveable.this[int].set""
-  IL_004e:  ret
+  IL_0006:  readonly.
+  IL_0008:  ldelema    ""T""
+  IL_000d:  stloc.1
+  IL_000e:  ldloca.s   V_4
+  IL_0010:  initobj    ""T""
+  IL_0016:  ldloc.s    V_4
+  IL_0018:  box        ""T""
+  IL_001d:  brtrue.s   IL_002a
+  IL_001f:  ldloc.1
+  IL_0020:  ldobj      ""T""
+  IL_0025:  stloc.0
+  IL_0026:  ldloca.s   V_0
+  IL_0028:  br.s       IL_002b
+  IL_002a:  ldloc.1
+  IL_002b:  ldarga.s   V_0
+  IL_002d:  call       ""int Program.GetOffset<T>(ref T[])""
+  IL_0032:  stloc.2
+  IL_0033:  dup
+  IL_0034:  ldloc.2
+  IL_0035:  constrained. ""T""
+  IL_003b:  callvirt   ""int IMoveable.this[int].get""
+  IL_0040:  stloc.3
+  IL_0041:  ldloc.2
+  IL_0042:  ldloc.3
+  IL_0043:  ldc.i4.1
+  IL_0044:  add
+  IL_0045:  constrained. ""T""
+  IL_004b:  callvirt   ""void IMoveable.this[int].set""
+  IL_0050:  ret
 }
 ");
 
-            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput, verify: Verification.Fails).VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70267")]
+        public void GenericTypeParameterElementReference_BaseClassConstraint()
+        {
+            var source = """
+                class Base
+                {
+                    public int Prop { get; set; }
+                }
+
+                class Derived : Base { }
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        var a = new[] { new Derived() };
+                        F<Base>(a);
+                        System.Console.Write(a[0].Prop);
+                    }
+
+                    static void F<T>(T[] a) where T : Base
+                    {
+                        a[0].Prop++;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(source, expectedOutput: "1").VerifyDiagnostics();
+            verifier.VerifyIL("Program.F<T>", """
+                {
+                  // Code size       37 (0x25)
+                  .maxstack  3
+                  .locals init (int V_0)
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.0
+                  IL_0002:  readonly.
+                  IL_0004:  ldelema    "T"
+                  IL_0009:  dup
+                  IL_000a:  constrained. "T"
+                  IL_0010:  callvirt   "int Base.Prop.get"
+                  IL_0015:  stloc.0
+                  IL_0016:  ldloc.0
+                  IL_0017:  ldc.i4.1
+                  IL_0018:  add
+                  IL_0019:  constrained. "T"
+                  IL_001f:  callvirt   "void Base.Prop.set"
+                  IL_0024:  ret
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70267")]
+        public void GenericTypeParameterElementReference_Struct()
+        {
+            var source = """
+                interface IBase
+                {
+                    int Prop { get; set; }
+                }
+
+                struct Derived : IBase
+                {
+                    public int Prop { get; set; }
+                }
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        var a = new[] { new Derived() };
+                        F(a);
+                        System.Console.WriteLine(a[0].Prop);
+                    }
+
+                    static void F<T>(T[] a) where T : IBase
+                    {
+                        a[0].Prop++;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(source, expectedOutput: "1").VerifyDiagnostics();
+            verifier.VerifyIL("Program.F<T>", """
+                {
+                  // Code size       37 (0x25)
+                  .maxstack  3
+                  .locals init (int V_0)
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.0
+                  IL_0002:  readonly.
+                  IL_0004:  ldelema    "T"
+                  IL_0009:  dup
+                  IL_000a:  constrained. "T"
+                  IL_0010:  callvirt   "int IBase.Prop.get"
+                  IL_0015:  stloc.0
+                  IL_0016:  ldloc.0
+                  IL_0017:  ldc.i4.1
+                  IL_0018:  add
+                  IL_0019:  constrained. "T"
+                  IL_001f:  callvirt   "void IBase.Prop.set"
+                  IL_0024:  ret
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70267")]
+        public void GenericTypeParameterElementReference_ArrayTypeMismatchException()
+        {
+            var source = """
+                using System;
+
+                class Base
+                {
+                    public Base() { Console.WriteLine("Base ctor"); }
+                }
+
+                class Derived : Base
+                {
+                    public Derived() { Console.WriteLine("Derived ctor"); }
+                }
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        var a = new[] { new Derived() };
+                        try
+                        {
+                            F<Base>(a);
+                        }
+                        catch (ArrayTypeMismatchException)
+                        {
+                            Console.WriteLine("exception");
+                        }
+                        Console.Write(a[0].GetType());
+                    }
+
+                    static void F<T>(T[] a) where T : Base, new()
+                    {
+                        ref T x = ref a[0];
+                        x = new T();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(source, expectedOutput: """
+                Base ctor
+                Derived ctor
+                exception
+                Derived
+                """).VerifyDiagnostics();
+            verifier.VerifyIL("Program.F<T>", """
+                {
+                  // Code size       18 (0x12)
+                  .maxstack  2
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.0
+                  IL_0002:  ldelema    "T"
+                  IL_0007:  call       "T System.Activator.CreateInstance<T>()"
+                  IL_000c:  stobj      "T"
+                  IL_0011:  ret
+                }
+                """);
         }
 
         [Fact]
@@ -10486,7 +10648,7 @@ Position set for item '-1'
 Position get for item '-2'
 Position set for item '-2'
 ";
-            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput, verify: Verification.Fails).VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Shift1<T>",
 @"
@@ -10516,7 +10678,7 @@ Position set for item '-2'
 }
 ");
 
-            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput, verify: Verification.Fails).VerifyDiagnostics();
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70267.