### PR TITLE
Decrease allocations in ObjectReaderTextReader.Create.

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
@@ -257,7 +257,7 @@ internal static partial class SourceTextExtensions
             var offset = 0;
             for (var i = 0; i < numberOfChunks; i++)
             {
-                (var currentChunk, var currentChunkLength) = reader.ReadCharArray(static length =>
+                var (currentChunk, currentChunkLength) = reader.ReadCharArray(static length =>
                 {
                     if (length <= SharedPools.CharBufferSize)
                         return SharedPools.CharArray.Allocate();

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
@@ -8,352 +8,376 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Shared.Extensions
+namespace Microsoft.CodeAnalysis.Shared.Extensions;
+
+internal static partial class SourceTextExtensions
 {
-    internal static partial class SourceTextExtensions
+    public static void GetLineAndOffset(this SourceText text, int position, out int lineNumber, out int offset)
     {
-        public static void GetLineAndOffset(this SourceText text, int position, out int lineNumber, out int offset)
-        {
-            var line = text.Lines.GetLineFromPosition(position);
+        var line = text.Lines.GetLineFromPosition(position);
 
-            lineNumber = line.LineNumber;
-            offset = position - line.Start;
+        lineNumber = line.LineNumber;
+        offset = position - line.Start;
+    }
+
+    public static int GetOffset(this SourceText text, int position)
+    {
+        GetLineAndOffset(text, position, out _, out var offset);
+        return offset;
+    }
+
+    public static void GetLinesAndOffsets(
+        this SourceText text,
+        TextSpan textSpan,
+        out int startLineNumber,
+        out int startOffset,
+        out int endLineNumber,
+        out int endOffset)
+    {
+        text.GetLineAndOffset(textSpan.Start, out startLineNumber, out startOffset);
+        text.GetLineAndOffset(textSpan.End, out endLineNumber, out endOffset);
+    }
+
+    public static TextChangeRange GetEncompassingTextChangeRange(this SourceText newText, SourceText oldText)
+    {
+        var ranges = newText.GetChangeRanges(oldText);
+        if (ranges.Count == 0)
+        {
+            return default;
         }
 
-        public static int GetOffset(this SourceText text, int position)
+        // simple case.
+        if (ranges.Count == 1)
         {
-            GetLineAndOffset(text, position, out _, out var offset);
-            return offset;
+            return ranges[0];
         }
 
-        public static void GetLinesAndOffsets(
-            this SourceText text,
-            TextSpan textSpan,
-            out int startLineNumber,
-            out int startOffset,
-            out int endLineNumber,
-            out int endOffset)
-        {
-            text.GetLineAndOffset(textSpan.Start, out startLineNumber, out startOffset);
-            text.GetLineAndOffset(textSpan.End, out endLineNumber, out endOffset);
-        }
+        return TextChangeRange.Collapse(ranges);
+    }
 
-        public static TextChangeRange GetEncompassingTextChangeRange(this SourceText newText, SourceText oldText)
+    public static int IndexOf(this SourceText text, string value, int startIndex, bool caseSensitive)
+    {
+        var length = text.Length - value.Length;
+        var normalized = caseSensitive ? value : CaseInsensitiveComparison.ToLower(value);
+
+        for (var i = startIndex; i <= length; i++)
         {
-            var ranges = newText.GetChangeRanges(oldText);
-            if (ranges.Count == 0)
+            var match = true;
+            for (var j = 0; j < normalized.Length; j++)
             {
-                return default;
-            }
-
-            // simple case.
-            if (ranges.Count == 1)
-            {
-                return ranges[0];
-            }
-
-            return TextChangeRange.Collapse(ranges);
-        }
-
-        public static int IndexOf(this SourceText text, string value, int startIndex, bool caseSensitive)
-        {
-            var length = text.Length - value.Length;
-            var normalized = caseSensitive ? value : CaseInsensitiveComparison.ToLower(value);
-
-            for (var i = startIndex; i <= length; i++)
-            {
-                var match = true;
-                for (var j = 0; j < normalized.Length; j++)
+                // just use indexer of source text. perf of indexer depends on actual implementation of SourceText.
+                // * all of our implementation at editor layer should provide either O(1) or O(log n).
+                //
+                // only one implementation we have that could have bad indexer perf is CompositeText with heavily modified text
+                // at compiler layer but I believe that being used in find all reference will be very rare if not none.
+                if (!Match(normalized[j], text[i + j], caseSensitive))
                 {
-                    // just use indexer of source text. perf of indexer depends on actual implementation of SourceText.
-                    // * all of our implementation at editor layer should provide either O(1) or O(logn).
-                    //
-                    // only one implementation we have that could have bad indexer perf is CompositeText with heavily modified text
-                    // at compiler layer but I believe that being used in find all reference will be very rare if not none.
-                    if (!Match(normalized[j], text[i + j], caseSensitive))
-                    {
-                        match = false;
-                        break;
-                    }
-                }
-
-                if (match)
-                {
-                    return i;
+                    match = false;
+                    break;
                 }
             }
 
-            return -1;
+            if (match)
+            {
+                return i;
+            }
         }
 
-        public static int LastIndexOf(this SourceText text, string value, int startIndex, bool caseSensitive)
+        return -1;
+    }
+
+    public static int LastIndexOf(this SourceText text, string value, int startIndex, bool caseSensitive)
+    {
+        var normalized = caseSensitive ? value : CaseInsensitiveComparison.ToLower(value);
+        startIndex = startIndex + normalized.Length > text.Length
+            ? text.Length - normalized.Length
+            : startIndex;
+
+        for (var i = startIndex; i >= 0; i--)
         {
-            var normalized = caseSensitive ? value : CaseInsensitiveComparison.ToLower(value);
-            startIndex = startIndex + normalized.Length > text.Length
-                ? text.Length - normalized.Length
-                : startIndex;
-
-            for (var i = startIndex; i >= 0; i--)
+            var match = true;
+            for (var j = 0; j < normalized.Length; j++)
             {
-                var match = true;
-                for (var j = 0; j < normalized.Length; j++)
+                // just use indexer of source text. perf of indexer depends on actual implementation of SourceText.
+                // * all of our implementation at editor layer should provide either O(1) or O(log n).
+                //
+                // only one implementation we have that could have bad indexer perf is CompositeText with heavily modified text
+                // at compiler layer but I believe that being used in find all reference will be very rare if not none.
+                if (!Match(normalized[j], text[i + j], caseSensitive))
                 {
-                    // just use indexer of source text. perf of indexer depends on actual implementation of SourceText.
-                    // * all of our implementation at editor layer should provide either O(1) or O(logn).
-                    //
-                    // only one implementation we have that could have bad indexer perf is CompositeText with heavily modified text
-                    // at compiler layer but I believe that being used in find all reference will be very rare if not none.
-                    if (!Match(normalized[j], text[i + j], caseSensitive))
-                    {
-                        match = false;
-                        break;
-                    }
-                }
-
-                if (match)
-                {
-                    return i;
+                    match = false;
+                    break;
                 }
             }
 
-            return -1;
+            if (match)
+            {
+                return i;
+            }
         }
 
-        private static bool Match(char normalizedLeft, char right, bool caseSensitive)
-            => caseSensitive ? normalizedLeft == right : normalizedLeft == CaseInsensitiveComparison.ToLower(right);
+        return -1;
+    }
 
-        public static bool ContentEquals(this SourceText text, int position, string value)
+    private static bool Match(char normalizedLeft, char right, bool caseSensitive)
+        => caseSensitive ? normalizedLeft == right : normalizedLeft == CaseInsensitiveComparison.ToLower(right);
+
+    public static bool ContentEquals(this SourceText text, int position, string value)
+    {
+        if (position + value.Length > text.Length)
         {
-            if (position + value.Length > text.Length)
+            return false;
+        }
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (text[position + i] != value[i])
             {
                 return false;
             }
-
-            for (var i = 0; i < value.Length; i++)
-            {
-                if (text[position + i] != value[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
-        public static int IndexOfNonWhiteSpace(this SourceText text, int start, int length)
-        {
-            for (var i = 0; i < length; i++)
-            {
-                if (!char.IsWhiteSpace(text[start + i]))
-                {
-                    return start + i;
-                }
-            }
+        return true;
+    }
 
-            return -1;
+    public static int IndexOfNonWhiteSpace(this SourceText text, int start, int length)
+    {
+        for (var i = 0; i < length; i++)
+        {
+            if (!char.IsWhiteSpace(text[start + i]))
+            {
+                return start + i;
+            }
         }
 
-        // 32KB. comes from SourceText char buffer size and less than large object size
-        internal const int SourceTextLengthThreshold = 32 * 1024 / sizeof(char);
+        return -1;
+    }
 
-        public static void WriteTo(this SourceText sourceText, ObjectWriter writer, CancellationToken cancellationToken)
+    // 32KB. comes from SourceText char buffer size and less than large object size
+    internal const int SourceTextLengthThreshold = 32 * 1024 / sizeof(char);
+
+    public static void WriteTo(this SourceText sourceText, ObjectWriter writer, CancellationToken cancellationToken)
+    {
+        // Source length
+        var length = sourceText.Length;
+        writer.WriteInt32(length);
+
+        // if source is small, no point on optimizing. just write out string
+        if (length < SourceTextLengthThreshold)
         {
-            // Source length
-            var length = sourceText.Length;
-            writer.WriteInt32(length);
+            writer.WriteString(sourceText.ToString());
+        }
+        else
+        {
+            // if bigger, write out as chunks
+            WriteChunksTo(sourceText, writer, length, cancellationToken);
+        }
+    }
 
-            // if source is small, no point on optimizing. just write out string
+    private static void WriteChunksTo(SourceText sourceText, ObjectWriter writer, int length, CancellationToken cancellationToken)
+    {
+        // chunk size
+        var buffer = SharedPools.CharArray.Allocate();
+        writer.WriteInt32(buffer.Length);
+
+        // number of chunks
+        var numberOfChunks = 1 + (length / buffer.Length);
+        writer.WriteInt32(numberOfChunks);
+
+        // write whole chunks
+        try
+        {
+            var offset = 0;
+            for (var i = 0; i < numberOfChunks; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var count = Math.Min(buffer.Length, length - offset);
+                if ((i < numberOfChunks - 1) || (count == buffer.Length))
+                {
+                    // chunks before last chunk or last chunk match buffer size
+                    sourceText.CopyTo(offset, buffer, 0, buffer.Length);
+                    writer.WriteValue(buffer);
+                }
+                else if (i == numberOfChunks - 1)
+                {
+                    // last chunk which size is not buffer size
+                    var tempArray = new char[count];
+
+                    sourceText.CopyTo(offset, tempArray, 0, tempArray.Length);
+                    writer.WriteValue(tempArray);
+                }
+
+                offset += count;
+            }
+
+            Contract.ThrowIfFalse(offset == length);
+        }
+        finally
+        {
+            SharedPools.CharArray.Free(buffer);
+        }
+    }
+
+    public static SourceText ReadFrom(ITextFactoryService textService, ObjectReader reader, Encoding? encoding, SourceHashAlgorithm checksumAlgorithm, CancellationToken cancellationToken)
+    {
+        using var textReader = ObjectReaderTextReader.Create(reader);
+
+        return textService.CreateText(textReader, encoding, checksumAlgorithm, cancellationToken);
+    }
+
+    private class ObjectReaderTextReader : TextReaderWithLength
+    {
+        private readonly ImmutableArray<char[]> _chunks;
+        private readonly int _chunkSize;
+        private bool _disposed;
+
+        private int _position;
+
+        public static TextReader Create(ObjectReader reader)
+        {
+            var length = reader.ReadInt32();
             if (length < SourceTextLengthThreshold)
             {
-                writer.WriteString(sourceText.ToString());
+                // small size, read as string
+                return new StringReader(reader.ReadString());
             }
-            else
+
+            // read as chunks
+            using var _ = ArrayBuilder<char[]>.GetInstance(out var builder);
+
+            var chunkSize = reader.ReadInt32();
+            var numberOfChunks = reader.ReadInt32();
+
+            var offset = 0;
+            for (var i = 0; i < numberOfChunks; i++)
             {
-                // if bigger, write out as chunks
-                WriteChunksTo(sourceText, writer, length, cancellationToken);
+                (var currentChunk, var currentChunkLength) = reader.ReadCharArray(static length =>
+                {
+                    if (length <= SharedPools.CharBufferSize)
+                        return SharedPools.CharArray.Allocate();
+
+                    return new char[length];
+                });
+
+                builder.Add(currentChunk);
+
+                offset += currentChunkLength;
             }
+
+            Contract.ThrowIfFalse(offset == length);
+            return new ObjectReaderTextReader(builder.ToImmutable(), chunkSize, length);
         }
 
-        private static void WriteChunksTo(SourceText sourceText, ObjectWriter writer, int length, CancellationToken cancellationToken)
+        private ObjectReaderTextReader(ImmutableArray<char[]> chunks, int chunkSize, int length)
+            : base(length)
         {
-            // chunk size
-            var buffer = SharedPools.CharArray.Allocate();
-            writer.WriteInt32(buffer.Length);
-
-            // number of chunks
-            var numberOfChunks = 1 + (length / buffer.Length);
-            writer.WriteInt32(numberOfChunks);
-
-            // write whole chunks
-            try
-            {
-                var offset = 0;
-                for (var i = 0; i < numberOfChunks; i++)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    var count = Math.Min(buffer.Length, length - offset);
-                    if ((i < numberOfChunks - 1) || (count == buffer.Length))
-                    {
-                        // chunks before last chunk or last chunk match buffer size
-                        sourceText.CopyTo(offset, buffer, 0, buffer.Length);
-                        writer.WriteValue(buffer);
-                    }
-                    else if (i == numberOfChunks - 1)
-                    {
-                        // last chunk which size is not buffer size
-                        var tempArray = new char[count];
-
-                        sourceText.CopyTo(offset, tempArray, 0, tempArray.Length);
-                        writer.WriteValue(tempArray);
-                    }
-
-                    offset += count;
-                }
-
-                Contract.ThrowIfFalse(offset == length);
-            }
-            finally
-            {
-                SharedPools.CharArray.Free(buffer);
-            }
+            _chunks = chunks;
+            _chunkSize = chunkSize;
+            _disposed = false;
         }
 
-        public static SourceText ReadFrom(ITextFactoryService textService, ObjectReader reader, Encoding? encoding, SourceHashAlgorithm checksumAlgorithm, CancellationToken cancellationToken)
+        protected override void Dispose(bool disposing)
         {
-            using var textReader = ObjectReaderTextReader.Create(reader);
+            if (!_disposed)
+            {
+                _disposed = true;
+                foreach (var chunk in _chunks)
+                {
+                    if (chunk.Length <= SharedPools.CharBufferSize)
+                        SharedPools.CharArray.Free(chunk);
+                }
+            }
 
-            return textService.CreateText(textReader, encoding, checksumAlgorithm, cancellationToken);
+            base.Dispose(disposing);
         }
 
-        private class ObjectReaderTextReader : TextReaderWithLength
+        public override int Peek()
         {
-            private readonly ImmutableArray<char[]> _chunks;
-            private readonly int _chunkSize;
-
-            private int _position;
-
-            public static TextReader Create(ObjectReader reader)
+            if (_position >= Length)
             {
-                var length = reader.ReadInt32();
-                if (length < SourceTextLengthThreshold)
-                {
-                    // small size, read as string
-                    return new StringReader(reader.ReadString());
-                }
-
-                // read as chunks
-                var builder = ImmutableArray.CreateBuilder<char[]>();
-
-                var chunkSize = reader.ReadInt32();
-                var numberOfChunks = reader.ReadInt32();
-
-                var offset = 0;
-                for (var i = 0; i < numberOfChunks; i++)
-                {
-                    var currentLine = (char[])reader.ReadValue();
-                    builder.Add(currentLine);
-
-                    offset += currentLine.Length;
-                }
-
-                Contract.ThrowIfFalse(offset == length);
-                return new ObjectReaderTextReader(builder.ToImmutable(), chunkSize, length);
+                return -1;
             }
 
-            private ObjectReaderTextReader(ImmutableArray<char[]> chunks, int chunkSize, int length)
-                : base(length)
-            {
-                _chunks = chunks;
-                _chunkSize = chunkSize;
-            }
-
-            public override int Peek()
-            {
-                if (_position >= Length)
-                {
-                    return -1;
-                }
-
-                return Read(_position);
-            }
-
-            public override int Read()
-            {
-                if (_position >= Length)
-                {
-                    return -1;
-                }
-
-                return Read(_position++);
-            }
-
-            public override int Read(char[] buffer, int index, int count)
-            {
-                if (buffer == null)
-                {
-                    throw new ArgumentNullException(nameof(buffer));
-                }
-
-                if (index < 0 || index >= buffer.Length)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index));
-                }
-
-                if (count < 0 || (index + count) > buffer.Length)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(count));
-                }
-
-                // check quick bail out
-                if (count == 0)
-                {
-                    return 0;
-                }
-
-                // adjust to actual char to read
-                var totalCharsToRead = Math.Min(count, Length - _position);
-                count = totalCharsToRead;
-
-                var chunkIndex = GetIndexFromPosition(_position);
-                var chunkStartOffset = GetColumnFromPosition(_position);
-
-                while (true)
-                {
-                    var chunk = _chunks[chunkIndex];
-                    var charsToCopy = Math.Min(chunk.Length - chunkStartOffset, count);
-
-                    Array.Copy(chunk, chunkStartOffset, buffer, index, charsToCopy);
-                    count -= charsToCopy;
-
-                    if (count <= 0)
-                    {
-                        break;
-                    }
-
-                    index += charsToCopy;
-                    chunkStartOffset = 0;
-                    chunkIndex++;
-                }
-
-                _position += totalCharsToRead;
-                return totalCharsToRead;
-            }
-
-            private int Read(int position)
-            {
-                var chunkIndex = GetIndexFromPosition(position);
-                var chunkColumn = GetColumnFromPosition(position);
-
-                return _chunks[chunkIndex][chunkColumn];
-            }
-
-            private int GetIndexFromPosition(int position) => position / _chunkSize;
-            private int GetColumnFromPosition(int position) => position % _chunkSize;
+            return Read(_position);
         }
+
+        public override int Read()
+        {
+            if (_position >= Length)
+            {
+                return -1;
+            }
+
+            return Read(_position++);
+        }
+
+        public override int Read(char[] buffer, int index, int count)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (index < 0 || index >= buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            if (count < 0 || (index + count) > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            // check quick bail out
+            if (count == 0)
+            {
+                return 0;
+            }
+
+            // adjust to actual char to read
+            var totalCharsToRead = Math.Min(count, Length - _position);
+            count = totalCharsToRead;
+
+            var chunkIndex = GetIndexFromPosition(_position);
+            var chunkStartOffset = GetColumnFromPosition(_position);
+
+            while (true)
+            {
+                var chunk = _chunks[chunkIndex];
+                var charsToCopy = Math.Min(chunk.Length - chunkStartOffset, count);
+
+                Array.Copy(chunk, chunkStartOffset, buffer, index, charsToCopy);
+                count -= charsToCopy;
+
+                if (count <= 0)
+                {
+                    break;
+                }
+
+                index += charsToCopy;
+                chunkStartOffset = 0;
+                chunkIndex++;
+            }
+
+            _position += totalCharsToRead;
+            return totalCharsToRead;
+        }
+
+        private int Read(int position)
+        {
+            var chunkIndex = GetIndexFromPosition(position);
+            var chunkColumn = GetColumnFromPosition(position);
+
+            return _chunks[chunkIndex][chunkColumn];
+        }
+
+        private int GetIndexFromPosition(int position) => position / _chunkSize;
+        private int GetColumnFromPosition(int position) => position % _chunkSize;
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/SharedPools.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/SharedPools.cs
@@ -6,77 +6,77 @@ using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;
 
-namespace Microsoft.CodeAnalysis
+namespace Microsoft.CodeAnalysis;
+
+/// <summary>
+/// Shared object pool for Roslyn
+/// 
+/// Use this shared pool if only concern is reducing object allocations.
+/// if perf of an object pool itself is also a concern, use ObjectPool directly.
+/// 
+/// For example, if you want to create a million of small objects within a second, 
+/// use the ObjectPool directly. it should have much less overhead than using this.
+/// </summary>
+internal static class SharedPools
 {
     /// <summary>
-    /// Shared object pool for roslyn
-    /// 
-    /// Use this shared pool if only concern is reducing object allocations.
-    /// if perf of an object pool itself is also a concern, use ObjectPool directly.
-    /// 
-    /// For example, if you want to create a million of small objects within a second, 
-    /// use the ObjectPool directly. it should have much less overhead than using this.
+    /// pool that uses default constructor with 100 elements pooled
     /// </summary>
-    internal static class SharedPools
+    public static ObjectPool<T> BigDefault<T>() where T : class, new()
+        => DefaultBigPool<T>.Instance;
+
+    /// <summary>
+    /// pool that uses default constructor with 20 elements pooled
+    /// </summary>
+    public static ObjectPool<T> Default<T>() where T : class, new()
+        => DefaultNormalPool<T>.Instance;
+
+    /// <summary>
+    /// pool that uses string as key with StringComparer.OrdinalIgnoreCase as key comparer
+    /// </summary>
+    public static ObjectPool<Dictionary<string, T>> StringIgnoreCaseDictionary<T>()
+        => StringIgnoreCaseDictionaryNormalPool<T>.Instance;
+
+    /// <summary>
+    /// pool that uses string as element with StringComparer.OrdinalIgnoreCase as element comparer
+    /// </summary>
+    public static readonly ObjectPool<HashSet<string>> StringIgnoreCaseHashSet =
+        new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase), 20);
+
+    /// <summary>
+    /// pool that uses string as element with StringComparer.Ordinal as element comparer
+    /// </summary>
+    public static readonly ObjectPool<HashSet<string>> StringHashSet =
+        new(() => new HashSet<string>(StringComparer.Ordinal), 20);
+
+    /// <summary>
+    /// Used to reduce the # of temporary byte[]s created to satisfy serialization and
+    /// other I/O requests
+    /// </summary>
+    public static readonly ObjectPool<byte[]> ByteArray = new(() => new byte[ByteBufferSize], ByteBufferCount);
+    public static readonly ObjectPool<char[]> CharArray = new(() => new char[CharBufferSize], CharBufferCount);
+
+    // byte pooled memory : 4K * 512 = 2MB
+    public const int ByteBufferSize = 4 * 1024;
+    private const int ByteBufferCount = 512;
+
+    // char pooled memory : 8K * 256 = 2MB
+    public const int CharBufferSize = 4 * 1024;
+    private const int CharBufferCount = 256;
+
+    private static class DefaultBigPool<T> where T : class, new()
     {
-        /// <summary>
-        /// pool that uses default constructor with 100 elements pooled
-        /// </summary>
-        public static ObjectPool<T> BigDefault<T>() where T : class, new()
-            => DefaultBigPool<T>.Instance;
+        public static readonly ObjectPool<T> Instance = new(() => new T(), 100);
+    }
 
-        /// <summary>
-        /// pool that uses default constructor with 20 elements pooled
-        /// </summary>
-        public static ObjectPool<T> Default<T>() where T : class, new()
-            => DefaultNormalPool<T>.Instance;
+    private static class DefaultNormalPool<T> where T : class, new()
+    {
+        public static readonly ObjectPool<T> Instance = new(() => new T(), 20);
+    }
 
-        /// <summary>
-        /// pool that uses string as key with StringComparer.OrdinalIgnoreCase as key comparer
-        /// </summary>
-        public static ObjectPool<Dictionary<string, T>> StringIgnoreCaseDictionary<T>()
-            => StringIgnoreCaseDictionaryNormalPool<T>.Instance;
-
-        /// <summary>
-        /// pool that uses string as element with StringComparer.OrdinalIgnoreCase as element comparer
-        /// </summary>
-        public static readonly ObjectPool<HashSet<string>> StringIgnoreCaseHashSet =
-            new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase), 20);
-
-        /// <summary>
-        /// pool that uses string as element with StringComparer.Ordinal as element comparer
-        /// </summary>
-        public static readonly ObjectPool<HashSet<string>> StringHashSet =
-            new(() => new HashSet<string>(StringComparer.Ordinal), 20);
-
-        /// <summary>
-        /// Used to reduce the # of temporary byte[]s created to satisfy serialization and
-        /// other I/O requests
-        /// </summary>
-        public static readonly ObjectPool<byte[]> ByteArray = new(() => new byte[ByteBufferSize], ByteBufferCount);
-        public static readonly ObjectPool<char[]> CharArray = new(() => new char[ByteBufferSize], CharBufferCount);
-
-        // byte pooled memory : 4K * 512 = 4MB
-        public const int ByteBufferSize = 4 * 1024;
-        private const int ByteBufferCount = 512;
-
-        // char pooled memory : 8K * 5 = 40K
-        private const int CharBufferCount = 5;
-
-        private static class DefaultBigPool<T> where T : class, new()
-        {
-            public static readonly ObjectPool<T> Instance = new(() => new T(), 100);
-        }
-
-        private static class DefaultNormalPool<T> where T : class, new()
-        {
-            public static readonly ObjectPool<T> Instance = new(() => new T(), 20);
-        }
-
-        private static class StringIgnoreCaseDictionaryNormalPool<T>
-        {
-            public static readonly ObjectPool<Dictionary<string, T>> Instance =
-                new(() => new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase), 20);
-        }
+    private static class StringIgnoreCaseDictionaryNormalPool<T>
+    {
+        public static readonly ObjectPool<Dictionary<string, T>> Instance =
+            new(() => new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase), 20);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectReader.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectReader.cs
@@ -253,7 +253,7 @@ internal sealed partial class ObjectReader : IDisposable
         }
     }
 
-    public (char[] Array, int Length) ReadCharArray(Func<int, char[]> getArray)
+    public (char[] array, int length) ReadCharArray(Func<int, char[]> getArray)
     {
         var kind = (TypeCode)_reader.ReadByte();
 
@@ -389,7 +389,7 @@ internal sealed partial class ObjectReader : IDisposable
         }
     }
 
-    private (int Length, TypeCode ElementKind) ReadArrayLengthAndElementKind(TypeCode kind)
+    private (int length, TypeCode elementKind) ReadArrayLengthAndElementKind(TypeCode kind)
     {
         var length = kind switch
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectReader.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectReader.cs
@@ -253,7 +253,7 @@ internal sealed partial class ObjectReader : IDisposable
         }
     }
 
-    public (char[], int) ReadCharArray(Func<int, char[]> getArray)
+    public (char[] Array, int Length) ReadCharArray(Func<int, char[]> getArray)
     {
         var kind = (TypeCode)_reader.ReadByte();
 
@@ -376,7 +376,7 @@ internal sealed partial class ObjectReader : IDisposable
 
     private Array ReadArray(TypeCode kind)
     {
-        (var length, var elementKind) = ReadArrayLengthAndElementKind(kind);
+        var (length, elementKind) = ReadArrayLengthAndElementKind(kind);
 
         var elementType = ObjectWriter.s_reverseTypeMap[(int)elementKind];
         if (elementType != null)
@@ -389,7 +389,7 @@ internal sealed partial class ObjectReader : IDisposable
         }
     }
 
-    private (int, TypeCode) ReadArrayLengthAndElementKind(TypeCode kind)
+    private (int Length, TypeCode ElementKind) ReadArrayLengthAndElementKind(TypeCode kind)
     {
         var length = kind switch
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectReader.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectReader.cs
@@ -5,614 +5,608 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis;
-using System.Runtime.ExceptionServices;
 
-namespace Roslyn.Utilities
-{
+namespace Roslyn.Utilities;
+
 #if COMPILERCORE
-    using Resources = CodeAnalysisResources;
+using Resources = CodeAnalysisResources;
 #elif CODE_STYLE
-    using Resources = CodeStyleResources;
+using Resources = CodeStyleResources;
 #else
-    using Resources = WorkspacesResources;
+using Resources = WorkspacesResources;
 #endif
 
-    using TypeCode = ObjectWriter.TypeCode;
+using TypeCode = ObjectWriter.TypeCode;
+
+/// <summary>
+/// An <see cref="ObjectReader"/> that deserializes objects from a byte stream.
+/// </summary>
+internal sealed partial class ObjectReader : IDisposable
+{
+    /// <summary>
+    /// We start the version at something reasonably random.  That way an older file, with 
+    /// some random start-bytes, has little chance of matching our version.  When incrementing
+    /// this version, just change VersionByte2.
+    /// </summary>
+    internal const byte VersionByte1 = 0b10101010;
+    internal const byte VersionByte2 = 0b00001100;
+
+    private readonly BinaryReader _reader;
+    private readonly CancellationToken _cancellationToken;
 
     /// <summary>
-    /// An <see cref="ObjectReader"/> that deserializes objects from a byte stream.
+    /// Map of reference id's to deserialized strings.
     /// </summary>
-    internal sealed partial class ObjectReader : IDisposable
+    private readonly ReaderReferenceMap<string> _stringReferenceMap;
+
+    /// <summary>
+    /// Creates a new instance of a <see cref="ObjectReader"/>.
+    /// </summary>
+    /// <param name="stream">The stream to read objects from.</param>
+    /// <param name="leaveOpen">True to leave the <paramref name="stream"/> open after the <see cref="ObjectWriter"/> is disposed.</param>
+    /// <param name="cancellationToken"></param>
+    private ObjectReader(
+        Stream stream,
+        bool leaveOpen,
+        CancellationToken cancellationToken)
     {
-        /// <summary>
-        /// We start the version at something reasonably random.  That way an older file, with 
-        /// some random start-bytes, has little chance of matching our version.  When incrementing
-        /// this version, just change VersionByte2.
-        /// </summary>
-        internal const byte VersionByte1 = 0b10101010;
-        internal const byte VersionByte2 = 0b00001100;
+        // String serialization assumes both reader and writer to be of the same endianness.
+        // It can be adjusted for BigEndian if needed.
+        Debug.Assert(BitConverter.IsLittleEndian);
 
-        private readonly BinaryReader _reader;
-        private readonly CancellationToken _cancellationToken;
+        _reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen);
+        _stringReferenceMap = ReaderReferenceMap<string>.Create();
 
-        /// <summary>
-        /// Map of reference id's to deserialized strings.
-        /// </summary>
-        private readonly ReaderReferenceMap<string> _stringReferenceMap;
+        _cancellationToken = cancellationToken;
+    }
 
-        /// <summary>
-        /// Creates a new instance of a <see cref="ObjectReader"/>.
-        /// </summary>
-        /// <param name="stream">The stream to read objects from.</param>
-        /// <param name="leaveOpen">True to leave the <paramref name="stream"/> open after the <see cref="ObjectWriter"/> is disposed.</param>
-        /// <param name="cancellationToken"></param>
-        private ObjectReader(
-            Stream stream,
-            bool leaveOpen,
-            CancellationToken cancellationToken)
+    /// <summary>
+    /// Attempts to create a <see cref="ObjectReader"/> from the provided <paramref name="stream"/>.
+    /// If the <paramref name="stream"/> does not start with a valid header, then <see langword="null"/> will
+    /// be returned.
+    /// </summary>
+    public static ObjectReader TryGetReader(
+        Stream stream,
+        bool leaveOpen = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (stream == null)
         {
-            // String serialization assumes both reader and writer to be of the same endianness.
-            // It can be adjusted for BigEndian if needed.
-            Debug.Assert(BitConverter.IsLittleEndian);
-
-            _reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen);
-            _stringReferenceMap = ReaderReferenceMap<string>.Create();
-
-            _cancellationToken = cancellationToken;
+            return null;
         }
 
-        /// <summary>
-        /// Attempts to create a <see cref="ObjectReader"/> from the provided <paramref name="stream"/>.
-        /// If the <paramref name="stream"/> does not start with a valid header, then <see langword="null"/> will
-        /// be returned.
-        /// </summary>
-        public static ObjectReader TryGetReader(
-            Stream stream,
-            bool leaveOpen = false,
-            CancellationToken cancellationToken = default)
+        try
         {
-            if (stream == null)
+            if (stream.ReadByte() != VersionByte1 ||
+                stream.ReadByte() != VersionByte2)
             {
                 return null;
             }
-
-            try
-            {
-                if (stream.ReadByte() != VersionByte1 ||
-                    stream.ReadByte() != VersionByte2)
-                {
-                    return null;
-                }
-            }
-            catch (AggregateException ex) when (ex.InnerException is not null)
-            {
-                // PipeReaderStream wraps any exception it throws in an AggregateException, which is not expected by
-                // callers treating it as a normal stream. Unwrap and rethrow the inner exception for clarity.
-                // https://github.com/dotnet/runtime/issues/70206
-#if NETCOREAPP
-                ExceptionDispatchInfo.Throw(ex.InnerException);
-#else
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-#endif
-            }
-
-            return new ObjectReader(stream, leaveOpen, cancellationToken);
         }
-
-        /// <summary>
-        /// Creates an <see cref="ObjectReader"/> from the provided <paramref name="stream"/>.
-        /// Unlike <see cref="TryGetReader(Stream, bool, CancellationToken)"/>, it requires the version
-        /// of the data in the stream to exactly match the current format version.
-        /// Should only be used to read data written by the same version of Roslyn.
-        /// </summary>
-        public static ObjectReader GetReader(
-            Stream stream,
-            bool leaveOpen,
-            CancellationToken cancellationToken)
+        catch (AggregateException ex) when (ex.InnerException is not null)
         {
-            var b = stream.ReadByte();
-            if (b == -1)
-            {
-                throw new EndOfStreamException();
-            }
-
-            if (b != VersionByte1)
-            {
-                throw ExceptionUtilities.UnexpectedValue(b);
-            }
-
-            b = stream.ReadByte();
-            if (b == -1)
-            {
-                throw new EndOfStreamException();
-            }
-
-            if (b != VersionByte2)
-            {
-                throw ExceptionUtilities.UnexpectedValue(b);
-            }
-
-            return new ObjectReader(stream, leaveOpen, cancellationToken);
+            // PipeReaderStream wraps any exception it throws in an AggregateException, which is not expected by
+            // callers treating it as a normal stream. Unwrap and rethrow the inner exception for clarity.
+            // https://github.com/dotnet/runtime/issues/70206
+#if NETCOREAPP
+            ExceptionDispatchInfo.Throw(ex.InnerException);
+#else
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+#endif
         }
+
+        return new ObjectReader(stream, leaveOpen, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ObjectReader"/> from the provided <paramref name="stream"/>.
+    /// Unlike <see cref="TryGetReader(Stream, bool, CancellationToken)"/>, it requires the version
+    /// of the data in the stream to exactly match the current format version.
+    /// Should only be used to read data written by the same version of Roslyn.
+    /// </summary>
+    public static ObjectReader GetReader(
+        Stream stream,
+        bool leaveOpen,
+        CancellationToken cancellationToken)
+    {
+        var b = stream.ReadByte();
+        if (b == -1)
+        {
+            throw new EndOfStreamException();
+        }
+
+        if (b != VersionByte1)
+        {
+            throw ExceptionUtilities.UnexpectedValue(b);
+        }
+
+        b = stream.ReadByte();
+        if (b == -1)
+        {
+            throw new EndOfStreamException();
+        }
+
+        if (b != VersionByte2)
+        {
+            throw ExceptionUtilities.UnexpectedValue(b);
+        }
+
+        return new ObjectReader(stream, leaveOpen, cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        _stringReferenceMap.Dispose();
+    }
+
+    public bool ReadBoolean() => _reader.ReadBoolean();
+    public byte ReadByte() => _reader.ReadByte();
+    // read as ushort because BinaryWriter fails on chars that are unicode surrogates
+    public char ReadChar() => (char)_reader.ReadUInt16();
+    public decimal ReadDecimal() => _reader.ReadDecimal();
+    public double ReadDouble() => _reader.ReadDouble();
+    public float ReadSingle() => _reader.ReadSingle();
+    public int ReadInt32() => _reader.ReadInt32();
+    public long ReadInt64() => _reader.ReadInt64();
+    public sbyte ReadSByte() => _reader.ReadSByte();
+    public short ReadInt16() => _reader.ReadInt16();
+    public uint ReadUInt32() => _reader.ReadUInt32();
+    public ulong ReadUInt64() => _reader.ReadUInt64();
+    public ushort ReadUInt16() => _reader.ReadUInt16();
+    public string ReadString() => ReadStringValue();
+
+    public Guid ReadGuid()
+    {
+        var accessor = new ObjectWriter.GuidAccessor
+        {
+            Low64 = ReadInt64(),
+            High64 = ReadInt64()
+        };
+
+        return accessor.Guid;
+    }
+
+    public object ReadValue()
+    {
+        var code = (TypeCode)_reader.ReadByte();
+        switch (code)
+        {
+            case TypeCode.Null: return null;
+            case TypeCode.Boolean_True: return true;
+            case TypeCode.Boolean_False: return false;
+            case TypeCode.Int8: return _reader.ReadSByte();
+            case TypeCode.UInt8: return _reader.ReadByte();
+            case TypeCode.Int16: return _reader.ReadInt16();
+            case TypeCode.UInt16: return _reader.ReadUInt16();
+            case TypeCode.Int32: return _reader.ReadInt32();
+            case TypeCode.Int32_1Byte: return (int)_reader.ReadByte();
+            case TypeCode.Int32_2Bytes: return (int)_reader.ReadUInt16();
+            case TypeCode.Int32_0:
+            case TypeCode.Int32_1:
+            case TypeCode.Int32_2:
+            case TypeCode.Int32_3:
+            case TypeCode.Int32_4:
+            case TypeCode.Int32_5:
+            case TypeCode.Int32_6:
+            case TypeCode.Int32_7:
+            case TypeCode.Int32_8:
+            case TypeCode.Int32_9:
+            case TypeCode.Int32_10:
+                return (int)code - (int)TypeCode.Int32_0;
+            case TypeCode.UInt32: return _reader.ReadUInt32();
+            case TypeCode.UInt32_1Byte: return (uint)_reader.ReadByte();
+            case TypeCode.UInt32_2Bytes: return (uint)_reader.ReadUInt16();
+            case TypeCode.UInt32_0:
+            case TypeCode.UInt32_1:
+            case TypeCode.UInt32_2:
+            case TypeCode.UInt32_3:
+            case TypeCode.UInt32_4:
+            case TypeCode.UInt32_5:
+            case TypeCode.UInt32_6:
+            case TypeCode.UInt32_7:
+            case TypeCode.UInt32_8:
+            case TypeCode.UInt32_9:
+            case TypeCode.UInt32_10:
+                return (uint)((int)code - (int)TypeCode.UInt32_0);
+            case TypeCode.Int64: return _reader.ReadInt64();
+            case TypeCode.UInt64: return _reader.ReadUInt64();
+            case TypeCode.Float4: return _reader.ReadSingle();
+            case TypeCode.Float8: return _reader.ReadDouble();
+            case TypeCode.Decimal: return _reader.ReadDecimal();
+            case TypeCode.Char:
+                // read as ushort because BinaryWriter fails on chars that are unicode surrogates
+                return (char)_reader.ReadUInt16();
+            case TypeCode.StringUtf8:
+            case TypeCode.StringUtf16:
+            case TypeCode.StringRef_4Bytes:
+            case TypeCode.StringRef_1Byte:
+            case TypeCode.StringRef_2Bytes:
+                return ReadStringValue(code);
+            case TypeCode.DateTime:
+                return DateTime.FromBinary(_reader.ReadInt64());
+            case TypeCode.Array:
+            case TypeCode.Array_0:
+            case TypeCode.Array_1:
+            case TypeCode.Array_2:
+            case TypeCode.Array_3:
+                return ReadArray(code);
+
+            case TypeCode.EncodingName:
+                return Encoding.GetEncoding(ReadString());
+
+            case >= TypeCode.FirstWellKnownTextEncoding and <= TypeCode.LastWellKnownTextEncoding:
+                return ObjectWriter.ToEncodingKind(code).GetEncoding();
+
+            case TypeCode.EncodingCodePage:
+                return Encoding.GetEncoding(ReadInt32());
+
+            default:
+                throw ExceptionUtilities.UnexpectedValue(code);
+        }
+    }
+
+    public (char[], int) ReadCharArray(Func<int, char[]> getArray)
+    {
+        var kind = (TypeCode)_reader.ReadByte();
+
+        (var length, _) = ReadArrayLengthAndElementKind(kind);
+        var array = getArray(length);
+
+        var charsRead = _reader.Read(array, 0, length);
+
+        return (array, charsRead);
+    }
+
+    /// <summary>
+    /// A reference-id to object map, that can share base data efficiently.
+    /// </summary>
+    private readonly struct ReaderReferenceMap<T> : IDisposable
+        where T : class
+    {
+        private readonly SegmentedList<T> _values;
+
+        private static readonly ObjectPool<SegmentedList<T>> s_objectListPool
+            = new(() => new SegmentedList<T>(20));
+
+        private ReaderReferenceMap(SegmentedList<T> values)
+            => _values = values;
+
+        public static ReaderReferenceMap<T> Create()
+            => new(s_objectListPool.Allocate());
 
         public void Dispose()
         {
-            _stringReferenceMap.Dispose();
+            _values.Clear();
+            s_objectListPool.Free(_values);
         }
 
-        public bool ReadBoolean() => _reader.ReadBoolean();
-        public byte ReadByte() => _reader.ReadByte();
-        // read as ushort because BinaryWriter fails on chars that are unicode surrogates
-        public char ReadChar() => (char)_reader.ReadUInt16();
-        public decimal ReadDecimal() => _reader.ReadDecimal();
-        public double ReadDouble() => _reader.ReadDouble();
-        public float ReadSingle() => _reader.ReadSingle();
-        public int ReadInt32() => _reader.ReadInt32();
-        public long ReadInt64() => _reader.ReadInt64();
-        public sbyte ReadSByte() => _reader.ReadSByte();
-        public short ReadInt16() => _reader.ReadInt16();
-        public uint ReadUInt32() => _reader.ReadUInt32();
-        public ulong ReadUInt64() => _reader.ReadUInt64();
-        public ushort ReadUInt16() => _reader.ReadUInt16();
-        public string ReadString() => ReadStringValue();
-
-        public Guid ReadGuid()
+        public int GetNextObjectId()
         {
-            var accessor = new ObjectWriter.GuidAccessor
-            {
-                Low64 = ReadInt64(),
-                High64 = ReadInt64()
-            };
-
-            return accessor.Guid;
+            var id = _values.Count;
+            _values.Add(null);
+            return id;
         }
 
-        public object ReadValue()
+        public void AddValue(T value)
+            => _values.Add(value);
+
+        public void AddValue(int index, T value)
+            => _values[index] = value;
+
+        public T GetValue(int referenceId)
+            => _values[referenceId];
+    }
+
+    internal uint ReadCompressedUInt()
+    {
+        var info = _reader.ReadByte();
+        var marker = (byte)(info & ObjectWriter.ByteMarkerMask);
+        var byte0 = (byte)(info & ~ObjectWriter.ByteMarkerMask);
+
+        if (marker == ObjectWriter.Byte1Marker)
         {
-            var code = (TypeCode)_reader.ReadByte();
-            switch (code)
+            return byte0;
+        }
+
+        if (marker == ObjectWriter.Byte2Marker)
+        {
+            var byte1 = _reader.ReadByte();
+            return (((uint)byte0) << 8) | byte1;
+        }
+
+        if (marker == ObjectWriter.Byte4Marker)
+        {
+            var byte1 = _reader.ReadByte();
+            var byte2 = _reader.ReadByte();
+            var byte3 = _reader.ReadByte();
+
+            return (((uint)byte0) << 24) | (((uint)byte1) << 16) | (((uint)byte2) << 8) | byte3;
+        }
+
+        throw ExceptionUtilities.UnexpectedValue(marker);
+    }
+
+    private string ReadStringValue()
+    {
+        var kind = (TypeCode)_reader.ReadByte();
+        return kind == TypeCode.Null ? null : ReadStringValue(kind);
+    }
+
+    private string ReadStringValue(TypeCode kind)
+    {
+        return kind switch
+        {
+            TypeCode.StringRef_1Byte => _stringReferenceMap.GetValue(_reader.ReadByte()),
+            TypeCode.StringRef_2Bytes => _stringReferenceMap.GetValue(_reader.ReadUInt16()),
+            TypeCode.StringRef_4Bytes => _stringReferenceMap.GetValue(_reader.ReadInt32()),
+            TypeCode.StringUtf16 or TypeCode.StringUtf8 => ReadStringLiteral(kind),
+            _ => throw ExceptionUtilities.UnexpectedValue(kind),
+        };
+    }
+
+    private unsafe string ReadStringLiteral(TypeCode kind)
+    {
+        string value;
+        if (kind == TypeCode.StringUtf8)
+        {
+            value = _reader.ReadString();
+        }
+        else
+        {
+            // This is rare, just allocate UTF-16 bytes for simplicity.
+            var characterCount = (int)ReadCompressedUInt();
+            var bytes = _reader.ReadBytes(characterCount * sizeof(char));
+            fixed (byte* bytesPtr = bytes)
             {
-                case TypeCode.Null: return null;
-                case TypeCode.Boolean_True: return true;
-                case TypeCode.Boolean_False: return false;
-                case TypeCode.Int8: return _reader.ReadSByte();
-                case TypeCode.UInt8: return _reader.ReadByte();
-                case TypeCode.Int16: return _reader.ReadInt16();
-                case TypeCode.UInt16: return _reader.ReadUInt16();
-                case TypeCode.Int32: return _reader.ReadInt32();
-                case TypeCode.Int32_1Byte: return (int)_reader.ReadByte();
-                case TypeCode.Int32_2Bytes: return (int)_reader.ReadUInt16();
-                case TypeCode.Int32_0:
-                case TypeCode.Int32_1:
-                case TypeCode.Int32_2:
-                case TypeCode.Int32_3:
-                case TypeCode.Int32_4:
-                case TypeCode.Int32_5:
-                case TypeCode.Int32_6:
-                case TypeCode.Int32_7:
-                case TypeCode.Int32_8:
-                case TypeCode.Int32_9:
-                case TypeCode.Int32_10:
-                    return (int)code - (int)TypeCode.Int32_0;
-                case TypeCode.UInt32: return _reader.ReadUInt32();
-                case TypeCode.UInt32_1Byte: return (uint)_reader.ReadByte();
-                case TypeCode.UInt32_2Bytes: return (uint)_reader.ReadUInt16();
-                case TypeCode.UInt32_0:
-                case TypeCode.UInt32_1:
-                case TypeCode.UInt32_2:
-                case TypeCode.UInt32_3:
-                case TypeCode.UInt32_4:
-                case TypeCode.UInt32_5:
-                case TypeCode.UInt32_6:
-                case TypeCode.UInt32_7:
-                case TypeCode.UInt32_8:
-                case TypeCode.UInt32_9:
-                case TypeCode.UInt32_10:
-                    return (uint)((int)code - (int)TypeCode.UInt32_0);
-                case TypeCode.Int64: return _reader.ReadInt64();
-                case TypeCode.UInt64: return _reader.ReadUInt64();
-                case TypeCode.Float4: return _reader.ReadSingle();
-                case TypeCode.Float8: return _reader.ReadDouble();
-                case TypeCode.Decimal: return _reader.ReadDecimal();
-                case TypeCode.Char:
-                    // read as ushort because BinaryWriter fails on chars that are unicode surrogates
-                    return (char)_reader.ReadUInt16();
-                case TypeCode.StringUtf8:
-                case TypeCode.StringUtf16:
-                case TypeCode.StringRef_4Bytes:
-                case TypeCode.StringRef_1Byte:
-                case TypeCode.StringRef_2Bytes:
-                    return ReadStringValue(code);
-                case TypeCode.DateTime:
-                    return DateTime.FromBinary(_reader.ReadInt64());
-                case TypeCode.Array:
-                case TypeCode.Array_0:
-                case TypeCode.Array_1:
-                case TypeCode.Array_2:
-                case TypeCode.Array_3:
-                    return ReadArray(code);
-
-                case TypeCode.EncodingName:
-                    return Encoding.GetEncoding(ReadString());
-
-                case >= TypeCode.FirstWellKnownTextEncoding and <= TypeCode.LastWellKnownTextEncoding:
-                    return ObjectWriter.ToEncodingKind(code).GetEncoding();
-
-                case TypeCode.EncodingCodePage:
-                    return Encoding.GetEncoding(ReadInt32());
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(code);
+                value = new string((char*)bytesPtr, 0, characterCount);
             }
         }
 
-        /// <summary>
-        /// A reference-id to object map, that can share base data efficiently.
-        /// </summary>
-        private readonly struct ReaderReferenceMap<T> : IDisposable
-            where T : class
+        _stringReferenceMap.AddValue(value);
+        return value;
+    }
+
+    private Array ReadArray(TypeCode kind)
+    {
+        (var length, var elementKind) = ReadArrayLengthAndElementKind(kind);
+
+        var elementType = ObjectWriter.s_reverseTypeMap[(int)elementKind];
+        if (elementType != null)
         {
-            private readonly SegmentedList<T> _values;
-
-            private static readonly ObjectPool<SegmentedList<T>> s_objectListPool
-                = new(() => new SegmentedList<T>(20));
-
-            private ReaderReferenceMap(SegmentedList<T> values)
-                => _values = values;
-
-            public static ReaderReferenceMap<T> Create()
-                => new(s_objectListPool.Allocate());
-
-            public void Dispose()
-            {
-                _values.Clear();
-                s_objectListPool.Free(_values);
-            }
-
-            public int GetNextObjectId()
-            {
-                var id = _values.Count;
-                _values.Add(null);
-                return id;
-            }
-
-            public void AddValue(T value)
-                => _values.Add(value);
-
-            public void AddValue(int index, T value)
-                => _values[index] = value;
-
-            public T GetValue(int referenceId)
-                => _values[referenceId];
+            return this.ReadPrimitiveTypeArrayElements(elementType, elementKind, length);
         }
-
-        internal uint ReadCompressedUInt()
+        else
         {
-            var info = _reader.ReadByte();
-            var marker = (byte)(info & ObjectWriter.ByteMarkerMask);
-            var byte0 = (byte)(info & ~ObjectWriter.ByteMarkerMask);
-
-            if (marker == ObjectWriter.Byte1Marker)
-            {
-                return byte0;
-            }
-
-            if (marker == ObjectWriter.Byte2Marker)
-            {
-                var byte1 = _reader.ReadByte();
-                return (((uint)byte0) << 8) | byte1;
-            }
-
-            if (marker == ObjectWriter.Byte4Marker)
-            {
-                var byte1 = _reader.ReadByte();
-                var byte2 = _reader.ReadByte();
-                var byte3 = _reader.ReadByte();
-
-                return (((uint)byte0) << 24) | (((uint)byte1) << 16) | (((uint)byte2) << 8) | byte3;
-            }
-
-            throw ExceptionUtilities.UnexpectedValue(marker);
+            throw ExceptionUtilities.UnexpectedValue(elementKind);
         }
+    }
 
-        private string ReadStringValue()
+    private (int, TypeCode) ReadArrayLengthAndElementKind(TypeCode kind)
+    {
+        var length = kind switch
         {
-            var kind = (TypeCode)_reader.ReadByte();
-            return kind == TypeCode.Null ? null : ReadStringValue(kind);
-        }
+            TypeCode.Array_0 => 0,
+            TypeCode.Array_1 => 1,
+            TypeCode.Array_2 => 2,
+            TypeCode.Array_3 => 3,
+            _ => (int)this.ReadCompressedUInt(),
+        };
 
-        private string ReadStringValue(TypeCode kind)
+        // SUBTLE: If it was a primitive array, only the EncodingKind byte of the element type was written, instead of encoding as a type.
+        var elementKind = (TypeCode)_reader.ReadByte();
+
+        return (length, elementKind);
+    }
+
+    private Array ReadPrimitiveTypeArrayElements(Type type, TypeCode kind, int length)
+    {
+        Debug.Assert(ObjectWriter.s_reverseTypeMap[(int)kind] == type);
+
+        // optimizations for supported array type by binary reader
+        if (type == typeof(byte))
+            return _reader.ReadBytes(length);
+        if (type == typeof(char))
+            return _reader.ReadChars(length);
+
+        // optimizations for string where object reader/writer has its own mechanism to
+        // reduce duplicated strings
+        if (type == typeof(string))
+            return ReadStringArrayElements(CreateArray<string>(length));
+        if (type == typeof(bool))
+            return ReadBooleanArrayElements(CreateArray<bool>(length));
+
+        // otherwise, read elements directly from underlying binary writer
+        return kind switch
         {
-            switch (kind)
-            {
-                case TypeCode.StringRef_1Byte:
-                    return _stringReferenceMap.GetValue(_reader.ReadByte());
+            TypeCode.Int8 => ReadInt8ArrayElements(CreateArray<sbyte>(length)),
+            TypeCode.Int16 => ReadInt16ArrayElements(CreateArray<short>(length)),
+            TypeCode.Int32 => ReadInt32ArrayElements(CreateArray<int>(length)),
+            TypeCode.Int64 => ReadInt64ArrayElements(CreateArray<long>(length)),
+            TypeCode.UInt16 => ReadUInt16ArrayElements(CreateArray<ushort>(length)),
+            TypeCode.UInt32 => ReadUInt32ArrayElements(CreateArray<uint>(length)),
+            TypeCode.UInt64 => ReadUInt64ArrayElements(CreateArray<ulong>(length)),
+            TypeCode.Float4 => ReadFloat4ArrayElements(CreateArray<float>(length)),
+            TypeCode.Float8 => ReadFloat8ArrayElements(CreateArray<double>(length)),
+            TypeCode.Decimal => ReadDecimalArrayElements(CreateArray<decimal>(length)),
+            _ => throw ExceptionUtilities.UnexpectedValue(kind),
+        };
+    }
 
-                case TypeCode.StringRef_2Bytes:
-                    return _stringReferenceMap.GetValue(_reader.ReadUInt16());
+    private bool[] ReadBooleanArrayElements(bool[] array)
+    {
+        // Confirm the type to be read below is ulong
+        Debug.Assert(BitVector.BitsPerWord == 64);
 
-                case TypeCode.StringRef_4Bytes:
-                    return _stringReferenceMap.GetValue(_reader.ReadInt32());
+        var wordLength = BitVector.WordsRequired(array.Length);
 
-                case TypeCode.StringUtf16:
-                case TypeCode.StringUtf8:
-                    return ReadStringLiteral(kind);
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(kind);
-            }
-        }
-
-        private unsafe string ReadStringLiteral(TypeCode kind)
+        var count = 0;
+        for (var i = 0; i < wordLength; i++)
         {
-            string value;
-            if (kind == TypeCode.StringUtf8)
+            var word = _reader.ReadUInt64();
+
+            for (var p = 0; p < BitVector.BitsPerWord; p++)
             {
-                value = _reader.ReadString();
-            }
-            else
-            {
-                // This is rare, just allocate UTF-16 bytes for simplicity.
-                var characterCount = (int)ReadCompressedUInt();
-                var bytes = _reader.ReadBytes(characterCount * sizeof(char));
-                fixed (byte* bytesPtr = bytes)
+                if (count >= array.Length)
                 {
-                    value = new string((char*)bytesPtr, 0, characterCount);
+                    return array;
                 }
-            }
 
-            _stringReferenceMap.AddValue(value);
-            return value;
-        }
-
-        private Array ReadArray(TypeCode kind)
-        {
-            int length;
-            switch (kind)
-            {
-                case TypeCode.Array_0:
-                    length = 0;
-                    break;
-                case TypeCode.Array_1:
-                    length = 1;
-                    break;
-                case TypeCode.Array_2:
-                    length = 2;
-                    break;
-                case TypeCode.Array_3:
-                    length = 3;
-                    break;
-                default:
-                    length = (int)this.ReadCompressedUInt();
-                    break;
-            }
-
-            // SUBTLE: If it was a primitive array, only the EncodingKind byte of the element type was written, instead of encoding as a type.
-            var elementKind = (TypeCode)_reader.ReadByte();
-
-            var elementType = ObjectWriter.s_reverseTypeMap[(int)elementKind];
-            if (elementType != null)
-            {
-                return this.ReadPrimitiveTypeArrayElements(elementType, elementKind, length);
-            }
-            else
-            {
-                throw ExceptionUtilities.UnexpectedValue(elementKind);
+                array[count++] = BitVector.IsTrue(word, p);
             }
         }
 
-        private Array ReadPrimitiveTypeArrayElements(Type type, TypeCode kind, int length)
+        return array;
+    }
+
+    private static T[] CreateArray<T>(int length)
+    {
+        if (length == 0)
         {
-            Debug.Assert(ObjectWriter.s_reverseTypeMap[(int)kind] == type);
+            // quick check
+            return Array.Empty<T>();
+        }
+        else
+        {
+            return new T[length];
+        }
+    }
 
-            // optimizations for supported array type by binary reader
-            if (type == typeof(byte))
-                return _reader.ReadBytes(length);
-            if (type == typeof(char))
-                return _reader.ReadChars(length);
-
-            // optimizations for string where object reader/writer has its own mechanism to
-            // reduce duplicated strings
-            if (type == typeof(string))
-                return ReadStringArrayElements(CreateArray<string>(length));
-            if (type == typeof(bool))
-                return ReadBooleanArrayElements(CreateArray<bool>(length));
-
-            // otherwise, read elements directly from underlying binary writer
-            switch (kind)
-            {
-                case TypeCode.Int8: return ReadInt8ArrayElements(CreateArray<sbyte>(length));
-                case TypeCode.Int16: return ReadInt16ArrayElements(CreateArray<short>(length));
-                case TypeCode.Int32: return ReadInt32ArrayElements(CreateArray<int>(length));
-                case TypeCode.Int64: return ReadInt64ArrayElements(CreateArray<long>(length));
-                case TypeCode.UInt16: return ReadUInt16ArrayElements(CreateArray<ushort>(length));
-                case TypeCode.UInt32: return ReadUInt32ArrayElements(CreateArray<uint>(length));
-                case TypeCode.UInt64: return ReadUInt64ArrayElements(CreateArray<ulong>(length));
-                case TypeCode.Float4: return ReadFloat4ArrayElements(CreateArray<float>(length));
-                case TypeCode.Float8: return ReadFloat8ArrayElements(CreateArray<double>(length));
-                case TypeCode.Decimal: return ReadDecimalArrayElements(CreateArray<decimal>(length));
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(kind);
-            }
+    private string[] ReadStringArrayElements(string[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = this.ReadStringValue();
         }
 
-        private bool[] ReadBooleanArrayElements(bool[] array)
+        return array;
+    }
+
+    private sbyte[] ReadInt8ArrayElements(sbyte[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
         {
-            // Confirm the type to be read below is ulong
-            Debug.Assert(BitVector.BitsPerWord == 64);
-
-            var wordLength = BitVector.WordsRequired(array.Length);
-
-            var count = 0;
-            for (var i = 0; i < wordLength; i++)
-            {
-                var word = _reader.ReadUInt64();
-
-                for (var p = 0; p < BitVector.BitsPerWord; p++)
-                {
-                    if (count >= array.Length)
-                    {
-                        return array;
-                    }
-
-                    array[count++] = BitVector.IsTrue(word, p);
-                }
-            }
-
-            return array;
+            array[i] = _reader.ReadSByte();
         }
 
-        private static T[] CreateArray<T>(int length)
+        return array;
+    }
+
+    private short[] ReadInt16ArrayElements(short[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
         {
-            if (length == 0)
-            {
-                // quick check
-                return Array.Empty<T>();
-            }
-            else
-            {
-                return new T[length];
-            }
+            array[i] = _reader.ReadInt16();
         }
 
-        private string[] ReadStringArrayElements(string[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = this.ReadStringValue();
-            }
+        return array;
+    }
 
-            return array;
+    private int[] ReadInt32ArrayElements(int[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = _reader.ReadInt32();
         }
 
-        private sbyte[] ReadInt8ArrayElements(sbyte[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadSByte();
-            }
+        return array;
+    }
 
-            return array;
+    private long[] ReadInt64ArrayElements(long[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = _reader.ReadInt64();
         }
 
-        private short[] ReadInt16ArrayElements(short[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadInt16();
-            }
+        return array;
+    }
 
-            return array;
+    private ushort[] ReadUInt16ArrayElements(ushort[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = _reader.ReadUInt16();
         }
 
-        private int[] ReadInt32ArrayElements(int[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadInt32();
-            }
+        return array;
+    }
 
-            return array;
+    private uint[] ReadUInt32ArrayElements(uint[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = _reader.ReadUInt32();
         }
 
-        private long[] ReadInt64ArrayElements(long[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadInt64();
-            }
+        return array;
+    }
 
-            return array;
+    private ulong[] ReadUInt64ArrayElements(ulong[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = _reader.ReadUInt64();
         }
 
-        private ushort[] ReadUInt16ArrayElements(ushort[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadUInt16();
-            }
+        return array;
+    }
 
-            return array;
+    private decimal[] ReadDecimalArrayElements(decimal[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = _reader.ReadDecimal();
         }
 
-        private uint[] ReadUInt32ArrayElements(uint[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadUInt32();
-            }
+        return array;
+    }
 
-            return array;
+    private float[] ReadFloat4ArrayElements(float[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = _reader.ReadSingle();
         }
 
-        private ulong[] ReadUInt64ArrayElements(ulong[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadUInt64();
-            }
+        return array;
+    }
 
-            return array;
+    private double[] ReadFloat8ArrayElements(double[] array)
+    {
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = _reader.ReadDouble();
         }
 
-        private decimal[] ReadDecimalArrayElements(decimal[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadDecimal();
-            }
+        return array;
+    }
 
-            return array;
-        }
+    public Type ReadType()
+    {
+        _reader.ReadByte();
+        return Type.GetType(ReadString());
+    }
 
-        private float[] ReadFloat4ArrayElements(float[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadSingle();
-            }
+    private static Exception DeserializationReadIncorrectNumberOfValuesException(string typeName)
+    {
+        throw new InvalidOperationException(String.Format(Resources.Deserialization_reader_for_0_read_incorrect_number_of_values, typeName));
+    }
 
-            return array;
-        }
+    private static Exception NoSerializationTypeException(string typeName)
+    {
+        return new InvalidOperationException(string.Format(Resources.The_type_0_is_not_understood_by_the_serialization_binder, typeName));
+    }
 
-        private double[] ReadFloat8ArrayElements(double[] array)
-        {
-            for (var i = 0; i < array.Length; i++)
-            {
-                array[i] = _reader.ReadDouble();
-            }
-
-            return array;
-        }
-
-        public Type ReadType()
-        {
-            _reader.ReadByte();
-            return Type.GetType(ReadString());
-        }
-
-        private static Exception DeserializationReadIncorrectNumberOfValuesException(string typeName)
-        {
-            throw new InvalidOperationException(String.Format(Resources.Deserialization_reader_for_0_read_incorrect_number_of_values, typeName));
-        }
-
-        private static Exception NoSerializationTypeException(string typeName)
-        {
-            return new InvalidOperationException(string.Format(Resources.The_type_0_is_not_understood_by_the_serialization_binder, typeName));
-        }
-
-        private static Exception NoSerializationReaderException(string typeName)
-        {
-            return new InvalidOperationException(string.Format(Resources.Cannot_serialize_type_0, typeName));
-        }
+    private static Exception NoSerializationReaderException(string typeName)
+    {
+        return new InvalidOperationException(string.Format(Resources.Cannot_serialize_type_0, typeName));
     }
 }


### PR DESCRIPTION
This change helps esepecially when editing larger files.

ObjectReaderTextReader.Create is called during remote asset deserialization of sourcetext. This method creates/stores char arrays for each chunk of text. The source text populates itself by calling into ObjectReaderTextReader.Read which copies from these arrays to populate the sourcetext. Once fully populated, the arrays in ObjectReaderTextReader are no longer used.

With this change, the arrays held by ObjectReaderTextReader are created via SharedPools.CharArray. Upon disposal of ObjectReaderTextReader, the arrays are added back to the pool.

Note that this required increasing SharedPools.CharBufferCount significantly. The new value should allow files up to 2 MB to be non-allocating wrt these arrays.

Old allocation profile: (note that it was 2.3% of allocations, the blue highlighted part is attacked by this PR)
![image](https://github.com/dotnet/roslyn/assets/6785178/187f6baa-752a-4cc5-bdf0-0c9d6e38db08)

New allocation profile: (note that it was 1.2% of allocations, the blue section from the previous profile is gone)
![image](https://github.com/dotnet/roslyn/assets/6785178/1bb28fb9-cac1-4f61-a044-1b135d47dad7)

It looks like this change should reduce the allocations occurring during SourceTextExtensions.ReadFrom in about half at the expense of increasing the count of objects in SharedPools.CharArray.
