### PR TITLE
Set stack trace on logged assertion failure exceptions

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestSetup/TestTraceListener.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/TestTraceListener.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.ErrorReporting
@@ -98,6 +99,16 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         private static void Exit(string? message)
         {
             var reportedException = new Exception(message);
+            try
+            {
+                // Set stack trace on the exception for logging
+                ExceptionDispatchInfo.Capture(reportedException).Throw();
+            }
+            catch (Exception ex)
+            {
+                reportedException = ex;
+            }
+
             if (message?.Contains("Pretty-listing introduced errors in error-free code") ?? false)
             {
                 // Ignore this known assertion failure


### PR DESCRIPTION
Prior to this, assertion failures in integration tests were causing test failures (good), but not providing any context about where the assertion failure occurred (bad). This change ensures the stack trace at the time of the assertion failure is captured for log reporting.

Here's an example of a stack trace prior to this change:

```
System.AggregateException: One or more errors occurred. ---> System.Exception: Assertion failed
   --- End of inner exception stack trace ---
   at Microsoft.CodeAnalysis.ErrorReporting.TestTraceListener.VerifyNoErrorsAndReset() in /_/src/VisualStudio/IntegrationTest/TestSetup/TestTraceListener.cs:line 124
   at Roslyn.VisualStudio.IntegrationTests.AbstractIntegrationTest.<DisposeAsync>d__6.MoveNext() in /_/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractIntegrationTest.cs:line 104
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Xunit.Threading.InProcessIdeTestInvoker.<>c__DisplayClass3_1.<<RunAsync>b__2>d.MoveNext()
---> (Inner Exception #0) System.Exception: Assertion failed<---
```