### PR TITLE
Do not try to share syntax trees in languages that don't have them

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
@@ -15,7 +15,6 @@ internal static class WorkspaceConfigurationOptionsStorage
             CacheStorage: globalOptions.GetOption(CloudCacheFeatureFlag) ? StorageDatabase.CloudCache : globalOptions.GetOption(Database),
             EnableOpeningSourceGeneratedFiles: globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspace) ??
                                                globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspaceFeatureFlag),
-            DisableSharedSyntaxTrees: globalOptions.GetOption(DisableSharedSyntaxTrees),
             DisableRecoverableText: globalOptions.GetOption(DisableRecoverableText),
             ValidateCompilationTrackerStates: globalOptions.GetOption(ValidateCompilationTrackerStates),
             RunSourceGeneratorsInSameProcessOnly: globalOptions.GetOption(RunSourceGeneratorsInSameProcessOnly));
@@ -25,9 +24,6 @@ internal static class WorkspaceConfigurationOptionsStorage
 
     public static readonly Option2<bool> CloudCacheFeatureFlag = new(
         "dotnet_storage_cloud_cache", WorkspaceConfigurationOptions.Default.CacheStorage == StorageDatabase.CloudCache);
-
-    public static readonly Option2<bool> DisableSharedSyntaxTrees = new(
-        "dotnet_disable_shared_syntax_trees", WorkspaceConfigurationOptions.Default.DisableSharedSyntaxTrees);
 
     public static readonly Option2<bool> DisableRecoverableText = new(
         "dotnet_disable_recoverable_text", WorkspaceConfigurationOptions.Default.DisableRecoverableText);

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -431,7 +431,6 @@ internal abstract class VisualStudioOptionStorage
         {"visual_basic_style_unused_value_expression_statement_preference", new RoamingProfileStorage("TextEditor.VisualBasic.Specific.UnusedValueExpressionStatementPreference")},
         {"visual_studio_navigate_to_object_browser", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.NavigateToObjectBrowser")},
         {"visual_studio_workspace_partial_load_mode", new FeatureFlagStorage(@"Roslyn.PartialLoadMode")},
-        {"dotnet_disable_shared_syntax_trees", new FeatureFlagStorage(@"Roslyn.DisableSharedSyntaxTrees")},
         {"dotnet_disable_recoverable_text", new FeatureFlagStorage(@"Roslyn.DisableRecoverableText")},
         {"dotnet_validate_compilation_tracker_states", new FeatureFlagStorage(@"Roslyn.ValidateCompilationTrackerStates")},
         {"dotnet_run_source_generators_in_same_process_only", new FeatureFlagStorage(@"Roslyn.RunSourceGeneratorsInSameProcessOnly")},

--- a/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
@@ -8,64 +8,57 @@ using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Storage;
 
-namespace Microsoft.CodeAnalysis.Host
+namespace Microsoft.CodeAnalysis.Host;
+
+internal interface IWorkspaceConfigurationService : IWorkspaceService
 {
-    internal interface IWorkspaceConfigurationService : IWorkspaceService
+    WorkspaceConfigurationOptions Options { get; }
+}
+
+[ExportWorkspaceService(typeof(IWorkspaceConfigurationService)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class DefaultWorkspaceConfigurationService() : IWorkspaceConfigurationService
+{
+    public WorkspaceConfigurationOptions Options => WorkspaceConfigurationOptions.Default;
+}
+
+/// <summary>
+/// Options that affect behavior of workspace core APIs (<see cref="Solution"/>, <see cref="Project"/>, <see
+/// cref="Document"/>, <see cref="SyntaxTree"/>, etc.) to which it would be impractical to flow these options
+/// explicitly. The options are instead provided by <see cref="IWorkspaceConfigurationService"/>. The remote
+/// instance of this service is initialized based on the in-proc values (which themselves are loaded from global
+/// options) when we establish connection from devenv to ServiceHub process. If another process connects to our
+/// ServiceHub process before that the remote instance provides a predefined set of options <see
+/// cref="RemoteDefault"/> that can later be updated when devenv connects to the ServiceHub process.
+/// </summary>
+[DataContract]
+internal readonly record struct WorkspaceConfigurationOptions(
+    [property: DataMember(Order = 0)] StorageDatabase CacheStorage = StorageDatabase.SQLite,
+    [property: DataMember(Order = 1)] bool EnableOpeningSourceGeneratedFiles = false,
+    [property: DataMember(Order = 2)] bool DisableRecoverableText = false,
+    [property: DataMember(Order = 3)] bool ValidateCompilationTrackerStates =
+#if DEBUG // We will default this on in DEBUG builds
+        true,
+#else
+        false,
+#endif
+    [property: DataMember(Order = 4)] bool RunSourceGeneratorsInSameProcessOnly = false)
+{
+    public WorkspaceConfigurationOptions()
+        : this(CacheStorage: StorageDatabase.SQLite)
     {
-        WorkspaceConfigurationOptions Options { get; }
     }
 
-    [ExportWorkspaceService(typeof(IWorkspaceConfigurationService)), Shared]
-    internal sealed class DefaultWorkspaceConfigurationService : IWorkspaceConfigurationService
-    {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultWorkspaceConfigurationService()
-        {
-        }
-
-        public WorkspaceConfigurationOptions Options => WorkspaceConfigurationOptions.Default;
-    }
+    public static readonly WorkspaceConfigurationOptions Default = new();
 
     /// <summary>
-    /// Options that affect behavior of workspace core APIs (<see cref="Solution"/>, <see cref="Project"/>, <see
-    /// cref="Document"/>, <see cref="SyntaxTree"/>, etc.) to which it would be impractical to flow these options
-    /// explicitly. The options are instead provided by <see cref="IWorkspaceConfigurationService"/>. The remote
-    /// instance of this service is initialized based on the in-proc values (which themselves are loaded from global
-    /// options) when we establish connection from devenv to ServiceHub process. If another process connects to our
-    /// ServiceHub process before that the remote instance provides a predefined set of options <see
-    /// cref="RemoteDefault"/> that can later be updated when devenv connects to the ServiceHub process.
+    /// These values are such that the correctness of remote services is not affected if these options are changed from defaults
+    /// to non-defaults while the services have already been executing.
     /// </summary>
-    [DataContract]
-    internal readonly record struct WorkspaceConfigurationOptions(
-        [property: DataMember(Order = 0)] StorageDatabase CacheStorage = StorageDatabase.SQLite,
-        [property: DataMember(Order = 1)] bool EnableOpeningSourceGeneratedFiles = false,
-        [property: DataMember(Order = 2)] bool DisableSharedSyntaxTrees = false,
-        [property: DataMember(Order = 3)] bool DisableRecoverableText = false,
-        [property: DataMember(Order = 4)] bool ValidateCompilationTrackerStates =
-#if DEBUG // We will default this on in DEBUG builds
-            true,
-#else
-            false,
-#endif
-        [property: DataMember(Order = 5)] bool RunSourceGeneratorsInSameProcessOnly = false)
-    {
-        public WorkspaceConfigurationOptions()
-            : this(CacheStorage: StorageDatabase.SQLite)
-        {
-        }
-
-        public static readonly WorkspaceConfigurationOptions Default = new();
-
-        /// <summary>
-        /// These values are such that the correctness of remote services is not affected if these options are changed from defaults
-        /// to non-defaults while the services have already been executing.
-        /// </summary>
-        public static readonly WorkspaceConfigurationOptions RemoteDefault = new(
-            CacheStorage: StorageDatabase.None,
-            EnableOpeningSourceGeneratedFiles: false,
-            DisableSharedSyntaxTrees: false,
-            DisableRecoverableText: false,
-            RunSourceGeneratorsInSameProcessOnly: false);
-    }
+    public static readonly WorkspaceConfigurationOptions RemoteDefault = new(
+        CacheStorage: StorageDatabase.None,
+        EnableOpeningSourceGeneratedFiles: false,
+        DisableRecoverableText: false,
+        RunSourceGeneratorsInSameProcessOnly: false);
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -250,10 +250,6 @@ namespace Microsoft.CodeAnalysis
                     var newSolution = data.transformation(oldSolution);
 
                     // Attempt to unify the syntax trees in the new solution (unless the option is set disabling that).
-                    var options = oldSolution.Services.GetRequiredService<IWorkspaceConfigurationService>().Options;
-                    if (options.DisableSharedSyntaxTrees)
-                        return newSolution;
-
                     return UnifyLinkedDocumentContents(oldSolution, newSolution);
                 },
                 mayRaiseEvents: true,
@@ -1162,15 +1158,12 @@ namespace Microsoft.CodeAnalysis
                             // shared across docs.
 
                             var options = oldSolution.Services.GetRequiredService<IWorkspaceConfigurationService>().Options;
-                            var shareSyntaxTrees = !options.DisableSharedSyntaxTrees;
 
                             var newDocument = newSolution.GetRequiredDocument(documentId);
                             foreach (var linkedDocumentId in linkedDocumentIds)
                             {
                                 previousSolution = newSolution;
-                                newSolution = shareSyntaxTrees
-                                    ? newSolution.WithDocumentContentsFrom(linkedDocumentId, newDocument.DocumentState)
-                                    : data.updateSolutionWithText(newSolution, linkedDocumentId, data.arg);
+                                newSolution = newSolution.WithDocumentContentsFrom(linkedDocumentId, newDocument.DocumentState);
 
                                 if (previousSolution != newSolution)
                                     updatedDocumentIds.Add(linkedDocumentId);

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -286,6 +286,10 @@ namespace Microsoft.CodeAnalysis
                 // For all added documents, see if they link to an existing document.  If so, use that existing documents text/tree.
                 foreach (var addedProject in changes.GetAddedProjects())
                 {
+                    // Ignore projects that don't even have syntax trees to share.
+                    if (!addedProject.SupportsCompilation)
+                        continue;
+
                     foreach (var addedDocument in addedProject.Documents)
                         newSolution = UpdateAddedDocumentToExistingContentsInSolution(newSolution, addedDocument.Id);
                 }
@@ -294,6 +298,10 @@ namespace Microsoft.CodeAnalysis
 
                 foreach (var projectChanges in changes.GetProjectChanges())
                 {
+                    // Ignore projects that don't even have syntax trees to share.
+                    if (!projectChanges.NewProject.SupportsCompilation)
+                        continue;
+
                     // Now do the same for all added documents in a project.
                     foreach (var addedDocument in projectChanges.GetAddedDocuments())
                         newSolution = UpdateAddedDocumentToExistingContentsInSolution(newSolution, addedDocument);


### PR DESCRIPTION
Addresses perf issue hitting TS.  It's common for TS to have single projects referencing *many* thousands of files.  This is because TS represents references (like nodejs references) by adding in tons of *source* `d.ts.` files to the project.  These nodejs references transitively can pull in tons of files.

As TS doesn't have SYntaxTrees though, there's no point in us walking their projects to try to share them.

--

Also, removed option to control sharing of syntax trees.  This was added when the feature was added as a safe-hatch to disable things using control-tower if we ran into problems.  However, the feature has had no issues in the year it's been in since https://github.com/dotnet/roslyn/pull/65885.  So we can remove the option.