### PR TITLE
Handle hoisted exception temps during closure rewriting

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/LambdaCapturedVariable.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/LambdaCapturedVariable.cs
@@ -64,6 +64,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case SynthesizedLocalKind.LambdaDisplayClass:
                         return GeneratedNames.MakeLambdaDisplayLocalName(uniqueId++);
                     case SynthesizedLocalKind.ExceptionFilterAwaitHoistedExceptionLocal:
+                    case SynthesizedLocalKind.TryAwaitPendingException:
+                    case SynthesizedLocalKind.TryAwaitPendingCaughtException:
                         return GeneratedNames.MakeHoistedLocalFieldName(local.SynthesizedKind, uniqueId++);
                     case SynthesizedLocalKind.InstrumentationPayload:
                         return GeneratedNames.MakeSynthesizedInstrumentationPayloadLocalFieldName(uniqueId++);

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/LambdaCapturedVariable.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/LambdaCapturedVariable.cs
@@ -59,19 +59,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (variable is LocalSymbol local)
             {
-                if (local.SynthesizedKind == SynthesizedLocalKind.LambdaDisplayClass)
+                switch (local.SynthesizedKind)
                 {
-                    return GeneratedNames.MakeLambdaDisplayLocalName(uniqueId++);
-                }
-
-                if (local.SynthesizedKind == SynthesizedLocalKind.ExceptionFilterAwaitHoistedExceptionLocal)
-                {
-                    return GeneratedNames.MakeHoistedLocalFieldName(local.SynthesizedKind, uniqueId++);
-                }
-
-                if (local.SynthesizedKind == SynthesizedLocalKind.InstrumentationPayload)
-                {
-                    return GeneratedNames.MakeSynthesizedInstrumentationPayloadLocalFieldName(uniqueId++);
+                    case SynthesizedLocalKind.LambdaDisplayClass:
+                        return GeneratedNames.MakeLambdaDisplayLocalName(uniqueId++);
+                    case SynthesizedLocalKind.ExceptionFilterAwaitHoistedExceptionLocal:
+                        return GeneratedNames.MakeHoistedLocalFieldName(local.SynthesizedKind, uniqueId++);
+                    case SynthesizedLocalKind.InstrumentationPayload:
+                        return GeneratedNames.MakeSynthesizedInstrumentationPayloadLocalFieldName(uniqueId++);
                 }
 
                 // should never be captured:


### PR DESCRIPTION
In debug mode, we can introduce hoisted variables for rethrown exceptions in the async rewriter. This was not handled correctly by the lambda rewriter, and it would generate fields without names in the hoisted display class. This failed an assert in LambdaCapturedVariable, and also caused a runtime crash when attempting to see if the display class had any required members. Fixes https://github.com/dotnet/roslyn/issues/70948.