### PR TITLE
Mitigate RemoteControlClient not properly caching values on netcore.

### DIFF
--- a/src/Features/Core/Portable/SymbolSearch/Windows/IFileDownloaderFactory.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/IFileDownloaderFactory.cs
@@ -18,5 +18,5 @@ internal interface IFileDownloaderFactory
 
 internal interface IFileDownloader : IDisposable
 {
-    public Task<Stream> ReadFileAsync(); // BehaviorOnStale.ReturnStale
+    public Task<Stream?> ReadFileAsync();
 }

--- a/src/VisualStudio/Core/Def/Storage/FileDownloader.cs
+++ b/src/VisualStudio/Core/Def/Storage/FileDownloader.cs
@@ -35,7 +35,7 @@ internal sealed class FileDownloader : IFileDownloader
     /// <summary>
     /// The netcore version of <see cref="RemoteControlClient"/> doesn't support ReturnStale.  It will download the file
     /// (on a separate thread), but then not cache it because it doesn't have access to the normal IE component that
-    /// does proper header reading/caching.  Then, when we call in to read thefile, we get nothing back, since nothing
+    /// does proper header reading/caching.  Then, when we call in to read the file, we get nothing back, since nothing
     /// was cached.
     /// <para/> The temporary solution to this is to force the download to happen.  This is not ideal as we will no
     /// longer be respecting the server "Cache-Control:Max-Age" header.  Which means we'll continually download the

--- a/src/VisualStudio/Core/Def/Storage/FileDownloader.cs
+++ b/src/VisualStudio/Core/Def/Storage/FileDownloader.cs
@@ -30,8 +30,35 @@ internal sealed class FileDownloader : IFileDownloader
     private FileDownloader(RemoteControlClient client)
         => _client = client;
 
+#if NET
+
+    /// <summary>
+    /// The netcore version of <see cref="RemoteControlClient"/> doesn't support ReturnStale.  It will download the file
+    /// (on a separate thread), but then not cache it because it doesn't have access to the normal IE component that
+    /// does proper header reading/caching.  Then, when we call in to read thefile, we get nothing back, since nothing
+    /// was cached.
+    /// <para/> The temporary solution to this is to force the download to happen.  This is not ideal as we will no
+    /// longer be respecting the server "Cache-Control:Max-Age" header.  Which means we'll continually download the
+    /// files, even if not needed (since the server says to use the local value).  This is not great, but is not
+    /// terrible either.  First, we will only download the full DB file <em>once</em>, when it is actually missing on
+    /// the user's machine.  From that point on, we'll only be querying the server for the delta-patch file for the DB
+    /// version we have locally.  The vast majority of the time that is a tiny document of the form <c><![CDATA[<Patch
+    /// upToDate="true" FileVersion="105" ChangesetId="1CBE1453" />]]></c> (around 70 bytes) which simply tells the user
+    /// they are up to date.  Only about once every three months will they actually download a large patch file.  Also,
+    /// this patch download will only happen once a day tops (as that is our cadence for checking if there are new index
+    /// versions out).
+    /// <para/> https://github.com/dotnet/roslyn/issues/71014 tracks this issue.  Once RemoteControlClient is updated to
+    /// support this again, we can remove this specialized code for netcore.
+    /// </summary>
+    public Task<Stream> ReadFileAsync()
+        => _client.ReadFileAsync(BehaviorOnStale.ForceDownload);
+
+#else
+
     public Task<Stream> ReadFileAsync()
         => _client.ReadFileAsync(BehaviorOnStale.ReturnStale);
+
+#endif
 
     public void Dispose()
         => _client.Dispose();


### PR DESCRIPTION
Mitigates https://devdiv.visualstudio.com/DevDiv/_queries/edit/1917394

Longer term fix tracked with https://github.com/dotnet/roslyn/issues/71014 and https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1846487

I have walked through the code verifying that it works, and that we only incur the expensive path once, and then the cheaper (but not cheapest) path once a day.  