### PR TITLE
Fix exception in PackageSettingsPersister

### DIFF
--- a/src/VisualStudio/Core/Def/Options/PackageSettingsPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/PackageSettingsPersister.cs
@@ -3,63 +3,90 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.LanguageServices.Setup;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Roslyn.Utilities;
 
-namespace Microsoft.VisualStudio.LanguageServices.Options
+namespace Microsoft.VisualStudio.LanguageServices.Options;
+
+internal sealed class PackageSettingsPersister : IOptionPersister
 {
-    internal sealed class PackageSettingsPersister(IGlobalOptionService optionService) : IOptionPersister
+    private RoslynPackage? _lazyRoslynPackage;
+    private readonly IGlobalOptionService _optionService;
+
+    public PackageSettingsPersister(
+        IThreadingContext threadingContext,
+        IAsyncServiceProvider serviceProvider,
+        IGlobalOptionService optionService)
     {
-        private RoslynPackage? _lazyRoslynPackage;
+        _optionService = optionService;
 
-        public void Initialize(RoslynPackage package)
+        // Start the process of loading the Roslyn package, but don't wait for it to complete.
+        // Roslyn package load will in turn invoke our Initialize method with the instance of the package.
+        LoadRoslynPackageAsync(threadingContext, serviceProvider).ReportNonFatalErrorAsync().Forget();
+    }
+
+    private static async Task LoadRoslynPackageAsync(IThreadingContext threadingContext, IAsyncServiceProvider serviceProvider)
+    {
+        var cancellationToken = threadingContext.DisposalToken;
+        await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        _ = await RoslynPackage.GetOrLoadAsync(threadingContext, serviceProvider, cancellationToken).ConfigureAwait(true);
+    }
+
+    public void Initialize(RoslynPackage package)
+    {
+        Assumes.Null(_lazyRoslynPackage);
+
+        _lazyRoslynPackage = package;
+        _optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
+        _lazyRoslynPackage.AnalysisScopeChanged += OnAnalysisScopeChanged;
+    }
+
+    private void OnAnalysisScopeChanged(object? sender, EventArgs e)
+    {
+        Assumes.Present(_lazyRoslynPackage);
+        _optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
+    }
+
+    public bool TryFetch(OptionKey2 optionKey, out object? value)
+    {
+        // This option is refreshed via the constructor to avoid UI dependencies when retrieving option values. If
+        // we happen to reach this point before the value is available, try to obtain it without blocking, and
+        // otherwise fall back to the default.
+        if (optionKey.Option == SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption)
         {
-            _lazyRoslynPackage = package;
-            optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
-            _lazyRoslynPackage.AnalysisScopeChanged += OnAnalysisScopeChanged;
-        }
-
-        private void OnAnalysisScopeChanged(object? sender, EventArgs e)
-        {
-            Assumes.Present(_lazyRoslynPackage);
-            optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
-        }
-
-        public bool TryFetch(OptionKey2 optionKey, out object? value)
-        {
-            // This option is refreshed via the constructor to avoid UI dependencies when retrieving option values. If
-            // we happen to reach this point before the value is available, try to obtain it without blocking, and
-            // otherwise fall back to the default.
-            if (optionKey.Option == SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption)
-            {
-                if (_lazyRoslynPackage is not null)
-                {
-                    value = _lazyRoslynPackage.AnalysisScope;
-                    return true;
-                }
-                else
-                {
-                    value = SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption.Definition.DefaultValue;
-                    return true;
-                }
-            }
-
-            value = null;
-            return false;
-        }
-
-        public bool TryPersist(OptionKey2 optionKey, object? value)
-        {
-            if (!Equals(optionKey.Option, SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption))
-                return false;
-
             if (_lazyRoslynPackage is not null)
             {
-                _lazyRoslynPackage.AnalysisScope = (BackgroundAnalysisScope?)value;
+                value = _lazyRoslynPackage.AnalysisScope;
+                return true;
             }
-
-            return true;
+            else
+            {
+                value = SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption.Definition.DefaultValue;
+                return true;
+            }
         }
+
+        value = null;
+        return false;
+    }
+
+    public bool TryPersist(OptionKey2 optionKey, object? value)
+    {
+        if (!Equals(optionKey.Option, SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption))
+            return false;
+
+        if (_lazyRoslynPackage is not null)
+        {
+            _lazyRoslynPackage.AnalysisScope = (BackgroundAnalysisScope?)value;
+        }
+
+        return true;
     }
 }

--- a/src/VisualStudio/Core/Def/Options/PackageSettingsPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/PackageSettingsPersister.cs
@@ -10,17 +10,21 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.LanguageServices.Setup;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Options
 {
-    internal sealed class PackageSettingsPersister : IOptionPersister
+    internal sealed class PackageSettingsPersister : IOptionPersister, IVsPackageLoadEvents, IDisposable
     {
         private readonly IThreadingContext _threadingContext;
         private readonly IAsyncServiceProvider _serviceProvider;
         private readonly IGlobalOptionService _optionService;
+
         private RoslynPackage? _lazyRoslynPackage;
+        private IVsShell6? _shell;
+        private uint _packageLoadEventsCookie = VSConstants.VSCOOKIE_NIL;
 
         public PackageSettingsPersister(
             IThreadingContext threadingContext,
@@ -40,9 +44,28 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            _lazyRoslynPackage = await RoslynPackage.GetOrLoadAsync(_threadingContext, _serviceProvider, cancellationToken).ConfigureAwait(true);
-            Assumes.Present(_lazyRoslynPackage);
+            // We attempt to get or load the RoslynPackage to proceed with the core initialization.
+            // However, this package load might fail under certain circumstances.
+            // If so, we start listening to the package load events from the shell and
+            // invoke InitializeCore when the RoslynPackage gets loaded in the future.
+            var package = await RoslynPackage.GetOrLoadAsync(_threadingContext, _serviceProvider, cancellationToken).ConfigureAwait(true);
+            if (package != null)
+            {
+                InitializeCore(package);
+            }
+            else
+            {
+                _shell = (IVsShell6?)(await _serviceProvider.GetServiceAsync(typeof(SVsShell)).ConfigureAwait(false));
+                Assumes.Present(_shell);
+                _packageLoadEventsCookie = _shell.AdvisePackageLoadEvents(this);
+            }
+        }
 
+        private void InitializeCore(RoslynPackage package)
+        {
+            Assumes.Null(_lazyRoslynPackage);
+
+            _lazyRoslynPackage = package;
             _optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
             _lazyRoslynPackage.AnalysisScopeChanged += OnAnalysisScopeChanged;
         }
@@ -88,5 +111,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
 
             return true;
         }
+
+        public void Dispose()
+        {
+            if (_packageLoadEventsCookie != VSConstants.VSCOOKIE_NIL)
+            {
+                Assumes.Present(_shell);
+                _shell.UnadvisePackageLoadEvents(_packageLoadEventsCookie);
+                _packageLoadEventsCookie = VSConstants.VSCOOKIE_NIL;
+            }
+        }
+
+        #region IVsPackageLoadEvents
+
+        void IVsPackageLoadEvents.OnPackageLoaded(ref Guid packageGuid, IVsPackage package)
+        {
+            if (packageGuid == typeof(RoslynPackage).GUID)
+                InitializeCore((RoslynPackage)package);
+        }
+
+        #endregion IVsPackageLoadEvents
     }
 }

--- a/src/VisualStudio/Core/Def/Options/PackageSettingsPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/PackageSettingsPersister.cs
@@ -3,77 +3,27 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.LanguageServices.Setup;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Options
 {
-    internal sealed class PackageSettingsPersister : IOptionPersister, IVsPackageLoadEvents, IDisposable
+    internal sealed class PackageSettingsPersister(IGlobalOptionService optionService) : IOptionPersister
     {
-        private readonly IThreadingContext _threadingContext;
-        private readonly IAsyncServiceProvider _serviceProvider;
-        private readonly IGlobalOptionService _optionService;
-
         private RoslynPackage? _lazyRoslynPackage;
-        private IVsShell6? _shell;
-        private uint _packageLoadEventsCookie = VSConstants.VSCOOKIE_NIL;
 
-        public PackageSettingsPersister(
-            IThreadingContext threadingContext,
-            IAsyncServiceProvider serviceProvider,
-            IGlobalOptionService optionService)
+        public void Initialize(RoslynPackage package)
         {
-            _threadingContext = threadingContext;
-            _serviceProvider = serviceProvider;
-            _optionService = optionService;
-
-            // Start the process of loading the Roslyn package and getting options, but don't wait for it to complete.
-            // The setting will be refreshed once available.
-            InitializeAsync(_threadingContext.DisposalToken).ReportNonFatalErrorAsync().Forget();
-        }
-
-        private async Task InitializeAsync(CancellationToken cancellationToken)
-        {
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            // We attempt to get or load the RoslynPackage to proceed with the core initialization.
-            // However, this package load might fail under certain circumstances.
-            // If so, we start listening to the package load events from the shell and
-            // invoke InitializeCore when the RoslynPackage gets loaded in the future.
-            var package = await RoslynPackage.GetOrLoadAsync(_threadingContext, _serviceProvider, cancellationToken).ConfigureAwait(true);
-            if (package != null)
-            {
-                InitializeCore(package);
-            }
-            else
-            {
-                _shell = (IVsShell6?)(await _serviceProvider.GetServiceAsync(typeof(SVsShell)).ConfigureAwait(false));
-                Assumes.Present(_shell);
-                _packageLoadEventsCookie = _shell.AdvisePackageLoadEvents(this);
-            }
-        }
-
-        private void InitializeCore(RoslynPackage package)
-        {
-            Assumes.Null(_lazyRoslynPackage);
-
             _lazyRoslynPackage = package;
-            _optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
+            optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
             _lazyRoslynPackage.AnalysisScopeChanged += OnAnalysisScopeChanged;
         }
 
         private void OnAnalysisScopeChanged(object? sender, EventArgs e)
         {
             Assumes.Present(_lazyRoslynPackage);
-            _optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
+            optionService.RefreshOption(new OptionKey2(SolutionCrawlerOptionsStorage.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
         }
 
         public bool TryFetch(OptionKey2 optionKey, out object? value)
@@ -111,25 +61,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
 
             return true;
         }
-
-        public void Dispose()
-        {
-            if (_packageLoadEventsCookie != VSConstants.VSCOOKIE_NIL)
-            {
-                Assumes.Present(_shell);
-                _shell.UnadvisePackageLoadEvents(_packageLoadEventsCookie);
-                _packageLoadEventsCookie = VSConstants.VSCOOKIE_NIL;
-            }
-        }
-
-        #region IVsPackageLoadEvents
-
-        void IVsPackageLoadEvents.OnPackageLoaded(ref Guid packageGuid, IVsPackage package)
-        {
-            if (packageGuid == typeof(RoslynPackage).GUID)
-                InitializeCore((RoslynPackage)package);
-        }
-
-        #endregion IVsPackageLoadEvents
     }
 }

--- a/src/VisualStudio/Core/Def/Options/PackageSettingsPersisterProvider.cs
+++ b/src/VisualStudio/Core/Def/Options/PackageSettingsPersisterProvider.cs
@@ -6,37 +6,21 @@ using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
-using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
-using SAsyncServiceProvider = Microsoft.VisualStudio.Shell.Interop.SAsyncServiceProvider;
 
 namespace Microsoft.VisualStudio.LanguageServices.Options
 {
     [Export(typeof(IOptionPersisterProvider))]
-    internal sealed class PackageSettingsPersisterProvider : IOptionPersisterProvider
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class PackageSettingsPersisterProvider(IGlobalOptionService optionService) : IOptionPersisterProvider
     {
-        private readonly IThreadingContext _threadingContext;
-        private readonly IAsyncServiceProvider _serviceProvider;
-        private readonly IGlobalOptionService _optionService;
         private PackageSettingsPersister? _lazyPersister;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public PackageSettingsPersisterProvider(
-            IThreadingContext threadingContext,
-            [Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider serviceProvider,
-            IGlobalOptionService optionService)
-        {
-            _threadingContext = threadingContext;
-            _serviceProvider = serviceProvider;
-            _optionService = optionService;
-        }
 
         public ValueTask<IOptionPersister> GetOrCreatePersisterAsync(CancellationToken cancellationToken)
         {
-            _lazyPersister ??= new PackageSettingsPersister(_threadingContext, _serviceProvider, _optionService);
+            _lazyPersister ??= new PackageSettingsPersister(optionService);
             return new ValueTask<IOptionPersister>(_lazyPersister);
         }
     }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -32,6 +32,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.SyncNamespaces;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource;
 using Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReferences;
 using Microsoft.VisualStudio.LanguageServices.InheritanceMargin;
+using Microsoft.VisualStudio.LanguageServices.Options;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem.BrokeredService;
 using Microsoft.VisualStudio.LanguageServices.StackTraceExplorer;
@@ -66,6 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
         private ColorSchemeApplier? _colorSchemeApplier;
         private IDisposable? _solutionEventMonitor;
 
+        private PackageSettingsPersister? _lazyPackageSettingsPersister;
         private BackgroundAnalysisScope? _analysisScope;
 
         public RoslynPackage()
@@ -194,7 +196,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
 
             foreach (var provider in persisterProviders)
             {
-                _ = await provider.GetOrCreatePersisterAsync(cancellationToken).ConfigureAwait(true);
+                var persister = await provider.GetOrCreatePersisterAsync(cancellationToken).ConfigureAwait(true);
+                if (persister is PackageSettingsPersister packageSettingsPersister)
+                    _lazyPackageSettingsPersister = packageSettingsPersister;
             }
         }
 
@@ -314,6 +318,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
                 _solutionEventMonitor.Dispose();
                 _solutionEventMonitor = null;
             }
+
+            _lazyPackageSettingsPersister?.Dispose();
 
             base.Dispose(disposing);
         }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -67,7 +67,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
         private ColorSchemeApplier? _colorSchemeApplier;
         private IDisposable? _solutionEventMonitor;
 
-        private PackageSettingsPersister? _lazyPackageSettingsPersister;
         private BackgroundAnalysisScope? _analysisScope;
 
         public RoslynPackage()
@@ -198,7 +197,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             {
                 var persister = await provider.GetOrCreatePersisterAsync(cancellationToken).ConfigureAwait(true);
                 if (persister is PackageSettingsPersister packageSettingsPersister)
-                    _lazyPackageSettingsPersister = packageSettingsPersister;
+                    packageSettingsPersister.Initialize(this);
             }
         }
 
@@ -318,8 +317,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
                 _solutionEventMonitor.Dispose();
                 _solutionEventMonitor = null;
             }
-
-            _lazyPackageSettingsPersister?.Dispose();
 
             base.Dispose(disposing);
         }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -196,6 +196,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             foreach (var provider in persisterProviders)
             {
                 var persister = await provider.GetOrCreatePersisterAsync(cancellationToken).ConfigureAwait(true);
+
+                // Initialize the PackageSettingsPersister to allow it to listen to analysis scope changed
+                // events from this package.
                 if (persister is PackageSettingsPersister packageSettingsPersister)
                     packageSettingsPersister.Initialize(this);
             }


### PR DESCRIPTION
Fixes #70740

~~PackageSettingsPersister attempts to get or load RoslynPackage during initialization. Package load might not succeed at this point under certain circumstances (the reasons for which are not clearly understood as of now). Instead of assuming package load succeeded during PackageSettingsPersister initialization, we start listening to package load events for this case and perform the initialization when RoslynPackage gets loaded in future.~~

Initialize the `PackageSettingsPersister` from the `RoslynPackage` directly instead of it attempting to get or load `RoslynPackage` and initialize itself.

Verified that fixes the repro in #70740