### PR TITLE
Update TFM for BuildHost in source build

### DIFF
--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -111,7 +111,7 @@
     <!-- For source build, we just build the SourceBuild targeted version -->
     <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
       <_NetFrameworkBuildHostProjectReference Include="..\..\..\Workspaces\Core\MSBuild.BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj">
-        <TargetFramework>$(NetPrevious)</TargetFramework>
+        <TargetFramework>$(SourceBuildToolsetTargetFramework)</TargetFramework>
         <ContentFolderName>BuildHost-netcore</ContentFolderName>
       </_NetFrameworkBuildHostProjectReference>
     </ItemGroup>


### PR DESCRIPTION
The [dependency flow of sdk to installer](https://github.com/dotnet/installer/pull/17875) is failing in full VMR source build with this error:

```
##[error]/vmr/.dotnet/sdk/9.0.100-alpha.1.23524.3/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1005: (NETCORE_ENGINEERING_TELEMETRY=Build) Assets file '/vmr/src/roslyn/artifacts/source-build/self/src/artifacts/obj/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost/project.assets.json' doesn't have a target for 'net8.0'. Ensure that restore has run and that you have included 'net8.0' in the TargetFrameworks for your project.
```

This is caused by the change in https://github.com/dotnet/roslyn/commit/65694dd7f2ca2747a1e6ba1209e140d6f3cf86b7 which set the TFM for Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost to use `NetPrevious`. In the VMR, `NetPrevious` is `net8.0` but Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost was only built for `net9.0`, as it should. This leads to the failure of `net8.0` not existing in project.assets.json.

The correct thing to do instead is to use the `SourceBuildToolsetTargetFramework` property which [gets dynamically set according to the context of the build](https://github.com/dotnet/roslyn/blob/043209469646ae7c3d1d5da015bafcff355bcce2/eng/targets/Settings.props#L70-L87). In the full VMR build, that means that `NetCurrent` will be used, equating to `net9.0`.