### PR TITLE
Properly escape ref path names that contain equals

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -2625,33 +2625,24 @@ print Goodbye, World";
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71022")]
         public void ParseReferencesAlias()
         {
-            Assert.True(parseRef(@"/r:a=util.dll") is
-            {
-                Reference: @"util.dll",
-                Properties.Aliases: ["a"],
-                Properties.EmbedInteropTypes: false
-            });
+            assert(@"/r:a=util.dll", @"util.dll", ["a"], false);
+            assert(@"/r:""a=util.dll""", @"a=util.dll", [], false);
+            assert(@"/r:""c:\users\app=exe\util.dll""", @"c:\users\app=exe\util.dll", [], false);
+            assert(@"/r:a=b=util.dll", @"b=util.dll", ["a"], false);
+            assert(@"/r:""a=b""=util.dll", @"a=b=util.dll", [], false);
+            assert(@"/r:\""a=b\""=util.dll", @"""a=b""=util.dll", [], false);
+            assert(@"/r:a""b=util.dll", "ab=util.dll", [], false);
+            assert(@"/r:a\""b=util.dll", @"a""b=util.dll", [], false);
+            assert(@"/r:""a""=""util.dll""", @"a=util.dll", [], false);
+            assert(@"/r:\""a\""=\""util.dll""", @"""a""=""util.dll", [], false);
 
-            Assert.True(parseRef(@"/r:""a=util.dll""") is
+            void assert(string arg, string expectedRef, string[] expectedAliases, bool expectedEmbed)
             {
-                Reference: @"a=util.dll",
-                Properties.Aliases: [],
-                Properties.EmbedInteropTypes: false
-            });
-
-            Assert.True(parseRef(@"/r:""c:\users\app=exe\util.dll""") is
-            {
-                Reference: @"c:\users\app=exe\util.dll",
-                Properties.Aliases: [],
-                Properties.EmbedInteropTypes: false
-            });
-
-            Assert.True(parseRef(@"/r:a=b=util.dll") is
-            {
-                Reference: @"b=util.dll",
-                Properties.Aliases: ["a"],
-                Properties.EmbedInteropTypes: false
-            });
+                var result = parseRef(arg);
+                Assert.Equal(expectedRef, result.Reference);
+                Assert.Equal(expectedAliases, result.Properties.Aliases);
+                Assert.Equal(expectedEmbed, result.Properties.EmbedInteropTypes);
+            }
 
             CommandLineReference parseRef(string refText)
             {

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -2622,7 +2622,7 @@ print Goodbye, World";
             // TODO: multiple files, quotes, etc.
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71022")]
         public void ParseReferencesAlias()
         {
             Assert.True(parseRef(@"/r:a=util.dll") is

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -2623,6 +2623,59 @@ print Goodbye, World";
         }
 
         [Fact]
+        public void ParseReferencesAlias()
+        {
+            Assert.True(parseRef(@"/r:a=util.dll") is
+            {
+                Reference: @"util.dll",
+                Properties.Aliases: ["a"],
+                Properties.EmbedInteropTypes: false
+            });
+
+            Assert.True(parseRef(@"/r:""a=util.dll""") is
+            {
+                Reference: @"a=util.dll",
+                Properties.Aliases: [],
+                Properties.EmbedInteropTypes: false
+            });
+
+            Assert.True(parseRef(@"/r:""c:\users\app=exe\util.dll""") is
+            {
+                Reference: @"c:\users\app=exe\util.dll",
+                Properties.Aliases: [],
+                Properties.EmbedInteropTypes: false
+            });
+
+            Assert.True(parseRef(@"/r:a=b=util.dll") is
+            {
+                Reference: @"b=util.dll",
+                Properties.Aliases: ["a"],
+                Properties.EmbedInteropTypes: false
+            });
+
+            CommandLineReference parseRef(string refText)
+            {
+                var parsedArgs = DefaultParse([refText, "test.cs"], WorkingDirectory);
+                Assert.Equal(2, parsedArgs.MetadataReferences.Length);
+                Assert.Empty(parsedArgs.Errors);
+                return parsedArgs.MetadataReferences[1];
+            }
+        }
+
+        [Fact]
+        public void ParseReferencesAliasErrors()
+        {
+            parseRef(@"/reference:a\b=util.dll").Verify();
+
+            ImmutableArray<Diagnostic> parseRef(string refText)
+            {
+                var parsedArgs = DefaultParse([refText, "test.cs"], WorkingDirectory);
+                return parsedArgs.Errors;
+            }
+        }
+
+
+        [Fact]
         public void ParseAnalyzers()
         {
             var parsedArgs = DefaultParse(new string[] { @"/a:goo.dll", "a.cs" }, WorkingDirectory);

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -2665,7 +2665,17 @@ print Goodbye, World";
         [Fact]
         public void ParseReferencesAliasErrors()
         {
-            parseRef(@"/reference:a\b=util.dll").Verify();
+            parseRef(@"/reference:a\b=util.dll").Verify(
+                Diagnostic(ErrorCode.ERR_BadExternIdentifier).WithArguments(@"a\b").WithLocation(1, 1));
+
+            parseRef(@"/reference:a$b=util.dll").Verify(
+                Diagnostic(ErrorCode.ERR_BadExternIdentifier).WithArguments(@"a$b").WithLocation(1, 1));
+
+            parseRef(@"/reference:a=util.dll,util2.dll").Verify(
+                Diagnostic(ErrorCode.ERR_OneAliasPerReference).WithLocation(1, 1));
+
+            parseRef(@"/reference:a=").Verify(
+                Diagnostic(ErrorCode.ERR_AliasMissingFile).WithArguments("a").WithLocation(1, 1));
 
             ImmutableArray<Diagnostic> parseRef(string refText)
             {
@@ -2673,7 +2683,6 @@ print Goodbye, World";
                 return parsedArgs.Errors;
             }
         }
-
 
         [Fact]
         public void ParseAnalyzers()

--- a/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
+++ b/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
@@ -17,6 +17,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// </summary>
     public class CommandLineBuilderExtension : CommandLineBuilder
     {
+        private bool _isQuotingRequired;
+
+        protected override bool IsQuotingRequired(string parameter) => 
+            _isQuotingRequired
+            ? true
+            : base.IsQuotingRequired(parameter);
+
         /// <summary>
         /// Set a boolean switch iff its value exists and its value is 'true'.
         /// </summary>
@@ -108,6 +115,42 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             AppendSwitchUnquotedIfNotNull(switchName, alias + "=");
             AppendTextWithQuoting(parameter);
+        }
+
+        /// <summary>
+        /// Appends a switch with a value that is force quoted. This will quote as if <see cref="CommandLineBuilder.IsQuotingRequired(string)"/>
+        /// returns true for <paramref name="parameter"/>. That means even simple values will be quoted.
+        /// </summary>
+        internal void AppendTextWithForceQuoting(string parameter)
+        {
+            Debug.Assert(!_isQuotingRequired);
+            _isQuotingRequired = true;
+            try
+            {
+                AppendTextWithQuoting(parameter);
+            }
+            finally
+            {
+                _isQuotingRequired = false;
+            }
+        }
+
+        /// <summary>
+        /// Appends a switch with a value that is force quoted. This will quote as if <see cref="CommandLineBuilder.IsQuotingRequired(string)"/>
+        /// returns true for <paramref name="parameter"/>. That means even simple values will be quoted.
+        /// </summary>
+        internal void AppendSwitchForceQuoted(string switchName, string parameter)
+        {
+            AppendSwitch(switchName);
+            _isQuotingRequired = true;
+            try
+            {
+                AppendTextWithQuoting(parameter);
+            }
+            finally
+            {
+                _isQuotingRequired = false;
+            }
         }
 
         /// <summary>

--- a/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
+++ b/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
@@ -140,15 +140,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         internal void AppendSwitchForceQuoted(string switchName, string parameter)
         {
             AppendSwitch(switchName);
-            _isQuotingRequired = true;
-            try
-            {
-                AppendTextWithQuoting(parameter);
-            }
-            finally
-            {
-                _isQuotingRequired = false;
-            }
+            AppendTextWithForceQuoting(parameter);
         }
 
         /// <summary>

--- a/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
+++ b/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
@@ -19,10 +19,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     {
         private bool _isQuotingRequired;
 
-        protected override bool IsQuotingRequired(string parameter) => 
-            _isQuotingRequired
-            ? true
-            : base.IsQuotingRequired(parameter);
+        protected override bool IsQuotingRequired(string parameter)
+            => _isQuotingRequired || base.IsQuotingRequired(parameter);
 
         /// <summary>
         /// Set a boolean switch iff its value exists and its value is 'true'.

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -24,8 +24,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// </summary>
     public class Csc : ManagedCompiler
     {
-        private static readonly char[] s_quoteOrEquals = { '"', '=' };
-
         #region Properties
 
         // Please keep these alphabetized.  These are the parameters specific to Csc.  The
@@ -375,7 +373,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         // error out on those.  The ones we're checking for here are the ones
                         // that could seriously screw up the command-line parsing or could
                         // allow parameter injection.
-                        if (trimmedAlias.IndexOfAny(new char[] { ',', ' ', ';', '"' }) != -1)
+                        if (trimmedAlias.AsSpan().IndexOfAny([' ', ';', '"', '=']) != -1)
                         {
                             throw Utilities.GetLocalizedArgumentException(
                                 ErrorString.Csc_AssemblyAliasContainsIllegalCharacters,
@@ -406,7 +404,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         return;
                     }
 
-                    var index = itemSpec.IndexOfAny(s_quoteOrEquals);
+                    var index = itemSpec.AsSpan().IndexOfAny(['"', '=']);
                     if (index >= 0 && itemSpec[index] == '=')
                     {
                         // The presence of a = in the name before the first quote will cause the

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// </summary>
     public class Csc : ManagedCompiler
     {
+        private static readonly char[] s_quoteOrEquals = { '"', '=' };
+
         #region Properties
 
         // Please keep these alphabetized.  These are the parameters specific to Csc.  The
@@ -345,7 +347,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 if (string.IsNullOrEmpty(aliasString))
                 {
                     // If there was no "Alias" attribute, just add this as a global reference.
-                    commandLine.AppendSwitchIfNotNull(switchName, reference.ItemSpec);
+                    appendGlobalReference(reference.ItemSpec);
                 }
                 else
                 {
@@ -385,7 +387,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         // give it an alias on the command-line.
                         if (string.Compare("global", trimmedAlias, StringComparison.OrdinalIgnoreCase) == 0)
                         {
-                            commandLine.AppendSwitchIfNotNull(switchName, reference.ItemSpec);
+                            appendGlobalReference(reference.ItemSpec);
                         }
                         else
                         {
@@ -394,6 +396,27 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                             //      /reference:Goo=System.Xml.dll
                             commandLine.AppendSwitchAliased(switchName, trimmedAlias, reference.ItemSpec);
                         }
+                    }
+                }
+
+                void appendGlobalReference(string? itemSpec)
+                {
+                    if (itemSpec is null)
+                    {
+                        return;
+                    }
+
+                    var index = itemSpec.IndexOfAny(s_quoteOrEquals);
+                    if (index >= 0 && itemSpec[index] == '=')
+                    {
+                        // The presence of a = in the name before the first quote will cause the
+                        // compiler to treat this as an alias reference instead of a global
+                        // reference. Force quote the reference to ensure it's treated as global reference.
+                        commandLine.AppendSwitchForceQuoted(switchName, reference.ItemSpec);
+                    }
+                    else
+                    {
+                        commandLine.AppendSwitchIfNotNull(switchName, reference.ItemSpec);
                     }
                 }
             }

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -590,13 +590,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             parseMultiple(@"c:\a=b\util.dll", "global,c", @"/reference:""c:\a=b\util.dll""", @"/reference:c=c:\a=b\util.dll");
             parseMultiple(@"c:\a=b\util.dll", "x,z", @"/reference:x=c:\a=b\util.dll", @"/reference:z=c:\a=b\util.dll");
 
-            void parse(string refText, string? alias, string args, bool embedInteropTypes = false) =>
-                parseCore(refText, alias, embedInteropTypes, [args]);
+            void parse(string refText, string? alias, string expectedArg, bool embedInteropTypes = false) =>
+                parseCore(refText, alias, embedInteropTypes, [expectedArg]);
 
-            void parseMultiple(string refText, string? alias, params string[] args) =>
-                parseCore(refText, alias, embedInteropTypes: false, args);
+            void parseMultiple(string refText, string? alias, params string[] expectedArgs) =>
+                parseCore(refText, alias, embedInteropTypes: false, expectedArgs);
 
-            void parseCore(string refText, string? alias, bool embedInteropTypes, string[] args)
+            void parseCore(string refText, string? alias, bool embedInteropTypes, string[] expectedArgs)
             {
                 var engine = new MockEngine(TestOutputHelper);
                 var csc = new Csc()
@@ -607,7 +607,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                     References = [SimpleTaskItem.CreateReference(refText, alias: alias, embedInteropTypes)],
                 };
 
-                TaskTestUtil.AssertCommandLine(csc, engine, [.. args, "/out:test.dll", "/target:library", "test.cs"]);
+                TaskTestUtil.AssertCommandLine(csc, engine, [.. expectedArgs, "/out:test.dll", "/target:library", "test.cs"]);
             }
         }
 
@@ -617,6 +617,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             parseRef(@"util.dll", "a=b");
             parseRef(@"util.dll", "a b");
             parseRef(@"util.dll", "a;b");
+            parseRef(@"util.dll", @"a""b");
 
             void parseRef(string refText, string alias)
             {

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -568,5 +568,33 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 
             TaskTestUtil.AssertCommandLine(csc, engine, "/out:test.dll", "/target:library", "test.cs", "blah.cs");
         }
+
+        [Fact]
+        public void References_Equals()
+        {
+            core(@"util.dll", null, @"/reference:util.dll");
+            core(@"util.dll", "global", @"/reference:util.dll");
+            core(@"util.dll", "lib", @"/reference:lib=util.dll");
+            core(@"""util.dll""", "global", @"/reference:""\""util.dll\""""");
+            core(@"c:\a=util.dll", null, @"/reference:""c:\a=util.dll""");
+            core(@"c:\a=util.dll", "global", @"/reference:""c:\a=util.dll""");
+            core(@"""c:\a=util.dll""", "global", @"/reference:""\""c:\a=util.dll\""""");
+            core(@"a=util.dll", null, @"/reference:""a=util.dll""");
+            core(@"util.dll", "lib", @"/reference:lib=util.dll");
+            core(@"c:\a=util.dll", "lib", @"/reference:lib=c:\a=util.dll");
+            void core(string refText, string? alias, params string[] args)
+            {
+                var engine = new MockEngine(TestOutputHelper);
+                var csc = new Csc()
+                {
+                    BuildEngine = engine,
+                    Sources = MSBuildUtil.CreateTaskItems("test.cs"),
+                    TargetType = "library",
+                    References = [SimpleTaskItem.CreateReference(refText, alias: alias)],
+                };
+
+                TaskTestUtil.AssertCommandLine(csc, engine, [.. args, "/out:test.dll", "/target:library", "test.cs"]);
+            }
+        }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -582,6 +582,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             core(@"a=util.dll", null, @"/reference:""a=util.dll""");
             core(@"util.dll", "lib", @"/reference:lib=util.dll");
             core(@"c:\a=util.dll", "lib", @"/reference:lib=c:\a=util.dll");
+
+            // These result in illegal /reference: syntax but that is for the compiler to 
+            // determine
+            core(@"util.dll", "lib=bad", @"/reference:lib=bad=util.dll");
+            core(@"util.dll", @"lib\bad", @"/reference:lib\bad=util.dll");
             void core(string refText, string? alias, params string[] args)
             {
                 var engine = new MockEngine(TestOutputHelper);

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/SimpleTaskItem.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/SimpleTaskItem.cs
@@ -5,12 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ICSharpCode.Decompiler.Metadata;
 using Microsoft.Build.Framework;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
 

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/SimpleTaskItem.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/SimpleTaskItem.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ICSharpCode.Decompiler.Metadata;
+using Microsoft.Build.Framework;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
+
+internal sealed class SimpleTaskItem : ITaskItem
+{
+    public string ItemSpec { get; set; }
+
+    public Dictionary<string, string> Metadata { get; }
+
+    public ICollection MetadataNames => Metadata.Keys;
+
+    public int MetadataCount => Metadata.Count;
+
+    internal SimpleTaskItem(string itemSpec, Dictionary<string, string> metadata)
+    {
+        ItemSpec = itemSpec;
+        Metadata = metadata;
+    }
+
+    public IDictionary CloneCustomMetadata() => throw new NotImplementedException();
+
+    public void CopyMetadataTo(ITaskItem destinationItem) => throw new NotImplementedException();
+
+    public string? GetMetadata(string metadataName)
+    {
+        if (Metadata is not null)
+        {
+            return Metadata.TryGetValue(metadataName, out var metadataValue) ? metadataValue : null;
+        }
+
+        return null;
+    }
+
+    public void RemoveMetadata(string metadataName)
+    {
+        if (Metadata is { })
+        {
+            Metadata.Remove(metadataName);
+        }
+    }
+
+    public void SetMetadata(string metadataName, string metadataValue)
+    {
+        Metadata[metadataName] = metadataValue;
+    }
+
+    public static SimpleTaskItem CreateReference(string itemSpec, string? alias = null, bool? embedInteropTypes = null)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (alias is not null)
+        {
+            map["Aliases"] = alias;
+        }
+
+        if (embedInteropTypes is { } e)
+        {
+            map["EmbedInteropTypes"] = e.ToString();
+        }
+
+        return new SimpleTaskItem(itemSpec, map);
+    }
+}

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/SimpleTaskItem.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/SimpleTaskItem.cs
@@ -34,23 +34,11 @@ internal sealed class SimpleTaskItem : ITaskItem
 
     public void CopyMetadataTo(ITaskItem destinationItem) => throw new NotImplementedException();
 
-    public string? GetMetadata(string metadataName)
-    {
-        if (Metadata is not null)
-        {
-            return Metadata.TryGetValue(metadataName, out var metadataValue) ? metadataValue : null;
-        }
+    public string? GetMetadata(string metadataName) =>
+        Metadata.TryGetValue(metadataName, out var metadataValue) ? metadataValue : null;
 
-        return null;
-    }
-
-    public void RemoveMetadata(string metadataName)
-    {
-        if (Metadata is { })
-        {
-            Metadata.Remove(metadataName);
-        }
-    }
+    public void RemoveMetadata(string metadataName) =>
+       _ = Metadata.Remove(metadataName);
 
     public void SetMetadata(string metadataName, string metadataValue)
     {


### PR DESCRIPTION
The `Csc` task was passing references that contains `=` in the paths directly to `/reference` commands. 

```xml
<Reference Include="c:\users\a=b\util.dll" />
```

Was resulting in a `/reference:c:\users\a=b\util.dll` argument being passed to the compiler. That is interpreted as an alias reference due to the `=` instead of a pure path. This PR changes the MSBuild task to properly escape such paths by surrounding them in quotes (prevents them from being treated as aliases).

closes #71022