### PR TITLE
Offer use-primary-constructor on abtract types with protected constructors

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
@@ -278,8 +278,17 @@ internal sealed class CSharpUsePrimaryConstructorDiagnosticAnalyzer()
                 if (primaryConstructor.Parameters.Length == 0)
                     return null;
 
-                if (primaryConstructor.DeclaredAccessibility != Accessibility.Public)
+                // protected constructor in an abstract type is fine.  It will stay protected even as a primary constructor.
+                // otherwise it has to be public.
+                if (primaryConstructor.DeclaredAccessibility == Accessibility.Protected)
+                {
+                    if (!namedType.IsAbstract)
+                        return null;
+                }
+                else if (primaryConstructor.DeclaredAccessibility != Accessibility.Public)
+                {
                     return null;
+                }
 
                 // Constructor has to have a real body (can't be extern/etc.).
                 if (primaryConstructorDeclaration is { Body: null, ExpressionBody: null })

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -3583,4 +3583,65 @@ public partial class UsePrimaryConstructorTests
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestAbstractClass1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                abstract class C
+                {
+                    protected [|C|](int i)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                abstract class C(int i)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestAbstractClass2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                abstract class C
+                {
+                    public [|C|](int i)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                abstract class C(int i)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestAbstractClass3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                abstract class C
+                {
+                    internal C(int i)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
 }


### PR DESCRIPTION
Noticed while dogfooding and not getting this feature.