### PR TITLE
Pass through folders for additional files

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.CodeAnalysis.LanguageServer.BrokeredServices;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
-using Microsoft.CodeAnalysis.LanguageServer.Logging;
 using Microsoft.CodeAnalysis.Remote.ProjectSystem;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
@@ -37,14 +36,20 @@ public class WorkspaceProjectFactoryServiceTests
         var sourceFilePath = MakeAbsolutePath("SourceFile.cs");
         var additionalFilePath = MakeAbsolutePath("AdditionalFile.txt");
 
-        await workspaceProject.AddSourceFilesAsync(new[] { new SourceFileInfo(sourceFilePath, Array.Empty<string>()) }, CancellationToken.None);
-        await workspaceProject.AddAdditionalFilesAsync(new[] { additionalFilePath }, CancellationToken.None);
+        await workspaceProject.AddSourceFilesAsync([new SourceFileInfo(sourceFilePath, ["Folder"])], CancellationToken.None);
+        await workspaceProject.AddAdditionalFilesAsync([new SourceFileInfo(additionalFilePath, FolderNames: ["Folder"])], CancellationToken.None);
         await batch.ApplyAsync(CancellationToken.None);
 
         // Verify it actually did something; we won't exclusively test each method since those are tested at lower layers
         var project = workspaceFactory.Workspace.CurrentSolution.Projects.Single();
-        Assert.Equal(sourceFilePath, project.Documents.Single().FilePath);
-        Assert.Equal(additionalFilePath, project.AdditionalDocuments.Single().FilePath);
+
+        var document = Assert.Single(project.Documents);
+        Assert.Equal(sourceFilePath, document.FilePath);
+        Assert.Equal("Folder", Assert.Single(document.Folders));
+
+        var additionalDocument = Assert.Single(project.AdditionalDocuments);
+        Assert.Equal(additionalFilePath, additionalDocument.FilePath);
+        Assert.Equal("Folder", Assert.Single(additionalDocument.Folders));
     }
 
     private static string MakeAbsolutePath(string relativePath)

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DebugConfiguration;
-using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
@@ -163,7 +161,7 @@ internal sealed class LoadedProject : IDisposable
             newProjectInfo.AdditionalDocuments,
             _mostRecentFileInfo?.AdditionalDocuments,
             DocumentFileInfoComparer.Instance,
-            document => _projectSystemProject.AddAdditionalFile(document.FilePath),
+            document => _projectSystemProject.AddAdditionalFile(document.FilePath, folders: document.Folders),
             document => _projectSystemProject.RemoveAdditionalFile(document.FilePath),
             "Project {0} now has {1} additional file(s).");
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/WorkspaceProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/WorkspaceProject.cs
@@ -24,12 +24,21 @@ internal class WorkspaceProject : IWorkspaceProject
         _targetFrameworkManager = targetFrameworkManager;
     }
 
+    [Obsolete($"Call the {nameof(AddAdditionalFilesAsync)} overload that takes {nameof(SourceFileInfo)}.")]
     public async Task AddAdditionalFilesAsync(IReadOnlyList<string> additionalFilePaths, CancellationToken _)
     {
         await using var batchScope = _project.CreateBatchScope();
 
         foreach (var additionalFilePath in additionalFilePaths)
             _project.AddAdditionalFile(additionalFilePath);
+    }
+
+    public async Task AddAdditionalFilesAsync(IReadOnlyList<SourceFileInfo> additionalFiles, CancellationToken cancellationToken)
+    {
+        await using var batchScope = _project.CreateBatchScope();
+
+        foreach (var additionalFile in additionalFiles)
+            _project.AddAdditionalFile(additionalFile.FilePath, folders: additionalFile.FolderNames.ToImmutableArray());
     }
 
     public async Task AddAnalyzerConfigFilesAsync(IReadOnlyList<string> analyzerConfigPaths, CancellationToken _)

--- a/src/Tools/ExternalAccess/FSharp/VS/IFSharpWorkspaceProjectContextFactory.cs
+++ b/src/Tools/ExternalAccess/FSharp/VS/IFSharpWorkspaceProjectContextFactory.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
 
         public string BinOutputPath
         {
-            get => _vsProjectContext.BinOutputPath;
+            get => _vsProjectContext.BinOutputPath!;
             set => _vsProjectContext.BinOutputPath = value;
         }
 
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
             => _vsProjectContext.Id;
 
         public string FilePath
-            => _vsProjectContext.ProjectFilePath;
+            => _vsProjectContext.ProjectFilePath!;
 
         public int ProjectReferenceCount
             => _projectReferences.Count;

--- a/src/VisualStudio/Core/Def/ProjectSystem/BrokeredService/WorkspaceProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/BrokeredService/WorkspaceProject.cs
@@ -29,12 +29,21 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem.BrokeredService
             _project.Dispose();
         }
 
+        [Obsolete($"Call the {nameof(AddAdditionalFilesAsync)} overload that takes {nameof(SourceFileInfo)}.")]
         public async Task AddAdditionalFilesAsync(IReadOnlyList<string> additionalFilePaths, CancellationToken cancellationToken)
         {
             await using var batch = _project.CreateBatchScope().ConfigureAwait(false);
 
             foreach (var additionalFilePath in additionalFilePaths)
                 _project.AddAdditionalFile(additionalFilePath);
+        }
+
+        public async Task AddAdditionalFilesAsync(IReadOnlyList<SourceFileInfo> additionalFiles, CancellationToken cancellationToken)
+        {
+            await using var batchScope = _project.CreateBatchScope().ConfigureAwait(false);
+
+            foreach (var additionalFile in additionalFiles)
+                _project.AddAdditionalFile(additionalFile.FilePath, folderNames: additionalFile.FolderNames.ToImmutableArray());
         }
 
         public async Task RemoveAdditionalFilesAsync(IReadOnlyList<string> additionalFilePaths, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -54,7 +54,9 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         // Files.
         void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string>? folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular);
         void RemoveSourceFile(string filePath);
+        [Obsolete($"Call the {nameof(AddAdditionalFile)} method that takes folder names.")]
         void AddAdditionalFile(string filePath, bool isInCurrentContext = true);
+        void AddAdditionalFile(string filePath, IEnumerable<string> folderNames, bool isInCurrentContext = true);
         void RemoveAdditionalFile(string filePath);
         void AddDynamicFile(string filePath, IEnumerable<string>? folderNames = null);
         void RemoveDynamicFile(string filePath);

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
 {
@@ -23,10 +20,10 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
     {
         // Project properties.
         string DisplayName { get; set; }
-        string ProjectFilePath { get; set; }
+        string? ProjectFilePath { get; set; }
         Guid Guid { get; set; }
         bool LastDesignTimeBuildSucceeded { get; set; }
-        string BinOutputPath { get; set; }
+        string? BinOutputPath { get; set; }
 
         /// <summary>
         /// When this project is one of a multi-targeting group of projects, this value indicates whether or not this
@@ -55,11 +52,11 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         void RemoveAnalyzerReference(string referencePath);
 
         // Files.
-        void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string> folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular);
+        void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string>? folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular);
         void RemoveSourceFile(string filePath);
         void AddAdditionalFile(string filePath, bool isInCurrentContext = true);
         void RemoveAdditionalFile(string filePath);
-        void AddDynamicFile(string filePath, IEnumerable<string> folderNames = null);
+        void AddDynamicFile(string filePath, IEnumerable<string>? folderNames = null);
         void RemoveDynamicFile(string filePath);
 
         /// <summary>

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -183,13 +183,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 return;
             }
 
-            ImmutableArray<string> folders = default;
-
-            var itemid = Hierarchy.TryGetItemId(filename);
-            if (itemid != VSConstants.VSITEMID_NIL)
-            {
-                folders = GetFolderNamesForDocument(itemid);
-            }
+            var folders = GetFolderNamesForDocument(filename);
 
             ProjectSystemProject.AddSourceFile(filename, sourceCodeKind, folders);
         }
@@ -308,6 +302,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         /// <remarks>Using item IDs as a key like this in a long-lived way is considered unsupported by CPS and other
         /// IVsHierarchy providers, but this code (which is fairly old) still makes the assumptions anyways.</remarks>
         private readonly Dictionary<uint, ImmutableArray<string>> _folderNameMap = new();
+
+        private ImmutableArray<string> GetFolderNamesForDocument(string filename)
+        {
+            var itemid = Hierarchy.TryGetItemId(filename);
+            if (itemid != VSConstants.VSITEMID_NIL)
+            {
+                return GetFolderNamesForDocument(itemid);
+            }
+
+            return default;
+        }
 
         private ImmutableArray<string> GetFolderNamesForDocument(uint documentItemID)
         {

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerHost.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerHost.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         }
 
         void IAnalyzerHost.AddAdditionalFile(string additionalFilePath)
-            => ProjectSystemProject.AddAdditionalFile(additionalFilePath);
+            => ProjectSystemProject.AddAdditionalFile(additionalFilePath, folders: GetFolderNamesForDocument(additionalFilePath));
 
         void IAnalyzerHost.RemoveAdditionalFile(string additionalFilePath)
             => ProjectSystemProject.RemoveAdditionalFile(additionalFilePath);

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -235,6 +235,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         public void AddAdditionalFile(string filePath, bool isInCurrentContext = true)
             => _projectSystemProject.AddAdditionalFile(filePath);
 
+        public void AddAdditionalFile(string filePath, IEnumerable<string> folderNames, bool isInCurrentContext = true)
+            => _projectSystemProject.AddAdditionalFile(filePath, folders: folderNames.ToImmutableArray());
+
         public void Dispose()
         {
             _projectCodeModel?.OnProjectClosed();

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -719,8 +719,8 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
         #region Additional File Addition/Removal
 
         // TODO: should AdditionalFiles have source code kinds?
-        public void AddAdditionalFile(string fullPath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
-            => _additionalFiles.AddFile(fullPath, sourceCodeKind, folders: default);
+        public void AddAdditionalFile(string fullPath, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, ImmutableArray<string> folders = default)
+            => _additionalFiles.AddFile(fullPath, sourceCodeKind, folders);
 
         public bool ContainsAdditionalFile(string fullPath)
             => _additionalFiles.ContainsFile(fullPath);

--- a/src/Workspaces/Remote/Core/ProjectSystem/IWorkspaceProject.cs
+++ b/src/Workspaces/Remote/Core/ProjectSystem/IWorkspaceProject.cs
@@ -24,7 +24,9 @@ internal interface IWorkspaceProject : IDisposable
     Task AddMetadataReferencesAsync(IReadOnlyList<MetadataReferenceInfo> metadataReferences, CancellationToken cancellationToken);
     Task RemoveMetadataReferencesAsync(IReadOnlyList<MetadataReferenceInfo> metadataReferences, CancellationToken cancellationToken);
 
+    [Obsolete($"Call the {nameof(AddAdditionalFilesAsync)} overload that takes {nameof(SourceFileInfo)}.")]
     Task AddAdditionalFilesAsync(IReadOnlyList<string> additionalFilePaths, CancellationToken cancellationToken);
+    Task AddAdditionalFilesAsync(IReadOnlyList<SourceFileInfo> additionalFiles, CancellationToken cancellationToken);
     Task RemoveAdditionalFilesAsync(IReadOnlyList<string> additionalFilePaths, CancellationToken cancellationToken);
 
     Task AddAnalyzerReferencesAsync(IReadOnlyList<string> analyzerPaths, CancellationToken cancellationToken);


### PR DESCRIPTION
Our workspace model always allowed this at the document level, we just
never had a request for it until recently for some XAML support. This
adds support for legacy project systems in VS and the base C# extension
project system. Changes will need to be made in other repos for the
CPS-based project systems to consume the APIs being added here.

Partially fixes https://github.com/dotnet/roslyn/issues/65589