### PR TITLE
Give our analyzer loaders independent directories across hosts

### DIFF
--- a/src/Workspaces/Core/Portable/Diagnostics/DefaultAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DefaultAnalyzerAssemblyLoaderService.cs
@@ -7,21 +7,29 @@ using System.Composition;
 using System.IO;
 using Microsoft.CodeAnalysis.Host.Mef;
 
-namespace Microsoft.CodeAnalysis.Host
-{
-    [Shared]
-    [ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider))]
-    internal sealed class DefaultAnalyzerAssemblyLoaderService : IAnalyzerAssemblyLoaderProvider
-    {
-        private readonly IAnalyzerAssemblyLoader _loader = new DefaultAnalyzerAssemblyLoader();
-        private readonly IAnalyzerAssemblyLoader _shadowCopyLoader = DefaultAnalyzerAssemblyLoader.CreateNonLockingLoader(
-            Path.Combine(Path.GetTempPath(), "CodeAnalysis", "WorkspacesAnalyzerShadowCopies"));
+namespace Microsoft.CodeAnalysis.Host;
 
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultAnalyzerAssemblyLoaderService()
-        {
-        }
+[ExportWorkspaceServiceFactory(typeof(IAnalyzerAssemblyLoaderProvider)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class DefaultAnalyzerAssemblyLoaderServiceFactory() : IWorkspaceServiceFactory
+{
+    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+        => new DefaultAnalyzerAssemblyLoaderProvider(workspaceServices.Workspace.Kind ?? "default");
+
+    private sealed class DefaultAnalyzerAssemblyLoaderProvider(string kind) : IAnalyzerAssemblyLoaderProvider
+    {
+        private readonly DefaultAnalyzerAssemblyLoader _loader = new();
+
+        /// <summary>
+        /// We include the <see cref="WorkspaceKind"/> of the workspace in the path we produce.  That way we don't
+        /// collide in the common case of a normal host workspace and OOP workspace running together.  This avoids an
+        /// annoying exception as each will try to clean up this directory, throwing exceptions because the other is
+        /// locking it.  The exception is fine, since the cleanup is just hygenic and isn't intended to be needed for
+        /// correctness.  But it is annoying and does cause noise in our perf test harness.
+        /// </summary>
+        private readonly IAnalyzerAssemblyLoader _shadowCopyLoader = DefaultAnalyzerAssemblyLoader.CreateNonLockingLoader(
+            Path.Combine(Path.GetTempPath(), "CodeAnalysis", "WorkspacesAnalyzerShadowCopies", kind));
 
         public IAnalyzerAssemblyLoader GetLoader(in AnalyzerAssemblyLoaderOptions options)
             => options.ShadowCopy ? _shadowCopyLoader : _loader;

--- a/src/Workspaces/Core/Portable/Diagnostics/DefaultAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DefaultAnalyzerAssemblyLoaderService.cs
@@ -17,7 +17,7 @@ internal sealed class DefaultAnalyzerAssemblyLoaderServiceFactory() : IWorkspace
     public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         => new DefaultAnalyzerAssemblyLoaderProvider(workspaceServices.Workspace.Kind ?? "default");
 
-    private sealed class DefaultAnalyzerAssemblyLoaderProvider(string kind) : IAnalyzerAssemblyLoaderProvider
+    private sealed class DefaultAnalyzerAssemblyLoaderProvider(string workspaceKind) : IAnalyzerAssemblyLoaderProvider
     {
         private readonly DefaultAnalyzerAssemblyLoader _loader = new();
 
@@ -29,7 +29,7 @@ internal sealed class DefaultAnalyzerAssemblyLoaderServiceFactory() : IWorkspace
         /// correctness.  But it is annoying and does cause noise in our perf test harness.
         /// </summary>
         private readonly IAnalyzerAssemblyLoader _shadowCopyLoader = DefaultAnalyzerAssemblyLoader.CreateNonLockingLoader(
-            Path.Combine(Path.GetTempPath(), "CodeAnalysis", "WorkspacesAnalyzerShadowCopies", kind));
+            Path.Combine(Path.GetTempPath(), "CodeAnalysis", "WorkspacesAnalyzerShadowCopies", workspaceKind));
 
         public IAnalyzerAssemblyLoader GetLoader(in AnalyzerAssemblyLoaderOptions options)
             => options.ShadowCopy ? _shadowCopyLoader : _loader;


### PR DESCRIPTION
Internal perf runs are showing noise due to the exceptions thrown when both VS and our other processes attempt to delete the same 'analyzer shadow copy directory'.  This deletion is best effort, and is about cleaning up stale data, not correctness.  However, the exception makes things noisy for the test runs.  To help mitigate this, we just place the directories in a deeper directory depending on workspace kind.  This will ensure that there is no collision in practice.

Note: opening multiple VS' will still cause collisions.  But, as per above, it's entirely fine for one of those VS' to not be able to clean up the directory because the other is lockign it.
