### PR TITLE
Fix LSIF generator's indexing of Razor projects

### DIFF
--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -81,6 +81,11 @@
     <ProjectReference Include="..\..\..\Workspaces\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj" />
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />
 
+    <!-- Make sure we include the RazorCompiler ExternalAccess since this needs to be deployed with the compiler for things that might
+         run the Razor generator. We bundle this in the MWorkspaces.MSBuild NuGet package directly, but since we're consuming a project reference
+         rather than a package reference we'll have to include this here. -->
+    <ProjectReference Include="..\..\..\Tools\ExternalAccess\RazorCompiler\Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.csproj" />
+
     <!-- Below is the transitive closure of the project references above to placate BuildBoss. If changes are made above this line,
          please update the stuff here accordingly. -->
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -33,7 +33,7 @@
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
 
-  <Target Name="_GetFilesToPackage" DependsOnTargets="ResolveReferences;BuiltProjectOutputGroup">
+  <Target Name="_GetFilesToPackage" DependsOnTargets="ResolveReferences;BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems">
     <ItemGroup>
       <!-- Include all dependencies; the DestinationSubDirectory is to handle culture-specific resource files that should be placed in
            subdirectories -->
@@ -44,8 +44,13 @@
                               PackagePath="tools\$(TargetFramework)\any\%(ReferenceCopyLocalPaths.DestinationSubDirectory)"
                               Condition="'%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' and '%(Extension)' != '.pdb' and '%(Extension)' != '.xml'" />
 
-      <TfmSpecificPackageFile Include="@(BuiltProjectOutputGroupOutput)" PackagePath="tools\$(TargetFramework)\any" />
-      <TfmSpecificPackageFile Include="$(ProjectDepsFilePath)" PackagePath="tools\$(TargetFramework)\any" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+      <!-- Include content output as well, for the BuildHost -->
+      <TfmSpecificPackageFile Include="@(AllItemsFullPathWithTargetPath)"
+                              PackagePath="tools\$(TargetFramework)\any\%(AllItemsFullPathWithTargetPath.TargetPath)"
+                              Condition="'%(Extension)' != '.pdb' and '%(Extension)' != '.xml'" />
+
+      <TfmSpecificPackageFile Include="@(BuiltProjectOutputGroupOutput)" PackagePath="tools\$(TargetFramework)\any"
+                              Condition="'%(FullPath)' != '$(ProjectRuntimeConfigFilePath)'"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This adds the missing ExternalAccess binary, and also fixes the fact we weren't bundling the BuildHost content files.