### PR TITLE
Cherry-pick the LINQ expression fix

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _listenerProvider = listenerProvider;
             if (smartRenameSessionFactory is not null)
             {
-                _smartRenameSessionFactory = new Lazy<ISmartRenameSessionFactoryWrapper>(() => ISmartRenameSessionFactoryWrapper.FromInstance(smartRenameSessionFactory));
+                _smartRenameSessionFactory = new Lazy<ISmartRenameSessionFactoryWrapper>(() => ISmartRenameSessionFactoryWrapper.FromInstance(smartRenameSessionFactory.Value));
             }
 
             _threadingContext = threadingContext;

--- a/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionFactoryWrapper.cs
+++ b/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionFactoryWrapper.cs
@@ -23,7 +23,6 @@ internal readonly struct ISmartRenameSessionFactoryWrapper
     static ISmartRenameSessionFactoryWrapper()
     {
         s_wrappedType = typeof(AggregateFocusInterceptor).Assembly.GetType(WrappedTypeName, throwOnError: false, ignoreCase: false);
-
         s_createSmartRenameSession = LightupHelpers.CreateFunctionAccessor<object, SnapshotSpan, object?>(s_wrappedType, nameof(CreateSmartRenameSession), typeof(SnapshotSpan), SpecializedTasks.Null<object>());
     }
 
@@ -58,6 +57,6 @@ internal readonly struct ISmartRenameSessionFactoryWrapper
         if (!ISmartRenameSessionWrapper.IsInstance(session))
             return null;
 
-        return (ISmartRenameSessionWrapper)session;
+        return ISmartRenameSessionWrapper.FromInstance(session);
     }
 }


### PR DESCRIPTION
This is part of the change in https://github.com/dotnet/roslyn/pull/71055
The linked PR contains another change about cancellation, and PMs are discussing it.
Meanwhile, let's get this in to fix the rename, otherwise the rename UI won't shown up