### PR TITLE
Do not resolve diagnostics early during attribute binding

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6846,7 +6846,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // NOTE: ReplaceTypeOrValueReceiver will call CheckValue explicitly.
                                 boundValue = BindToNaturalType(boundValue, valueDiagnostics);
                                 return new BoundTypeOrValueExpression(left,
-                                    new BoundTypeOrValueData(leftSymbol, boundValue, valueDiagnostics.ToReadOnlyAndFree(), boundType, typeDiagnostics.ToReadOnlyAndFree()), leftType);
+                                    new BoundTypeOrValueData(leftSymbol, boundValue, valueDiagnostics, boundType, typeDiagnostics), leftType);
                             }
 
                             typeDiagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6846,7 +6846,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // NOTE: ReplaceTypeOrValueReceiver will call CheckValue explicitly.
                                 boundValue = BindToNaturalType(boundValue, valueDiagnostics);
                                 return new BoundTypeOrValueExpression(left,
-                                    new BoundTypeOrValueData(leftSymbol, boundValue, valueDiagnostics.ToReadOnlyAndFree(), boundType, typeDiagnostics.ToReadOnlyAndFree()), leftType);
+                                    new BoundTypeOrValueData(leftSymbol, boundValue, valueDiagnostics.ToReadOnlyAndFree(forceDiagnosticResolution: false), boundType, typeDiagnostics.ToReadOnlyAndFree(forceDiagnosticResolution: false)), leftType);
                             }
 
                             typeDiagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6846,7 +6846,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // NOTE: ReplaceTypeOrValueReceiver will call CheckValue explicitly.
                                 boundValue = BindToNaturalType(boundValue, valueDiagnostics);
                                 return new BoundTypeOrValueExpression(left,
-                                    new BoundTypeOrValueData(leftSymbol, boundValue, valueDiagnostics.ToReadOnlyAndFree(forceDiagnosticResolution: false), boundType, typeDiagnostics.ToReadOnlyAndFree(forceDiagnosticResolution: false)), leftType);
+                                    new BoundTypeOrValueData(leftSymbol, boundValue, valueDiagnostics.ToReadOnlyAndFree(), boundType, typeDiagnostics.ToReadOnlyAndFree()), leftType);
                             }
 
                             typeDiagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6846,7 +6846,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // NOTE: ReplaceTypeOrValueReceiver will call CheckValue explicitly.
                                 boundValue = BindToNaturalType(boundValue, valueDiagnostics);
                                 return new BoundTypeOrValueExpression(left,
-                                    new BoundTypeOrValueData(leftSymbol, boundValue, valueDiagnostics, boundType, typeDiagnostics), leftType);
+                                    new BoundTypeOrValueData(leftSymbol, boundValue, valueDiagnostics.ToReadOnlyAndFree(forceDiagnosticResolution: false), boundType, typeDiagnostics.ToReadOnlyAndFree(forceDiagnosticResolution: false)), leftType);
                             }
 
                             typeDiagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -9727,7 +9727,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            var sealedDiagnostics = ImmutableBindingDiagnostic<AssemblySymbol>.Empty;
+            var sealedDiagnostics = ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty;
             if (node.LookupError != null)
             {
                 var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false);

--- a/src/Compilers/CSharp/Portable/Binder/LockOrUsingBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LockOrUsingBinder.cs
@@ -110,9 +110,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private class ExpressionAndDiagnostics
         {
             public readonly BoundExpression Expression;
-            public readonly ImmutableBindingDiagnostic<AssemblySymbol> Diagnostics;
+            public readonly ReadOnlyBindingDiagnostic<AssemblySymbol> Diagnostics;
 
-            public ExpressionAndDiagnostics(BoundExpression expression, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics)
+            public ExpressionAndDiagnostics(BoundExpression expression, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics)
             {
                 this.Expression = expression;
                 this.Diagnostics = diagnostics;

--- a/src/Compilers/CSharp/Portable/Binder/MethodGroupResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/MethodGroupResolution.cs
@@ -21,15 +21,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly Symbol OtherSymbol;
         public readonly OverloadResolutionResult<MethodSymbol> OverloadResolutionResult;
         public readonly AnalyzedArguments AnalyzedArguments;
-        public readonly ImmutableBindingDiagnostic<AssemblySymbol> Diagnostics;
+        public readonly ReadOnlyBindingDiagnostic<AssemblySymbol> Diagnostics;
         public readonly LookupResultKind ResultKind;
 
-        public MethodGroupResolution(MethodGroup methodGroup, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics)
+        public MethodGroupResolution(MethodGroup methodGroup, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics)
             : this(methodGroup, otherSymbol: null, overloadResolutionResult: null, analyzedArguments: null, methodGroup.ResultKind, diagnostics)
         {
         }
 
-        public MethodGroupResolution(Symbol otherSymbol, LookupResultKind resultKind, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics)
+        public MethodGroupResolution(Symbol otherSymbol, LookupResultKind resultKind, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics)
             : this(methodGroup: null, otherSymbol, overloadResolutionResult: null, analyzedArguments: null, resultKind, diagnostics)
         {
         }
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             OverloadResolutionResult<MethodSymbol> overloadResolutionResult,
             AnalyzedArguments analyzedArguments,
             LookupResultKind resultKind,
-            ImmutableBindingDiagnostic<AssemblySymbol> diagnostics)
+            ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics)
         {
             Debug.Assert((methodGroup == null) || (methodGroup.Methods.Count > 0));
             Debug.Assert((methodGroup == null) || ((object)otherSymbol == null));

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -47,12 +47,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected TypeSymbol SwitchGoverningType => SwitchGoverningExpression.Type;
 
-        protected ImmutableBindingDiagnostic<AssemblySymbol> SwitchGoverningDiagnostics
+        protected ReadOnlyBindingDiagnostic<AssemblySymbol> SwitchGoverningDiagnostics
         {
             get
             {
                 EnsureSwitchGoverningExpressionAndDiagnosticsBound();
-                return new ImmutableBindingDiagnostic<AssemblySymbol>(_switchGoverningDiagnostics, _switchGoverningDependencies);
+                return new ReadOnlyBindingDiagnostic<AssemblySymbol>(_switchGoverningDiagnostics, _switchGoverningDependencies);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -640,11 +640,11 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public Symbol ValueSymbol { get; }
         public BoundExpression ValueExpression { get; }
-        public ImmutableBindingDiagnostic<AssemblySymbol> ValueDiagnostics { get; }
+        public ReadOnlyBindingDiagnostic<AssemblySymbol> ValueDiagnostics { get; }
         public BoundExpression TypeExpression { get; }
-        public ImmutableBindingDiagnostic<AssemblySymbol> TypeDiagnostics { get; }
+        public ReadOnlyBindingDiagnostic<AssemblySymbol> TypeDiagnostics { get; }
 
-        public BoundTypeOrValueData(Symbol valueSymbol, BoundExpression valueExpression, ImmutableBindingDiagnostic<AssemblySymbol> valueDiagnostics, BoundExpression typeExpression, ImmutableBindingDiagnostic<AssemblySymbol> typeDiagnostics)
+        public BoundTypeOrValueData(Symbol valueSymbol, BoundExpression valueExpression, ReadOnlyBindingDiagnostic<AssemblySymbol> valueDiagnostics, BoundExpression typeExpression, ReadOnlyBindingDiagnostic<AssemblySymbol> typeDiagnostics)
         {
             Debug.Assert(valueSymbol != null, "Field 'valueSymbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(valueExpression != null, "Field 'valueExpression' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -636,15 +636,22 @@ namespace Microsoft.CodeAnalysis.CSharp
     //       BoundTypeOrValueExpression from the bound tree generator, which would otherwise generate
     //       a constructor that may spuriously set hasErrors to true if either field had errors.
     //       A BoundTypeOrValueExpression should never have errors if it is present in the tree.
-    internal readonly struct BoundTypeOrValueData : System.IEquatable<BoundTypeOrValueData>
+    /// <remarks>
+    /// A BoundTypeOrValueData takes a BindingDiagnosticBag (including taking ownership of freeing that bag) instead of <see cref="ImmutableBindingDiagnostic{TAssemblySymbol}"/>
+    /// in order to avoid forcing resolution of lazy diagnostics. Early resolution can cause a binding cycle in color color tests involving assembly attribute arguments, so we
+    /// want to avoid that by delaying resolution until later in the process. The diagnostic bags are extracted by <see cref="Binder.ReplaceTypeOrValueReceiver(BoundExpression, bool, BindingDiagnosticBag)"/>,
+    /// which takes ownership of the diagnostic bags and frees them after extracting the diagnostics.
+    /// </remarks>
+    internal class BoundTypeOrValueData
     {
+        private Optional<BindingDiagnosticBag> _valueDiagnostics;
+        private Optional<BindingDiagnosticBag> _typeDiagnostics;
+
         public Symbol ValueSymbol { get; }
         public BoundExpression ValueExpression { get; }
-        public ImmutableBindingDiagnostic<AssemblySymbol> ValueDiagnostics { get; }
         public BoundExpression TypeExpression { get; }
-        public ImmutableBindingDiagnostic<AssemblySymbol> TypeDiagnostics { get; }
 
-        public BoundTypeOrValueData(Symbol valueSymbol, BoundExpression valueExpression, ImmutableBindingDiagnostic<AssemblySymbol> valueDiagnostics, BoundExpression typeExpression, ImmutableBindingDiagnostic<AssemblySymbol> typeDiagnostics)
+        public BoundTypeOrValueData(Symbol valueSymbol, BoundExpression valueExpression, BindingDiagnosticBag valueDiagnostics, BoundExpression typeExpression, BindingDiagnosticBag typeDiagnostics)
         {
             Debug.Assert(valueSymbol != null, "Field 'valueSymbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(valueExpression != null, "Field 'valueExpression' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
@@ -652,43 +659,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             this.ValueSymbol = valueSymbol;
             this.ValueExpression = valueExpression;
-            this.ValueDiagnostics = valueDiagnostics;
+            _valueDiagnostics = valueDiagnostics;
             this.TypeExpression = typeExpression;
-            this.TypeDiagnostics = typeDiagnostics;
+            _typeDiagnostics = typeDiagnostics;
         }
 
-        // operator==, operator!=, GetHashCode, and Equals are needed by the generated bound tree.
-
-        public static bool operator ==(BoundTypeOrValueData a, BoundTypeOrValueData b)
+        public void TakeDiagnosticBagOwnership(out BindingDiagnosticBag valueDiagnostics, out BindingDiagnosticBag typeDiagnostics)
         {
-            return (object)a.ValueSymbol == (object)b.ValueSymbol &&
-                (object)a.ValueExpression == (object)b.ValueExpression &&
-                a.ValueDiagnostics == b.ValueDiagnostics &&
-                (object)a.TypeExpression == (object)b.TypeExpression &&
-                a.TypeDiagnostics == b.TypeDiagnostics;
-        }
-
-        public static bool operator !=(BoundTypeOrValueData a, BoundTypeOrValueData b)
-        {
-            return !(a == b);
-        }
-
-        public override bool Equals(object? obj)
-        {
-            return obj is BoundTypeOrValueData && (BoundTypeOrValueData)obj == this;
-        }
-
-        public override int GetHashCode()
-        {
-            return Hash.Combine(ValueSymbol.GetHashCode(),
-                Hash.Combine(ValueExpression.GetHashCode(),
-                Hash.Combine(ValueDiagnostics.GetHashCode(),
-                Hash.Combine(TypeExpression.GetHashCode(), TypeDiagnostics.GetHashCode()))));
-        }
-
-        bool System.IEquatable<BoundTypeOrValueData>.Equals(BoundTypeOrValueData b)
-        {
-            return b == this;
+            Debug.Assert(_typeDiagnostics.HasValue && _valueDiagnostics.HasValue);
+            valueDiagnostics = _valueDiagnostics.Value;
+            typeDiagnostics = _typeDiagnostics.Value;
+            _valueDiagnostics = default;
+            _typeDiagnostics = default;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -34,7 +34,7 @@
   <ValueType Name="BoundLocalDeclarationKind"/>
   <ValueType Name="NullableAnnotation"/>
   <ValueType Name="ErrorCode"/>
-  <ValueType Name="ImmutableBindingDiagnostic"/>
+  <ValueType Name="ReadOnlyBindingDiagnostic"/>
   <ValueType Name="InterpolatedStringHandlerData"/>
   <ValueType Name="WellKnownMember"/>
   <ValueType Name="CollectionExpressionTypeKind"/>
@@ -2253,7 +2253,7 @@
     <Field Name="Symbol" Type="LambdaSymbol" Null="disallow"/>
     <Field Name="Type" Type="TypeSymbol?" Override="true"/>
     <Field Name="Body" Type="BoundBlock"/>
-    <Field Name="Diagnostics" Type="ImmutableBindingDiagnostic&lt;AssemblySymbol&gt;"/>
+    <Field Name="Diagnostics" Type="ReadOnlyBindingDiagnostic&lt;AssemblySymbol&gt;"/>
     <Field Name="Binder" Type="Binder" Null="disallow" />
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -30,6 +30,7 @@
   <ValueType Name="LookupResultKind"/>
   <ValueType Name="NoOpStatementFlavor"/>
   <ValueType Name="RefKind"/>
+  <ValueType Name="BoundTypeOrValueData"/>
   <ValueType Name="BoundLocalDeclarationKind"/>
   <ValueType Name="NullableAnnotation"/>
   <ValueType Name="ErrorCode"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -30,7 +30,6 @@
   <ValueType Name="LookupResultKind"/>
   <ValueType Name="NoOpStatementFlavor"/>
   <ValueType Name="RefKind"/>
-  <ValueType Name="BoundTypeOrValueData"/>
   <ValueType Name="BoundLocalDeclarationKind"/>
   <ValueType Name="NullableAnnotation"/>
   <ValueType Name="ErrorCode"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         SyntaxNode IBoundLambdaOrFunction.Syntax { get { return Syntax; } }
 
-        public BoundLambda(SyntaxNode syntax, UnboundLambda unboundLambda, BoundBlock body, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? delegateType, InferredLambdaReturnType inferredReturnType)
+        public BoundLambda(SyntaxNode syntax, UnboundLambda unboundLambda, BoundBlock body, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? delegateType, InferredLambdaReturnType inferredReturnType)
             : this(syntax, unboundLambda.WithNoCache(), (LambdaSymbol)binder.ContainingMemberOrLambda!, body, diagnostics, binder, delegateType)
         {
             InferredReturnType = inferredReturnType;
@@ -1295,7 +1295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var allBags = convBags.Concat(retBags);
 
             FirstAmongEqualsSet<Diagnostic>? intersection = null;
-            foreach (ImmutableBindingDiagnostic<AssemblySymbol> bag in allBags)
+            foreach (ReadOnlyBindingDiagnostic<AssemblySymbol> bag in allBags)
             {
                 if (intersection == null)
                 {
@@ -1318,7 +1318,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             FirstAmongEqualsSet<Diagnostic>? union = null;
 
-            foreach (ImmutableBindingDiagnostic<AssemblySymbol> bag in allBags)
+            foreach (ReadOnlyBindingDiagnostic<AssemblySymbol> bag in allBags)
             {
                 if (union == null)
                 {

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -2402,7 +2402,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             get { return true; }
         }
 
-        internal override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
+        internal override ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
         {
             throw new NotImplementedException();
         }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1812,7 +1812,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (entryPoint is null)
                     {
-                        ImmutableBindingDiagnostic<AssemblySymbol> diagnostics;
+                        ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics;
                         var entryPointMethod = FindEntryPoint(simpleProgramEntryPointSymbol, cancellationToken, out diagnostics);
                         entryPoint = new EntryPoint(entryPointMethod, diagnostics);
                     }
@@ -1822,7 +1822,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var diagnostics = DiagnosticBag.GetInstance();
                         diagnostics.Add(ErrorCode.ERR_SimpleProgramDisallowsMainType, NoLocation.Singleton);
                         entryPoint = new EntryPoint(entryPoint.MethodSymbol,
-                                                    new ImmutableBindingDiagnostic<AssemblySymbol>(
+                                                    new ReadOnlyBindingDiagnostic<AssemblySymbol>(
                                                         entryPoint.Diagnostics.Diagnostics.Concat(diagnostics.ToReadOnlyAndFree()), entryPoint.Diagnostics.Dependencies));
                     }
                 }
@@ -1833,7 +1833,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _lazyEntryPoint;
         }
 
-        private MethodSymbol? FindEntryPoint(MethodSymbol? simpleProgramEntryPointSymbol, CancellationToken cancellationToken, out ImmutableBindingDiagnostic<AssemblySymbol> sealedDiagnostics)
+        private MethodSymbol? FindEntryPoint(MethodSymbol? simpleProgramEntryPointSymbol, CancellationToken cancellationToken, out ReadOnlyBindingDiagnostic<AssemblySymbol> sealedDiagnostics)
         {
             var diagnostics = BindingDiagnosticBag.GetInstance();
             RoslynDebug.Assert(diagnostics.DiagnosticBag is object);
@@ -2176,11 +2176,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal class EntryPoint
         {
             public readonly MethodSymbol? MethodSymbol;
-            public readonly ImmutableBindingDiagnostic<AssemblySymbol> Diagnostics;
+            public readonly ReadOnlyBindingDiagnostic<AssemblySymbol> Diagnostics;
 
-            public static readonly EntryPoint None = new EntryPoint(null, ImmutableBindingDiagnostic<AssemblySymbol>.Empty);
+            public static readonly EntryPoint None = new EntryPoint(null, ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty);
 
-            public EntryPoint(MethodSymbol? methodSymbol, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics)
+            public EntryPoint(MethodSymbol? methodSymbol, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics)
             {
                 this.MethodSymbol = methodSymbol;
                 this.Diagnostics = diagnostics;
@@ -3103,7 +3103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private ImmutableBindingDiagnostic<AssemblySymbol> GetSourceDeclarationDiagnostics(SyntaxTree? syntaxTree = null, TextSpan? filterSpanWithinTree = null, Func<IEnumerable<Diagnostic>, SyntaxTree, TextSpan?, IEnumerable<Diagnostic>>? locationFilterOpt = null, CancellationToken cancellationToken = default)
+        private ReadOnlyBindingDiagnostic<AssemblySymbol> GetSourceDeclarationDiagnostics(SyntaxTree? syntaxTree = null, TextSpan? filterSpanWithinTree = null, Func<IEnumerable<Diagnostic>, SyntaxTree, TextSpan?, IEnumerable<Diagnostic>>? locationFilterOpt = null, CancellationToken cancellationToken = default)
         {
             UsingsFromOptions.Complete(this, cancellationToken);
 
@@ -3139,12 +3139,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // NOTE: Concatenate the CLS diagnostics *after* filtering by tree/span, because they're already filtered.
-            ImmutableBindingDiagnostic<AssemblySymbol> clsDiagnostics = GetClsComplianceDiagnostics(syntaxTree, filterSpanWithinTree, cancellationToken);
+            ReadOnlyBindingDiagnostic<AssemblySymbol> clsDiagnostics = GetClsComplianceDiagnostics(syntaxTree, filterSpanWithinTree, cancellationToken);
 
-            return new ImmutableBindingDiagnostic<AssemblySymbol>(result.AsImmutable().Concat(clsDiagnostics.Diagnostics), clsDiagnostics.Dependencies);
+            return new ReadOnlyBindingDiagnostic<AssemblySymbol>(result.AsImmutable().Concat(clsDiagnostics.Diagnostics), clsDiagnostics.Dependencies);
         }
 
-        private ImmutableBindingDiagnostic<AssemblySymbol> GetClsComplianceDiagnostics(SyntaxTree? syntaxTree, TextSpan? filterSpanWithinTree, CancellationToken cancellationToken)
+        private ReadOnlyBindingDiagnostic<AssemblySymbol> GetClsComplianceDiagnostics(SyntaxTree? syntaxTree, TextSpan? filterSpanWithinTree, CancellationToken cancellationToken)
         {
             if (syntaxTree != null)
             {
@@ -3164,7 +3164,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(!_lazyClsComplianceDependencies.IsDefault);
             Debug.Assert(!_lazyClsComplianceDiagnostics.IsDefault);
-            return new ImmutableBindingDiagnostic<AssemblySymbol>(_lazyClsComplianceDiagnostics, _lazyClsComplianceDependencies);
+            return new ReadOnlyBindingDiagnostic<AssemblySymbol>(_lazyClsComplianceDiagnostics, _lazyClsComplianceDependencies);
         }
 
         private static IEnumerable<Diagnostic> FilterDiagnosticsByLocation(IEnumerable<Diagnostic> diagnostics, SyntaxTree tree, TextSpan? filterSpanWithinTree)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1088,7 +1088,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     try
                     {
                         bool diagsWritten;
-                        actualDiagnostics = new ImmutableBindingDiagnostic<AssemblySymbol>(sourceMethod.SetDiagnostics(actualDiagnostics.Diagnostics, out diagsWritten), actualDiagnostics.Dependencies);
+                        actualDiagnostics = new ReadOnlyBindingDiagnostic<AssemblySymbol>(sourceMethod.SetDiagnostics(actualDiagnostics.Diagnostics, out diagsWritten), actualDiagnostics.Dependencies);
 
                         if (diagsWritten && !methodSymbol.IsImplicitlyDeclared && _compilation.EventQueue != null)
                         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.PlaceholderLocal.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.PlaceholderLocal.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override RefKind RefKind => RefKind.None;
             internal override SynthesizedLocalKind SynthesizedKind => throw ExceptionUtilities.Unreachable();
             internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, BindingDiagnosticBag diagnostics = null) => null;
-            internal override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue) => ImmutableBindingDiagnostic<AssemblySymbol>.Empty;
+            internal override ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue) => ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty;
             internal override SyntaxNode GetDeclaratorSyntax() => throw ExceptionUtilities.Unreachable();
             internal override bool HasSourceLocation => false;
             internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -7477,7 +7477,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundLambda : BoundExpression
     {
-        public BoundLambda(SyntaxNode syntax, UnboundLambda unboundLambda, LambdaSymbol symbol, BoundBlock body, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? type, bool hasErrors = false)
+        public BoundLambda(SyntaxNode syntax, UnboundLambda unboundLambda, LambdaSymbol symbol, BoundBlock body, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? type, bool hasErrors = false)
             : base(BoundKind.Lambda, syntax, type, hasErrors || unboundLambda.HasErrors() || body.HasErrors())
         {
 
@@ -7497,13 +7497,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public LambdaSymbol Symbol { get; }
         public new TypeSymbol? Type => base.Type;
         public BoundBlock Body { get; }
-        public ImmutableBindingDiagnostic<AssemblySymbol> Diagnostics { get; }
+        public ReadOnlyBindingDiagnostic<AssemblySymbol> Diagnostics { get; }
         public Binder Binder { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitLambda(this);
 
-        public BoundLambda Update(UnboundLambda unboundLambda, LambdaSymbol symbol, BoundBlock body, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? type)
+        public BoundLambda Update(UnboundLambda unboundLambda, LambdaSymbol symbol, BoundBlock body, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics, Binder binder, TypeSymbol? type)
         {
             if (unboundLambda != this.UnboundLambda || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(symbol, this.Symbol) || body != this.Body || diagnostics != this.Diagnostics || binder != this.Binder || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -267,6 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 
 
+
     internal abstract partial class BoundInitializer : BoundNode
     {
         protected BoundInitializer(BoundKind kind, SyntaxNode syntax, bool hasErrors)
@@ -1099,7 +1100,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(BoundKind.TypeOrValueExpression, syntax, type, hasErrors)
         {
 
-            RoslynDebug.Assert(data is object, "Field 'data' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
             RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Data = data;
@@ -1109,7 +1109,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(BoundKind.TypeOrValueExpression, syntax, type)
         {
 
-            RoslynDebug.Assert(data is object, "Field 'data' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
             RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Data = data;

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -267,7 +267,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 
 
-
     internal abstract partial class BoundInitializer : BoundNode
     {
         protected BoundInitializer(BoundKind kind, SyntaxNode syntax, bool hasErrors)
@@ -1100,6 +1099,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(BoundKind.TypeOrValueExpression, syntax, type, hasErrors)
         {
 
+            RoslynDebug.Assert(data is object, "Field 'data' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
             RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Data = data;
@@ -1109,6 +1109,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(BoundKind.TypeOrValueExpression, syntax, type)
         {
 
+            RoslynDebug.Assert(data is object, "Field 'data' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
             RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Data = data;

--- a/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed class EvaluatedConstant
     {
         public readonly ConstantValue Value;
-        public readonly ImmutableBindingDiagnostic<AssemblySymbol> Diagnostics;
+        public readonly ReadOnlyBindingDiagnostic<AssemblySymbol> Diagnostics;
 
-        public EvaluatedConstant(ConstantValue value, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics)
+        public EvaluatedConstant(ConstantValue value, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics)
         {
             this.Value = value;
             this.Diagnostics = diagnostics.NullToEmpty();

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, BindingDiagnosticBag diagnostics = null);
 
-        internal abstract ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue);
+        internal abstract ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue);
 
         public bool IsRef => RefKind != RefKind.None;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -472,9 +472,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        internal override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
+        internal override ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
         {
-            return ImmutableBindingDiagnostic<AssemblySymbol>.Empty;
+            return ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty;
         }
 
         public override RefKind RefKind
@@ -588,11 +588,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return _constantTuple == null ? null : _constantTuple.Value;
             }
 
-            internal override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
+            internal override ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
             {
                 Debug.Assert(boundInitValue != null);
                 MakeConstantTuple(inProgress: null, boundInitValue: boundInitValue);
-                return _constantTuple == null ? ImmutableBindingDiagnostic<AssemblySymbol>.Empty : _constantTuple.Diagnostics;
+                return _constantTuple == null ? ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty : _constantTuple.Diagnostics;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -162,11 +162,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             case 0:
                                 continue; // There is no requirement to implement anything in an interface
                             case 1:
-                                implementingMemberAndDiagnostics = new SymbolAndDiagnostics(explicitImpl.Single(), ImmutableBindingDiagnostic<AssemblySymbol>.Empty);
+                                implementingMemberAndDiagnostics = new SymbolAndDiagnostics(explicitImpl.Single(), ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty);
                                 break;
                             default:
                                 Diagnostic diag = new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_DuplicateExplicitImpl, interfaceMember), this.GetFirstLocation());
-                                implementingMemberAndDiagnostics = new SymbolAndDiagnostics(null, new ImmutableBindingDiagnostic<AssemblySymbol>(ImmutableArray.Create(diag), default));
+                                implementingMemberAndDiagnostics = new SymbolAndDiagnostics(null, new ReadOnlyBindingDiagnostic<AssemblySymbol>(ImmutableArray.Create(diag), default));
                                 break;
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -192,9 +192,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        internal sealed override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
+        internal sealed override ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
         {
-            return ImmutableBindingDiagnostic<AssemblySymbol>.Empty;
+            return ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty;
         }
 
 #if DEBUG

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _originalVariable.GetConstantValue(node, inProgress, diagnostics);
         }
 
-        internal override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
+        internal override ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
         {
             return _originalVariable.GetConstantValueDiagnostics(boundInitValue);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.SymbolAndDiagnostics.cs
@@ -18,12 +18,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal class SymbolAndDiagnostics
         {
-            public static readonly SymbolAndDiagnostics Empty = new SymbolAndDiagnostics(null, ImmutableBindingDiagnostic<AssemblySymbol>.Empty);
+            public static readonly SymbolAndDiagnostics Empty = new SymbolAndDiagnostics(null, ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty);
 
             public readonly Symbol Symbol;
-            public readonly ImmutableBindingDiagnostic<AssemblySymbol> Diagnostics;
+            public readonly ReadOnlyBindingDiagnostic<AssemblySymbol> Diagnostics;
 
-            public SymbolAndDiagnostics(Symbol symbol, ImmutableBindingDiagnostic<AssemblySymbol> diagnostics)
+            public SymbolAndDiagnostics(Symbol symbol, ReadOnlyBindingDiagnostic<AssemblySymbol> diagnostics)
             {
                 this.Symbol = symbol;
                 this.Diagnostics = diagnostics;

--- a/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override ScopedKind Scope => _underlyingLocal.Scope;
         internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, BindingDiagnosticBag? diagnostics = null) =>
             _underlyingLocal.GetConstantValue(node, inProgress, diagnostics);
-        internal override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue) =>
+        internal override ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue) =>
             _underlyingLocal.GetConstantValueDiagnostics(boundInitValue);
         internal override SyntaxNode GetDeclaratorSyntax() =>
             _underlyingLocal.GetDeclaratorSyntax();

--- a/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
@@ -80,14 +80,14 @@ namespace Microsoft.CodeAnalysis
             ((PooledHashSet<TAssemblySymbol>?)DependenciesBag)?.Free();
         }
 
-        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnly()
+        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnly(bool forceDiagnosticResolution = true)
         {
-            return new ReadOnlyBindingDiagnostic<TAssemblySymbol>(DiagnosticBag?.ToReadOnly(forceResolution: false) ?? default, DependenciesBag?.ToImmutableArray() ?? default);
+            return new ReadOnlyBindingDiagnostic<TAssemblySymbol>(DiagnosticBag?.ToReadOnly(forceDiagnosticResolution) ?? default, DependenciesBag?.ToImmutableArray() ?? default);
         }
 
-        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnlyAndFree()
+        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnlyAndFree(bool forceDiagnosticResolution = true)
         {
-            var result = ToReadOnly();
+            var result = ToReadOnly(forceDiagnosticResolution);
             Free();
             return result;
         }

--- a/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
@@ -80,14 +80,14 @@ namespace Microsoft.CodeAnalysis
             ((PooledHashSet<TAssemblySymbol>?)DependenciesBag)?.Free();
         }
 
-        internal ImmutableBindingDiagnostic<TAssemblySymbol> ToReadOnly()
+        internal ImmutableBindingDiagnostic<TAssemblySymbol> ToReadOnly(bool forceDiagnosticResolution = true)
         {
-            return new ImmutableBindingDiagnostic<TAssemblySymbol>(DiagnosticBag?.ToReadOnly() ?? default, DependenciesBag?.ToImmutableArray() ?? default);
+            return new ImmutableBindingDiagnostic<TAssemblySymbol>(DiagnosticBag?.ToReadOnly(forceDiagnosticResolution) ?? default, DependenciesBag?.ToImmutableArray() ?? default);
         }
 
-        internal ImmutableBindingDiagnostic<TAssemblySymbol> ToReadOnlyAndFree()
+        internal ImmutableBindingDiagnostic<TAssemblySymbol> ToReadOnlyAndFree(bool forceDiagnosticResolution = true)
         {
-            var result = ToReadOnly();
+            var result = ToReadOnly(forceDiagnosticResolution);
             Free();
             return result;
         }

--- a/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
@@ -80,12 +80,12 @@ namespace Microsoft.CodeAnalysis
             ((PooledHashSet<TAssemblySymbol>?)DependenciesBag)?.Free();
         }
 
-        internal ImmutableBindingDiagnostic<TAssemblySymbol> ToReadOnly(bool forceDiagnosticResolution = true)
+        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnly(bool forceDiagnosticResolution = true)
         {
-            return new ImmutableBindingDiagnostic<TAssemblySymbol>(DiagnosticBag?.ToReadOnly(forceDiagnosticResolution) ?? default, DependenciesBag?.ToImmutableArray() ?? default);
+            return new ReadOnlyBindingDiagnostic<TAssemblySymbol>(DiagnosticBag?.ToReadOnly(forceDiagnosticResolution) ?? default, DependenciesBag?.ToImmutableArray() ?? default);
         }
 
-        internal ImmutableBindingDiagnostic<TAssemblySymbol> ToReadOnlyAndFree(bool forceDiagnosticResolution = true)
+        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnlyAndFree(bool forceDiagnosticResolution = true)
         {
             var result = ToReadOnly(forceDiagnosticResolution);
             Free();
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis
             DependenciesBag?.Clear();
         }
 
-        internal void AddRange(ImmutableBindingDiagnostic<TAssemblySymbol> other, bool allowMismatchInDependencyAccumulation = false)
+        internal void AddRange(ReadOnlyBindingDiagnostic<TAssemblySymbol> other, bool allowMismatchInDependencyAccumulation = false)
         {
             AddRange(other.Diagnostics);
             Debug.Assert(allowMismatchInDependencyAccumulation || other.Dependencies.IsDefaultOrEmpty || this.AccumulatesDependencies || !this.AccumulatesDiagnostics);
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis
         }
     }
 
-    internal readonly struct ImmutableBindingDiagnostic<TAssemblySymbol> where TAssemblySymbol : class, IAssemblySymbolInternal
+    internal readonly struct ReadOnlyBindingDiagnostic<TAssemblySymbol> where TAssemblySymbol : class, IAssemblySymbolInternal
     {
         private readonly ImmutableArray<Diagnostic> _diagnostics;
         private readonly ImmutableArray<TAssemblySymbol> _dependencies;
@@ -317,32 +317,32 @@ namespace Microsoft.CodeAnalysis
         public ImmutableArray<Diagnostic> Diagnostics => _diagnostics.NullToEmpty();
         public ImmutableArray<TAssemblySymbol> Dependencies => _dependencies.NullToEmpty();
 
-        public static ImmutableBindingDiagnostic<TAssemblySymbol> Empty => new ImmutableBindingDiagnostic<TAssemblySymbol>(default, default);
+        public static ReadOnlyBindingDiagnostic<TAssemblySymbol> Empty => new ReadOnlyBindingDiagnostic<TAssemblySymbol>(default, default);
 
-        public ImmutableBindingDiagnostic(ImmutableArray<Diagnostic> diagnostics, ImmutableArray<TAssemblySymbol> dependencies)
+        public ReadOnlyBindingDiagnostic(ImmutableArray<Diagnostic> diagnostics, ImmutableArray<TAssemblySymbol> dependencies)
         {
             _diagnostics = diagnostics.NullToEmpty();
             _dependencies = dependencies.NullToEmpty();
         }
 
-        public ImmutableBindingDiagnostic<TAssemblySymbol> NullToEmpty() => new ImmutableBindingDiagnostic<TAssemblySymbol>(Diagnostics, Dependencies);
+        public ReadOnlyBindingDiagnostic<TAssemblySymbol> NullToEmpty() => new ReadOnlyBindingDiagnostic<TAssemblySymbol>(Diagnostics, Dependencies);
 
-        public static bool operator ==(ImmutableBindingDiagnostic<TAssemblySymbol> first, ImmutableBindingDiagnostic<TAssemblySymbol> second)
+        public static bool operator ==(ReadOnlyBindingDiagnostic<TAssemblySymbol> first, ReadOnlyBindingDiagnostic<TAssemblySymbol> second)
         {
             return first.Diagnostics == second.Diagnostics && first.Dependencies == second.Dependencies;
         }
 
-        public static bool operator !=(ImmutableBindingDiagnostic<TAssemblySymbol> first, ImmutableBindingDiagnostic<TAssemblySymbol> second)
+        public static bool operator !=(ReadOnlyBindingDiagnostic<TAssemblySymbol> first, ReadOnlyBindingDiagnostic<TAssemblySymbol> second)
         {
             return !(first == second);
         }
 
         public override bool Equals(object? obj)
         {
-            return (obj as ImmutableBindingDiagnostic<TAssemblySymbol>?)?.Equals(this) ?? false;
+            return (obj as ReadOnlyBindingDiagnostic<TAssemblySymbol>?)?.Equals(this) ?? false;
         }
 
-        public bool Equals(ImmutableBindingDiagnostic<TAssemblySymbol> other)
+        public bool Equals(ReadOnlyBindingDiagnostic<TAssemblySymbol> other)
         {
             return this == other;
         }

--- a/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
@@ -80,14 +80,14 @@ namespace Microsoft.CodeAnalysis
             ((PooledHashSet<TAssemblySymbol>?)DependenciesBag)?.Free();
         }
 
-        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnly(bool forceDiagnosticResolution = true)
+        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnly()
         {
-            return new ReadOnlyBindingDiagnostic<TAssemblySymbol>(DiagnosticBag?.ToReadOnly(forceDiagnosticResolution) ?? default, DependenciesBag?.ToImmutableArray() ?? default);
+            return new ReadOnlyBindingDiagnostic<TAssemblySymbol>(DiagnosticBag?.ToReadOnly(forceResolution: false) ?? default, DependenciesBag?.ToImmutableArray() ?? default);
         }
 
-        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnlyAndFree(bool forceDiagnosticResolution = true)
+        internal ReadOnlyBindingDiagnostic<TAssemblySymbol> ToReadOnlyAndFree()
         {
-            var result = ToReadOnly(forceDiagnosticResolution);
+            var result = ToReadOnly();
             Free();
             return result;
         }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -476,6 +476,11 @@ namespace Microsoft.CodeAnalysis
         // compatibility
         internal virtual int Code { get { return 0; } }
 
+        /// <summary>
+        /// True if this diagnostic represents the given error code. This does not force resolution of lazy diagnostics and is safe to call at any time.
+        /// </summary>
+        internal virtual bool IsCode(int code) { return false; }
+
         internal virtual IReadOnlyList<object?> Arguments
         {
             get { return SpecializedCollections.EmptyReadOnlyList<object?>(); }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -476,11 +476,6 @@ namespace Microsoft.CodeAnalysis
         // compatibility
         internal virtual int Code { get { return 0; } }
 
-        /// <summary>
-        /// True if this diagnostic represents the given error code. This does not force resolution of lazy diagnostics and is safe to call at any time.
-        /// </summary>
-        internal virtual bool IsCode(int code) { return false; }
-
         internal virtual IReadOnlyList<object?> Arguments
         {
             get { return SpecializedCollections.EmptyReadOnlyList<object?>(); }

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
@@ -167,12 +167,12 @@ namespace Microsoft.CodeAnalysis
         /// Seal the bag so no further errors can be added, while clearing it and returning the old set of errors.
         /// Return the bag to the pool.
         /// </summary>
-        public ImmutableArray<TDiagnostic> ToReadOnlyAndFree<TDiagnostic>() where TDiagnostic : Diagnostic
+        public ImmutableArray<TDiagnostic> ToReadOnlyAndFree<TDiagnostic>(bool forceResolution = true) where TDiagnostic : Diagnostic
         {
             ConcurrentQueue<Diagnostic>? oldBag = _lazyBag;
             Free();
 
-            return ToReadOnlyCore<TDiagnostic>(oldBag);
+            return ToReadOnlyCore<TDiagnostic>(oldBag, forceResolution);
         }
 
         public ImmutableArray<Diagnostic> ToReadOnlyAndFree()
@@ -180,18 +180,18 @@ namespace Microsoft.CodeAnalysis
             return ToReadOnlyAndFree<Diagnostic>();
         }
 
-        public ImmutableArray<TDiagnostic> ToReadOnly<TDiagnostic>() where TDiagnostic : Diagnostic
+        public ImmutableArray<TDiagnostic> ToReadOnly<TDiagnostic>(bool forceResolution = true) where TDiagnostic : Diagnostic
         {
             ConcurrentQueue<Diagnostic>? oldBag = _lazyBag;
-            return ToReadOnlyCore<TDiagnostic>(oldBag);
+            return ToReadOnlyCore<TDiagnostic>(oldBag, forceResolution);
         }
 
-        public ImmutableArray<Diagnostic> ToReadOnly()
+        public ImmutableArray<Diagnostic> ToReadOnly(bool forceResolution = true)
         {
-            return ToReadOnly<Diagnostic>();
+            return ToReadOnly<Diagnostic>(forceResolution);
         }
 
-        private static ImmutableArray<TDiagnostic> ToReadOnlyCore<TDiagnostic>(ConcurrentQueue<Diagnostic>? oldBag) where TDiagnostic : Diagnostic
+        private static ImmutableArray<TDiagnostic> ToReadOnlyCore<TDiagnostic>(ConcurrentQueue<Diagnostic>? oldBag, bool forceResolution) where TDiagnostic : Diagnostic
         {
             if (oldBag == null)
             {
@@ -202,9 +202,16 @@ namespace Microsoft.CodeAnalysis
 
             foreach (TDiagnostic diagnostic in oldBag) // Cast should be safe since all diagnostics should be from same language.
             {
-                if (diagnostic.Severity != InternalDiagnosticSeverity.Void)
+                if (forceResolution)
                 {
-                    Debug.Assert(diagnostic.Severity != InternalDiagnosticSeverity.Unknown); //Info access should have forced resolution.
+                    if (diagnostic.Severity != InternalDiagnosticSeverity.Void)
+                    {
+                        Debug.Assert(diagnostic.Severity != InternalDiagnosticSeverity.Unknown); //Info access should have forced resolution.
+                        builder.Add(diagnostic);
+                    }
+                }
+                else
+                {
                     builder.Add(diagnostic);
                 }
             }

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
@@ -175,9 +175,9 @@ namespace Microsoft.CodeAnalysis
             return ToReadOnlyCore<TDiagnostic>(oldBag, forceResolution);
         }
 
-        public ImmutableArray<Diagnostic> ToReadOnlyAndFree(bool forceResolution = true)
+        public ImmutableArray<Diagnostic> ToReadOnlyAndFree()
         {
-            return ToReadOnlyAndFree<Diagnostic>(forceResolution);
+            return ToReadOnlyAndFree<Diagnostic>();
         }
 
         public ImmutableArray<TDiagnostic> ToReadOnly<TDiagnostic>(bool forceResolution = true) where TDiagnostic : Diagnostic

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
@@ -175,9 +175,9 @@ namespace Microsoft.CodeAnalysis
             return ToReadOnlyCore<TDiagnostic>(oldBag, forceResolution);
         }
 
-        public ImmutableArray<Diagnostic> ToReadOnlyAndFree()
+        public ImmutableArray<Diagnostic> ToReadOnlyAndFree(bool forceResolution = true)
         {
-            return ToReadOnlyAndFree<Diagnostic>();
+            return ToReadOnlyAndFree<Diagnostic>(forceResolution);
         }
 
         public ImmutableArray<TDiagnostic> ToReadOnly<TDiagnostic>(bool forceResolution = true) where TDiagnostic : Diagnostic

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
@@ -147,14 +147,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        /// <summary>
-        /// True if this diagnostic represents the given error code. This does not force resolution of lazy diagnostics and is safe to call at any time.
-        /// </summary>
-        internal override bool IsCode(int code)
-        {
-            return _info.Code == code;
-        }
-
         public override int GetHashCode()
         {
             return Hash.Combine(this.Location.GetHashCode(), this.Info.GetHashCode());

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
@@ -147,6 +147,14 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <summary>
+        /// True if this diagnostic represents the given error code. This does not force resolution of lazy diagnostics and is safe to call at any time.
+        /// </summary>
+        internal override bool IsCode(int code)
+        {
+            return _info.Code == code;
+        }
+
         public override int GetHashCode()
         {
             return Hash.Combine(this.Location.GetHashCode(), this.Info.GetHashCode());

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -89,6 +89,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 #pragma warning restore RS0013 
 
                 internal override int Code => _original.Code;
+                internal override bool IsCode(int code) => _original.IsCode(code);
                 internal override IReadOnlyList<object?> Arguments => _original.Arguments;
 
                 public override string Id => _original.Id;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -89,7 +89,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 #pragma warning restore RS0013 
 
                 internal override int Code => _original.Code;
-                internal override bool IsCode(int code) => _original.IsCode(code);
                 internal override IReadOnlyList<object?> Arguments => _original.Arguments;
 
                 public override string Id => _original.Id;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         /// <summary>
         /// A set of symbols, from the old compilation, that have been deleted from the new compilation
-        /// keyed by the containing type from the new compilation.
+        /// keyed by the containing type from the new compilation
         /// Populated based on semantic edits with <see cref="SemanticEditKind.Delete"/>.
         /// </summary>
         public readonly IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> DeletedMembers;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         /// <summary>
         /// A set of symbols, from the old compilation, that have been deleted from the new compilation
-        /// keyed by the containing type from the new compilation
+        /// keyed by the containing type from the new compilation.
         /// Populated based on semantic edits with <see cref="SemanticEditKind.Delete"/>.
         /// </summary>
         public readonly IReadOnlyDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> DeletedMembers;

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -955,7 +955,7 @@ internal static class Extensions
         return result;
     }
 
-    public static void Verify(this ImmutableBindingDiagnostic<AssemblySymbol> actual, params Microsoft.CodeAnalysis.Test.Utilities.DiagnosticDescription[] expected)
+    public static void Verify(this ReadOnlyBindingDiagnostic<AssemblySymbol> actual, params Microsoft.CodeAnalysis.Test.Utilities.DiagnosticDescription[] expected)
     {
         actual.Diagnostics.Verify(expected);
     }

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -358,7 +358,7 @@ Friend Module Extensions
     End Function
 
     <Extension>
-    Friend Sub Verify(this As ImmutableBindingDiagnostic(Of AssemblySymbol), ParamArray expected As DiagnosticDescription())
+    Friend Sub Verify(this As ReadOnlyBindingDiagnostic(Of AssemblySymbol), ParamArray expected As DiagnosticDescription())
         this.Diagnostics.Verify(expected)
     End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -1303,7 +1303,7 @@ DoneWithDiagnostics:
                 Dim anonymousDelegate As BoundExpression = ReclassifyUnboundLambdaExpression(unboundLambda, diagnostics)
 
 #If DEBUG Then
-                Dim anonymousDelegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = unboundLambda.InferredAnonymousDelegate
+                Dim anonymousDelegateInfo As KeyValuePair(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)) = unboundLambda.InferredAnonymousDelegate
 
                 Debug.Assert(anonymousDelegate.Type Is anonymousDelegateInfo.Key)
 
@@ -1342,7 +1342,7 @@ DoneWithDiagnostics:
                         delegateInvoke = Nothing ' No conversion
 
                     ElseIf unboundLambda.IsInferredDelegateForThisLambda(delegateInvoke.ContainingType) Then
-                        Dim inferenceDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol) = unboundLambda.InferredAnonymousDelegate.Value
+                        Dim inferenceDiagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol) = unboundLambda.InferredAnonymousDelegate.Value
 
                         diagnostics.AddRange(inferenceDiagnostics)
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
@@ -22,13 +22,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Public ReadOnly DelegateConversions As ConversionKind
             Public ReadOnly Target As MethodSymbol
             Public ReadOnly MethodConversions As MethodConversionKind
-            Public ReadOnly Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+            Public ReadOnly Diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
 
             Public Sub New(
                 DelegateConversions As ConversionKind,
                 Target As MethodSymbol,
                 MethodConversions As MethodConversionKind,
-                Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+                Diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
             )
                 Me.DelegateConversions = DelegateConversions
                 Me.Target = Target
@@ -1280,7 +1280,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim boundLambda = New BoundLambda(syntaxNode,
                                           lambdaSymbol,
                                           lambdaBody,
-                                          ImmutableBindingDiagnostic(Of AssemblySymbol).Empty,
+                                          ReadOnlyBindingDiagnostic(Of AssemblySymbol).Empty,
                                           Nothing,
                                           delegateRelaxation,
                                           MethodConversionKind.Identity)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -1833,7 +1833,7 @@ ProduceBoundNode:
             queryMode As Boolean,
             callerInfoOpt As SyntaxNode
         )
-            Dim diagnosticPerSymbol = ArrayBuilder(Of KeyValuePair(Of Symbol, ImmutableBindingDiagnostic(Of AssemblySymbol))).GetInstance(candidates.Count)
+            Dim diagnosticPerSymbol = ArrayBuilder(Of KeyValuePair(Of Symbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))).GetInstance(candidates.Count)
 
             If arguments.IsDefault Then
                 arguments = ImmutableArray(Of BoundExpression).Empty
@@ -1932,7 +1932,7 @@ ProduceBoundNode:
         End Sub
 
         Private Shared Function ReportCommonErrorsFromLambdas(
-            diagnosticPerSymbol As ArrayBuilder(Of KeyValuePair(Of Symbol, ImmutableBindingDiagnostic(Of AssemblySymbol))),
+            diagnosticPerSymbol As ArrayBuilder(Of KeyValuePair(Of Symbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))),
             arguments As ImmutableArray(Of BoundExpression),
             diagnostics As BindingDiagnosticBag
         ) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
@@ -206,7 +206,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                                returnsByRef:=False)
                     End If
 
-                    Dim typeInfo As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = source.InferReturnType(targetForInference)
+                    Dim typeInfo As KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)) = source.InferReturnType(targetForInference)
 
                     targetReturnType = typeInfo.Key
                     diagnostics.AddRange(typeInfo.Value)
@@ -764,7 +764,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
-        Friend Function InferAnonymousDelegateForLambda(source As UnboundLambda) As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
+        Friend Function InferAnonymousDelegateForLambda(source As UnboundLambda) As KeyValuePair(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))
             Debug.Assert(Me Is source.Binder)
 
             Dim diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, source.WithDependencies)
@@ -773,7 +773,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim targetSignature As New UnboundLambda.TargetSignature(ImmutableArray(Of ParameterSymbol).Empty, Compilation.GetSpecialType(SpecialType.System_Void), returnsByRef:=False)
             Dim parameters As ImmutableArray(Of BoundLambdaParameterSymbol) = BuildBoundLambdaParameters(source, targetSignature, diagnostics)
 
-            Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
+            Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))
             returnTypeInfo = source.InferReturnType(New UnboundLambda.TargetSignature(StaticCast(Of ParameterSymbol).From(parameters), targetSignature.ReturnType, targetSignature.ReturnsByRef))
             Dim returnType As TypeSymbol = returnTypeInfo.Key
 
@@ -781,7 +781,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim delegateType As NamedTypeSymbol = ConstructAnonymousDelegateSymbol(source, parameters, returnType, diagnostics)
 
-            Return New KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(delegateType, diagnostics.ToReadOnlyAndFree())
+            Return New KeyValuePair(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))(delegateType, diagnostics.ToReadOnlyAndFree())
         End Function
 
         Private Function ConstructAnonymousDelegateSymbol(
@@ -885,14 +885,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function InferFunctionLambdaReturnType(
             source As UnboundLambda,
             targetParameters As UnboundLambda.TargetSignature
-        ) As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
+        ) As KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))
             Debug.Assert(Me Is source.Binder AndAlso source.IsFunctionLambda AndAlso
                          source.ReturnType Is Nothing AndAlso targetParameters.ReturnType.IsVoidType())
 
             ' If both Async and Iterator are specified, we cannot really infer return type.
             If source.Flags = (SourceMemberFlags.Async Or SourceMemberFlags.Iterator) Then
                 ' No need to report any error because we complained about conflicting modifiers.
-                Return New KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(LambdaSymbol.ReturnTypeIsUnknown, ImmutableBindingDiagnostic(Of AssemblySymbol).Empty)
+                Return New KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))(LambdaSymbol.ReturnTypeIsUnknown, ReadOnlyBindingDiagnostic(Of AssemblySymbol).Empty)
             End If
 
             Dim diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, source.WithDependencies)
@@ -904,7 +904,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim block As BoundBlock = BindLambdaBody(symbol, diagnostics, lambdaBinder:=Nothing)
 
             If block.HasErrors OrElse diagnostics.HasAnyErrors() Then
-                Return New KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(LambdaSymbol.ReturnTypeIsUnknown, diagnostics.ToReadOnlyAndFree())
+                Return New KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))(LambdaSymbol.ReturnTypeIsUnknown, diagnostics.ToReadOnlyAndFree())
             End If
 
             diagnostics.Clear()
@@ -1001,7 +1001,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             returnExpressions.Free()
 
-            Return New KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(lambdaReturnType, diagnostics.ToReadOnlyAndFree())
+            Return New KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))(lambdaReturnType, diagnostics.ToReadOnlyAndFree())
         End Function
 
         Private Shared Function LambdaHeaderErrorNode(source As UnboundLambda) As SyntaxNode

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_WithBlock.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_WithBlock.vb
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            draftSubstitute As BoundExpression,
                            draftInitializers As ImmutableArray(Of BoundExpression),
                            capturedLvalueByRefCallOrProperty As BoundExpression,
-                           diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol))
+                           diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol))
 
                 Debug.Assert(originalExpression IsNot Nothing)
                 Debug.Assert(expressionPlaceholder IsNot Nothing AndAlso (expressionPlaceholder.Kind = BoundKind.WithLValueExpressionPlaceholder OrElse expressionPlaceholder.Kind = BoundKind.WithRValueExpressionPlaceholder))
@@ -125,7 +125,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Public ReadOnly ExpressionPlaceholder As BoundValuePlaceholderBase
 
             ''' <summary> Diagnostics produced while binding the expression </summary>
-            Public ReadOnly Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+            Public ReadOnly Diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
 
             ''' <summary> 
             ''' Draft initializers for With statement, is based on initial binding tree 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -35,7 +35,7 @@
     <ValueType Name="NoOpStatementFlavor"/>
     <ValueType Name="BoundTypeOrValueData"/>
     <ValueType Name="BitVector" />
-    <ValueType Name="ImmutableBindingDiagnostic" />
+    <ValueType Name="ReadOnlyBindingDiagnostic" />
 
   <AbstractNode Name="BoundExpression" Base="BoundNode">
     <Field Name="Type" Type="TypeSymbol" Null="allow"/>
@@ -1491,7 +1491,7 @@
 
       <Field Name="LambdaSymbol" Type="LambdaSymbol" Null="disallow" />
       <Field Name="Body" Type="BoundBlock"/>
-      <Field Name="Diagnostics" Type="ImmutableBindingDiagnostic(Of AssemblySymbol)"/> 
+      <Field Name="Diagnostics" Type="ReadOnlyBindingDiagnostic(Of AssemblySymbol)"/> 
       <Field Name="LambdaBinderOpt" Type="LambdaBodyBinder" Null="allow" />
 
       <!-- 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundTypeOrValueExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundTypeOrValueExpression.vb
@@ -20,8 +20,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private ReadOnly _valueDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
-        Public ReadOnly Property ValueDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+        Private ReadOnly _valueDiagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
+        Public ReadOnly Property ValueDiagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
             Get
                 Return Me._valueDiagnostics
             End Get
@@ -34,14 +34,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private ReadOnly _typeDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
-        Public ReadOnly Property TypeDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+        Private ReadOnly _typeDiagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
+        Public ReadOnly Property TypeDiagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
             Get
                 Return Me._typeDiagnostics
             End Get
         End Property
 
-        Public Sub New(valueExpression As BoundExpression, valueDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol), typeExpression As BoundExpression, typeDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol))
+        Public Sub New(valueExpression As BoundExpression, valueDiagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol), typeExpression As BoundExpression, typeDiagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol))
             Debug.Assert(valueExpression IsNot Nothing, "Field 'valueExpression' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
             Debug.Assert(typeExpression IsNot Nothing, "Field 'typeExpression' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
@@ -57,11 +57,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' target.ReturnType is ignored and must be Void, only parameter types are taken into consideration.
         ''' </summary>
-        Public Function InferReturnType(target As TargetSignature) As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
+        Public Function InferReturnType(target As TargetSignature) As KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))
             Debug.Assert(target IsNot Nothing AndAlso target.ReturnType.IsVoidType())
 
             If Me.ReturnType IsNot Nothing Then
-                Dim result = New KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(If(Me.IsFunctionLambda AndAlso Me.ReturnType.IsVoidType(),
+                Dim result = New KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))(If(Me.IsFunctionLambda AndAlso Me.ReturnType.IsVoidType(),
                                                                                LambdaSymbol.ReturnTypeVoidReplacement,
                                                                          Me.ReturnType),
                                                                       Nothing)
@@ -92,29 +92,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return _Binder.BindUnboundLambda(Me, target)
         End Function
 
-        Private Function DoInferFunctionLambdaReturnType(target As TargetSignature) As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
+        Private Function DoInferFunctionLambdaReturnType(target As TargetSignature) As KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))
             Return _Binder.InferFunctionLambdaReturnType(Me, target)
         End Function
 
-        Public ReadOnly Property InferredAnonymousDelegate As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
+        Public ReadOnly Property InferredAnonymousDelegate As KeyValuePair(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))
             Get
-                Dim info As Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = _BindingCache.AnonymousDelegate
+                Dim info As Tuple(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)) = _BindingCache.AnonymousDelegate
                 If info Is Nothing Then
-                    Dim delegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = _Binder.InferAnonymousDelegateForLambda(Me)
+                    Dim delegateInfo As KeyValuePair(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)) = _Binder.InferAnonymousDelegateForLambda(Me)
 
                     Interlocked.CompareExchange(_BindingCache.AnonymousDelegate,
-                                                New Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(delegateInfo.Key, delegateInfo.Value),
+                                                New Tuple(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))(delegateInfo.Key, delegateInfo.Value),
                                                 Nothing)
 
                     info = _BindingCache.AnonymousDelegate
                 End If
 
-                Return New KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(info.Item1, info.Item2)
+                Return New KeyValuePair(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))(info.Item1, info.Item2)
             End Get
         End Property
 
         Public Function IsInferredDelegateForThisLambda(delegateType As NamedTypeSymbol) As Boolean
-            Dim info As Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = _BindingCache.AnonymousDelegate
+            Dim info As Tuple(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)) = _BindingCache.AnonymousDelegate
             If info Is Nothing Then
                 Return False
             End If
@@ -216,8 +216,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Class UnboundLambdaBindingCache
             Public ReadOnly WithDependencies As Boolean
-            Public AnonymousDelegate As Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
-            Public ReadOnly InferredReturnType As New ConcurrentDictionary(Of TargetSignature, KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)))()
+            Public AnonymousDelegate As Tuple(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol))
+            Public ReadOnly InferredReturnType As New ConcurrentDictionary(Of TargetSignature, KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)))()
             Public ReadOnly BoundLambdas As New ConcurrentDictionary(Of TargetSignature, BoundLambda)()
             Public ErrorRecoverySignature As TargetSignature
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2216,7 +2216,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If _lazyClsComplianceDiagnostics.IsDefault OrElse _lazyClsComplianceDependencies.IsDefault Then
                 Dim builder = BindingDiagnosticBag.GetInstance()
                 ClsComplianceChecker.CheckCompliance(Me, builder, cancellationToken)
-                Dim result As ImmutableBindingDiagnostic(Of AssemblySymbol) = builder.ToReadOnlyAndFree()
+                Dim result As ReadOnlyBindingDiagnostic(Of AssemblySymbol) = builder.ToReadOnlyAndFree()
                 ImmutableInterlocked.InterlockedInitialize(_lazyClsComplianceDependencies, result.Dependencies)
                 ImmutableInterlocked.InterlockedInitialize(_lazyClsComplianceDiagnostics, result.Diagnostics)
             End If
@@ -2224,7 +2224,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(Not _lazyClsComplianceDependencies.IsDefault)
             Debug.Assert(Not _lazyClsComplianceDiagnostics.IsDefault)
 
-            diagnostics.AddRange(New ImmutableBindingDiagnostic(Of AssemblySymbol)(_lazyClsComplianceDiagnostics, _lazyClsComplianceDependencies), allowMismatchInDependencyAccumulation:=True)
+            diagnostics.AddRange(New ReadOnlyBindingDiagnostic(Of AssemblySymbol)(_lazyClsComplianceDiagnostics, _lazyClsComplianceDependencies), allowMismatchInDependencyAccumulation:=True)
         End Sub
 
         Private Shared Iterator Function FilterDiagnosticsByLocation(diagnostics As IEnumerable(Of Diagnostic), tree As SyntaxTree, filterSpanWithinTree As TextSpan?) As IEnumerable(Of Diagnostic)

--- a/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
@@ -6853,7 +6853,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend NotInheritable Class BoundLambda
         Inherits BoundExpression
 
-        Public Sub New(syntax As SyntaxNode, lambdaSymbol As LambdaSymbol, body As BoundBlock, diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol), lambdaBinderOpt As LambdaBodyBinder, delegateRelaxation As ConversionKind, methodConversionKind As MethodConversionKind, Optional hasErrors As Boolean = False)
+        Public Sub New(syntax As SyntaxNode, lambdaSymbol As LambdaSymbol, body As BoundBlock, diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol), lambdaBinderOpt As LambdaBodyBinder, delegateRelaxation As ConversionKind, methodConversionKind As MethodConversionKind, Optional hasErrors As Boolean = False)
             MyBase.New(BoundKind.Lambda, syntax, Nothing, hasErrors OrElse body.NonNullAndHasErrors())
 
             Debug.Assert(lambdaSymbol IsNot Nothing, "Field 'lambdaSymbol' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
@@ -6887,8 +6887,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private ReadOnly _Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
-        Public ReadOnly Property Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+        Private ReadOnly _Diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
+        Public ReadOnly Property Diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
             Get
                 Return _Diagnostics
             End Get
@@ -6920,7 +6920,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return visitor.VisitLambda(Me)
         End Function
 
-        Public Function Update(lambdaSymbol As LambdaSymbol, body As BoundBlock, diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol), lambdaBinderOpt As LambdaBodyBinder, delegateRelaxation As ConversionKind, methodConversionKind As MethodConversionKind) As BoundLambda
+        Public Function Update(lambdaSymbol As LambdaSymbol, body As BoundBlock, diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol), lambdaBinderOpt As LambdaBodyBinder, delegateRelaxation As ConversionKind, methodConversionKind As MethodConversionKind) As BoundLambda
             If lambdaSymbol IsNot Me.LambdaSymbol OrElse body IsNot Me.Body OrElse diagnostics <> Me.Diagnostics OrElse lambdaBinderOpt IsNot Me.LambdaBinderOpt OrElse delegateRelaxation <> Me.DelegateRelaxation OrElse methodConversionKind <> Me.MethodConversionKind Then
                 Dim result = New BoundLambda(Me.Syntax, lambdaSymbol, body, diagnostics, lambdaBinderOpt, delegateRelaxation, methodConversionKind, Me.HasErrors)
                 result.CopyAttributes(Me)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LateAddressOf.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LateAddressOf.vb
@@ -137,7 +137,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim boundLambda = New BoundLambda(syntaxNode,
                                           lambdaSymbol,
                                           lambdaBody,
-                                          ImmutableBindingDiagnostic(Of AssemblySymbol).Empty,
+                                          ReadOnlyBindingDiagnostic(Of AssemblySymbol).Empty,
                                           Nothing,
                                           ConversionKind.DelegateRelaxationLevelWidening,
                                           MethodConversionKind.Identity)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
@@ -204,7 +204,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim result As BoundLambda = New BoundLambda(originalNode.Syntax,
                                    originalNode.LambdaSymbol,
                                    lambdaBody,
-                                   ImmutableBindingDiagnostic(Of AssemblySymbol).Empty,
+                                   ReadOnlyBindingDiagnostic(Of AssemblySymbol).Empty,
                                    Nothing,
                                    ConversionKind.DelegateRelaxationLevelNone,
                                    MethodConversionKind.Identity)

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -1089,7 +1089,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 leastRelaxationLevel = ConversionKind.DelegateRelaxationLevelWideningToNonLambda
 
                 ' Infer Anonymous Delegate as the target for the lambda.
-                Dim anonymousDelegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = source.InferredAnonymousDelegate
+                Dim anonymousDelegateInfo As KeyValuePair(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)) = source.InferredAnonymousDelegate
 
                 ' If we have errors for the inference, we know that there is no conversion.
                 If Not anonymousDelegateInfo.Value.Diagnostics.IsDefault AndAlso anonymousDelegateInfo.Value.Diagnostics.HasAnyErrors() Then
@@ -1112,7 +1112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If source.IsInferredDelegateForThisLambda(delegateInvoke.ContainingType) Then
-                    Dim inferenceDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol) = source.InferredAnonymousDelegate.Value
+                    Dim inferenceDiagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol) = source.InferredAnonymousDelegate.Value
 
                     ' If we have errors for the inference, we know that there is no conversion.
                     If Not inferenceDiagnostics.Diagnostics.IsDefault AndAlso inferenceDiagnostics.Diagnostics.HasAnyErrors() Then

--- a/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
@@ -710,7 +710,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Public NotInferredTypeArguments As BitVector
 
-            Public TypeArgumentInferenceDiagnosticsOpt As ImmutableBindingDiagnostic(Of AssemblySymbol)
+            Public TypeArgumentInferenceDiagnosticsOpt As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
 
             Public Sub New(candidate As Candidate, state As CandidateAnalysisResultState)
                 Me.Candidate = candidate

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -1998,7 +1998,7 @@ HandleAsAGeneralExpression:
 
                         Case BoundKind.UnboundLambda
                             ' Infer Anonymous Delegate type from unbound lambda.
-                            Dim inferredAnonymousDelegate As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = DirectCast(argument, UnboundLambda).InferredAnonymousDelegate
+                            Dim inferredAnonymousDelegate As KeyValuePair(Of NamedTypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)) = DirectCast(argument, UnboundLambda).InferredAnonymousDelegate
 
                             If (inferredAnonymousDelegate.Value.Diagnostics.IsDefault OrElse Not inferredAnonymousDelegate.Value.Diagnostics.HasAnyErrors()) Then
 
@@ -2132,7 +2132,7 @@ HandleAsAGeneralExpression:
 
                             If unboundLambda.IsFunctionLambda Then
                                 Dim inferenceSignature As New UnboundLambda.TargetSignature(delegateParams, unboundLambda.Binder.Compilation.GetSpecialType(SpecialType.System_Void), returnsByRef:=False)
-                                Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = unboundLambda.InferReturnType(inferenceSignature)
+                                Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ReadOnlyBindingDiagnostic(Of AssemblySymbol)) = unboundLambda.InferReturnType(inferenceSignature)
 
                                 If Not returnTypeInfo.Value.Diagnostics.IsDefault AndAlso returnTypeInfo.Value.Diagnostics.HasAnyErrors() Then
                                     lambdaReturnType = Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/LocalSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/LocalSymbol.vb
@@ -362,7 +362,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overridable Function GetConstantValueDiagnostics(binder As Binder) As ImmutableBindingDiagnostic(Of AssemblySymbol)
+        Friend Overridable Function GetConstantValueDiagnostics(binder As Binder) As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
             Throw ExceptionUtilities.Unreachable
         End Function
 
@@ -809,7 +809,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Private NotInheritable Class EvaluatedConstantInfo
                 Inherits EvaluatedConstant
 
-                Public Sub New(value As ConstantValue, type As TypeSymbol, expression As BoundExpression, diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol))
+                Public Sub New(value As ConstantValue, type As TypeSymbol, expression As BoundExpression, diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol))
                     MyBase.New(value, type)
 
                     Debug.Assert(expression IsNot Nothing)
@@ -819,7 +819,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Sub
 
                 Public ReadOnly Expression As BoundExpression
-                Public ReadOnly Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+                Public ReadOnly Diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
             End Class
 
             ''' <summary>
@@ -907,12 +907,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return If(_evaluatedConstant IsNot Nothing, _evaluatedConstant.Value, Nothing)
             End Function
 
-            Friend Overrides Function GetConstantValueDiagnostics(containingBinder As Binder) As ImmutableBindingDiagnostic(Of AssemblySymbol)
+            Friend Overrides Function GetConstantValueDiagnostics(containingBinder As Binder) As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
                 GetConstantValue(containingBinder)
-                Return If(_evaluatedConstant IsNot Nothing, _evaluatedConstant.Diagnostics, ImmutableBindingDiagnostic(Of AssemblySymbol).Empty)
+                Return If(_evaluatedConstant IsNot Nothing, _evaluatedConstant.Diagnostics, ReadOnlyBindingDiagnostic(Of AssemblySymbol).Empty)
             End Function
 
-            Private Sub SetConstantExpression(type As TypeSymbol, constantValue As ConstantValue, expression As BoundExpression, diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol))
+            Private Sub SetConstantExpression(type As TypeSymbol, constantValue As ConstantValue, expression As BoundExpression, diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol))
                 If _evaluatedConstant Is Nothing Then
                     Interlocked.CompareExchange(_evaluatedConstant, New EvaluatedConstantInfo(constantValue, type, expression, diagnostics), Nothing)
                 End If
@@ -1014,7 +1014,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return _originalVariable.GetConstantValue(binder)
             End Function
 
-            Friend Overrides Function GetConstantValueDiagnostics(binder As Binder) As ImmutableBindingDiagnostic(Of AssemblySymbol)
+            Friend Overrides Function GetConstantValueDiagnostics(binder As Binder) As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
                 Return _originalVariable.GetConstantValueDiagnostics(binder)
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -960,7 +960,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim displayName As String = TryCast(attrData.CommonConstructorArguments(0).ValueInternal, String)
 
             If displayName Is Nothing Then
-                diagnostics.Add(ERRID.ERR_FriendAssemblyNameInvalid, If(nodeOpt IsNot Nothing, nodeOpt.GetLocation(), NoLocation.Singleton), displayName)
+                diagnostics.Add(ERRID.ERR_FriendAssemblyNameInvalid, If(nodeOpt IsNot Nothing, nodeOpt.GetLocation(), NoLocation.Singleton), "")
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1191,7 +1191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Get assembly level declaration errors.
         ''' </summary>
         Private Function GetAssemblyLevelDeclarationErrors(
-            haveExtensionMethodsInSource As Boolean) As ImmutableBindingDiagnostic(Of AssemblySymbol)
+            haveExtensionMethodsInSource As Boolean) As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
 
             If _lazyAssemblyLevelDeclarationErrors.IsDefault OrElse _lazyAssemblyLevelDeclarationDependencies.IsDefault Then
 
@@ -1269,7 +1269,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ReportDiagnosticsForSynthesizedAttributes(DeclaringCompilation, diagnostics)
                 ReportDiagnosticsForAddedModules(diagnostics)
 
-                Dim immutableBindingDiagnostic As ImmutableBindingDiagnostic(Of AssemblySymbol) = diagnostics.ToReadOnlyAndFree()
+                Dim immutableBindingDiagnostic As ReadOnlyBindingDiagnostic(Of AssemblySymbol) = diagnostics.ToReadOnlyAndFree()
                 ImmutableInterlocked.InterlockedInitialize(_lazyAssemblyLevelDeclarationDependencies, immutableBindingDiagnostic.Dependencies)
                 ImmutableInterlocked.InterlockedInitialize(_lazyAssemblyLevelDeclarationErrors, immutableBindingDiagnostic.Diagnostics)
             End If
@@ -1277,7 +1277,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(Not _lazyAssemblyLevelDeclarationErrors.IsDefault)
             Debug.Assert(Not _lazyAssemblyLevelDeclarationDependencies.IsDefault)
 
-            Return New ImmutableBindingDiagnostic(Of AssemblySymbol)(_lazyAssemblyLevelDeclarationErrors, _lazyAssemblyLevelDeclarationDependencies)
+            Return New ReadOnlyBindingDiagnostic(Of AssemblySymbol)(_lazyAssemblyLevelDeclarationErrors, _lazyAssemblyLevelDeclarationDependencies)
         End Function
 
         Private Sub DetectAttributeAndOptionConflicts(diagnostics As BindingDiagnosticBag)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.BoundImports.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.BoundImports.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' can be Nothing if no xmlns imports
             Public ReadOnly XmlNamespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition)
 
-            Public ReadOnly Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+            Public ReadOnly Diagnostics As ReadOnlyBindingDiagnostic(Of AssemblySymbol)
 
             Public Sub New(memberImports As ImmutableArray(Of NamespaceOrTypeAndImportsClausePosition),
                            memberImportsInfo As ImmutableArray(Of GlobalImportInfo),
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                            aliasImports As ImmutableArray(Of AliasAndImportsClausePosition),
                            aliasImportsInfo As ImmutableArray(Of GlobalImportInfo),
                            xmlNamespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition),
-                           diags As ImmutableBindingDiagnostic(Of AssemblySymbol))
+                           diags As ReadOnlyBindingDiagnostic(Of AssemblySymbol))
                 Me.MemberImports = memberImports
                 Me.MemberImportsInfo = memberImportsInfo
                 Me.AliasImportsMap = aliasImportsMap

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         ' lazily populated with the bound imports
         Private _lazyBoundImports As BoundImports
-        Private _lazyBoundImportsAdditionalDiagnostics As StrongBox(Of ImmutableBindingDiagnostic(Of AssemblySymbol))
+        Private _lazyBoundImportsAdditionalDiagnostics As StrongBox(Of ReadOnlyBindingDiagnostic(Of AssemblySymbol))
 
         ' lazily populate with quick attribute checker that is initialized with the imports.
         Private _lazyQuickAttributeChecker As QuickAttributeChecker
@@ -360,7 +360,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If _lazyBoundImportsAdditionalDiagnostics Is Nothing Then
                 Dim diagnosticBag = BindingDiagnosticBag.GetInstance()
                 ValidateImports(_lazyBoundImports.MemberImports, _lazyBoundImports.MemberImportsInfo, _lazyBoundImports.AliasImports, _lazyBoundImports.AliasImportsInfo, diagnosticBag)
-                Interlocked.CompareExchange(_lazyBoundImportsAdditionalDiagnostics, New StrongBox(Of ImmutableBindingDiagnostic(Of AssemblySymbol))(diagnosticBag.ToReadOnlyAndFree()), Nothing)
+                Interlocked.CompareExchange(_lazyBoundImportsAdditionalDiagnostics, New StrongBox(Of ReadOnlyBindingDiagnostic(Of AssemblySymbol))(diagnosticBag.ToReadOnlyAndFree()), Nothing)
             End If
         End Sub
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
@@ -38,9 +38,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return null;
         }
 
-        internal override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
+        internal override ReadOnlyBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue)
         {
-            return ImmutableBindingDiagnostic<AssemblySymbol>.Empty;
+            return ReadOnlyBindingDiagnostic<AssemblySymbol>.Empty;
         }
 
         internal sealed override SynthesizedLocalKind SynthesizedKind


### PR DESCRIPTION
We were attempt to resolve diagnostics in ColorColor attribute argument scenarios while we were in the middle of attribute argument binding. This then caused us to need to bind attributes to resolve the diagnostic, entering an infinite loop that eventually overflows. To solve this, I've allowed `ImmutableBindingDiagnostics` to avoid eagerly resolving diagnostics during construction. To better convey this new contract, I've also renamed the type to `ReadOnlyBindingDiagnostics`. As there are extensive uses of `ReadOnlyBindingDiagnostics`, and many should continue to eagerly resolve diagnostics, I've left it as resolving by default, and only adjusted this one codepath. Fixes https://github.com/dotnet/roslyn/issues/71039.
