### PR TITLE
Ensure we publish symbols for the BuildHost

### DIFF
--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -9,6 +9,17 @@
     <UseAppHost>false</UseAppHost>
     <!-- Set to false since it's also set in Microsoft.CodeAnalysis.LanguageServer -->
     <SelfContained>false</SelfContained>
+    <!-- We don't ship a regular NuGet package for this (it gets included in the Workspaces.MSBuild package directly), but we still need to publish symbols -->
+    <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+    <!-- Explicitly mark ourselves as AnyCPU; if we don't do this, since this project is an executable targeting net472, the SDK has logic that assumes we're targeting Windows
+         and will explicitly provide a RuntimeIdentifier for us which will target win7-x86. This then causes PlatformTarget to be set to x86, which
+         in turn causes our NuGet PackageId (set by IsSymbolPublishingPackage above) to be set to a different name only the net472 variant. This mismatched PackageId
+         can then break the NuGet tooling which assumes the package will have a single PackageId across all TFMs.
+
+         Although we could change the logic in IsSymbolPublishingPackage to ignore that PlatformTarget, it seems more robust to explicitly be AnyCPU so we don't get
+         a RuntimeIdentifier given to us, since we really don't want to accidentally pick up platform specific binaries since we also have to run on Mono.
+         -->
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(RefOnlyMicrosoftBuildVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />


### PR DESCRIPTION
Now with less NuGet restore problems!

Fixes https://github.com/dotnet/roslyn/issues/70987