### PR TITLE
Split integration test build from test run

### DIFF
--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -70,34 +70,28 @@ parameters:
   type: number
   default: 150
 
-jobs:
-- job: VS_Integration_CoreHost_Debug
-  pool:
-    name: ${{ parameters.poolName }}
-    demands: ImageOverride -equals ${{ parameters.queueName }}
-  timeoutInMinutes: ${{ parameters.timeout }}
-  variables:
-    - name: XUNIT_LOGS
-      value: $(Build.SourcesDirectory)\artifacts\log\Debug
-  steps:
-    - template: eng/pipelines/test-integration-job.yml
-      parameters:
-        configuration: Debug
-        oop64bit: true
+stages:
+- template: eng/pipelines/test-integration-helix.yml
+  parameters:
+    poolName: ${{ parameters.poolName }}
+    queueName: ${{ parameters.queueName }}
+    timeout: ${{ parameters.timeout }}
+    configuration: Debug
+    testRuns:
+      - oop64bit: true
         oopCoreClr: true
+        lspEditor: false
+        runName: VS_Integration_CoreHost_Debug
 
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - job: VS_Integration_CoreHost_Release
-    pool:
-      name: ${{ parameters.poolName }}
-      demands: ImageOverride -equals ${{ parameters.queueName }}
-    timeoutInMinutes: ${{ parameters.timeout }}
-    variables:
-      - name: XUNIT_LOGS
-        value: $(Build.SourcesDirectory)\artifacts\log\Debug
-    steps:
-      - template: eng/pipelines/test-integration-job.yml
-        parameters:
-          configuration: Release
-          oop64bit: true
+  - template: eng/pipelines/test-integration-helix.yml
+    parameters:
+      poolName: ${{ parameters.poolName }}
+      queueName: ${{ parameters.queueName }}
+      timeout: ${{ parameters.timeout }}
+      configuration: Release
+      testRuns:
+        - oop64bit: true
           oopCoreClr: true
+          lspEditor: false
+          runName: VS_Integration_CoreHost_Release

--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -56,20 +56,15 @@ parameters:
   type: number
   default: 150
 
-variables:
-- name: XUNIT_LOGS
-  value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
-
-jobs:
-- job: VS_Integration_LSP
-  pool:
-    name: ${{ parameters.poolName }}
-    demands: ImageOverride -equals ${{ parameters.queueName }}
-  timeoutInMinutes: ${{ parameters.timeout }}
-
-  steps:
-    - template: eng/pipelines/test-integration-job.yml
-      parameters:
-        configuration: Debug
-        oop64bit: true
+stages:
+- template: eng/pipelines/test-integration-helix.yml
+  parameters:
+    poolName: ${{ parameters.poolName }}
+    queueName: ${{ parameters.queueName }}
+    timeout: ${{ parameters.timeout }}
+    configuration: Debug
+    testRuns:
+      - oop64bit: true
+        oopCoreClr: false
         lspEditor: true
+        runName: VS_Integration_LSP_Debug_64

--- a/azure-pipelines-integration-scouting.yml
+++ b/azure-pipelines-integration-scouting.yml
@@ -34,62 +34,34 @@ parameters:
   default: 150
 
 stages:
-- stage: Debug_Integration
-  dependsOn: []
-  variables:
-  - name: XUNIT_LOGS
-    value: $(Build.SourcesDirectory)\artifacts\log\Debug
-  jobs:
-  - job: VS_Integration_Debug_32
-    pool:
-      name: ${{ parameters.poolName }}
-      demands: ImageOverride -equals ${{ parameters.queueName }}
-    timeoutInMinutes: ${{ parameters.timeout }}
-    steps:
-      - template: eng/pipelines/test-integration-job.yml
-        parameters:
-          configuration: Debug
-          oop64bit: false
-          lspEditor: false
+- template: eng/pipelines/test-integration-helix.yml
+  parameters:
+    poolName: ${{ parameters.poolName }}
+    queueName: ${{ parameters.queueName }}
+    timeout: ${{ parameters.timeout }}
+    configuration: Debug
+    testRuns:
+      - oop64bit: false
+        oopCoreClr: false
+        lspEditor: false
+        runName: VS_Integration_Debug_32
+      - oop64bit: true
+        oopCoreClr: false
+        lspEditor: false
+        runName: VS_Integration_Debug_64
 
-  - job: VS_Integration_Debug_64
-    pool:
-      name: ${{ parameters.poolName }}
-      demands: ImageOverride -equals ${{ parameters.queueName }}
-    timeoutInMinutes: ${{ parameters.timeout }}
-    steps:
-      - template: eng/pipelines/test-integration-job.yml
-        parameters:
-          configuration: Debug
-          oop64bit: true
-          lspEditor: false
-
-- stage: Release_Integration
-  dependsOn: []
-  variables:
-  - name: XUNIT_LOGS
-    value: $(Build.SourcesDirectory)\artifacts\log\Release
-  jobs:
-  - job: VS_Integration_Release_32
-    pool:
-      name: ${{ parameters.poolName }}
-      demands: ImageOverride -equals ${{ parameters.queueName }}
-    timeoutInMinutes: ${{ parameters.timeout }}
-    steps:
-      - template: eng/pipelines/test-integration-job.yml
-        parameters:
-          configuration: Release
-          oop64bit: false
-          lspEditor: false
-
-  - job: VS_Integration_Release_64
-    pool:
-      name: ${{ parameters.poolName }}
-      demands: ImageOverride -equals ${{ parameters.queueName }}
-    timeoutInMinutes: ${{ parameters.timeout }}
-    steps:
-      - template: eng/pipelines/test-integration-job.yml
-        parameters:
-          configuration: Release
-          oop64bit: true
-          lspEditor: false
+- template: eng/pipelines/test-integration-helix.yml
+  parameters:
+    poolName: ${{ parameters.poolName }}
+    queueName: ${{ parameters.queueName }}
+    timeout: ${{ parameters.timeout }}
+    configuration: Release
+    testRuns:
+      - oop64bit: false
+        oopCoreClr: false
+        lspEditor: false
+        runName: VS_Integration_Release_32
+      - oop64bit: true
+        oopCoreClr: false
+        lspEditor: false
+        runName: VS_Integration_Release_64

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -68,64 +68,36 @@ parameters:
   default: 150
 
 stages:
-- stage: Debug_Integration
-  dependsOn: []
-  variables:
-  - name: XUNIT_LOGS
-    value: $(Build.SourcesDirectory)\artifacts\log\Debug
-  jobs:
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-    - job: VS_Integration_Debug_32
-      pool:
-        name: ${{ parameters.poolName }}
-        demands: ImageOverride -equals ${{ parameters.queueName }}
-      timeoutInMinutes: ${{ parameters.timeout }}
-      steps:
-        - template: eng/pipelines/test-integration-job.yml
-          parameters:
-            configuration: Debug
-            oop64bit: false
-            lspEditor: false
-
-  - job: VS_Integration_Debug_64
-    pool:
-      name: ${{ parameters.poolName }}
-      demands: ImageOverride -equals ${{ parameters.queueName }}
-    timeoutInMinutes: ${{ parameters.timeout }}
-    steps:
-      - template: eng/pipelines/test-integration-job.yml
-        parameters:
-          configuration: Debug
-          oop64bit: true
+- template: eng/pipelines/test-integration-helix.yml
+  parameters:
+    poolName: ${{ parameters.poolName }}
+    queueName: ${{ parameters.queueName }}
+    timeout: ${{ parameters.timeout }}
+    configuration: Debug
+    testRuns:
+      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+        - oop64bit: false
+          oopCoreClr: false
           lspEditor: false
+          runName: VS_Integration_Debug_32
+      - oop64bit: true
+        oopCoreClr: false
+        lspEditor: false
+        runName: VS_Integration_Debug_64
 
-- stage: Release_Integration
-  dependsOn: []
-  variables:
-  - name: XUNIT_LOGS
-    value: $(Build.SourcesDirectory)\artifacts\log\Release
-  jobs:
-  - job: VS_Integration_Release_32
-    pool:
-      name: ${{ parameters.poolName }}
-      demands: ImageOverride -equals ${{ parameters.queueName }}
-    timeoutInMinutes: ${{ parameters.timeout }}
-    steps:
-      - template: eng/pipelines/test-integration-job.yml
-        parameters:
-          configuration: Release
-          oop64bit: false
+- template: eng/pipelines/test-integration-helix.yml
+  parameters:
+    poolName: ${{ parameters.poolName }}
+    queueName: ${{ parameters.queueName }}
+    timeout: ${{ parameters.timeout }}
+    configuration: Release
+    testRuns:
+      - oop64bit: false
+        oopCoreClr: false
+        lspEditor: false
+        runName: VS_Integration_Release_32
+      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+        - oop64bit: true
+          oopCoreClr: false
           lspEditor: false
-
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-    - job: VS_Integration_Release_64
-      pool:
-        name: ${{ parameters.poolName }}
-        demands: ImageOverride -equals ${{ parameters.queueName }}
-      timeoutInMinutes: ${{ parameters.timeout }}
-      steps:
-        - template: eng/pipelines/test-integration-job.yml
-          parameters:
-            configuration: Release
-            oop64bit: true
-            lspEditor: false
+          runName: VS_Integration_Release_64

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -539,8 +539,13 @@ function EnablePreviewSdks() {
 # Deploy our core VSIX libraries to Visual Studio via the Roslyn VSIX tool.  This is an alternative to
 # deploying at build time.
 function Deploy-VsixViaTool() {
-  $vsixDir = Get-PackageDir "RoslynTools.VSIXExpInstaller"
-  $vsixExe = Join-Path $vsixDir "tools\VsixExpInstaller.exe"
+
+  $vsixExe = Join-Path $ArtifactsDir "bin\RunTests\$configuration\net7.0\VSIXExpInstaller\VSIXExpInstaller.exe"
+  Write-Host "VSIX EXE path: " $vsixExe
+  if (-not (Test-Path $vsixExe)) {
+    Write-Host "VSIX EXE not found: '$vsixExe'." -ForegroundColor Red
+    ExitWithExitCode 1
+  }
 
   $vsInfo = LocateVisualStudio
   if ($vsInfo -eq $null) {

--- a/eng/pipelines/test-integration-helix.yml
+++ b/eng/pipelines/test-integration-helix.yml
@@ -1,0 +1,118 @@
+parameters:
+  - name: poolName
+    type: string
+  - name: queueName
+    type: string
+  - name: configuration
+    type: string
+    default: 'Debug'
+    values: [ 'Debug', 'Release' ] 
+  - name: timeout
+    type: number
+  - name: testRuns
+    type: object
+    default:
+      - oop64bit: true
+        oopCoreClr: false
+        lspEditor: false
+        runName: 64
+  
+
+stages:
+- stage: Windows_${{ parameters.configuration }}_Build
+  dependsOn: []
+  jobs:
+  - template: build-windows-job.yml
+    parameters:
+      jobName: Build_Windows_${{ parameters.configuration }}
+      testArtifactName: Transport_Artifacts_Windows_${{ parameters.configuration }}
+      configuration: ${{ parameters.configuration }}
+      poolName: ${{ parameters.poolName }}
+      queueName: ${{ parameters.queueName }}
+      restoreArguments: -msbuildEngine vs
+      buildArguments: -msbuildEngine vs
+
+- stage: ${{ parameters.configuration }}_Integration
+  dependsOn: Windows_${{ parameters.configuration }}_Build
+  variables:
+  - name: XUNIT_LOGS
+    value: $(Build.SourcesDirectory)\artifacts\log\${{ parameters.configuration }}
+  jobs:
+  - ${{ each testParameters in parameters.testRuns }}:
+    - job: ${{ testParameters.runName }}
+      timeoutInMinutes: ${{ parameters.timeout }}
+      pool:
+        name: ${{ parameters.poolName }}
+        demands: ImageOverride -equals ${{ parameters.queueName }}
+      steps:
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Test Payload
+        inputs:
+          artifact: Transport_Artifacts_Windows_${{ parameters.configuration }}
+          path: '$(Build.SourcesDirectory)'
+
+      - task: BatchScript@1
+        displayName: Rehydrate RunTests
+        inputs:
+          filename: ./artifacts/bin/RunTests/${{ parameters.configuration }}/net7.0/rehydrate.cmd
+        env:
+          HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)\.duplicate'
+      
+      # This is a temporary step until the actual test run moves to helix (then we would need to rehydrate the tests there instead)
+      - task: BatchScript@1
+        displayName: Rehydrate Microsoft.VisualStudio.LanguageServices.New.IntegrationTests
+        inputs:
+          filename: ./artifacts/bin/Microsoft.VisualStudio.LanguageServices.New.IntegrationTests/${{ parameters.configuration }}/net472/rehydrate.cmd
+        env:
+          HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)\.duplicate'
+
+      # This is a temporary step until the actual test run moves to helix (then we would need to rehydrate the tests there instead)
+      - task: BatchScript@1
+        displayName: Rehydrate Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests (net6.0-windows)
+        inputs:
+          filename: ./artifacts\bin\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests/${{ parameters.configuration }}/net6.0-windows/rehydrate.cmd
+        env:
+          HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)\.duplicate'
+
+      # This is a temporary step until the actual test run moves to helix (then we would need to rehydrate the tests there instead)
+      - task: BatchScript@1
+        displayName: Rehydrate Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests (net472)
+        inputs:
+          filename: ./artifacts\bin\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests/${{ parameters.configuration }}/net472/rehydrate.cmd
+        env:
+          HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)\.duplicate'
+
+      - task: PowerShell@2
+        displayName: Run Integration Tests
+        inputs:
+          filePath: eng/build.ps1
+          arguments: -ci -prepareMachine -testVsi -configuration ${{ parameters.configuration }} -oop64bit:$${{ testParameters.oop64bit }} -oopCoreClr:$${{ testParameters.oopCoreClr }} -collectDumps -lspEditor:$${{ testParameters.lspEditor }}
+
+      # These are temporary publishing steps - once the tests run on helix, the artifacts will be attached to the helix payload.
+      - task: PublishTestResults@2
+        displayName: Publish xUnit Test Results
+        inputs:
+          testRunner: XUnit
+          testResultsFiles: $(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}\*.xml
+          mergeTestResults: true
+          testRunTitle: '$(System.JobAttempt)-Integration ${{ parameters.configuration }} OOP64_${{ testParameters.oop64bit }} OOPCoreClr_${{ testParameters.oopCoreClr }}'
+        condition: always()
+
+      # Dumps from test timeouts or crashes get published to the test results directory by dotnet test, so make sure to publish any here.
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Test Results Directory
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}'
+          ArtifactName: '$(System.JobAttempt)-Logs ${{ parameters.configuration }} OOP64_${{ testParameters.oop64bit }} OOPCoreClr_${{ testParameters.oopCoreClr }} LspEditor_${{ testParameters.lspEditor }} $(Build.BuildNumber)'
+          publishLocation: Container
+        continueOnError: true
+        condition: not(succeeded())
+    
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Logs
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\${{ parameters.configuration }}'
+          ArtifactName: '$(System.JobAttempt)-Logs ${{ parameters.configuration }} OOP64_${{ testParameters.oop64bit }} OOPCoreClr_${{ testParameters.oopCoreClr }} LspEditor_${{ testParameters.lspEditor }} $(Build.BuildNumber)'
+          publishLocation: Container
+        continueOnError: true
+        condition: not(succeeded())

--- a/src/Tools/PrepareTests/TestDiscovery.cs
+++ b/src/Tools/PrepareTests/TestDiscovery.cs
@@ -120,8 +120,10 @@ internal class TestDiscovery
 
     private static List<string> GetAssemblies(string binDirectory, bool isUnix)
     {
-        var unitTestAssemblies = Directory.GetFiles(binDirectory, "*.UnitTests.dll", SearchOption.AllDirectories).Where(ShouldInclude);
-        return unitTestAssemblies.ToList();
+        var unitTestAssemblies = Directory.GetFiles(binDirectory, "*UnitTests.dll", SearchOption.AllDirectories);
+        var integrationTestAssemblies = Directory.GetFiles(binDirectory, "*IntegrationTests.dll", SearchOption.AllDirectories);
+        var assemblies = unitTestAssemblies.Concat(integrationTestAssemblies).Where(ShouldInclude);
+        return assemblies.ToList();
 
         bool ShouldInclude(string path)
         {

--- a/src/Tools/Source/RunTests/RunTests.csproj
+++ b/src/Tools/Source/RunTests/RunTests.csproj
@@ -18,4 +18,16 @@
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="$(MicrosoftTeamFoundationServerClientVersion)" />
     <ProjectReference Include="..\..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
   </ItemGroup>
+
+  
+  <!-- Include the VSIX installer so we have it in the build payload for integration tests -->
+  <ItemGroup>
+    <PackageReference Include="RoslynTools.VSIXExpInstaller" Version="$(RoslynToolsVSIXExpInstallerVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <_CopyItems Include="$(NuGetPackageRoot)roslyntools.vsixexpinstaller\$(RoslynToolsVSIXExpInstallerVersion)\tools\*.*" />
+  </ItemGroup>
+  <Target Name="CopyCustomContent" AfterTargets="AfterBuild" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <Copy SourceFiles="@(_CopyItems)" DestinationFolder="$(OutDir)/VSIXExpInstaller" />
+  </Target>
 </Project>


### PR DESCRIPTION
This is part 1 of running integration tests on helix.  This PR separates the build and testing stages in preparation for running on helix, it does not actually send the tests to helix to run.

This PR updates the integration test pipeline to use the same payload creation that we use for our helix unit tests.  The integration test pipeline now does the following:
1.  First build the assets once per configuration
2.  Re-use the `PrepareTests.csproj` to create a minimized test assets payload containing the VSIX and integration test project outputs.
3.  Upload that payload to the pipeline artifacts.
4.  In a separate stage, we then download the test payload
5.  Rehydrate the payload
6.  Install the VSIXs and run the tests

In followup PRs, instead of running the integration tests on a normal ADO machine, we will instead partition them and upload them to helix, using the same payload support that I've added in this PR.

Example PR run:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=495861&view=results
![image](https://github.com/dotnet/roslyn/assets/5749229/0c31d9f5-0e50-41b2-9b7f-7d14da871a35)

Example CI run:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=496084&view=results
![image](https://github.com/dotnet/roslyn/assets/5749229/7a0e428d-e206-4d7c-ada4-a10eed33ea28)

