### PR TITLE
Reduce size of source constructor symbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -47,7 +47,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                     isNullableAnalysisEnabled: false,
                                                     isVarArg: baseMethod.IsVararg,
                                                     isExpressionBodied: false,
-                                                    isExplicitInterfaceImplementation: false)))
+                                                    isExplicitInterfaceImplementation: false,
+                                                    hasThisInitializer: false)))
         {
             Debug.Assert((object)containingType != null);
             Debug.Assert((object)baseMethod != null);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             : base(delegateType, syntax.GetReference(), location: syntax.Identifier.GetLocation(), isIterator: false,
                    (declarationModifiers, MakeFlags(
                                                     methodKind, refKind, declarationModifiers, returnType.IsVoidType(), returnsVoidIsSet: true, isExpressionBodied: false,
-                                                    isExtensionMethod: false, isVarArg: false, isNullableAnalysisEnabled: false, isExplicitInterfaceImplementation: false)))
+                                                    isExtensionMethod: false, isVarArg: false, isNullableAnalysisEnabled: false, isExplicitInterfaceImplementation: false, hasThisInitializer: false)))
         {
             _returnType = returnType;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Flags flags = MakeFlags(
                                     MethodKind.Destructor, RefKind.None, declarationModifiers, returnsVoid: true, returnsVoidIsSet: true,
                                     isExpressionBodied: syntax.IsExpressionBodied(), isExtensionMethod: false,
-                                    isVarArg: false, isNullableAnalysisEnabled: isNullableAnalysisEnabled, isExplicitInterfaceImplementation: false);
+                                    isVarArg: false, isNullableAnalysisEnabled: isNullableAnalysisEnabled, isExplicitInterfaceImplementation: false, hasThisInitializer: false);
 
             return (declarationModifiers, flags);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -42,7 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                 isExtensionMethod: false,
                                                 isNullableAnalysisEnabled: isNullableAnalysisEnabled,
                                                 isVarArg: false,
-                                                isExplicitInterfaceImplementation: @event.IsExplicitInterfaceImplementation)))
+                                                isExplicitInterfaceImplementation: @event.IsExplicitInterfaceImplementation,
+                                                hasThisInitializer: false)))
         {
             _event = @event;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // We currently pack everything into a 32 bit int with the following layout:
             //
-            // |              |a|b|e|n|vvv|yy|s|r|q|z|kkk|wwwww|
+            // |            |t|a|b|e|n|vvv|yy|s|r|q|z|kkk|wwwww|
             // 
             // w = method kind.  5 bits.
             // k = ref kind.  3 bits.
@@ -37,7 +37,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // n = IsNullableAnalysisEnabled. 1 bit.
             // e = IsExpressionBody. 1 bit.
             // b = HasAnyBody. 1 bit.
-            // a = IsVararg. 1 bit
+            // a = IsVararg. 1 bit.
+            // t = HasThisInitializer. 1 bit.
             private int _flags;
 
             private const int MethodKindOffset = 0;
@@ -77,8 +78,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private const int HasAnyBodySize = 1;
 
             private const int IsVarargOffset = HasAnyBodyOffset + HasAnyBodySize;
-#pragma warning disable IDE0051 // Remove unused private members
             private const int IsVarargSize = 1;
+
+            private const int HasThisInitializerOffset = IsVarargOffset + IsVarargSize;
+#pragma warning disable IDE0051 // Remove unused private members
+            private const int HasThisInitializerSize = 1;
 #pragma warning restore IDE0051 // Remove unused private members
 
             private const int HasAnyBodyBit = 1 << HasAnyBodyOffset;
@@ -88,6 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private const int IsMetadataVirtualBit = 1 << IsMetadataVirtualIgnoringInterfaceChangesOffset;
             private const int IsMetadataVirtualLockedBit = 1 << IsMetadataVirtualLockedOffset;
             private const int IsVarargBit = 1 << IsVarargOffset;
+            private const int HasThisInitializerBit = 1 << HasThisInitializerOffset;
 
             private const int ReturnsVoidBit = 1 << ReturnsVoidOffset;
             private const int ReturnsVoidIsSetBit = 1 << ReturnsVoidOffset + 1;
@@ -153,6 +158,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return (_flags & IsVarargBit) != 0; }
             }
 
+            public readonly bool HasThisInitializer
+                => (_flags & HasThisInitializerBit) != 0;
+
 #if DEBUG
             static Flags()
             {
@@ -179,7 +187,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 bool isExtensionMethod,
                 bool isNullableAnalysisEnabled,
                 bool isVararg,
-                bool isExplicitInterfaceImplementation)
+                bool isExplicitInterfaceImplementation,
+                bool hasThisInitializer)
             {
                 Debug.Assert(!returnsVoid || returnsVoidIsSet);
 
@@ -194,6 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 int isVarargInt = isVararg ? IsVarargBit : 0;
                 int isMetadataVirtualIgnoringInterfaceImplementationChangesInt = isMetadataVirtual ? IsMetadataVirtualIgnoringInterfaceChangesBit : 0;
                 int isMetadataVirtualInt = isMetadataVirtual ? IsMetadataVirtualBit : 0;
+                int hasThisInitializerInt = hasThisInitializer ? HasThisInitializerBit : 0;
 
                 _flags = methodKindInt
                     | refKindInt
@@ -204,6 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     | isVarargInt
                     | isMetadataVirtualIgnoringInterfaceImplementationChangesInt
                     | isMetadataVirtualInt
+                    | hasThisInitializerInt
                     | (returnsVoid ? ReturnsVoidBit : 0)
                     | (returnsVoidIsSet ? ReturnsVoidIsSetBit : 0);
             }
@@ -218,7 +229,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 bool isExtensionMethod,
                 bool isNullableAnalysisEnabled,
                 bool isVararg,
-                bool isExplicitInterfaceImplementation)
+                bool isExplicitInterfaceImplementation,
+                bool hasThisInitializer)
                 : this(methodKind,
                        refKind,
                        declarationModifiers,
@@ -229,7 +241,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                        isExtensionMethod: isExtensionMethod,
                        isNullableAnalysisEnabled: isNullableAnalysisEnabled,
                        isVararg: isVararg,
-                       isExplicitInterfaceImplementation: isExplicitInterfaceImplementation)
+                       isExplicitInterfaceImplementation: isExplicitInterfaceImplementation,
+                       hasThisInitializer: hasThisInitializer)
             {
             }
 
@@ -387,9 +400,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool isExtensionMethod,
             bool isNullableAnalysisEnabled,
             bool isVarArg,
-            bool isExplicitInterfaceImplementation)
+            bool isExplicitInterfaceImplementation,
+            bool hasThisInitializer = false)
         {
-            return new Flags(methodKind, refKind, declarationModifiers, returnsVoid, returnsVoidIsSet, isExpressionBodied, isExtensionMethod, isNullableAnalysisEnabled, isVarArg, isExplicitInterfaceImplementation);
+            return new Flags(methodKind, refKind, declarationModifiers, returnsVoid, returnsVoidIsSet, isExpressionBodied, isExtensionMethod, isNullableAnalysisEnabled, isVarArg, isExplicitInterfaceImplementation, hasThisInitializer);
         }
 
         protected void SetReturnsVoid(bool returnsVoid)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool isNullableAnalysisEnabled,
             bool isVarArg,
             bool isExplicitInterfaceImplementation,
-            bool hasThisInitializer = false)
+            bool hasThisInitializer)
         {
             return new Flags(methodKind, refKind, declarationModifiers, returnsVoid, returnsVoidIsSet, isExpressionBodied, isExtensionMethod, isNullableAnalysisEnabled, isVarArg, isExplicitInterfaceImplementation, hasThisInitializer);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -101,7 +101,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                        firstParam.Modifiers.Any(SyntaxKind.ThisKeyword),
                                     isNullableAnalysisEnabled: isNullableAnalysisEnabled,
                                     isVararg: syntax.IsVarArg(),
-                                    isExplicitInterfaceImplementation: methodKind == MethodKind.ExplicitInterfaceImplementation);
+                                    isExplicitInterfaceImplementation: methodKind == MethodKind.ExplicitInterfaceImplementation,
+                                    hasThisInitializer: false);
 
             return (declarationModifiers, flags);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // returnsVoid argument to MakeFlags is ignored.
             Flags flags = MakeFlags(MethodKind.PropertyGet, property.RefKind, declarationModifiers, returnsVoid: false, returnsVoidIsSet: false,
                                     isExpressionBodied: true, isExtensionMethod: false, isNullableAnalysisEnabled: isNullableAnalysisEnabled,
-                                    isVarArg: false, isExplicitInterfaceImplementation: property.IsExplicitInterfaceImplementation);
+                                    isVarArg: false, isExplicitInterfaceImplementation: property.IsExplicitInterfaceImplementation, hasThisInitializer: false);
 
             return (declarationModifiers, flags);
         }
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // returnsVoid argument to MakeFlags is ignored.
             Flags flags = MakeFlags(methodKind, property.RefKind, declarationModifiers, returnsVoid: false, returnsVoidIsSet: false,
                                     isExpressionBodied: isExpressionBodied, isExtensionMethod: false, isNullableAnalysisEnabled: isNullableAnalysisEnabled,
-                                    isVarArg: false, isExplicitInterfaceImplementation: isExplicitInterfaceImplementation);
+                                    isVarArg: false, isExplicitInterfaceImplementation: isExplicitInterfaceImplementation, hasThisInitializer: false);
 
             return (declarationModifiers, flags);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -44,7 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                   returnsVoidIsSet: false,
                                                   isExpressionBodied: isExpressionBodied,
                                                   isExtensionMethod: false, isVarArg: false, isNullableAnalysisEnabled: isNullableAnalysisEnabled,
-                                                  isExplicitInterfaceImplementation: methodKind == MethodKind.ExplicitInterfaceImplementation)))
+                                                  isExplicitInterfaceImplementation: methodKind == MethodKind.ExplicitInterfaceImplementation,
+                                                  hasThisInitializer: false)))
         {
             _explicitInterfaceType = explicitInterfaceType;
             _name = name;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedPrimaryConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedPrimaryConstructor.cs
@@ -48,7 +48,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     isExtensionMethod: false,
                                     isVarArg: syntax.ParameterList.IsVarArg(),
                                     isNullableAnalysisEnabled: false, // IsNullableAnalysisEnabled uses containing type instead.
-                                    isExplicitInterfaceImplementation: false);
+                                    isExplicitInterfaceImplementation: false,
+                                    hasThisInitializer: false);
 
             return (declarationModifiers, flags);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordOrdinaryMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordOrdinaryMethod.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                    (declarationModifiers, MakeFlags(
                                                     MethodKind.Ordinary, RefKind.None, declarationModifiers, returnsVoid: false, returnsVoidIsSet: false,
                                                     isExpressionBodied: false, isExtensionMethod: false, isNullableAnalysisEnabled: false, isVarArg: false,
-                                                    isExplicitInterfaceImplementation: false)))
+                                                    isExplicitInterfaceImplementation: false, hasThisInitializer: false)))
         {
             _memberOffset = memberOffset;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -78,7 +78,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     isExtensionMethod: false,
                                     isNullableAnalysisEnabled: isNullableAnalysisEnabled,
                                     isVarArg: false,
-                                    isExplicitInterfaceImplementation: false);
+                                    isExplicitInterfaceImplementation: false,
+                                    hasThisInitializer: false);
 
             return (declarationModifiers, flags);
         }


### PR DESCRIPTION
I didn't do this before because constructors still had data in them about if they were expression bodied or not.  But we moved that into the flags.  So we can trim this as well, removing all fields from this type.