### PR TITLE
Remove navigation helpers based on line+offset

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveDocumentNavigationService.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveDocumentNavigationService.cs
@@ -28,9 +28,6 @@ namespace Microsoft.CodeAnalysis.Interactive
         public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
             => SpecializedTasks.True;
 
-        public Task<bool> CanNavigateToLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-            => SpecializedTasks.False;
-
         public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
             => SpecializedTasks.False;
 
@@ -85,9 +82,6 @@ namespace Microsoft.CodeAnalysis.Interactive
                 return true;
             });
         }
-
-        public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<INavigableLocation>();
 
         public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
             => SpecializedTasks.Null<INavigableLocation>();

--- a/src/EditorFeatures/Core/Navigation/IDocumentNavigationServiceExtensions.cs
+++ b/src/EditorFeatures/Core/Navigation/IDocumentNavigationServiceExtensions.cs
@@ -6,68 +6,87 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
-namespace Microsoft.CodeAnalysis.Navigation
+namespace Microsoft.CodeAnalysis.Navigation;
+
+internal static class INavigableLocationExtensions
 {
-    internal static class INavigableLocationExtensions
+    public static async Task<bool> TryNavigateToAsync(
+        this INavigableLocation? location, IThreadingContext threadingContext, NavigationOptions options, CancellationToken cancellationToken)
     {
-        public static async Task<bool> TryNavigateToAsync(
-            this INavigableLocation? location, IThreadingContext threadingContext, NavigationOptions options, CancellationToken cancellationToken)
-        {
-            if (location == null)
-                return false;
+        if (location == null)
+            return false;
 
-            // This switch is currently unnecessary.  Howevver, it helps support a future where location.NavigateTo becomes
-            // async and must be on the UI thread.
-            await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            return await location.NavigateToAsync(options, cancellationToken).ConfigureAwait(false);
-        }
+        // This switch is currently unnecessary.  Howevver, it helps support a future where location.NavigateTo becomes
+        // async and must be on the UI thread.
+        await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        return await location.NavigateToAsync(options, cancellationToken).ConfigureAwait(false);
+    }
+}
+
+internal static class IDocumentNavigationServiceExtensions
+{
+    public static async Task<bool> TryNavigateToSpanAsync(
+        this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, bool allowInvalidSpan, CancellationToken cancellationToken)
+    {
+        var location = await service.GetLocationForSpanAsync(workspace, documentId, textSpan, allowInvalidSpan, cancellationToken).ConfigureAwait(false);
+        return await location.TryNavigateToAsync(threadingContext, options, cancellationToken).ConfigureAwait(false);
     }
 
-    internal static class IDocumentNavigationServiceExtensions
+    public static async Task<bool> TryNavigateToSpanAsync(
+        this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, CancellationToken cancellationToken)
     {
-        public static async Task<bool> TryNavigateToSpanAsync(
-            this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, bool allowInvalidSpan, CancellationToken cancellationToken)
-        {
-            var location = await service.GetLocationForSpanAsync(workspace, documentId, textSpan, allowInvalidSpan, cancellationToken).ConfigureAwait(false);
-            return await location.TryNavigateToAsync(threadingContext, options, cancellationToken).ConfigureAwait(false);
-        }
+        var location = await service.GetLocationForSpanAsync(workspace, documentId, textSpan, cancellationToken).ConfigureAwait(false);
+        return await location.TryNavigateToAsync(threadingContext, options, cancellationToken).ConfigureAwait(false);
+    }
 
-        public static async Task<bool> TryNavigateToSpanAsync(
-            this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, CancellationToken cancellationToken)
-        {
-            var location = await service.GetLocationForSpanAsync(workspace, documentId, textSpan, cancellationToken).ConfigureAwait(false);
-            return await location.TryNavigateToAsync(threadingContext, options, cancellationToken).ConfigureAwait(false);
-        }
+    public static async Task<bool> TryNavigateToSpanAsync(
+        this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
+    {
+        var location = await service.GetLocationForSpanAsync(workspace, documentId, textSpan, cancellationToken).ConfigureAwait(false);
+        return await location.TryNavigateToAsync(threadingContext, NavigationOptions.Default, cancellationToken).ConfigureAwait(false);
+    }
 
-        public static async Task<bool> TryNavigateToSpanAsync(
-            this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
-        {
-            var location = await service.GetLocationForSpanAsync(workspace, documentId, textSpan, cancellationToken).ConfigureAwait(false);
-            return await location.TryNavigateToAsync(threadingContext, NavigationOptions.Default, cancellationToken).ConfigureAwait(false);
-        }
+    public static async Task<bool> TryNavigateToPositionAsync(
+        this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, int position, int virtualSpace, NavigationOptions options, CancellationToken cancellationToken)
+    {
+        var location = await service.GetLocationForPositionAsync(workspace, documentId, position, virtualSpace, cancellationToken).ConfigureAwait(false);
+        return await location.TryNavigateToAsync(threadingContext, options, cancellationToken).ConfigureAwait(false);
+    }
 
-        public static async Task<bool> TryNavigateToPositionAsync(
-            this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, int position, int virtualSpace, NavigationOptions options, CancellationToken cancellationToken)
-        {
-            var location = await service.GetLocationForPositionAsync(workspace, documentId, position, virtualSpace, cancellationToken).ConfigureAwait(false);
-            return await location.TryNavigateToAsync(threadingContext, options, cancellationToken).ConfigureAwait(false);
-        }
+    public static async Task<bool> TryNavigateToPositionAsync(
+        this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
+    {
+        var location = await service.GetLocationForPositionAsync(
+            workspace, documentId, position, cancellationToken).ConfigureAwait(false);
+        return await location.TryNavigateToAsync(threadingContext, NavigationOptions.Default, cancellationToken).ConfigureAwait(false);
+    }
 
-        public static async Task<bool> TryNavigateToPositionAsync(
-            this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
-        {
-            var location = await service.GetLocationForPositionAsync(
-                workspace, documentId, position, cancellationToken).ConfigureAwait(false);
-            return await location.TryNavigateToAsync(threadingContext, NavigationOptions.Default, cancellationToken).ConfigureAwait(false);
-        }
+    public static async Task<bool> TryNavigateToLineAndOffsetAsync(
+        this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, int lineNumber, int offset, NavigationOptions options, CancellationToken cancellationToken)
+    {
+        // Navigation should not change the context of linked files and Shared Projects.
+        documentId = workspace.GetDocumentIdInCurrentContext(documentId);
 
-        public static async Task<bool> TryNavigateToLineAndOffsetAsync(
-            this IDocumentNavigationService service, IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, int lineNumber, int offset, NavigationOptions options, CancellationToken cancellationToken)
-        {
-            var location = await service.GetLocationForLineAndOffsetAsync(
-                workspace, documentId, lineNumber, offset, cancellationToken).ConfigureAwait(false);
-            return await location.TryNavigateToAsync(threadingContext, options, cancellationToken).ConfigureAwait(false);
-        }
+        var document = workspace.CurrentSolution.GetDocument(documentId);
+        if (document is null)
+            return false;
+
+        // DocumentId+Line+Column come from sources that are not snapshot based.  In other words, the data may
+        // correspond to some point in time in the past.  As such, we have to try to clamp it against the current
+        // view of the document text.
+        var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+        var linePosition = new LinePosition(lineNumber, offset);
+        var linePositionSpan = new LinePositionSpan(linePosition, linePosition);
+        var clampedSpan = linePositionSpan.GetClampedTextSpan(text);
+
+        // This operation is fundamentally racey.  Between getting the clamped span and navigating the document may
+        // have changed.  So allow for invalid spans here.
+        var location = await service.GetLocationForSpanAsync(
+            workspace, documentId, clampedSpan, allowInvalidSpan: true, cancellationToken).ConfigureAwait(false);
+
+        return location != null && await location.TryNavigateToAsync(threadingContext, options, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTestsBase.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTestsBase.vb
@@ -89,7 +89,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
                             ' The INavigableItemsPresenter should not have been called
                             Assert.False(presenterCalled)
                         Else
-                            Assert.False(mockDocumentNavigationService._triedNavigationToLineAndOffset)
                             Assert.True(presenterCalled)
 
                             Dim actualLocations As New List(Of FilePathAndSpan)

--- a/src/EditorFeatures/Test2/NavigableSymbols/NavigableSymbolsTest.vb
+++ b/src/EditorFeatures/Test2/NavigableSymbols/NavigableSymbolsTest.vb
@@ -135,7 +135,6 @@ End Class"
             Await listenerProvider.GetWaiter(FeatureAttribute.NavigableSymbols).ExpeditedWaitAsync()
 
             Dim navigationService = DirectCast(workspace.Services.GetService(Of IDocumentNavigationService)(), MockDocumentNavigationServiceProvider.MockDocumentNavigationService)
-            Assert.Equal(True, navigationService.TryNavigateToLineAndOffsetReturnValue)
             Assert.Equal(True, navigationService.TryNavigateToPositionReturnValue)
             Assert.Equal(True, navigationService.TryNavigateToSpanReturnValue)
 

--- a/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockDocumentNavigationService.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockDocumentNavigationService.vb
@@ -12,11 +12,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
     Friend Class MockDocumentNavigationService
         Implements IDocumentNavigationService
 
-        Public _canNavigateToLineAndOffset As Boolean = True
         Public _canNavigateToPosition As Boolean = True
         Public _canNavigateToSpan As Boolean = True
 
-        Public _triedNavigationToLineAndOffset As Boolean
         Public _triedNavigationToPosition As Boolean
         Public _triedNavigationToSpan As Boolean
 
@@ -27,27 +25,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
         Public _position As Integer = -1
         Public _positionVirtualSpace As Integer = -1
 
-        Public Function CanNavigateToLineAndOffsetAsync(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToLineAndOffsetAsync
-            Return If(_canNavigateToLineAndOffset, SpecializedTasks.True, SpecializedTasks.False)
-        End Function
-
         Public Function CanNavigateToPositionAsync(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToPositionAsync
             Return If(_canNavigateToPosition, SpecializedTasks.True, SpecializedTasks.False)
         End Function
 
         Public Function CanNavigateToSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, allowInvalidSpan As Boolean, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToSpanAsync
             Return If(_canNavigateToSpan, SpecializedTasks.True, SpecializedTasks.False)
-        End Function
-
-        Public Function GetLocationForLineAndOffsetAsync(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForLineAndOffsetAsync
-            Return Task.FromResult(Of INavigableLocation)(New NavigableLocation(
-                Function(o, c)
-                    _triedNavigationToLineAndOffset = True
-                    _documentId = documentId
-                    _line = lineNumber
-                    _offset = offset
-                    Return SpecializedTasks.True
-                End Function))
         End Function
 
         Public Function GetLocationForPositionAsync(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForPositionAsync

--- a/src/EditorFeatures/TestUtilities2/Utilities/MockDocumentNavigationServiceProvider.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/MockDocumentNavigationServiceProvider.vb
@@ -33,25 +33,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 
             Public ProvidedDocumentId As DocumentId
             Public ProvidedTextSpan As TextSpan
-            Public ProvidedLineNumber As Integer
-            Public ProvidedOffset As Integer
             Public ProvidedPosition As Integer
             Public ProvidedVirtualSpace As Integer
 
-            Public CanNavigateToLineAndOffsetReturnValue As Boolean = True
             Public CanNavigateToPositionReturnValue As Boolean = True
             Public CanNavigateToSpanReturnValue As Boolean = True
 
-            Public TryNavigateToLineAndOffsetReturnValue As Boolean = True
             Public TryNavigateToPositionReturnValue As Boolean = True
             Public TryNavigateToSpanReturnValue As Boolean = True
-
-            Public Function CanNavigateToLineAndOffsetAsync(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToLineAndOffsetAsync
-                Me.ProvidedDocumentId = documentId
-                Me.ProvidedLineNumber = lineNumber
-
-                Return If(CanNavigateToLineAndOffsetReturnValue, SpecializedTasks.True, SpecializedTasks.False)
-            End Function
 
             Public Function CanNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToPositionAsync
                 Me.ProvidedDocumentId = documentId
@@ -66,14 +55,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
                 Me.ProvidedTextSpan = textSpan
 
                 Return If(CanNavigateToSpanReturnValue, SpecializedTasks.True, SpecializedTasks.False)
-            End Function
-
-            Public Function GetLocationForLineAndOffsetAsync(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForLineAndOffsetAsync
-                Me.ProvidedDocumentId = documentId
-                Me.ProvidedLineNumber = lineNumber
-                Me.ProvidedOffset = offset
-
-                Return NavigableLocation.TestAccessor.Create(TryNavigateToLineAndOffsetReturnValue)
             End Function
 
             Public Function GetLocationForPositionAsync(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForPositionAsync

--- a/src/Features/Core/Portable/Navigation/DefaultDocumentNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultDocumentNavigationService.cs
@@ -7,26 +7,19 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Navigation
+namespace Microsoft.CodeAnalysis.Navigation;
+
+internal sealed class DefaultDocumentNavigationService : IDocumentNavigationService
 {
-    internal sealed class DefaultDocumentNavigationService : IDocumentNavigationService
-    {
-        public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
-            => SpecializedTasks.False;
+    public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        => SpecializedTasks.False;
 
-        public Task<bool> CanNavigateToLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-            => SpecializedTasks.False;
+    public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+        => SpecializedTasks.False;
 
-        public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
-            => SpecializedTasks.False;
+    public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        => SpecializedTasks.Null<INavigableLocation>();
 
-        public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<INavigableLocation>();
-
-        public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<INavigableLocation>();
-
-        public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<INavigableLocation>();
-    }
+    public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+        => SpecializedTasks.Null<INavigableLocation>();
 }

--- a/src/Features/Core/Portable/Navigation/IDocumentNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/IDocumentNavigationService.cs
@@ -2,49 +2,42 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.Navigation
+namespace Microsoft.CodeAnalysis.Navigation;
+
+internal interface IDocumentNavigationService : IWorkspaceService
 {
-    internal interface IDocumentNavigationService : IWorkspaceService
-    {
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given position in the specified document.
-        /// </summary>
-        /// <remarks>Legal to call from any thread.</remarks>
-        Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken);
+    /// <summary>
+    /// Determines whether it is possible to navigate to the given position in the specified document.
+    /// </summary>
+    /// <remarks>Legal to call from any thread.</remarks>
+    Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given line/offset in the specified document.
-        /// </summary>
-        Task<bool> CanNavigateToLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
+    /// <summary>
+    /// Determines whether it is possible to navigate to the given virtual position in the specified document.
+    /// </summary>
+    /// <remarks>Legal to call from any thread.</remarks>
+    Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given virtual position in the specified document.
-        /// </summary>
-        Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
+    Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken);
+    Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
+}
 
-        Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken);
-        Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
-        Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
-    }
+internal static class IDocumentNavigationServiceExtensions
+{
+    public static Task<bool> CanNavigateToSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
+        => service.CanNavigateToSpanAsync(workspace, documentId, textSpan, allowInvalidSpan: false, cancellationToken);
 
-    internal static class IDocumentNavigationServiceExtensions
-    {
-        public static Task<bool> CanNavigateToSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
-            => service.CanNavigateToSpanAsync(workspace, documentId, textSpan, allowInvalidSpan: false, cancellationToken);
+    public static Task<bool> CanNavigateToPositionAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
+        => service.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace: 0, cancellationToken);
 
-        public static Task<bool> CanNavigateToPositionAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
-            => service.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace: 0, cancellationToken);
+    public static Task<INavigableLocation?> GetLocationForSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
+        => service.GetLocationForSpanAsync(workspace, documentId, textSpan, allowInvalidSpan: false, cancellationToken);
 
-        public static Task<INavigableLocation?> GetLocationForSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
-            => service.GetLocationForSpanAsync(workspace, documentId, textSpan, allowInvalidSpan: false, cancellationToken);
-
-        public static Task<INavigableLocation?> GetLocationForPositionAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
-            => service.GetLocationForPositionAsync(workspace, documentId, position, virtualSpace: 0, cancellationToken);
-    }
+    public static Task<INavigableLocation?> GetLocationForPositionAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
+        => service.GetLocationForPositionAsync(workspace, documentId, position, virtualSpace: 0, cancellationToken);
 }

--- a/src/Tools/ExternalAccess/FSharp/Navigation/FSharpDocumentNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/FSharpDocumentNavigationService.cs
@@ -13,88 +13,77 @@ using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation;
+
+[ExportWorkspaceService(typeof(IFSharpDocumentNavigationService)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class FSharpDocumentNavigationService(IThreadingContext threadingContext)
+    : IFSharpDocumentNavigationService
 {
-    [ExportWorkspaceService(typeof(IFSharpDocumentNavigationService)), Shared]
-    internal class FSharpDocumentNavigationService : IFSharpDocumentNavigationService
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan)
+        => CanNavigateToSpan(workspace, documentId, textSpan, CancellationToken.None);
+
+    public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
     {
-        private readonly IThreadingContext _threadingContext;
+        var service = workspace.Services.GetService<IDocumentNavigationService>();
+        return threadingContext.JoinableTaskFactory.Run(() =>
+            service.CanNavigateToSpanAsync(workspace, documentId, textSpan, cancellationToken));
+    }
 
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public FSharpDocumentNavigationService(
-            IThreadingContext threadingContext)
-        {
-            _threadingContext = threadingContext;
-        }
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset)
+        => CanNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, CancellationToken.None);
 
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan)
-            => CanNavigateToSpan(workspace, documentId, textSpan, CancellationToken.None);
+    [Obsolete("Call overloads that take a span or position", error: false)]
+    public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
+        => false;
 
-        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
-        {
-            var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return _threadingContext.JoinableTaskFactory.Run(() =>
-                service.CanNavigateToSpanAsync(workspace, documentId, textSpan, cancellationToken));
-        }
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace)
+        => CanNavigateToPosition(workspace, documentId, position, virtualSpace, CancellationToken.None);
 
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset)
-            => CanNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, CancellationToken.None);
+    public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+    {
+        var service = workspace.Services.GetService<IDocumentNavigationService>();
+        return threadingContext.JoinableTaskFactory.Run(() =>
+            service.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace, cancellationToken));
+    }
 
-        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-        {
-            var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return _threadingContext.JoinableTaskFactory.Run(() =>
-                service.CanNavigateToLineAndOffsetAsync(workspace, documentId, lineNumber, offset, cancellationToken));
-        }
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options)
+        => TryNavigateToSpan(workspace, documentId, textSpan, CancellationToken.None);
 
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace)
-            => CanNavigateToPosition(workspace, documentId, position, virtualSpace, CancellationToken.None);
+    public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
+    {
+        var service = workspace.Services.GetService<IDocumentNavigationService>();
+        return threadingContext.JoinableTaskFactory.Run(() =>
+            service.TryNavigateToSpanAsync(
+                threadingContext, workspace, documentId, textSpan, NavigationOptions.Default with { PreferProvisionalTab = true }, cancellationToken));
+    }
 
-        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
-        {
-            var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return _threadingContext.JoinableTaskFactory.Run(() =>
-                service.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace, cancellationToken));
-        }
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
+        => TryNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, CancellationToken.None);
 
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options)
-            => TryNavigateToSpan(workspace, documentId, textSpan, CancellationToken.None);
+    public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
+    {
+        var service = workspace.Services.GetService<IDocumentNavigationService>();
+        return threadingContext.JoinableTaskFactory.Run(() =>
+            service.TryNavigateToPositionAsync(
+                threadingContext, workspace, documentId, lineNumber, offset, NavigationOptions.Default with { PreferProvisionalTab = true }, cancellationToken));
+    }
 
-        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
-        {
-            var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return _threadingContext.JoinableTaskFactory.Run(() =>
-                service.TryNavigateToSpanAsync(
-                    _threadingContext, workspace, documentId, textSpan, NavigationOptions.Default with { PreferProvisionalTab = true }, cancellationToken));
-        }
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
+        => TryNavigateToPosition(workspace, documentId, position, virtualSpace, CancellationToken.None);
 
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
-            => TryNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, CancellationToken.None);
-
-        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-        {
-            var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return _threadingContext.JoinableTaskFactory.Run(() =>
-                service.TryNavigateToPositionAsync(
-                    _threadingContext, workspace, documentId, lineNumber, offset, NavigationOptions.Default with { PreferProvisionalTab = true }, cancellationToken));
-        }
-
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
-            => TryNavigateToPosition(workspace, documentId, position, virtualSpace, CancellationToken.None);
-
-        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
-        {
-            var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return _threadingContext.JoinableTaskFactory.Run(() =>
-                service.TryNavigateToPositionAsync(
-                    _threadingContext, workspace, documentId, position, virtualSpace, NavigationOptions.Default with { PreferProvisionalTab = true }, cancellationToken));
-        }
+    public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+    {
+        var service = workspace.Services.GetService<IDocumentNavigationService>();
+        return threadingContext.JoinableTaskFactory.Run(() =>
+            service.TryNavigateToPositionAsync(
+                threadingContext, workspace, documentId, position, virtualSpace, NavigationOptions.Default with { PreferProvisionalTab = true }, cancellationToken));
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpDocumentNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpDocumentNavigationService.cs
@@ -11,37 +11,37 @@ using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation;
+
+internal interface IFSharpDocumentNavigationService : IWorkspaceService
 {
-    internal interface IFSharpDocumentNavigationService : IWorkspaceService
-    {
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan);
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset);
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan);
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset);
 #pragma warning disable RS0060 // API with optional parameter(s) should have the most parameters amongst its public overloads
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0);
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null);
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null);
-        [Obsolete("Call overload that takes a CancellationToken", error: false)]
-        bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null);
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0);
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null);
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null);
+    [Obsolete("Call overload that takes a CancellationToken", error: false)]
+    bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null);
 #pragma warning restore RS0060 // API with optional parameter(s) should have the most parameters amongst its public overloads
 
-        /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToSpanAsync"/>
-        bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
-        /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToLineAndOffsetAsync"/>
-        bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
-        /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToPositionAsync"/>
-        bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
+    [Obsolete("Call overloads that take a span or position", error: false)]
+    bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
+    [Obsolete("Call overloads that take a span or position", error: false)]
+    bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
 
-        /// <inheritdoc cref="IDocumentNavigationService.GetLocationForSpanAsync"/>
-        bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
-        /// <inheritdoc cref="IDocumentNavigationService.GetLocationForLineAndOffsetAsync"/>
-        bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
-        /// <inheritdoc cref="IDocumentNavigationService.GetLocationForPositionAsync"/>
-        bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
-    }
+    /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToSpanAsync"/>
+    bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
+    /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToPositionAsync"/>
+    bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
+
+    /// <inheritdoc cref="IDocumentNavigationService.GetLocationForSpanAsync"/>
+    bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
+    /// <inheritdoc cref="IDocumentNavigationService.GetLocationForPositionAsync"/>
+    bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
 }

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
@@ -29,83 +29,111 @@ using Roslyn.Utilities;
 using TextSpan = Microsoft.CodeAnalysis.Text.TextSpan;
 using VsTextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation
+namespace Microsoft.VisualStudio.LanguageServices.Implementation;
+
+[ExportWorkspaceService(typeof(IDocumentNavigationService), ServiceLayer.Host), Shared]
+[Export(typeof(VisualStudioDocumentNavigationService))]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class VisualStudioDocumentNavigationService(
+    IThreadingContext threadingContext,
+    SVsServiceProvider serviceProvider,
+    IVsEditorAdaptersFactoryService editorAdaptersFactoryService,
+    // lazy to avoid circularities
+    Lazy<SourceGeneratedFileManager> sourceGeneratedFileManager)
+    : ForegroundThreadAffinitizedObject(threadingContext), IDocumentNavigationService
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService = editorAdaptersFactoryService;
+    private readonly IVsRunningDocumentTable4 _runningDocumentTable = (IVsRunningDocumentTable4)serviceProvider.GetService(typeof(SVsRunningDocumentTable));
+    private readonly IThreadingContext _threadingContext = threadingContext;
+    private readonly Lazy<SourceGeneratedFileManager> _sourceGeneratedFileManager = sourceGeneratedFileManager;
 
-    [ExportWorkspaceService(typeof(IDocumentNavigationService), ServiceLayer.Host), Shared]
-    [Export(typeof(VisualStudioDocumentNavigationService))]
-    internal sealed class VisualStudioDocumentNavigationService : ForegroundThreadAffinitizedObject, IDocumentNavigationService
+    public async Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
     {
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
-        private readonly IVsRunningDocumentTable4 _runningDocumentTable;
-        private readonly IThreadingContext _threadingContext;
-        private readonly Lazy<SourceGeneratedFileManager> _sourceGeneratedFileManager;
+        // Navigation should not change the context of linked files and Shared Projects.
+        documentId = workspace.GetDocumentIdInCurrentContext(documentId);
 
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VisualStudioDocumentNavigationService(
-            IThreadingContext threadingContext,
-            SVsServiceProvider serviceProvider,
-            IVsEditorAdaptersFactoryService editorAdaptersFactoryService,
-            Lazy<SourceGeneratedFileManager> sourceGeneratedFileManager /* lazy to avoid circularities */)
-            : base(threadingContext)
+        if (!IsSecondaryBuffer(documentId))
+            return true;
+
+        var document = workspace.CurrentSolution.GetRequiredDocument(documentId);
+        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+
+        var vsTextSpan = GetVsTextSpan(text, textSpan, allowInvalidSpan);
+        return await CanMapFromSecondaryBufferToPrimaryBufferAsync(
+            documentId, vsTextSpan, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+    {
+        // Navigation should not change the context of linked files and Shared Projects.
+        documentId = workspace.GetDocumentIdInCurrentContext(documentId);
+
+        if (!IsSecondaryBuffer(documentId))
+            return true;
+
+        var document = workspace.CurrentSolution.GetRequiredDocument(documentId);
+        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+
+        var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
+        if (boundedPosition != position)
         {
-            _serviceProvider = serviceProvider;
-            _editorAdaptersFactoryService = editorAdaptersFactoryService;
-            _runningDocumentTable = (IVsRunningDocumentTable4)serviceProvider.GetService(typeof(SVsRunningDocumentTable));
-            _threadingContext = threadingContext;
-            _sourceGeneratedFileManager = sourceGeneratedFileManager;
-        }
-
-        public async Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
-        {
-            // Navigation should not change the context of linked files and Shared Projects.
-            documentId = workspace.GetDocumentIdInCurrentContext(documentId);
-
-            if (!IsSecondaryBuffer(documentId))
-                return true;
-
-            var document = workspace.CurrentSolution.GetRequiredDocument(documentId);
-            var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-
-            var vsTextSpan = GetVsTextSpan(text, textSpan, allowInvalidSpan);
-            return await CanMapFromSecondaryBufferToPrimaryBufferAsync(
-                documentId, vsTextSpan, cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task<bool> CanNavigateToLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-        {
-            // Navigation should not change the context of linked files and Shared Projects.
-            documentId = workspace.GetDocumentIdInCurrentContext(documentId);
-
-            if (!IsSecondaryBuffer(documentId))
+            try
             {
-                return true;
+                throw new ArgumentOutOfRangeException();
+            }
+            catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
+            {
             }
 
-            var document = workspace.CurrentSolution.GetRequiredDocument(documentId);
-            var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-            var vsTextSpan = text.GetVsTextSpanForLineOffset(lineNumber, offset);
-
-            return await CanMapFromSecondaryBufferToPrimaryBufferAsync(
-                documentId, vsTextSpan, cancellationToken).ConfigureAwait(false);
+            return false;
         }
 
-        public async Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+        var vsTextSpan = text.GetVsTextSpanForPosition(position, virtualSpace);
+
+        return await CanMapFromSecondaryBufferToPrimaryBufferAsync(
+            documentId, vsTextSpan, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<INavigableLocation?> GetLocationForSpanAsync(
+        Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+    {
+        if (!await this.CanNavigateToSpanAsync(workspace, documentId, textSpan, allowInvalidSpan, cancellationToken).ConfigureAwait(false))
+            return null;
+
+        return await GetNavigableLocationAsync(workspace,
+            documentId,
+            _ => Task.FromResult(textSpan),
+            text => GetVsTextSpan(text, textSpan, allowInvalidSpan),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<INavigableLocation?> GetLocationForPositionAsync(
+        Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+    {
+        if (!await this.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace, cancellationToken).ConfigureAwait(false))
+            return null;
+
+        return await GetNavigableLocationAsync(workspace,
+            documentId,
+            document => GetTextSpanFromPositionAsync(document, position, virtualSpace, cancellationToken),
+            text => GetVsTextSpan(text, position, virtualSpace),
+            cancellationToken).ConfigureAwait(false);
+
+        static async Task<TextSpan> GetTextSpanFromPositionAsync(Document document, int position, int virtualSpace, CancellationToken cancellationToken)
         {
-            // Navigation should not change the context of linked files and Shared Projects.
-            documentId = workspace.GetDocumentIdInCurrentContext(documentId);
-
-            if (!IsSecondaryBuffer(documentId))
-            {
-                return true;
-            }
-
-            var document = workspace.CurrentSolution.GetRequiredDocument(documentId);
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+            text.GetLineAndOffset(position, out var lineNumber, out var offset);
 
+            offset += virtualSpace;
+
+            var linePosition = new LinePosition(lineNumber, offset);
+            return text.Lines.GetTextSpan(new LinePositionSpan(linePosition, linePosition));
+        }
+
+        static VsTextSpan GetVsTextSpan(SourceText text, int position, int virtualSpace)
+        {
             var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
             if (boundedPosition != position)
             {
@@ -116,368 +144,283 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
                 {
                 }
+            }
 
+            return text.GetVsTextSpanForPosition(boundedPosition, virtualSpace);
+        }
+    }
+
+    private async Task<INavigableLocation?> GetNavigableLocationAsync(
+        Workspace workspace,
+        DocumentId documentId,
+        Func<Document, Task<TextSpan>> getTextSpanForMappingAsync,
+        Func<SourceText, VsTextSpan> getVsTextSpan,
+        CancellationToken cancellationToken)
+    {
+        var callback = await GetNavigationCallbackAsync(
+            workspace, documentId, getTextSpanForMappingAsync, getVsTextSpan, cancellationToken).ConfigureAwait(true);
+        if (callback == null)
+            return null;
+
+        return new NavigableLocation(async (options, cancellationToken) =>
+        {
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            using (OpenNewDocumentStateScope(options))
+            {
+                // Ensure we come back to the UI Thread after navigating so we close the state scope.
+                return await callback(cancellationToken).ConfigureAwait(true);
+            }
+        });
+    }
+
+    private async Task<Func<CancellationToken, Task<bool>>?> GetNavigationCallbackAsync(
+        Workspace workspace,
+        DocumentId documentId,
+        Func<Document, Task<TextSpan>> getTextSpanForMappingAsync,
+        Func<SourceText, VsTextSpan> getVsTextSpan,
+        CancellationToken cancellationToken)
+    {
+        // Navigation should not change the context of linked files and Shared Projects.
+        documentId = workspace.GetDocumentIdInCurrentContext(documentId);
+
+        var solution = workspace.CurrentSolution;
+        var document = solution.GetDocument(documentId);
+        if (document == null)
+        {
+            var project = solution.GetProject(documentId.ProjectId);
+            if (project is null)
+            {
+                // This is a source generated document shown in Solution Explorer, but is no longer valid since
+                // the configuration and/or platform changed since the last generation completed.
+                return null;
+            }
+
+            var generatedDocument = await project.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
+            if (generatedDocument == null)
+                return null;
+
+            return _sourceGeneratedFileManager.Value.GetNavigationCallback(
+                generatedDocument,
+                await getTextSpanForMappingAsync(generatedDocument).ConfigureAwait(false));
+        }
+
+        // Before attempting to open the document, check if the location maps to a different file that should be opened instead.
+        var spanMappingService = document.Services.GetService<ISpanMappingService>();
+        if (spanMappingService != null)
+        {
+            var mappedSpan = await GetMappedSpanAsync(
+                spanMappingService,
+                document,
+                await getTextSpanForMappingAsync(document).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
+            if (mappedSpan.HasValue)
+            {
+                // Check if the mapped file matches one already in the workspace.
+                // If so use the workspace APIs to navigate to it.  Otherwise use VS APIs to navigate to the file path.
+                var documentIdsForFilePath = solution.GetDocumentIdsWithFilePath(mappedSpan.Value.FilePath);
+                if (!documentIdsForFilePath.IsEmpty)
+                {
+                    // If the mapped file maps to the same document that was passed in, then re-use the documentId to preserve context.
+                    // Otherwise, just pick one of the ids to use for navigation.
+                    var documentIdToNavigate = documentIdsForFilePath.Contains(documentId) ? documentId : documentIdsForFilePath.First();
+                    return GetNavigationCallback(documentIdToNavigate, workspace, getVsTextSpan);
+                }
+
+                return await GetNavigableLocationForMappedFileAsync(
+                    workspace, document, mappedSpan.Value, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return GetNavigationCallback(documentId, workspace, getVsTextSpan);
+    }
+
+    private Func<CancellationToken, Task<bool>>? GetNavigationCallback(
+        DocumentId documentId,
+        Workspace workspace,
+        Func<SourceText, VsTextSpan> getVsTextSpan)
+    {
+        return async cancellationToken =>
+        {
+            // Always open the document again, even if the document is already open in the 
+            // workspace. If a document is already open in a preview tab and it is opened again 
+            // in a permanent tab, this allows the document to transition to the new state.
+
+            if (workspace.CanOpenDocuments)
+                await OpenDocumentAsync(_threadingContext, workspace, documentId, cancellationToken).ConfigureAwait(false);
+
+            if (!workspace.IsDocumentOpen(documentId))
+                return false;
+
+            // Now that we've opened the document reacquire the corresponding Document in the current solution.
+            var document = workspace.CurrentSolution.GetDocument(documentId);
+            if (document == null)
+                return false;
+
+            // Reacquire the SourceText for it as well.  This will be a practically free as this just wraps
+            // the open text buffer.  So it's ok to do this in the navigation step.
+            var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+
+            // Map the given span to the right location in the buffer.  If we're in a projection scenario, ensure
+            // the span reflects that.
+            var vsTextSpan = getVsTextSpan(text);
+            if (IsSecondaryBuffer(documentId))
+            {
+                var mapped = await vsTextSpan.MapSpanFromSecondaryBufferToPrimaryBufferAsync(
+                    _threadingContext, documentId, cancellationToken).ConfigureAwait(false);
+                if (mapped == null)
+                    return false;
+
+                vsTextSpan = mapped.Value;
+            }
+
+            return await NavigateToTextBufferAsync(
+                text.Container.GetTextBuffer(), vsTextSpan, cancellationToken).ConfigureAwait(false);
+        };
+
+        async static Task OpenDocumentAsync(
+            IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+        {
+            // OpenDocument must be called on the UI thread.
+            await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            workspace.OpenDocument(documentId);
+        }
+    }
+
+    private async Task<Func<CancellationToken, Task<bool>>?> GetNavigableLocationForMappedFileAsync(
+        Workspace workspace, Document generatedDocument, MappedSpanResult mappedSpanResult, CancellationToken cancellationToken)
+    {
+        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        var vsWorkspace = (VisualStudioWorkspaceImpl)workspace;
+        // TODO - Move to IOpenDocumentService - https://github.com/dotnet/roslyn/issues/45954
+        // Pass the original result's project context so that if the mapped file has the same context available, we navigate
+        // to the mapped file with a consistent project context.
+        vsWorkspace.OpenDocumentFromPath(mappedSpanResult.FilePath, generatedDocument.Project.Id);
+        if (!_runningDocumentTable.TryGetBufferFromMoniker(_editorAdaptersFactoryService, mappedSpanResult.FilePath, out var textBuffer))
+            return null;
+
+        var vsTextSpan = new VsTextSpan
+        {
+            iStartIndex = mappedSpanResult.LinePositionSpan.Start.Character,
+            iStartLine = mappedSpanResult.LinePositionSpan.Start.Line,
+            iEndIndex = mappedSpanResult.LinePositionSpan.End.Character,
+            iEndLine = mappedSpanResult.LinePositionSpan.End.Line
+        };
+
+        return cancellationToken => NavigateToTextBufferAsync(textBuffer, vsTextSpan, cancellationToken);
+    }
+
+    private static async Task<MappedSpanResult?> GetMappedSpanAsync(
+        ISpanMappingService spanMappingService, Document generatedDocument, TextSpan textSpan, CancellationToken cancellationToken)
+    {
+        var results = await spanMappingService.MapSpansAsync(
+            generatedDocument, SpecializedCollections.SingletonEnumerable(textSpan), cancellationToken).ConfigureAwait(false);
+
+        if (!results.IsDefaultOrEmpty)
+        {
+            return results.First();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// It is unclear why, but we are sometimes asked to navigate to a position that is not
+    /// inside the bounds of the associated <see cref="Document"/>. This method returns a
+    /// position that is guaranteed to be inside the <see cref="Document"/> bounds. If the
+    /// returned position is different from the given position, then the worst observable
+    /// behavior is either no navigation or navigation to the end of the document. See the
+    /// following bugs for more details:
+    ///     https://devdiv.visualstudio.com/DevDiv/_workitems?id=112211
+    ///     https://devdiv.visualstudio.com/DevDiv/_workitems?id=136895
+    ///     https://devdiv.visualstudio.com/DevDiv/_workitems?id=224318
+    ///     https://devdiv.visualstudio.com/DevDiv/_workitems?id=235409
+    /// </summary>
+    private static int GetPositionWithinDocumentBounds(int position, int documentLength)
+        => Math.Min(documentLength, Math.Max(position, 0));
+
+    private static VsTextSpan GetVsTextSpan(SourceText text, TextSpan textSpan, bool allowInvalidSpan)
+    {
+        var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
+        if (boundedTextSpan != textSpan && !allowInvalidSpan)
+        {
+            try
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+            catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
+            {
+            }
+        }
+
+        return text.GetVsTextSpanForSpan(boundedTextSpan);
+    }
+
+    /// <summary>
+    /// It is unclear why, but we are sometimes asked to navigate to a <see cref="TextSpan"/>
+    /// that is not inside the bounds of the associated <see cref="Document"/>. This method
+    /// returns a span that is guaranteed to be inside the <see cref="Document"/> bounds. If
+    /// the returned span is different from the given span, then the worst observable behavior
+    /// is either no navigation or navigation to the end of the document.
+    /// See https://github.com/dotnet/roslyn/issues/7660 for more details.
+    /// </summary>
+    private static TextSpan GetSpanWithinDocumentBounds(TextSpan span, int documentLength)
+        => TextSpan.FromBounds(GetPositionWithinDocumentBounds(span.Start, documentLength), GetPositionWithinDocumentBounds(span.End, documentLength));
+
+    public async Task<bool> NavigateToTextBufferAsync(
+        ITextBuffer textBuffer, VsTextSpan vsTextSpan, CancellationToken cancellationToken)
+    {
+        Contract.ThrowIfNull(textBuffer);
+        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        using (Logger.LogBlock(FunctionId.NavigationService_VSDocumentNavigationService_NavigateTo, cancellationToken))
+        {
+            var vsTextBuffer = _editorAdaptersFactoryService.GetBufferAdapter(textBuffer);
+            if (vsTextBuffer == null)
+            {
+                Debug.Fail("Could not get IVsTextBuffer for document!");
                 return false;
             }
 
-            var vsTextSpan = text.GetVsTextSpanForPosition(position, virtualSpace);
-
-            return await CanMapFromSecondaryBufferToPrimaryBufferAsync(
-                documentId, vsTextSpan, cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task<INavigableLocation?> GetLocationForSpanAsync(
-            Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
-        {
-            if (!await this.CanNavigateToSpanAsync(workspace, documentId, textSpan, allowInvalidSpan, cancellationToken).ConfigureAwait(false))
-                return null;
-
-            return await GetNavigableLocationAsync(workspace,
-                documentId,
-                _ => Task.FromResult(textSpan),
-                text => GetVsTextSpan(text, textSpan, allowInvalidSpan),
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(
-            Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-        {
-            if (!await this.CanNavigateToLineAndOffsetAsync(workspace, documentId, lineNumber, offset, cancellationToken).ConfigureAwait(false))
-                return null;
-
-            return await GetNavigableLocationAsync(workspace,
-                documentId,
-                document => GetTextSpanFromLineAndOffsetAsync(document, lineNumber, offset, cancellationToken),
-                text => GetVsTextSpan(text, lineNumber, offset),
-                cancellationToken).ConfigureAwait(false);
-
-            static async Task<TextSpan> GetTextSpanFromLineAndOffsetAsync(Document document, int lineNumber, int offset, CancellationToken cancellationToken)
+            var textManager = (IVsTextManager2)_serviceProvider.GetService(typeof(SVsTextManager));
+            if (textManager == null)
             {
-                var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-
-                var linePosition = new LinePosition(lineNumber, offset);
-                return text.Lines.GetTextSpan(new LinePositionSpan(linePosition, linePosition));
+                Debug.Fail("Could not get IVsTextManager service!");
+                return false;
             }
 
-            static VsTextSpan GetVsTextSpan(SourceText text, int lineNumber, int offset)
-            {
-                return text.GetVsTextSpanForLineOffset(lineNumber, offset);
-            }
+            return ErrorHandler.Succeeded(
+                textManager.NavigateToLineAndColumn2(
+                    vsTextBuffer,
+                    VSConstants.LOGVIEWID.TextView_guid,
+                    vsTextSpan.iStartLine,
+                    vsTextSpan.iStartIndex,
+                    vsTextSpan.iEndLine,
+                    vsTextSpan.iEndIndex,
+                    (uint)_VIEWFRAMETYPE.vftCodeWindow));
         }
+    }
 
-        public async Task<INavigableLocation?> GetLocationForPositionAsync(
-            Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+    private static bool IsSecondaryBuffer(DocumentId documentId)
+        => ContainedDocument.TryGetContainedDocument(documentId) != null;
+
+    private async Task<bool> CanMapFromSecondaryBufferToPrimaryBufferAsync(
+        DocumentId documentId, VsTextSpan spanInSecondaryBuffer, CancellationToken cancellationToken)
+    {
+        var mapped = await spanInSecondaryBuffer.MapSpanFromSecondaryBufferToPrimaryBufferAsync(
+            _threadingContext, documentId, cancellationToken).ConfigureAwait(false);
+        return mapped != null;
+    }
+
+    private static IDisposable OpenNewDocumentStateScope(NavigationOptions options)
+    {
+        var state = options.PreferProvisionalTab
+            ? __VSNEWDOCUMENTSTATE.NDS_Provisional
+            : __VSNEWDOCUMENTSTATE.NDS_Permanent;
+
+        if (!options.ActivateTab)
         {
-            if (!await this.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace, cancellationToken).ConfigureAwait(false))
-                return null;
-
-            return await GetNavigableLocationAsync(workspace,
-                documentId,
-                document => GetTextSpanFromPositionAsync(document, position, virtualSpace, cancellationToken),
-                text => GetVsTextSpan(text, position, virtualSpace),
-                cancellationToken).ConfigureAwait(false);
-
-            static async Task<TextSpan> GetTextSpanFromPositionAsync(Document document, int position, int virtualSpace, CancellationToken cancellationToken)
-            {
-                var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-                text.GetLineAndOffset(position, out var lineNumber, out var offset);
-
-                offset += virtualSpace;
-
-                var linePosition = new LinePosition(lineNumber, offset);
-                return text.Lines.GetTextSpan(new LinePositionSpan(linePosition, linePosition));
-            }
-
-            static VsTextSpan GetVsTextSpan(SourceText text, int position, int virtualSpace)
-            {
-                var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
-                if (boundedPosition != position)
-                {
-                    try
-                    {
-                        throw new ArgumentOutOfRangeException();
-                    }
-                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
-                    {
-                    }
-                }
-
-                return text.GetVsTextSpanForPosition(boundedPosition, virtualSpace);
-            }
+            state |= __VSNEWDOCUMENTSTATE.NDS_NoActivate;
         }
 
-        private async Task<INavigableLocation?> GetNavigableLocationAsync(
-            Workspace workspace,
-            DocumentId documentId,
-            Func<Document, Task<TextSpan>> getTextSpanForMappingAsync,
-            Func<SourceText, VsTextSpan> getVsTextSpan,
-            CancellationToken cancellationToken)
-        {
-            var callback = await GetNavigationCallbackAsync(
-                workspace, documentId, getTextSpanForMappingAsync, getVsTextSpan, cancellationToken).ConfigureAwait(true);
-            if (callback == null)
-                return null;
-
-            return new NavigableLocation(async (options, cancellationToken) =>
-            {
-                await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                using (OpenNewDocumentStateScope(options))
-                {
-                    // Ensure we come back to the UI Thread after navigating so we close the state scope.
-                    return await callback(cancellationToken).ConfigureAwait(true);
-                }
-            });
-        }
-
-        private async Task<Func<CancellationToken, Task<bool>>?> GetNavigationCallbackAsync(
-            Workspace workspace,
-            DocumentId documentId,
-            Func<Document, Task<TextSpan>> getTextSpanForMappingAsync,
-            Func<SourceText, VsTextSpan> getVsTextSpan,
-            CancellationToken cancellationToken)
-        {
-            // Navigation should not change the context of linked files and Shared Projects.
-            documentId = workspace.GetDocumentIdInCurrentContext(documentId);
-
-            var solution = workspace.CurrentSolution;
-            var document = solution.GetDocument(documentId);
-            if (document == null)
-            {
-                var project = solution.GetProject(documentId.ProjectId);
-                if (project is null)
-                {
-                    // This is a source generated document shown in Solution Explorer, but is no longer valid since
-                    // the configuration and/or platform changed since the last generation completed.
-                    return null;
-                }
-
-                var generatedDocument = await project.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
-                if (generatedDocument == null)
-                    return null;
-
-                return _sourceGeneratedFileManager.Value.GetNavigationCallback(
-                    generatedDocument,
-                    await getTextSpanForMappingAsync(generatedDocument).ConfigureAwait(false));
-            }
-
-            // Before attempting to open the document, check if the location maps to a different file that should be opened instead.
-            var spanMappingService = document.Services.GetService<ISpanMappingService>();
-            if (spanMappingService != null)
-            {
-                var mappedSpan = await GetMappedSpanAsync(
-                    spanMappingService,
-                    document,
-                    await getTextSpanForMappingAsync(document).ConfigureAwait(false),
-                    cancellationToken).ConfigureAwait(false);
-                if (mappedSpan.HasValue)
-                {
-                    // Check if the mapped file matches one already in the workspace.
-                    // If so use the workspace APIs to navigate to it.  Otherwise use VS APIs to navigate to the file path.
-                    var documentIdsForFilePath = solution.GetDocumentIdsWithFilePath(mappedSpan.Value.FilePath);
-                    if (!documentIdsForFilePath.IsEmpty)
-                    {
-                        // If the mapped file maps to the same document that was passed in, then re-use the documentId to preserve context.
-                        // Otherwise, just pick one of the ids to use for navigation.
-                        var documentIdToNavigate = documentIdsForFilePath.Contains(documentId) ? documentId : documentIdsForFilePath.First();
-                        return GetNavigationCallback(documentIdToNavigate, workspace, getVsTextSpan);
-                    }
-
-                    return await GetNavigableLocationForMappedFileAsync(
-                        workspace, document, mappedSpan.Value, cancellationToken).ConfigureAwait(false);
-                }
-            }
-
-            return GetNavigationCallback(documentId, workspace, getVsTextSpan);
-        }
-
-        private Func<CancellationToken, Task<bool>>? GetNavigationCallback(
-            DocumentId documentId,
-            Workspace workspace,
-            Func<SourceText, VsTextSpan> getVsTextSpan)
-        {
-            return async cancellationToken =>
-            {
-                // Always open the document again, even if the document is already open in the 
-                // workspace. If a document is already open in a preview tab and it is opened again 
-                // in a permanent tab, this allows the document to transition to the new state.
-
-                if (workspace.CanOpenDocuments)
-                    await OpenDocumentAsync(_threadingContext, workspace, documentId, cancellationToken).ConfigureAwait(false);
-
-                if (!workspace.IsDocumentOpen(documentId))
-                    return false;
-
-                // Now that we've opened the document reacquire the corresponding Document in the current solution.
-                var document = workspace.CurrentSolution.GetDocument(documentId);
-                if (document == null)
-                    return false;
-
-                // Reacquire the SourceText for it as well.  This will be a practically free as this just wraps
-                // the open text buffer.  So it's ok to do this in the navigation step.
-                var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-
-                // Map the given span to the right location in the buffer.  If we're in a projection scenario, ensure
-                // the span reflects that.
-                var vsTextSpan = getVsTextSpan(text);
-                if (IsSecondaryBuffer(documentId))
-                {
-                    var mapped = await vsTextSpan.MapSpanFromSecondaryBufferToPrimaryBufferAsync(
-                        _threadingContext, documentId, cancellationToken).ConfigureAwait(false);
-                    if (mapped == null)
-                        return false;
-
-                    vsTextSpan = mapped.Value;
-                }
-
-                return await NavigateToTextBufferAsync(
-                    text.Container.GetTextBuffer(), vsTextSpan, cancellationToken).ConfigureAwait(false);
-            };
-
-            async static Task OpenDocumentAsync(
-                IThreadingContext threadingContext, Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
-            {
-                // OpenDocument must be called on the UI thread.
-                await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                workspace.OpenDocument(documentId);
-            }
-        }
-
-        private async Task<Func<CancellationToken, Task<bool>>?> GetNavigableLocationForMappedFileAsync(
-            Workspace workspace, Document generatedDocument, MappedSpanResult mappedSpanResult, CancellationToken cancellationToken)
-        {
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            var vsWorkspace = (VisualStudioWorkspaceImpl)workspace;
-            // TODO - Move to IOpenDocumentService - https://github.com/dotnet/roslyn/issues/45954
-            // Pass the original result's project context so that if the mapped file has the same context available, we navigate
-            // to the mapped file with a consistent project context.
-            vsWorkspace.OpenDocumentFromPath(mappedSpanResult.FilePath, generatedDocument.Project.Id);
-            if (!_runningDocumentTable.TryGetBufferFromMoniker(_editorAdaptersFactoryService, mappedSpanResult.FilePath, out var textBuffer))
-                return null;
-
-            var vsTextSpan = new VsTextSpan
-            {
-                iStartIndex = mappedSpanResult.LinePositionSpan.Start.Character,
-                iStartLine = mappedSpanResult.LinePositionSpan.Start.Line,
-                iEndIndex = mappedSpanResult.LinePositionSpan.End.Character,
-                iEndLine = mappedSpanResult.LinePositionSpan.End.Line
-            };
-
-            return cancellationToken => NavigateToTextBufferAsync(textBuffer, vsTextSpan, cancellationToken);
-        }
-
-        private static async Task<MappedSpanResult?> GetMappedSpanAsync(
-            ISpanMappingService spanMappingService, Document generatedDocument, TextSpan textSpan, CancellationToken cancellationToken)
-        {
-            var results = await spanMappingService.MapSpansAsync(
-                generatedDocument, SpecializedCollections.SingletonEnumerable(textSpan), cancellationToken).ConfigureAwait(false);
-
-            if (!results.IsDefaultOrEmpty)
-            {
-                return results.First();
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// It is unclear why, but we are sometimes asked to navigate to a position that is not
-        /// inside the bounds of the associated <see cref="Document"/>. This method returns a
-        /// position that is guaranteed to be inside the <see cref="Document"/> bounds. If the
-        /// returned position is different from the given position, then the worst observable
-        /// behavior is either no navigation or navigation to the end of the document. See the
-        /// following bugs for more details:
-        ///     https://devdiv.visualstudio.com/DevDiv/_workitems?id=112211
-        ///     https://devdiv.visualstudio.com/DevDiv/_workitems?id=136895
-        ///     https://devdiv.visualstudio.com/DevDiv/_workitems?id=224318
-        ///     https://devdiv.visualstudio.com/DevDiv/_workitems?id=235409
-        /// </summary>
-        private static int GetPositionWithinDocumentBounds(int position, int documentLength)
-            => Math.Min(documentLength, Math.Max(position, 0));
-
-        private static VsTextSpan GetVsTextSpan(SourceText text, TextSpan textSpan, bool allowInvalidSpan)
-        {
-            var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
-            if (boundedTextSpan != textSpan && !allowInvalidSpan)
-            {
-                try
-                {
-                    throw new ArgumentOutOfRangeException();
-                }
-                catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
-                {
-                }
-            }
-
-            return text.GetVsTextSpanForSpan(boundedTextSpan);
-        }
-
-        /// <summary>
-        /// It is unclear why, but we are sometimes asked to navigate to a <see cref="TextSpan"/>
-        /// that is not inside the bounds of the associated <see cref="Document"/>. This method
-        /// returns a span that is guaranteed to be inside the <see cref="Document"/> bounds. If
-        /// the returned span is different from the given span, then the worst observable behavior
-        /// is either no navigation or navigation to the end of the document.
-        /// See https://github.com/dotnet/roslyn/issues/7660 for more details.
-        /// </summary>
-        private static TextSpan GetSpanWithinDocumentBounds(TextSpan span, int documentLength)
-            => TextSpan.FromBounds(GetPositionWithinDocumentBounds(span.Start, documentLength), GetPositionWithinDocumentBounds(span.End, documentLength));
-
-        public async Task<bool> NavigateToTextBufferAsync(
-            ITextBuffer textBuffer, VsTextSpan vsTextSpan, CancellationToken cancellationToken)
-        {
-            Contract.ThrowIfNull(textBuffer);
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            using (Logger.LogBlock(FunctionId.NavigationService_VSDocumentNavigationService_NavigateTo, cancellationToken))
-            {
-                var vsTextBuffer = _editorAdaptersFactoryService.GetBufferAdapter(textBuffer);
-                if (vsTextBuffer == null)
-                {
-                    Debug.Fail("Could not get IVsTextBuffer for document!");
-                    return false;
-                }
-
-                var textManager = (IVsTextManager2)_serviceProvider.GetService(typeof(SVsTextManager));
-                if (textManager == null)
-                {
-                    Debug.Fail("Could not get IVsTextManager service!");
-                    return false;
-                }
-
-                return ErrorHandler.Succeeded(
-                    textManager.NavigateToLineAndColumn2(
-                        vsTextBuffer,
-                        VSConstants.LOGVIEWID.TextView_guid,
-                        vsTextSpan.iStartLine,
-                        vsTextSpan.iStartIndex,
-                        vsTextSpan.iEndLine,
-                        vsTextSpan.iEndIndex,
-                        (uint)_VIEWFRAMETYPE.vftCodeWindow));
-            }
-        }
-
-        private static bool IsSecondaryBuffer(DocumentId documentId)
-            => ContainedDocument.TryGetContainedDocument(documentId) != null;
-
-        private async Task<bool> CanMapFromSecondaryBufferToPrimaryBufferAsync(
-            DocumentId documentId, VsTextSpan spanInSecondaryBuffer, CancellationToken cancellationToken)
-        {
-            var mapped = await spanInSecondaryBuffer.MapSpanFromSecondaryBufferToPrimaryBufferAsync(
-                _threadingContext, documentId, cancellationToken).ConfigureAwait(false);
-            return mapped != null;
-        }
-
-        private static IDisposable OpenNewDocumentStateScope(NavigationOptions options)
-        {
-            var state = options.PreferProvisionalTab
-                ? __VSNEWDOCUMENTSTATE.NDS_Provisional
-                : __VSNEWDOCUMENTSTATE.NDS_Permanent;
-
-            if (!options.ActivateTab)
-            {
-                state |= __VSNEWDOCUMENTSTATE.NDS_NoActivate;
-            }
-
-            return new NewDocumentStateScope(state, VSConstants.NewDocumentStateReason.Navigation);
-        }
+        return new NewDocumentStateScope(state, VSConstants.NewDocumentStateReason.Navigation);
     }
 }

--- a/src/VisualStudio/LiveShare/Test/AbstractLiveShareRequestHandlerTests.cs
+++ b/src/VisualStudio/LiveShare/Test/AbstractLiveShareRequestHandlerTests.cs
@@ -17,67 +17,63 @@ using Newtonsoft.Json.Linq;
 using Roslyn.Test.Utilities;
 using Xunit.Abstractions;
 
-namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests;
+
+public abstract class AbstractLiveShareRequestHandlerTests(ITestOutputHelper testOutputHelper)
+    : AbstractLanguageServerProtocolTests(testOutputHelper)
 {
-    public abstract class AbstractLiveShareRequestHandlerTests : AbstractLanguageServerProtocolTests
+    private static readonly TestComposition s_composition = LiveShareTestCompositions.Features
+        .AddParts(typeof(MockDocumentNavigationService))
+        .AddParts(typeof(TestWorkspaceRegistrationService))
+        .AddParts(typeof(TestWorkspaceConfigurationService));
+
+    private class MockHostProtocolConverter : IHostProtocolConverter
     {
-        private static readonly TestComposition s_composition = LiveShareTestCompositions.Features
-            .AddParts(typeof(MockDocumentNavigationServiceFactory))
-            .AddParts(typeof(TestWorkspaceRegistrationService))
-            .AddParts(typeof(TestWorkspaceConfigurationService));
+        private readonly Func<Uri, Uri> _uriConversionFunction;
 
-        protected AbstractLiveShareRequestHandlerTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        public MockHostProtocolConverter() => _uriConversionFunction = uri => uri;
+
+        public MockHostProtocolConverter(Func<Uri, Uri> uriConversionFunction) => _uriConversionFunction = uriConversionFunction;
+
+        public Uri FromProtocolUri(Uri uri) => _uriConversionFunction(uri);
+
+        public bool IsContainedInRootFolders(Uri uriToCheck) => true;
+
+        public bool IsKnownWorkspaceFile(Uri uriToCheck) => throw new NotImplementedException();
+
+        public Task RegisterExternalFilesAsync(Uri[] filePaths) => Task.CompletedTask;
+
+        public Uri ToProtocolUri(Uri uri) => uri;
+
+        public bool TryGetExternalUris(string exernalUri, out Uri uri) => throw new NotImplementedException();
+    }
+
+    protected override TestComposition Composition => s_composition;
+
+    protected static async Task<ResponseType> TestHandleAsync<RequestType, ResponseType>(Solution solution, RequestType request, string methodName)
+    {
+        var requestContext = new RequestContext<Solution>(solution, new MockHostProtocolConverter(), JObject.FromObject(new ClientCapabilities()));
+        return await GetHandler<RequestType, ResponseType>(solution, methodName).HandleAsync(request, requestContext, CancellationToken.None);
+    }
+
+    protected static async Task<ResponseType> TestHandleAsync<RequestType, ResponseType>(Solution solution, RequestType request, string methodName, Func<Uri, Uri> uriMappingFunc)
+    {
+        var requestContext = new RequestContext<Solution>(solution, new MockHostProtocolConverter(uriMappingFunc), JObject.FromObject(new ClientCapabilities()));
+        return await GetHandler<RequestType, ResponseType>(solution, methodName).HandleAsync(request, requestContext, CancellationToken.None);
+    }
+
+    protected static ILspRequestHandler<RequestType, ResponseType, Solution> GetHandler<RequestType, ResponseType>(Solution solution, string methodName)
+    {
+        var workspace = (TestWorkspace)solution.Workspace;
+        var handlers = workspace.ExportProvider.GetExportedValues<ILspRequestHandler>(LiveShareConstants.RoslynContractName);
+        return (ILspRequestHandler<RequestType, ResponseType, Solution>)handlers.Single(handler => handler is ILspRequestHandler<RequestType, ResponseType, Solution> && IsMatchingMethod(handler, methodName));
+
+        // Since request handlers can have the same input and output types (especially with object), we need to also
+        // check that the LSP method the handler is exported for matches the one we're requesting.
+        static bool IsMatchingMethod(ILspRequestHandler handler, string methodName)
         {
-        }
-
-        private class MockHostProtocolConverter : IHostProtocolConverter
-        {
-            private readonly Func<Uri, Uri> _uriConversionFunction;
-
-            public MockHostProtocolConverter() => _uriConversionFunction = uri => uri;
-
-            public MockHostProtocolConverter(Func<Uri, Uri> uriConversionFunction) => _uriConversionFunction = uriConversionFunction;
-
-            public Uri FromProtocolUri(Uri uri) => _uriConversionFunction(uri);
-
-            public bool IsContainedInRootFolders(Uri uriToCheck) => true;
-
-            public bool IsKnownWorkspaceFile(Uri uriToCheck) => throw new NotImplementedException();
-
-            public Task RegisterExternalFilesAsync(Uri[] filePaths) => Task.CompletedTask;
-
-            public Uri ToProtocolUri(Uri uri) => uri;
-
-            public bool TryGetExternalUris(string exernalUri, out Uri uri) => throw new NotImplementedException();
-        }
-
-        protected override TestComposition Composition => s_composition;
-
-        protected static async Task<ResponseType> TestHandleAsync<RequestType, ResponseType>(Solution solution, RequestType request, string methodName)
-        {
-            var requestContext = new RequestContext<Solution>(solution, new MockHostProtocolConverter(), JObject.FromObject(new ClientCapabilities()));
-            return await GetHandler<RequestType, ResponseType>(solution, methodName).HandleAsync(request, requestContext, CancellationToken.None);
-        }
-
-        protected static async Task<ResponseType> TestHandleAsync<RequestType, ResponseType>(Solution solution, RequestType request, string methodName, Func<Uri, Uri> uriMappingFunc)
-        {
-            var requestContext = new RequestContext<Solution>(solution, new MockHostProtocolConverter(uriMappingFunc), JObject.FromObject(new ClientCapabilities()));
-            return await GetHandler<RequestType, ResponseType>(solution, methodName).HandleAsync(request, requestContext, CancellationToken.None);
-        }
-
-        protected static ILspRequestHandler<RequestType, ResponseType, Solution> GetHandler<RequestType, ResponseType>(Solution solution, string methodName)
-        {
-            var workspace = (TestWorkspace)solution.Workspace;
-            var handlers = workspace.ExportProvider.GetExportedValues<ILspRequestHandler>(LiveShareConstants.RoslynContractName);
-            return (ILspRequestHandler<RequestType, ResponseType, Solution>)handlers.Single(handler => handler is ILspRequestHandler<RequestType, ResponseType, Solution> && IsMatchingMethod(handler, methodName));
-
-            // Since request handlers can have the same input and output types (especially with object), we need to also
-            // check that the LSP method the handler is exported for matches the one we're requesting.
-            static bool IsMatchingMethod(ILspRequestHandler handler, string methodName)
-            {
-                var attribute = (ExportLspRequestHandlerAttribute)Attribute.GetCustomAttribute(handler.GetType(), typeof(ExportLspRequestHandlerAttribute));
-                return attribute?.MethodName == methodName;
-            }
+            var attribute = (ExportLspRequestHandlerAttribute)Attribute.GetCustomAttribute(handler.GetType(), typeof(ExportLspRequestHandlerAttribute));
+            return attribute?.MethodName == methodName;
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
+++ b/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
@@ -7,7 +7,6 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Text;
@@ -17,26 +16,20 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests;
 
 using Workspace = CodeAnalysis.Workspace;
 
-[ExportWorkspaceServiceFactory(typeof(IDocumentNavigationService), ServiceLayer.Test), Shared, PartNotDiscoverable]
+[ExportWorkspaceService(typeof(IDocumentNavigationService), ServiceLayer.Test), Shared, PartNotDiscoverable]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class MockDocumentNavigationServiceFactory() : IWorkspaceServiceFactory
+internal sealed class MockDocumentNavigationService() : IDocumentNavigationService
 {
-    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-    {
-        return new MockDocumentNavigationService();
-    }
+    public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+        => SpecializedTasks.True;
 
-    private class MockDocumentNavigationService : IDocumentNavigationService
-    {
-        public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken) => SpecializedTasks.True;
+    public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        => SpecializedTasks.True;
 
-        public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken) => SpecializedTasks.True;
+    public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+        => NavigableLocation.TestAccessor.Create(true);
 
-        public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
-            => NavigableLocation.TestAccessor.Create(true);
-
-        public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
-            => NavigableLocation.TestAccessor.Create(true);
-    }
+    public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        => NavigableLocation.TestAccessor.Create(true);
 }

--- a/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
+++ b/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
@@ -13,40 +13,30 @@ using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests;
+
+using Workspace = CodeAnalysis.Workspace;
+
+[ExportWorkspaceServiceFactory(typeof(IDocumentNavigationService), ServiceLayer.Test), Shared, PartNotDiscoverable]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class MockDocumentNavigationServiceFactory() : IWorkspaceServiceFactory
 {
-    using Workspace = CodeAnalysis.Workspace;
-
-    [ExportWorkspaceServiceFactory(typeof(IDocumentNavigationService), ServiceLayer.Test), Shared, PartNotDiscoverable]
-    internal class MockDocumentNavigationServiceFactory : IWorkspaceServiceFactory
+    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
     {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public MockDocumentNavigationServiceFactory()
-        {
-        }
+        return new MockDocumentNavigationService();
+    }
 
-        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        {
-            return new MockDocumentNavigationService();
-        }
+    private class MockDocumentNavigationService : IDocumentNavigationService
+    {
+        public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken) => SpecializedTasks.True;
 
-        private class MockDocumentNavigationService : IDocumentNavigationService
-        {
-            public Task<bool> CanNavigateToLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken) => SpecializedTasks.True;
+        public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken) => SpecializedTasks.True;
 
-            public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken) => SpecializedTasks.True;
+        public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+            => NavigableLocation.TestAccessor.Create(true);
 
-            public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken) => SpecializedTasks.True;
-
-            public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-                => NavigableLocation.TestAccessor.Create(true);
-
-            public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
-                => NavigableLocation.TestAccessor.Create(true);
-
-            public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
-                => NavigableLocation.TestAccessor.Create(true);
-        }
+        public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+            => NavigableLocation.TestAccessor.Create(true);
     }
 }


### PR DESCRIPTION
Roslyn apis want to do everything with spans/positions.

Components that do need to interface with external systems that are line/offset based now call through an appropriate helper to map between the disparate systems.