### PR TITLE
Ensure both parts of partial methods are analyzed when requesting analyzer diagnostics for a single file

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver;
@@ -1083,7 +1084,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             break;
 
                         case SymbolDeclaredCompilationEvent symbolDeclaredCompilationEvent:
-                            if (!symbolDeclaredCompilationEvent.SymbolInternal.IsDefinedInSourceTree(tree, definedWithinSpan: null, cancellationToken))
+                            if (!shouldIncludeSymbol(symbolDeclaredCompilationEvent.SymbolInternal, tree, cancellationToken))
                                 continue;
 
                             break;
@@ -1101,6 +1102,24 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 return builder.ToImmutableAndFree();
+
+                static bool shouldIncludeSymbol(ISymbolInternal symbol, SyntaxTree tree, CancellationToken cancellationToken)
+                {
+                    if (symbol.IsDefinedInSourceTree(tree, definedWithinSpan: null, cancellationToken))
+                        return true;
+
+                    // Always include both parts of partial in analysis if any one part is defined in the tree.
+                    if (symbol is IMethodSymbolInternal methodSymbol)
+                    {
+                        if (methodSymbol.PartialDefinitionPart?.IsDefinedInSourceTree(tree, definedWithinSpan: null, cancellationToken) == true
+                            || methodSymbol.PartialImplementationPart?.IsDefinedInSourceTree(tree, definedWithinSpan: null, cancellationToken) == true)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #71149

This is a bug in the core analyzer driver that only happens when we have a partial implementation part of a partial method in a separate file (doesn't matter if it is a regular file or a generated file), and this partial type definition has no other members defined. First commit in this PR: https://github.com/dotnet/roslyn/commit/65ca1555c5b80b23497736dff5eecd4e59ec61c2 shows the unit test that fails when `separateFiles = true` without the fix.

The fix is to ensure we analyze both parts of partial when requesting analyzer diagnostics for a single file (happens for open file analysis for IDE live analysis)