### PR TITLE
Generate protected constructors in abstract types

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConstructorSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConstructorSnippetCompletionProviderTests.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -96,9 +92,71 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 """
                 abstract class MyClass
                 {
-                    public MyClass()
+                    protected MyClass()
                     {
                         $$
+                    }
+                }
+                """;
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task InsertConstructorSnippetInAbstractClassTest_AbstractModifierInOtherPartialDeclaration()
+        {
+            var markupBeforeCommit =
+                """
+                partial class MyClass
+                {
+                    $$
+                }
+
+                abstract partial class MyClass
+                {
+                }
+                """;
+
+            var expectedCodeAfterCommit =
+                """
+                partial class MyClass
+                {
+                    protected MyClass()
+                    {
+                        $$
+                    }
+                }
+                
+                abstract partial class MyClass
+                {
+                }
+                """;
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task InsertConstructorSnippetInNestedAbstractClassTest()
+        {
+            var markupBeforeCommit =
+                """
+                class MyClass
+                {
+                    abstract class NestedClass
+                    {
+                        $$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit =
+                """
+                class MyClass
+                {
+                    abstract class NestedClass
+                    {
+                        protected NestedClass()
+                        {
+                            $$
+                        }
                     }
                 }
                 """;

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConstructorSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConstructorSnippetProvider.cs
@@ -34,9 +34,12 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
             var nodeAtPosition = root.FindNode(TextSpan.FromBounds(position, position));
             var containingType = nodeAtPosition.FirstAncestorOrSelf<SyntaxNode>(syntaxFacts.IsTypeDeclaration);
             Contract.ThrowIfNull(containingType);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var containingTypeSymbol = semanticModel.GetDeclaredSymbol(containingType, cancellationToken);
+            Contract.ThrowIfNull(containingTypeSymbol);
             var constructorDeclaration = generator.ConstructorDeclaration(
                 containingTypeName: syntaxFacts.GetIdentifierOfTypeDeclaration(containingType).ToString(),
-                accessibility: Accessibility.Public);
+                accessibility: containingTypeSymbol.IsAbstract ? Accessibility.Protected : Accessibility.Public);
             return new TextChange(TextSpan.FromBounds(position, position), constructorDeclaration.NormalizeWhitespace().ToFullString());
         }
     }


### PR DESCRIPTION
It is generally a good practice to make constructors inside `abstract` classes `protected`. I am 100% sure some roslyn codefixes/refactorings follow this rule, I just don't remember which exactly. Moreover, some 3d party analyzers explicitely suggest to change accessibility level of constructors inside `abstract` types from `public` to `protected` as well. Thus, I think, it makes sence to follow this rule in constructor semantic snippet, especially considering that it was just several lines to add to support it.