### PR TITLE
Don't consider `::` as format specifier in string interpolation

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -1033,11 +1033,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 goto default;
                             }
                         case ':':
-                            if (_lexer.TextWindow.PeekChar(1) == ':' || _lexer.TextWindow.PeekChar(-1) == ':')
+                            // If we have two consecutive colons, it's not a format specifier. It might be
+                            // alias qualified name, e.g, global::Something
+                            // In this case, we advance two characters.
+                            if (_lexer.TextWindow.PeekChar(1) == ':')
                             {
-                                goto default;
+                                _lexer.TextWindow.AdvanceChar();
+                                _lexer.TextWindow.AdvanceChar();
+                                continue;
                             }
 
+                            // the first colon not nested within matching delimiters is the start of the format string
                             if (isHole)
                             {
                                 Debug.Assert(colonRange.Equals(default(Range)));

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -1032,7 +1032,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                                 goto default;
                             }
-                        case ':':
+                        case ':' when _lexer.TextWindow.PeekChar(1) != ':':
                             // the first colon not nested within matching delimiters is the start of the format string
                             if (isHole)
                             {

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -1032,8 +1032,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                                 goto default;
                             }
-                        case ':' when _lexer.TextWindow.PeekChar(1) != ':':
-                            // the first colon not nested within matching delimiters is the start of the format string
+                        case ':':
+                            if (_lexer.TextWindow.PeekChar(1) == ':' || _lexer.TextWindow.PeekChar(-1) == ':')
+                            {
+                                goto default;
+                            }
+
                             if (isHole)
                             {
                                 Debug.Assert(colonRange.Equals(default(Range)));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -18243,5 +18243,18 @@ class C
                 //     public A(int x, A a = M($"{1}")) { }
                 Diagnostic(ErrorCode.ERR_BadArgRef, @"$""{1}""").WithArguments("1", "ref").WithLocation(8, 29));
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71203")]
+        public void TestAliasQualifiedNameShouldCompile()
+        {
+            var source =
+                """
+                using System;
+                Console.WriteLine($"Test: {global::System.Globalization.CultureInfo.CurrentCulture}");
+                """;
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp);
+
+            compilation.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Fixes #71203