### PR TITLE
Enable skipped tests (rename and extract methods)

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpExtractMethod.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpExtractMethod.cs
@@ -126,7 +126,7 @@ public class Program
     }", cancellationToken: HangMitigatingCancellationToken);
         }
 
-        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/71088")]
+        [IdeFact]
         public async Task ExtractViaCodeAction()
         {
             await TestServices.Editor.SetTextAsync(TestSource, HangMitigatingCancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpRename.cs
@@ -644,7 +644,7 @@ class p$$rogram
 }", HangMitigatingCancellationToken);
         }
 
-        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/71088")]
+        [IdeFact]
         public async Task VerifyTextSync()
         {
             var globalOptions = await TestServices.Shell.GetComponentModelServiceAsync<IGlobalOptionService>(HangMitigatingCancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicExtractMethod.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicExtractMethod.cs
@@ -91,7 +91,7 @@ End Module";
     End Sub", cancellationToken: HangMitigatingCancellationToken);
         }
 
-        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/71088")]
+        [IdeFact]
         public async Task ExtractViaCodeAction()
         {
             await TestServices.Editor.SetTextAsync(TestSource, HangMitigatingCancellationToken);


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/71088

Verified in https://dev.azure.com/dnceng-public/public/_build/results?buildId=496117&view=results

The real fix load should be https://github.com/dotnet/roslyn/pull/71132