### PR TITLE
Collection expressions: method type re-inference

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -568,7 +568,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (collectionTypeKind == CollectionExpressionTypeKind.None)
             {
-                return BindCollectionExpressionForErrorRecovery(node, targetType, diagnostics);
+                Debug.Assert(conversion.Kind is ConversionKind.NoConversion);
+                return BindCollectionExpressionForErrorRecovery(node, targetType, inConversion: false, diagnostics);
             }
 
             var syntax = (ExpressionSyntax)node.Syntax;
@@ -613,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (collectionBuilderMethod is null)
                         {
                             diagnostics.Add(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, syntax, methodName ?? "", elementTypeOriginalDefinition, targetTypeOriginalDefinition);
-                            return BindCollectionExpressionForErrorRecovery(node, targetType, diagnostics);
+                            return BindCollectionExpressionForErrorRecovery(node, targetType, inConversion: true, diagnostics);
                         }
 
                         Debug.Assert(collectionBuilderReturnTypeConversion.Exists);
@@ -641,7 +642,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (targetType.OriginalDefinition.Equals(Compilation.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T), TypeCompareKind.ConsiderEverything))
                     {
                         diagnostics.Add(ErrorCode.ERR_CollectionExpressionImmutableArray, syntax, targetType.OriginalDefinition);
-                        return BindCollectionExpressionForErrorRecovery(node, targetType, diagnostics);
+                        return BindCollectionExpressionForErrorRecovery(node, targetType, inConversion: true, diagnostics);
                     }
                     break;
             }
@@ -737,6 +738,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionBuilderMethod,
                 collectionBuilderInvocationPlaceholder,
                 collectionBuilderInvocationConversion,
+                wasTargetTyped: true,
                 builder.ToImmutableAndFree(),
                 targetType);
 
@@ -794,6 +796,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundCollectionExpression BindCollectionExpressionForErrorRecovery(
             BoundUnconvertedCollectionExpression node,
             TypeSymbol targetType,
+            bool inConversion,
             BindingDiagnosticBag diagnostics)
         {
             var syntax = node.Syntax;
@@ -813,6 +816,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionBuilderMethod: null,
                 collectionBuilderInvocationPlaceholder: null,
                 collectionBuilderInvocationConversion: null,
+                wasTargetTyped: inConversion,
                 elements: builder.ToImmutableAndFree(),
                 targetType,
                 hasErrors: true);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             diagnostics.Add(ErrorCode.ERR_CollectionExpressionNoTargetType, expr.Syntax.GetLocation());
                         }
-                        result = BindCollectionExpressionForErrorRecovery(expr, CreateErrorType(), diagnostics);
+                        result = BindCollectionExpressionForErrorRecovery(expr, CreateErrorType(), inConversion: false, diagnostics);
                     }
                     break;
                 default:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1900,6 +1900,8 @@
     <Field Name="CollectionBuilderInvocationPlaceholder" Type="BoundValuePlaceholder?" SkipInVisitor="true" Null="allow"/>
     <!-- Conversion from collection builder method invocation to collection type. -->
     <Field Name="CollectionBuilderInvocationConversion" Type="BoundExpression?" SkipInVisitor="true" Null="allow"/>
+    <!-- Indicates whether the collection expression was successfully target-typed (it is inside a conversion) -->
+    <Field Name="WasTargetTyped" Type="bool" />
   </Node>
 
   <Node Name="BoundCollectionExpressionSpreadExpressionPlaceholder" Base="BoundValuePlaceholderBase"/>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -147,12 +147,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(!StateForLambda.HasValue);
                     return new VisitResult(RValueType, lvalueType, NestedVisitResults);
                 }
-                else if (StateForLambda.HasValue)
-                {
-                    return new VisitResult(RValueType, lvalueType, StateForLambda);
-                }
 
-                return new VisitResult(RValueType, lvalueType);
+                return new VisitResult(RValueType, lvalueType, StateForLambda);
             }
 
             internal string GetDebuggerDisplay()

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -154,6 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return new VisitResult(RValueType, lvalueType);
             }
+
             internal string GetDebuggerDisplay()
             {
                 if (NestedVisitResults is null)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6592,20 +6592,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             if (IsTargetTypedExpression(argumentNoConversion) && _targetTypedAnalysisCompletionOpt?.TryGetValue(argumentNoConversion, out var completion) is true)
                             {
-                                if (method is ErrorMethodSymbol)
-                                {
-                                    // The parameter matching logic above is not as flexible as the one we use in `Binder.BuildArgumentsForErrorRecovery`
-                                    // so we may end up with a pending conversion completion for an argument apparently without a corresponding parameter.
-                                    // We flush the completion with a plausible/dummy type and remove it.
-                                    completion(TypeWithAnnotations.Create(argument.Type));
-                                    TargetTypedAnalysisCompletion.Remove(argumentNoConversion);
-                                }
-                                else
-                                {
-                                    // We've done something wrong if we have a target-typed expression and registered an analysis continuation for it
-                                    // (we won't be able to complete that continuation)
-                                    Debug.Assert(false);
-                                }
+                                // We've done something wrong if we have a target-typed expression and registered an analysis continuation for it
+                                // (we won't be able to complete that continuation)
+                                // We flush the completion with a plausible/dummy type and remove it.
+                                completion(TypeWithAnnotations.Create(argument.Type));
+                                TargetTypedAnalysisCompletion.Remove(argumentNoConversion);
+
+                                // This is known to happen for certain error scenarios, because
+                                // the parameter matching logic above is not as flexible as the one we use in `Binder.BuildArgumentsForErrorRecovery`
+                                // so we may end up with a pending conversion completion for an argument apparently without a corresponding parameter.
+                                Debug.Assert(method is ErrorMethodSymbol);
                             }
                             continue;
                         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -99,6 +99,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             public readonly TypeWithState RValueType;
             public readonly TypeWithAnnotations LValueType;
 
+            // For lambda expressions, we save the state when the lambda is analyzed,
+            // so we can use it when analyzing the lambda body as part of a delegate conversion.
+            public readonly Optional<LocalState> StateForLambda;
+
+            // For expressions that contain nested expressions (such as collection expressions),
+            // we store the results of visiting those nested expressions.
+            // Note: we cannot use ImmutableArray<VisitResult> because that yields a TypeLoad exception on .NET Framework.
+            public readonly VisitResult[]? NestedVisitResults;
+
             public VisitResult(TypeWithState rValueType, TypeWithAnnotations lValueType)
             {
                 RValueType = rValueType;
@@ -108,6 +117,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 //             RValueType.Type.Equals(LValueType.TypeSymbol, TypeCompareKind.ConsiderEverything | TypeCompareKind.AllIgnoreOptions));
             }
 
+            public VisitResult(TypeWithState rValueType, TypeWithAnnotations lValueType, Optional<LocalState> stateForLambda)
+                : this(rValueType, lValueType)
+            {
+                StateForLambda = stateForLambda;
+            }
+
             public VisitResult(TypeSymbol? type, NullableAnnotation annotation, NullableFlowState state)
             {
                 RValueType = TypeWithState.Create(type, state);
@@ -115,27 +130,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(TypeSymbol.Equals(RValueType.Type, LValueType.Type, TypeCompareKind.ConsiderEverything));
             }
 
-            internal string GetDebuggerDisplay() => $"{{LValue: {LValueType.GetDebuggerDisplay()}, RValue: {RValueType.GetDebuggerDisplay()}}}";
-        }
-
-        /// <summary>
-        /// Represents the result of visiting an argument expression.
-        /// In addition to storing the <see cref="VisitResult"/>, also stores the <see cref="LocalState"/>
-        /// for reanalyzing a lambda.
-        /// </summary>
-        [DebuggerDisplay("{VisitResult.GetDebuggerDisplay(), nq}")]
-        private readonly struct VisitArgumentResult
-        {
-            public readonly VisitResult VisitResult;
-            public readonly Optional<LocalState> StateForLambda;
-
-            public TypeWithState RValueType => VisitResult.RValueType;
-            public TypeWithAnnotations LValueType => VisitResult.LValueType;
-
-            public VisitArgumentResult(VisitResult visitResult, Optional<LocalState> stateForLambda)
+            /// <summary>
+            /// For expressions whose constituent parts contribute to method type inference (such as collection expressions),
+            /// we need to keep track of the visit results for those parts.
+            /// </summary>
+            public VisitResult(TypeWithState rValueType, TypeWithAnnotations lValueType, VisitResult[] nestedVisitResults)
+                : this(rValueType, lValueType)
             {
-                VisitResult = visitResult;
-                StateForLambda = stateForLambda;
+                NestedVisitResults = nestedVisitResults;
+            }
+
+            internal string GetDebuggerDisplay()
+            {
+                if (NestedVisitResults is null)
+                {
+                    return $"{{LValue: {LValueType.GetDebuggerDisplay()}, RValue: {RValueType.GetDebuggerDisplay()}}}";
+                }
+
+                return $$"""Collection: {{string.Join(", ", NestedVisitResults.Select(r => r.GetDebuggerDisplay()))}}""";
             }
         }
 
@@ -285,7 +297,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private void UseRvalueOnly(BoundExpression? expression)
         {
-            SetResult(expression, ResultType, ResultType.ToTypeWithAnnotations(compilation), isLvalue: false);
+            if (_visitResult.NestedVisitResults is null && !_visitResult.StateForLambda.HasValue)
+            {
+                SetResult(expression, ResultType, ResultType.ToTypeWithAnnotations(compilation), isLvalue: false);
+            }
         }
 
         private TypeWithAnnotations LvalueResultType
@@ -310,7 +325,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void SetResult(BoundExpression? expression, TypeWithState resultType, TypeWithAnnotations lvalueType, bool updateAnalyzedNullability = true, bool? isLvalue = null)
         {
-            _visitResult = new VisitResult(resultType, lvalueType);
+            SetResult(expression, new VisitResult(resultType, lvalueType), updateAnalyzedNullability, isLvalue);
+        }
+
+        private void SetResult(BoundExpression? expression, VisitResult visitResult, bool updateAnalyzedNullability, bool? isLvalue)
+        {
+            _visitResult = visitResult;
             if (updateAnalyzedNullability)
             {
                 SetAnalyzedNullability(expression, _visitResult, isLvalue);
@@ -321,8 +341,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             SetAnalyzedNullability(expression, new VisitResult(resultType, lvalueType), isLvalue);
         }
-
-        private bool ShouldMakeNotNullRvalue(BoundExpression node) => node.IsSuppressed || node.HasAnyErrors || !IsReachable();
 
         /// <summary>
         /// Sets the analyzed nullability of the expression to be the given result.
@@ -3359,11 +3377,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(AreCloseEnough(resultType.Type, node.Type));
 #endif
 
-            if (ShouldMakeNotNullRvalue(node))
+            if (shouldMakeNotNullRvalue(node) && _visitResult.NestedVisitResults is null && !_visitResult.StateForLambda.HasValue)
             {
                 var result = resultType.WithNotNullState();
                 SetResult(node, result, LvalueResultType);
             }
+            return;
+
+            bool shouldMakeNotNullRvalue(BoundExpression node) => node.IsSuppressed || node.HasAnyErrors || !IsReachable();
         }
 
 #if DEBUG
@@ -3472,68 +3493,125 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
         {
-            // https://github.com/dotnet/roslyn/issues/68786: Use inferInitialObjectState() to set the initial
-            // state of the instance: see the call to InheritNullableStateOfTrackableStruct() in particular.
-            int containerSlot = GetOrCreatePlaceholderSlot(node);
-            NullableFlowState resultState = NullableFlowState.NotNull;
+            // When the collection is target-typed, we can initially only visit the elements and update the state.
+            // When the target-typing conversion is processed, the completion continuation will be given a target-type and
+            // we'll be able to process the element conversions and compute the final visit result.
 
-            var collectionKind = ConversionsBase.GetCollectionExpressionTypeKind(this.compilation, node.Type, out var targetElementType);
-            if (collectionKind is CollectionExpressionTypeKind.CollectionBuilder)
-            {
-                var createMethod = node.CollectionBuilderMethod;
-                if (createMethod is not null)
-                {
-                    var readOnlySpan = (NamedTypeSymbol)createMethod.Parameters[0].Type;
-                    targetElementType = readOnlySpan.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
-                    var annotations = createMethod.GetFlowAnalysisAnnotations();
-                    resultState = ApplyUnconditionalAnnotations(createMethod.ReturnTypeWithAnnotations, annotations).ToTypeWithState().State;
-                }
-            }
+            var (collectionKind, elementType) = getCollectionDetails(node, node.Type);
 
+            var resultBuilder = ArrayBuilder<VisitResult>.GetInstance(node.Elements.Length);
+            var elementConversionCompletions = ArrayBuilder<Func<TypeWithAnnotations, TypeWithState>>.GetInstance();
             foreach (var element in node.Elements)
             {
                 switch (element)
                 {
                     case BoundCollectionElementInitializer initializer:
+                        // We don't visit the Add methods
+                        // But we should check conversion to the iteration type (for that we need to have identified the preferred IEnumerable<T> interface)
+                        // Tracked by https://github.com/dotnet/roslyn/issues/68786
+                        SetUnknownResultNullability(initializer);
                         Debug.Assert(node.Placeholder is { });
-                        var completion = VisitCollectionElementInitializer(
-                            initializer,
-                            containingType: node.Placeholder.Type,
-                            delayCompletionForType: false /* All collection expressions are target-typed */);
-
-                        Debug.Assert(completion is null);
+                        SetUnknownResultNullability(node.Placeholder);
+                        Visit(initializer.Arguments[0]);
                         break;
                     case BoundCollectionExpressionSpreadElement spread:
                         // https://github.com/dotnet/roslyn/issues/68786: We should check the spread
                         Visit(spread);
                         break;
                     default:
-                        _ = VisitOptionalImplicitConversion((BoundExpression)element, targetElementType, useLegacyWarnings: false, trackMembers: false, AssignmentKind.Assignment);
+                        var elementExpr = (BoundExpression)element;
+                        if (!elementType.HasType)
+                        {
+                            VisitRvalueWithState(elementExpr);
+                        }
+                        else
+                        {
+                            var completion = VisitOptionalImplicitConversion(elementExpr, elementType,
+                                useLegacyWarnings: false, trackMembers: false, AssignmentKind.Assignment, delayCompletionForTargetType: true).completion;
 
+                            Debug.Assert(completion is not null);
+                            elementConversionCompletions.Add(completion);
+                        }
                         break;
                 }
+
+                resultBuilder.Add(_visitResult);
             }
 
-            SetResultType(node, TypeWithState.Create(node.Type, resultState));
-            return null;
-        }
-
-        public override BoundNode? VisitUnconvertedCollectionExpression(BoundUnconvertedCollectionExpression node)
-        {
-            foreach (var element in node.Elements)
+            if (node.WasTargetTyped)
             {
-                if (element is BoundExpression expression)
-                {
-                    VisitRvalue(expression);
-                }
-                else
-                {
-                    Visit(element);
-                }
+                // We're in the context of a conversion, so the analysis of element conversions and the final visit result
+                // will be completed later (when that conversion is processed).
+                TargetTypedAnalysisCompletion[node] =
+                    (TypeWithAnnotations resultTypeWithAnnotations) => convertCollection(node, resultTypeWithAnnotations, elementConversionCompletions);
+            }
+            else
+            {
+                // We're not in the context of a conversion, so don't expect any target-type information to be provided later,
+                // so we're done. For example, `[1, 2].ToString()`.
+                elementConversionCompletions.Free();
             }
 
-            SetResultType(node, TypeWithState.Create(node.Type, NullableFlowState.NotNull));
+            var resultType = TypeWithAnnotations.Create(node.Type);
+            var visitResult = new VisitResult(TypeWithState.Create(resultType), resultType,
+                nestedVisitResults: resultBuilder.ToArrayAndFree());
+
+            SetResult(node, visitResult, updateAnalyzedNullability: !node.WasTargetTyped, isLvalue: false);
             return null;
+
+            TypeWithState convertCollection(BoundCollectionExpression node, TypeWithAnnotations targetCollectionType, ArrayBuilder<Func<TypeWithAnnotations, TypeWithState>> completions)
+            {
+                var strippedTargetCollectionType = targetCollectionType.Type.StrippedType();
+                Debug.Assert(TypeSymbol.Equals(strippedTargetCollectionType, node.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
+
+                // https://github.com/dotnet/roslyn/issues/68786: Use inferInitialObjectState() to set the initial
+                // state of the instance: see the call to InheritNullableStateOfTrackableStruct() in particular.
+
+                // Process the element conversions now that we have the target-type
+                var (collectionKind, targetElementType) = getCollectionDetails(node, strippedTargetCollectionType);
+                foreach (var completion in completions)
+                {
+                    _ = completion(targetElementType);
+                }
+                completions.Free();
+
+                // Record the final state
+                NullableFlowState resultState = getResultState(node, collectionKind);
+                var resultTypeWithState = TypeWithState.Create(node.Type, resultState);
+                SetAnalyzedNullability(node, resultTypeWithState);
+                return resultTypeWithState;
+            }
+
+            NullableFlowState getResultState(BoundCollectionExpression node, CollectionExpressionTypeKind collectionKind)
+            {
+                if (collectionKind is CollectionExpressionTypeKind.CollectionBuilder)
+                {
+                    var createMethod = node.CollectionBuilderMethod;
+                    if (createMethod is not null)
+                    {
+                        var annotations = createMethod.GetFlowAnalysisAnnotations();
+                        return ApplyUnconditionalAnnotations(createMethod.ReturnTypeWithAnnotations, annotations).ToTypeWithState().State;
+                    }
+                }
+
+                return NullableFlowState.NotNull;
+            }
+
+            (CollectionExpressionTypeKind, TypeWithAnnotations) getCollectionDetails(BoundCollectionExpression node, TypeSymbol collectionType)
+            {
+                var collectionKind = ConversionsBase.GetCollectionExpressionTypeKind(this.compilation, collectionType, out var targetElementType);
+                if (collectionKind is CollectionExpressionTypeKind.CollectionBuilder)
+                {
+                    var createMethod = node.CollectionBuilderMethod;
+                    if (createMethod is not null)
+                    {
+                        var foundIterationType = _binder.TryGetCollectionIterationType((ExpressionSyntax)node.Syntax, collectionType, out targetElementType);
+                        Debug.Assert(foundIterationType);
+                    }
+                }
+
+                return (collectionKind, targetElementType);
+            }
         }
 
         private void VisitObjectCreationExpressionBase(BoundObjectCreationExpressionBase node)
@@ -3543,7 +3621,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol? constructor = getConstructor(node, node.Type);
             var arguments = node.Arguments;
 
-            (_, ImmutableArray<VisitArgumentResult> argumentResults, _, ArgumentsCompletionDelegate? argumentsCompletion) =
+            (_, ImmutableArray<VisitResult> argumentResults, _, ArgumentsCompletionDelegate? argumentsCompletion) =
                 VisitArguments(
                            node, arguments, node.ArgumentRefKindsOpt, constructor?.Parameters ?? default,
                            node.ArgsToParamsOpt, node.DefaultArguments, node.Expanded, invokedAsExtensionMethod: false,
@@ -3567,7 +3645,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeWithState setAnalyzedNullability(
                 BoundObjectCreationExpressionBase node,
                 TypeSymbol? type,
-                ImmutableArray<VisitArgumentResult> argumentResults,
+                ImmutableArray<VisitResult> argumentResults,
                 ArgumentsCompletionDelegate? argumentsCompletion,
                 Func<TypeSymbol, MethodSymbol?, int>? initialStateInferenceCompletion,
                 Action<int, TypeSymbol>? initializerCompletion,
@@ -3596,7 +3674,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             void setAnalyzedNullabilityAsContinuation(
                 BoundObjectCreationExpressionBase node,
-                ImmutableArray<VisitArgumentResult> argumentResults,
+                ImmutableArray<VisitResult> argumentResults,
                 ArgumentsCompletionDelegate argumentsCompletion,
                 Func<TypeSymbol, MethodSymbol?, int> initialStateInferenceCompletion,
                 Action<int, TypeSymbol>? initializerCompletion,
@@ -3636,7 +3714,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             (int slot, NullableFlowState resultState, Func<TypeSymbol, MethodSymbol?, int>? completion) inferInitialObjectState(
                 BoundExpression node, TypeSymbol type, MethodSymbol? constructor,
-                ImmutableArray<BoundExpression> arguments, ImmutableArray<VisitArgumentResult> argumentResults,
+                ImmutableArray<BoundExpression> arguments, ImmutableArray<VisitResult> argumentResults,
                 bool isTargetTyped)
             {
                 if (isTargetTyped)
@@ -3707,7 +3785,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Func<TypeSymbol, MethodSymbol?, int> inferInitialObjectStateAsContinuation(
                 BoundExpression node,
                 ImmutableArray<BoundExpression> arguments,
-                ImmutableArray<VisitArgumentResult> argumentResults)
+                ImmutableArray<VisitResult> argumentResults)
             {
                 return (TypeSymbol type, MethodSymbol? constructor) =>
                 {
@@ -3797,7 +3875,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var objectInitializer = (BoundObjectInitializerMember)node.Left;
                 Symbol? symbol = getTargetMember(containingType, objectInitializer);
 
-                ImmutableArray<VisitArgumentResult> argumentResults = default;
+                ImmutableArray<VisitResult> argumentResults = default;
                 ArgumentsCompletionDelegate? argumentsCompletion = null;
                 if (!objectInitializer.Arguments.IsDefaultOrEmpty)
                 {
@@ -3833,7 +3911,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Action<int, TypeSymbol>? setAnalyzedNullability(
                 BoundAssignmentOperator node,
-                ImmutableArray<VisitArgumentResult> argumentResults,
+                ImmutableArray<VisitResult> argumentResults,
                 ArgumentsCompletionDelegate? argumentsCompletion,
                 Action<int, Symbol>? initializationCompletion,
                 bool delayCompletionForType)
@@ -3855,7 +3933,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Action<int, TypeSymbol>? setAnalyzedNullabilityAsContinuation(
                 BoundAssignmentOperator node,
-                ImmutableArray<VisitArgumentResult> argumentResults,
+                ImmutableArray<VisitResult> argumentResults,
                 ArgumentsCompletionDelegate? argumentsCompletion,
                 Action<int, Symbol>? initializationCompletion)
             {
@@ -3986,7 +4064,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private Action<int, TypeSymbol>? VisitCollectionElementInitializer(BoundCollectionElementInitializer node, TypeSymbol containingType, bool delayCompletionForType)
         {
-            ImmutableArray<VisitArgumentResult> argumentResults = default;
+            ImmutableArray<VisitResult> argumentResults = default;
             MethodSymbol addMethod = addMethodAsMemberOfContainingType(node, containingType, ref argumentResults);
 
             // Note: we analyze even omitted calls
@@ -4009,8 +4087,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
             if (node.InvokedAsExtensionMethod)
             {
-                VisitArgumentResult receiverResult = argumentResults[0];
-                Debug.Assert(TypeSymbol.Equals(containingType, receiverResult.VisitResult.RValueType.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
+                VisitResult receiverResult = argumentResults[0];
+                Debug.Assert(TypeSymbol.Equals(containingType, receiverResult.RValueType.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
                 Debug.Assert(TypeSymbol.Equals(containingType, receiverResult.LValueType.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
             }
 #endif
@@ -4021,7 +4099,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundCollectionElementInitializer node,
                 TypeSymbol containingType,
                 MethodSymbol? reinferredMethod,
-                ImmutableArray<VisitArgumentResult> argumentResults,
+                ImmutableArray<VisitResult> argumentResults,
                 ArgumentsCompletionDelegate? visitArgumentsCompletion,
                 bool delayCompletionForType)
             {
@@ -4046,7 +4124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Action<int, TypeSymbol>? setUpdatedSymbolAsContinuation(
                 BoundCollectionElementInitializer node,
-                ImmutableArray<VisitArgumentResult> argumentResults,
+                ImmutableArray<VisitResult> argumentResults,
                 ArgumentsCompletionDelegate visitArgumentsCompletion)
             {
                 return (int containingSlot, TypeSymbol containingType) =>
@@ -4059,7 +4137,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 };
             }
 
-            static MethodSymbol addMethodAsMemberOfContainingType(BoundCollectionElementInitializer node, TypeSymbol containingType, ref ImmutableArray<VisitArgumentResult> argumentResults)
+            static MethodSymbol addMethodAsMemberOfContainingType(BoundCollectionElementInitializer node, TypeSymbol containingType, ref ImmutableArray<VisitResult> argumentResults)
             {
                 var method = node.AddMethod;
 
@@ -4067,15 +4145,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (!argumentResults.IsDefault)
                     {
-                        VisitArgumentResult receiverResult = argumentResults[0];
-                        Debug.Assert(TypeSymbol.Equals(containingType, receiverResult.VisitResult.RValueType.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
+                        VisitResult receiverResult = argumentResults[0];
+                        Debug.Assert(TypeSymbol.Equals(containingType, receiverResult.RValueType.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
                         Debug.Assert(TypeSymbol.Equals(containingType, receiverResult.LValueType.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
 
-                        var builder = ArrayBuilder<VisitArgumentResult>.GetInstance(argumentResults.Length);
+                        var builder = ArrayBuilder<VisitResult>.GetInstance(argumentResults.Length);
                         builder.Add(
-                            new VisitArgumentResult(
-                                new VisitResult(
-                                    TypeWithState.Create(containingType, receiverResult.RValueType.State), receiverResult.LValueType.WithType(containingType)),
+                            new VisitResult(
+                                TypeWithState.Create(containingType, receiverResult.RValueType.State),
+                                receiverResult.LValueType.WithType(containingType),
                                 receiverResult.StateForLambda));
 
                         builder.AddRange(argumentResults, 1, argumentResults.Length - 1);
@@ -4094,6 +4172,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void SetNotNullResult(BoundExpression node)
         {
             SetResultType(node, TypeWithState.Create(node.Type, NullableFlowState.NotNull));
+        }
+
+        private void SetNotNullResultForLambda(BoundExpression node, LocalState stateForLambda)
+        {
+            var resultType = TypeWithState.Create(node.Type, NullableFlowState.NotNull);
+            var lvalueType = resultType.ToTypeWithAnnotations(compilation);
+            SetResult(node, new VisitResult(resultType, lvalueType, stateForLambda), updateAnalyzedNullability: true, isLvalue: null);
         }
 
         /// <summary>
@@ -4364,12 +4449,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        /// <summary>
+        /// For target-typed expressions, we first visit the constituent parts to determine the effect on the State,
+        /// but the final VisitResult isn't determined and the conversions on the constituent parts are not analyzed 
+        /// until the target-type is known and the containing conversion is processed.
+        /// This is done using <see cref="TargetTypedAnalysisCompletion"/>. All registered completions must be processed
+        /// (ie. analyzed via some conversion) before the nullable analysis completes.
+        /// </summary>
         private static bool IsTargetTypedExpression(BoundExpression node)
         {
             return node is BoundConditionalOperator { WasTargetTyped: true } or
                            BoundConvertedSwitchExpression { WasTargetTyped: true } or
                            BoundObjectCreationExpressionBase { WasTargetTyped: true } or
-                           BoundDelegateCreationExpression { WasTargetTyped: true };
+                           BoundDelegateCreationExpression { WasTargetTyped: true } or
+                           BoundCollectionExpression { WasTargetTyped: true };
         }
 
         /// <summary>
@@ -5843,7 +5936,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TakeIncrementalSnapshot(node); // Visit does this before visiting each node
                 TypeWithState receiverType = visitAndCheckReceiver(node);
 
-                VisitArgumentResult? extensionReceiverResult = null;
+                VisitResult? extensionReceiverResult = null;
                 while (true)
                 {
                     ReinferMethodAndVisitArguments(node, receiverType, firstArgumentResult: extensionReceiverResult);
@@ -5869,7 +5962,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(node.InvokedAsExtensionMethod);
                         var refKind = GetRefKind(node.ArgumentRefKindsOpt, 0);
                         var annotations = GetCorrespondingParameter(0, node.Method.Parameters, node.ArgsToParamsOpt, node.Expanded).Annotations;
-                        extensionReceiverResult = VisitArgumentEvaluateEpilogue(receiver, default, refKind, annotations);
+                        extensionReceiverResult = VisitArgumentEvaluateEpilogue(receiver, refKind, annotations);
                         receiverType = default;
                     }
                 }
@@ -5922,7 +6015,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void ReinferMethodAndVisitArguments(BoundCall node, TypeWithState receiverType, VisitArgumentResult? firstArgumentResult = null)
+        private void ReinferMethodAndVisitArguments(BoundCall node, TypeWithState receiverType, VisitResult? firstArgumentResult = null)
         {
             var method = node.Method;
             ImmutableArray<RefKind> refKindsOpt = node.ArgumentRefKindsOpt;
@@ -5932,7 +6025,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 method = (MethodSymbol)AsMemberOfType(receiverType.Type, method);
             }
 
-            ImmutableArray<VisitArgumentResult> results;
+            ImmutableArray<VisitResult> results;
             bool returnNotNull;
             (method, results, returnNotNull) = VisitArguments(node, node.Arguments, refKindsOpt, method!.Parameters, node.ArgsToParamsOpt, node.DefaultArguments,
                 node.Expanded, node.InvokedAsExtensionMethod, method, firstArgumentResult: firstArgumentResult);
@@ -5951,7 +6044,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SetUpdatedSymbol(node, node.Method, method);
         }
 
-        private void LearnFromEqualsMethod(MethodSymbol method, BoundCall node, TypeWithState receiverType, ImmutableArray<VisitArgumentResult> results)
+        private void LearnFromEqualsMethod(MethodSymbol method, BoundCall node, TypeWithState receiverType, ImmutableArray<VisitResult> results)
         {
             // easy out
             var parameterCount = method.ParameterCount;
@@ -6130,10 +6223,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly struct CompareExchangeInfo
         {
             public readonly ImmutableArray<BoundExpression> Arguments;
-            public readonly ImmutableArray<VisitArgumentResult> Results;
+            public readonly ImmutableArray<VisitResult> Results;
             public readonly ImmutableArray<int> ArgsToParamsOpt;
 
-            public CompareExchangeInfo(ImmutableArray<BoundExpression> arguments, ImmutableArray<VisitArgumentResult> results, ImmutableArray<int> argsToParamsOpt)
+            public CompareExchangeInfo(ImmutableArray<BoundExpression> arguments, ImmutableArray<VisitResult> results, ImmutableArray<int> argsToParamsOpt)
             {
                 Arguments = arguments;
                 Results = results;
@@ -6334,7 +6427,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.Unreachable();
         }
 
-        private (MethodSymbol? method, ImmutableArray<VisitArgumentResult> results, bool returnNotNull) VisitArguments(
+        private (MethodSymbol? method, ImmutableArray<VisitResult> results, bool returnNotNull) VisitArguments(
             BoundExpression node,
             ImmutableArray<BoundExpression> arguments,
             ImmutableArray<RefKind> refKindsOpt,
@@ -6347,7 +6440,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return VisitArguments(node, arguments, refKindsOpt, method is null ? default : method.Parameters, argsToParamsOpt, defaultArguments, expanded, invokedAsExtensionMethod, method);
         }
 
-        private ImmutableArray<VisitArgumentResult> VisitArguments(
+        private ImmutableArray<VisitResult> VisitArguments(
             BoundExpression node,
             ImmutableArray<BoundExpression> arguments,
             ImmutableArray<RefKind> refKindsOpt,
@@ -6362,7 +6455,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// If you pass in a method symbol, its type arguments will be re-inferred and the re-inferred method will be returned.
         /// </summary>
-        private (MethodSymbol? method, ImmutableArray<VisitArgumentResult> results, bool returnNotNull) VisitArguments(
+        private (MethodSymbol? method, ImmutableArray<VisitResult> results, bool returnNotNull) VisitArguments(
             BoundNode node,
             ImmutableArray<BoundExpression> arguments,
             ImmutableArray<RefKind> refKindsOpt,
@@ -6372,7 +6465,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool expanded,
             bool invokedAsExtensionMethod,
             MethodSymbol? method = null,
-            VisitArgumentResult? firstArgumentResult = null)
+            VisitResult? firstArgumentResult = null)
         {
             var result = VisitArguments(node, arguments, refKindsOpt, parametersOpt, argsToParamsOpt, defaultArguments, expanded, invokedAsExtensionMethod, method, delayCompletionForTargetMember: false, firstArgumentResult: firstArgumentResult);
             Debug.Assert(result.completion is null);
@@ -6380,9 +6473,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (result.method, result.results, result.returnNotNull);
         }
 
-        private delegate (MethodSymbol? method, bool returnNotNull) ArgumentsCompletionDelegate(ImmutableArray<VisitArgumentResult> argumentResults, ImmutableArray<ParameterSymbol> parametersOpt, MethodSymbol? method);
+        private delegate (MethodSymbol? method, bool returnNotNull) ArgumentsCompletionDelegate(ImmutableArray<VisitResult> argumentResults, ImmutableArray<ParameterSymbol> parametersOpt, MethodSymbol? method);
 
-        private (MethodSymbol? method, ImmutableArray<VisitArgumentResult> results, bool returnNotNull, ArgumentsCompletionDelegate? completion)
+        private (MethodSymbol? method, ImmutableArray<VisitResult> results, bool returnNotNull, ArgumentsCompletionDelegate? completion)
         VisitArguments(
             BoundNode node,
             ImmutableArray<BoundExpression> arguments,
@@ -6394,7 +6487,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool invokedAsExtensionMethod,
             MethodSymbol? method,
             bool delayCompletionForTargetMember,
-            VisitArgumentResult? firstArgumentResult = null)
+            VisitResult? firstArgumentResult = null)
         {
             Debug.Assert(!arguments.IsDefault);
             Debug.Assert(!expanded || !parametersOpt.IsDefault);
@@ -6413,20 +6506,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             (ImmutableArray<BoundExpression> argumentsNoConversions, ImmutableArray<Conversion> conversions) = RemoveArgumentConversions(arguments, refKindsOpt);
 
             // Visit the arguments and collect results
-            ImmutableArray<VisitArgumentResult> results = VisitArgumentsEvaluate(argumentsNoConversions, refKindsOpt, GetParametersAnnotations(arguments, parametersOpt, argsToParamsOpt, expanded), defaultArguments, firstArgumentResult: firstArgumentResult);
+            ImmutableArray<VisitResult> results = VisitArgumentsEvaluate(argumentsNoConversions, refKindsOpt, GetParametersAnnotations(arguments, parametersOpt, argsToParamsOpt, expanded), defaultArguments, firstArgumentResult: firstArgumentResult);
 
             return visitArguments(
                 node, arguments, argumentsNoConversions, conversions, results, refKindsOpt,
                 parametersOpt, argsToParamsOpt, defaultArguments, expanded, invokedAsExtensionMethod,
                 method, delayCompletionForTargetMember);
 
-            (MethodSymbol? method, ImmutableArray<VisitArgumentResult> results, bool returnNotNull, ArgumentsCompletionDelegate? completion)
+            (MethodSymbol? method, ImmutableArray<VisitResult> results, bool returnNotNull, ArgumentsCompletionDelegate? completion)
             visitArguments(
                 BoundNode node,
                 ImmutableArray<BoundExpression> arguments,
                 ImmutableArray<BoundExpression> argumentsNoConversions,
                 ImmutableArray<Conversion> conversions,
-                ImmutableArray<VisitArgumentResult> results,
+                ImmutableArray<VisitResult> results,
                 ImmutableArray<RefKind> refKindsOpt,
                 ImmutableArray<ParameterSymbol> parametersOpt,
                 ImmutableArray<int> argsToParamsOpt,
@@ -6481,11 +6574,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         (ParameterSymbol? parameter, TypeWithAnnotations parameterType, FlowAnalysisAnnotations parameterAnnotations, bool isExpandedParamsArgument) =
                             GetCorrespondingParameter(i, parametersOpt, argsToParamsOpt, expanded);
+
                         if (parameter is null)
                         {
-                            // If this assert fails, we are missing necessary info to visit the
-                            // conversion of a target typed construct.
-                            Debug.Assert(!IsTargetTypedExpression(argumentNoConversion) || _targetTypedAnalysisCompletionOpt?.ContainsKey(argumentNoConversion) is true);
+                            // We've done something wrong if we have a target-typed expression and registered an analysis continuation for it
+                            // (we won't be able to complete that continuation)
+                            Debug.Assert(!(IsTargetTypedExpression(argumentNoConversion) && _targetTypedAnalysisCompletionOpt?.ContainsKey(argumentNoConversion) is true));
                             continue;
                         }
 
@@ -6588,7 +6682,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool expanded,
                 bool invokedAsExtensionMethod)
             {
-                return (ImmutableArray<VisitArgumentResult> results, ImmutableArray<ParameterSymbol> parametersOpt, MethodSymbol? method) =>
+                return (ImmutableArray<VisitResult> results, ImmutableArray<ParameterSymbol> parametersOpt, MethodSymbol? method) =>
                        {
                            var result = visitArguments(
                                            node, arguments, argumentsNoConversions, conversions, results, refKindsOpt,
@@ -6759,21 +6853,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private ImmutableArray<VisitArgumentResult> VisitArgumentsEvaluate(
+        private ImmutableArray<VisitResult> VisitArgumentsEvaluate(
             ImmutableArray<BoundExpression> arguments,
             ImmutableArray<RefKind> refKindsOpt,
             ImmutableArray<FlowAnalysisAnnotations> parameterAnnotationsOpt,
             BitVector defaultArguments,
-            VisitArgumentResult? firstArgumentResult = null)
+            VisitResult? firstArgumentResult = null)
         {
             Debug.Assert(!IsConditionalState);
             int n = arguments.Length;
             if (n == 0 && parameterAnnotationsOpt.IsDefaultOrEmpty)
             {
-                return ImmutableArray<VisitArgumentResult>.Empty;
+                return ImmutableArray<VisitResult>.Empty;
             }
 
-            var resultsBuilder = ArrayBuilder<VisitArgumentResult>.GetInstance(n);
+            var resultsBuilder = ArrayBuilder<VisitResult>.GetInstance(n);
             var previousDisableDiagnostics = _disableDiagnostics;
             for (int i = 0; i < n; i++)
             {
@@ -6808,11 +6902,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return parameterAnnotationsOpt;
         }
 
-        private VisitArgumentResult VisitArgumentEvaluate(BoundExpression argument, RefKind refKind, FlowAnalysisAnnotations annotations)
+        private VisitResult VisitArgumentEvaluate(BoundExpression argument, RefKind refKind, FlowAnalysisAnnotations annotations)
         {
-            var savedState = VisitArgumentEvaluateNeedsCloningState(argument) ? this.State.Clone() : default(Optional<LocalState>);
             Visit(argument);
-            return VisitArgumentEvaluateEpilogue(argument, savedState, refKind, annotations);
+            return VisitArgumentEvaluateEpilogue(argument, refKind, annotations);
         }
 
         private bool VisitArgumentEvaluateNeedsCloningState(BoundExpression argument)
@@ -6821,7 +6914,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (argument.Kind == BoundKind.Lambda);
         }
 
-        private VisitArgumentResult VisitArgumentEvaluateEpilogue(BoundExpression argument, Optional<LocalState> savedState, RefKind refKind, FlowAnalysisAnnotations annotations)
+        private VisitResult VisitArgumentEvaluateEpilogue(BoundExpression argument, RefKind refKind, FlowAnalysisAnnotations annotations)
         {
             // Note: DoesNotReturnIf is ineffective on ref/out parameters
 
@@ -6866,7 +6959,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Debug.Assert(!IsConditionalState);
-            return new VisitArgumentResult(_visitResult, savedState);
+            return _visitResult;
         }
 
         /// <summary>
@@ -6880,7 +6973,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ParameterSymbol parameter,
             TypeWithAnnotations parameterType,
             FlowAnalysisAnnotations parameterAnnotations,
-            VisitArgumentResult result,
+            VisitResult result,
             ArrayBuilder<VisitResult>? conversionResultsBuilder,
             bool extensionMethodThisArgument)
         {
@@ -6948,10 +7041,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
 
-                    conversionResultsBuilder?.Add(result.VisitResult);
+                    conversionResultsBuilder?.Add(result);
                     break;
                 case RefKind.Out:
-                    conversionResultsBuilder?.Add(result.VisitResult);
+                    conversionResultsBuilder?.Add(result);
                     break;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(refKind);
@@ -7017,7 +7110,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ParameterSymbol parameter,
             TypeWithAnnotations parameterType,
             FlowAnalysisAnnotations parameterAnnotations,
-            VisitArgumentResult result,
+            VisitResult result,
             ArrayBuilder<ParameterSymbol>? notNullParametersOpt,
             CompareExchangeInfo compareExchangeInfoOpt)
         {
@@ -7284,6 +7377,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var before = argument;
                         (argument, conversion) = RemoveConversion(argument, includeExplicitConversions: false);
+
                         if (argument != before)
                         {
                             SnapshotWalkerThroughConversionGroup(before, argument);
@@ -7449,7 +7543,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private ImmutableArray<BoundExpression> GetArgumentsForMethodTypeInference(ImmutableArray<VisitArgumentResult> argumentResults, ImmutableArray<BoundExpression> arguments)
+        private ImmutableArray<BoundExpression> GetArgumentsForMethodTypeInference(ImmutableArray<VisitResult> argumentResults, ImmutableArray<BoundExpression> arguments)
         {
             // https://github.com/dotnet/roslyn/issues/27961 MethodTypeInferrer.Infer relies
             // on the BoundExpressions for tuple element types and method groups.
@@ -7461,15 +7555,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < n; i++)
             {
                 var visitArgumentResult = argumentResults[i];
-                var lambdaState = visitArgumentResult.StateForLambda;
-                // Note: for `out` arguments, the argument result contains the declaration type (see `VisitArgumentEvaluate`)
-                var argumentResult = visitArgumentResult.RValueType.ToTypeWithAnnotations(compilation);
-                builder.Add(getArgumentForMethodTypeInference(arguments[i], argumentResult, lambdaState));
+                builder.Add(getArgumentForMethodTypeInference(arguments[i], visitArgumentResult));
             }
             return builder.ToImmutableAndFree();
 
-            BoundExpression getArgumentForMethodTypeInference(BoundExpression argument, TypeWithAnnotations argumentType, Optional<LocalState> lambdaState)
+            BoundExpression getArgumentForMethodTypeInference(BoundExpression argument, VisitResult visitResult)
             {
+                var lambdaState = visitResult.StateForLambda;
                 if (argument.Kind == BoundKind.Lambda)
                 {
                     Debug.Assert(lambdaState.HasValue);
@@ -7478,15 +7570,47 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // to re-bind lambdas in MethodTypeInferrer.
                     return getUnboundLambda((BoundLambda)argument, GetVariableState(_variables, lambdaState.Value));
                 }
+
+                if (argument.Kind == BoundKind.CollectionExpression)
+                {
+                    // MethodTypeInferrer must infer types using the elements of an unconverted collection expression
+                    var collectionExpressionVisitResults = visitResult.NestedVisitResults;
+                    var collection = (BoundCollectionExpression)argument;
+
+                    Debug.Assert(collectionExpressionVisitResults is not null);
+                    Debug.Assert(collectionExpressionVisitResults.Length == collection.Elements.Length);
+
+                    var elementsBuilder = ArrayBuilder<BoundNode>.GetInstance(collectionExpressionVisitResults.Length);
+                    for (int i = 0; i < collectionExpressionVisitResults.Length; i++)
+                    {
+                        if (collection.Elements[i] is BoundExpression elementExpression)
+                        {
+                            var (elementNoConversion, _) = RemoveConversion(elementExpression, includeExplicitConversions: false);
+                            elementsBuilder.Add(getArgumentForMethodTypeInference(elementNoConversion, collectionExpressionVisitResults[i]));
+                        }
+                        else
+                        {
+                            elementsBuilder.Add(collection.Elements[i]);
+                        }
+                    }
+
+                    return new BoundUnconvertedCollectionExpression(collection.Syntax, elementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
+                }
+
+                // Note: for `out` arguments, the argument result contains the declaration type (see `VisitArgumentEvaluate`)
+                var argumentType = visitResult.RValueType.ToTypeWithAnnotations(compilation);
+
                 if (!argumentType.HasType)
                 {
                     return argument;
                 }
+
                 if (argument is BoundLocal { DeclarationKind: BoundLocalDeclarationKind.WithInferredType } || IsTargetTypedExpression(argument))
                 {
                     // target-typed contexts don't contribute to nullability
                     return new BoundExpressionWithNullability(argument.Syntax, argument, NullableAnnotation.Oblivious, type: null);
                 }
+
                 return new BoundExpressionWithNullability(argument.Syntax, argument, argumentType.NullableAnnotation, argumentType.Type);
             }
 
@@ -9321,6 +9445,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitLambda(BoundLambda node)
         {
+            var stateForLambda = this.State.Clone();
             // Lambda bodies are usually visited in VisitConversion (we need to know the target delegate type),
             // but in erroneous code, the lambda-to-delegate conversion might be missing, then we visit the lambda here.
             if (!node.InAnonymousFunctionConversion)
@@ -9328,8 +9453,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitLambda(node, delegateTypeOpt: null);
             }
 
-            // Here we just indicate that a lambda expression produces a non-null value.
-            SetNotNullResult(node);
+            SetNotNullResultForLambda(node, stateForLambda);
             return null;
         }
 
@@ -9704,7 +9828,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else
                     {
                         VisitArgumentConversionAndInboundAssignmentsAndPreConditions(conversionOpt: null, variable.Expression, underlyingConversion, parameter.RefKind,
-                            parameter, parameter.TypeWithAnnotations, GetParameterAnnotations(parameter), new VisitArgumentResult(new VisitResult(variable.Type.ToTypeWithState(), variable.Type), stateForLambda: default),
+                            parameter, parameter.TypeWithAnnotations, GetParameterAnnotations(parameter), new VisitResult(variable.Type.ToTypeWithState(), variable.Type),
                             conversionResultsBuilder: null, extensionMethodThisArgument: false);
                     }
                 }
@@ -9718,7 +9842,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         VisitArgumentOutboundAssignmentsAndPostConditions(
                             variable.Expression, parameter.RefKind, parameter, parameter.TypeWithAnnotations, GetRValueAnnotations(parameter),
-                            new VisitArgumentResult(new VisitResult(variable.Type.ToTypeWithState(), variable.Type), stateForLambda: default),
+                            new VisitResult(variable.Type.ToTypeWithState(), variable.Type),
                             notNullParametersOpt: null, compareExchangeInfoOpt: default);
                     }
                 }
@@ -11297,7 +11421,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 parameter,
                 parameter.TypeWithAnnotations,
                 GetParameterAnnotations(parameter),
-                new VisitArgumentResult(new VisitResult(result, result.ToTypeWithAnnotations(compilation)), stateForLambda: default),
+                new VisitResult(result, result.ToTypeWithAnnotations(compilation)),
                 conversionResultsBuilder: null,
                 extensionMethodThisArgument: true);
         }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -25697,15 +25697,14 @@ partial class Program
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
-            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
 
-            Assert.Equal("""M("hi", [null])""", invocations[0].ToString());
+            var invocation0 = GetSyntax<InvocationExpressionSyntax>(tree, """M("hi", [null])""");
             Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?> mc)",
-                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation0).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("M((string?)null, [null])", invocations[1].ToString());
+            var invocation1 = GetSyntax<InvocationExpressionSyntax>(tree, "M((string?)null, [null])");
             Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?> mc)",
-                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation1).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]
@@ -25746,19 +25745,18 @@ partial class Program
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
-            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
 
-            Assert.Equal("""M("hi", [null])""", invocations[0].ToString());
+            var invocation0 = GetSyntax<InvocationExpressionSyntax>(tree, """M("hi", [null])""");
             Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?>? mc)",
-                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation0).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("M((string?)null, [null])", invocations[1].ToString());
+            var invocation1 = GetSyntax<InvocationExpressionSyntax>(tree, "M((string?)null, [null])");
             Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?>? mc)",
-                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation1).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("M((string?)null, null)", invocations[2].ToString());
+            var invocation2 = GetSyntax<InvocationExpressionSyntax>(tree, "M((string?)null, null)");
             Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?>? mc)",
-                model.GetSymbolInfo(invocations[2]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation2).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]
@@ -25805,15 +25803,13 @@ partial class Program
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
-            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
-
-            Assert.Equal("M(ref notNull, [null])", invocations[0].ToString());
+            var invocation0 = GetSyntax<InvocationExpressionSyntax>(tree, "M(ref notNull, [null])");
             Assert.Equal("void M<System.String?>(ref System.String? t, MyCollection<System.String?> mc)",
-                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation0).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("M(ref maybeNull, [null])", invocations[1].ToString());
+            var invocation1 = GetSyntax<InvocationExpressionSyntax>(tree, "M(ref maybeNull, [null])");
             Assert.Equal("void M<System.String?>(ref System.String? t, MyCollection<System.String?> mc)",
-                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation1).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]
@@ -25905,19 +25901,18 @@ partial class Program
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
-            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
 
-            Assert.Equal("M([(string?)null])", invocations[0].ToString());
+            var invocation0 = GetSyntax<InvocationExpressionSyntax>(tree, "M([(string?)null])");
             Assert.Equal("void M<System.String?>(MyCollection<System.String?> mc)",
-                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation0).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("""M(["hi"])""", invocations[1].ToString());
+            var invocation1 = GetSyntax<InvocationExpressionSyntax>(tree, """M(["hi"])""");
             Assert.Equal("void M<System.String!>(MyCollection<System.String!> mc)",
-                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation1).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("""M(["hi", null])""", invocations[2].ToString());
+            var invocation2 = GetSyntax<InvocationExpressionSyntax>(tree, """M(["hi", null])""");
             Assert.Equal("void M<System.String?>(MyCollection<System.String?> mc)",
-                model.GetSymbolInfo(invocations[2]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation2).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]
@@ -26056,7 +26051,6 @@ partial class Program
                 }
                 """;
 
-            // We don't analyze the Add methods
             CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
                 // (9,1): warning CS8602: Dereference of a possibly null reference.
                 // M(ref maybeNull, [maybeNull]).ToString();
@@ -26097,7 +26091,9 @@ partial class Program
                 }
                 """;
 
-            // We don't analyze the Add methods
+            // We're missing a diagnostic for the `where T : notnull` constraint on the Create method
+            // Tracked by https://github.com/dotnet/roslyn/issues/68786
+
             CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
                 // (9,1): warning CS8602: Dereference of a possibly null reference.
                 // M(ref maybeNull, [maybeNull]).ToString();
@@ -26207,7 +26203,7 @@ partial class Program
                 M(CreateUnannotated(maybeNull), [maybeNull]);
                 M(CreateUnannotated(maybeNull), [notNull]);
 
-                M(CreateUnannotated(notNull), [maybeNull]); // 1
+                M(CreateUnannotated(notNull), [maybeNull]);
                 M(CreateUnannotated(notNull), [notNull]);
 
                 void M<T>(T t1, T t2) { }
@@ -26499,22 +26495,24 @@ partial class Program
                 using System.Collections.Generic;
 
                 #nullable enable
-                string? element = null;
+                string element = null; // 1
                 var collection = IdList([element]);
-                collection[0].ToString(); // 1
+                collection[0].ToString(); // 2
 
                 List<T> IdList<T>(List<T> l) => l;
                 """;
 
             var comp = CreateCompilation(src).VerifyEmitDiagnostics(
+                // (4,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                // string element = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(4, 18),
                 // (6,1): warning CS8602: Dereference of a possibly null reference.
-                // collection[0].ToString(); // 1
+                // collection[0].ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "collection[0]").WithLocation(6, 1)
                 );
 
             var tree = comp.SyntaxTrees.First();
-            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
-            Assert.Equal("IdList([element])", invocation.ToFullString());
+            var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "IdList([element])");
 
             var model = comp.GetSemanticModel(tree);
             Assert.Equal("System.Collections.Generic.List<System.String?> IdList<System.String?>(System.Collections.Generic.List<System.String?> l)",
@@ -26550,8 +26548,7 @@ partial class Program
             var comp = CreateCompilation(src).VerifyEmitDiagnostics();
 
             var tree = comp.SyntaxTrees.First();
-            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
-            Assert.Equal("IdList([element])", invocation.ToFullString());
+            var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "IdList([element])");
 
             var model = comp.GetSemanticModel(tree);
             Assert.Equal("System.Collections.Generic.List<System.String> IdList<System.String>(System.Collections.Generic.List<System.String> l)",
@@ -26565,24 +26562,25 @@ partial class Program
                 using System.Collections.Generic;
 
                 #nullable enable
-                string? element1 = null;
+                string element1 = null; // 1
                 string element2 = "hi";
                 var collection = IdList([element1, element2]);
-                collection[0].ToString(); // 1
+                collection[0].ToString(); // 2
 
                 List<T> IdList<T>(List<T> l) => l;
                 """;
 
             var comp = CreateCompilation(src).VerifyEmitDiagnostics(
+                // (4,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                // string element1 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(4, 19),
                 // (7,1): warning CS8602: Dereference of a possibly null reference.
-                // collection[0].ToString(); // 1
+                // collection[0].ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "collection[0]").WithLocation(7, 1)
                 );
 
             var tree = comp.SyntaxTrees.First();
-            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
-            Assert.Equal("IdList([element1, element2])", invocation.ToFullString());
-
+            var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "IdList([element1, element2])");
             var model = comp.GetSemanticModel(tree);
             Assert.Equal("System.Collections.Generic.List<System.String?> IdList<System.String?>(System.Collections.Generic.List<System.String?> l)",
                 model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
@@ -26610,9 +26608,7 @@ partial class Program
                 );
 
             var tree = comp.SyntaxTrees.First();
-            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
-            Assert.Equal("IdList([element1, element2])", invocation.ToFullString());
-
+            var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "IdList([element1, element2])");
             var model = comp.GetSemanticModel(tree);
             Assert.Equal("System.Collections.Generic.List<System.Object?> IdList<System.Object?>(System.Collections.Generic.List<System.Object?> l)",
                 model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
@@ -26654,9 +26650,7 @@ partial class Program
                 );
 
             var tree = comp.SyntaxTrees.First();
-            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
-            Assert.Equal("IdList([(string?)element1, element2])", invocation.ToFullString());
-
+            var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "IdList([(string?)element1, element2])");
             var model = comp.GetSemanticModel(tree);
             Assert.Equal("System.Collections.Generic.List<System.Object?> IdList<System.Object?>(System.Collections.Generic.List<System.Object?> l)",
                 model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
@@ -26705,9 +26699,7 @@ partial class Program
                 );
 
             var tree = comp.SyntaxTrees.First();
-            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
-            Assert.Equal("IdList([element1, element2])", invocation.ToFullString());
-
+            var invocation = GetSyntax<InvocationExpressionSyntax>(tree, "IdList([element1, element2])");
             var model = comp.GetSemanticModel(tree);
             Assert.Equal("System.Collections.Generic.List<Container<System.String>> IdList<Container<System.String>>(System.Collections.Generic.List<Container<System.String>> l)",
                 model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
@@ -26734,7 +26726,7 @@ partial class Program
                 #nullable enable
                 public class C
                 {
-                    void M1(string? maybeNull, string notNull)
+                    void M1(string notNull)
                     {
                         M(ref notNull, [null]); // 1
                     }
@@ -26748,6 +26740,10 @@ partial class Program
                     }
                     void M4(string? maybeNull, string notNull)
                     {
+                        M(ref notNull, [maybeNull, ""]); // 3
+                    }
+                    void M5(string? maybeNull, string notNull)
+                    {
                         M(ref maybeNull, [notNull, maybeNull, ""]);
                     }
                     void M<T>(ref T t, T[] a) { }
@@ -26760,28 +26756,34 @@ partial class Program
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(6, 15),
                 // (10,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         M(ref notNull, [maybeNull]); // 2
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 15)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 15),
+                // (18,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull, ""]); // 3
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(18, 15)
                 );
 
             var tree = comp.SyntaxTrees.First();
-            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
             var model = comp.GetSemanticModel(tree);
 
-            Assert.Equal("M(ref notNull, [null])", invocations[0].ToString());
+            var invocation0 = GetSyntax<InvocationExpressionSyntax>(tree, "M(ref notNull, [null])");
             Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]! a)",
-                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation0).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("M(ref notNull, [maybeNull])", invocations[1].ToString());
+            var invocation1 = GetSyntax<InvocationExpressionSyntax>(tree, "M(ref notNull, [maybeNull])");
             Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]! a)",
-                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation1).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("""M(ref notNull, [notNull, ""])""", invocations[2].ToString());
+            var invocation2 = GetSyntax<InvocationExpressionSyntax>(tree, """M(ref notNull, [notNull, ""])""");
             Assert.Equal("void C.M<System.String!>(ref System.String! t, System.String![]! a)",
-                model.GetSymbolInfo(invocations[2]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation2).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("""M(ref maybeNull, [notNull, maybeNull, ""])""", invocations[3].ToString());
+            var invocation3 = GetSyntax<InvocationExpressionSyntax>(tree, """M(ref notNull, [maybeNull, ""])""");
             Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]! a)",
-                model.GetSymbolInfo(invocations[3]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation3).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            var invocation4 = GetSyntax<InvocationExpressionSyntax>(tree, """M(ref maybeNull, [notNull, maybeNull, ""])""");
+            Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]! a)",
+                model.GetSymbolInfo(invocation4).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]
@@ -26789,23 +26791,26 @@ partial class Program
         {
             string src = """
                 #nullable enable
-                string? element1 = null;
+                string element1 = null; // 1
                 string element2 = "hi";
-                var collection = IdList((string[])[element1, element2]); // 1
+                var collection = IdList((string[])[element1, element2]); // 2
                 collection[0].ToString();
 
                 var collection2 = IdList([element1, element2]);
-                collection2[0].ToString(); // 2
+                collection2[0].ToString(); // 3
 
                 T[] IdList<T>(T[] l) => l;
                 """;
 
             CreateCompilation(src).VerifyEmitDiagnostics(
+                // (2,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                // string element1 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(2, 19),
                 // (4,36): warning CS8601: Possible null reference assignment.
-                // var collection = IdList((string[])[element1, element2]); // 1
+                // var collection = IdList((string[])[element1, element2]); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "element1").WithLocation(4, 36),
                 // (8,1): warning CS8602: Dereference of a possibly null reference.
-                // collection2[0].ToString(); // 2
+                // collection2[0].ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "collection2[0]").WithLocation(8, 1)
                 );
         }
@@ -26817,7 +26822,7 @@ partial class Program
                 #nullable enable
                 public class C
                 {
-                    void M1(string? maybeNull, string notNull)
+                    void M1(string notNull)
                     {
                         M(ref notNull, [[null]]); // 1
                     }
@@ -26831,6 +26836,10 @@ partial class Program
                     }
                     void M4(string? maybeNull, string notNull)
                     {
+                        M(ref notNull, [[maybeNull, ""]]); // 3
+                    }
+                    void M5(string? maybeNull, string notNull)
+                    {
                         M(ref maybeNull, [[notNull, maybeNull, ""]]);
                     }
                     void M<T>(ref T t, T[][] a) { }
@@ -26839,32 +26848,38 @@ partial class Program
 
             var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
                 // (6,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         M(ref notNull, [null]); // 1
+                //         M(ref notNull, [[null]]); // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(6, 15),
                 // (10,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         M(ref notNull, [maybeNull]); // 2
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 15)
-            );
+                //         M(ref notNull, [[maybeNull]]); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 15),
+                // (18,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [[maybeNull, ""]]); // 3
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(18, 15)
+                );
 
             var tree = comp.SyntaxTrees.First();
-            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
             var model = comp.GetSemanticModel(tree);
 
-            Assert.Equal("M(ref notNull, [[null]])", invocations[0].ToString());
+            var invocation0 = GetSyntax<InvocationExpressionSyntax>(tree, "M(ref notNull, [[null]])");
             Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]![]! a)",
-                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation0).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("M(ref notNull, [[maybeNull]])", invocations[1].ToString());
+            var invocation1 = GetSyntax<InvocationExpressionSyntax>(tree, "M(ref notNull, [[maybeNull]])");
             Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]![]! a)",
-                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation1).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("""M(ref notNull, [[notNull, ""]])""", invocations[2].ToString());
+            var invocation2 = GetSyntax<InvocationExpressionSyntax>(tree, """M(ref notNull, [[notNull, ""]])""");
             Assert.Equal("void C.M<System.String!>(ref System.String! t, System.String![]![]! a)",
-                model.GetSymbolInfo(invocations[2]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation2).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("""M(ref maybeNull, [[notNull, maybeNull, ""]])""", invocations[3].ToString());
+            var invocation3 = GetSyntax<InvocationExpressionSyntax>(tree, """M(ref notNull, [[maybeNull, ""]])""");
             Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]![]! a)",
-                model.GetSymbolInfo(invocations[3]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation3).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            var invocation4 = GetSyntax<InvocationExpressionSyntax>(tree, """M(ref maybeNull, [[notNull, maybeNull, ""]])""");
+            Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]![]! a)",
+                model.GetSymbolInfo(invocation4).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]
@@ -26968,16 +26983,21 @@ partial class Program
                     {
                         bool b = true;
                         Method([b ? (() => s) : (() => s)]).ToString(); // 1
+                        Method2(b ? (() => s) : (() => s)).ToString(); // 2
                     }
 
                     T Method<T>(System.Func<T>[] a) => throw null!;
+                    T Method2<T>(System.Func<T> a) => throw null!;
                 }
                 """;
 
             CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
                 // (7,9): error CS0411: The type arguments for method 'C.Method<T>(Func<T>[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         Method([b ? (() => s) : (() => s)]).ToString(); // 1
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Method").WithArguments("C.Method<T>(System.Func<T>[])").WithLocation(7, 9)
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Method").WithArguments("C.Method<T>(System.Func<T>[])").WithLocation(7, 9),
+                // (8,9): error CS0411: The type arguments for method 'C.Method2<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Method2(b ? (() => s) : (() => s)).ToString(); // 2
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Method2").WithArguments("C.Method2<T>(System.Func<T>)").WithLocation(8, 9)
                 );
         }
 
@@ -27234,16 +27254,15 @@ partial class Program
                 );
 
             var tree = comp.SyntaxTrees.First();
-            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
             var model = comp.GetSemanticModel(tree);
 
-            Assert.Equal("M([Copy(maybeNull, out var maybeNull2), maybeNull2])", invocations[0].ToString());
+            var invocation0 = GetSyntax<InvocationExpressionSyntax>(tree, "M([Copy(maybeNull, out var maybeNull2), maybeNull2])");
             Assert.Equal("System.Object? C.M<System.Object?>(System.Object?[]! a)",
-                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation0).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            Assert.Equal("M([Copy(maybeNull, out var maybeNull2), maybeNull2.ToString()])", invocations[3].ToString());
+            var invocation3 = GetSyntax<InvocationExpressionSyntax>(tree, "M([Copy(maybeNull, out var maybeNull2), maybeNull2.ToString()])");
             Assert.Equal("System.Object! C.M<System.Object!>(System.Object![]! a)",
-                model.GetSymbolInfo(invocations[3]).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation3).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -10210,7 +10210,7 @@ static class Program
                 }
                 """;
 
-            // Missing diagnostics for conversion of element to iteration type in Add scenario.
+            // We should check conversion to the iteration type
             // Tracked by https://github.com/dotnet/roslyn/issues/68786
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
@@ -26694,7 +26694,7 @@ partial class Program
                 }
                 """;
 
-            // Missing diagnostics for conversion of element to iteration type in Add scenario.
+            // We should check conversion to the iteration type
             // Tracked by https://github.com/dotnet/roslyn/issues/68786
             var comp = CreateCompilation(src).VerifyEmitDiagnostics();
 
@@ -27260,9 +27260,9 @@ partial class Program
             Assert.Equal("System.Object? C.M<System.Object?>(System.Object?[]! a)",
                 model.GetSymbolInfo(invocation0).Symbol.ToTestDisplayString(includeNonNullable: true));
 
-            var invocation3 = GetSyntax<InvocationExpressionSyntax>(tree, "M([Copy(maybeNull, out var maybeNull2), maybeNull2.ToString()])");
+            var invocation1 = GetSyntax<InvocationExpressionSyntax>(tree, "M([Copy(maybeNull, out var maybeNull2), maybeNull2.ToString()])");
             Assert.Equal("System.Object! C.M<System.Object!>(System.Object![]! a)",
-                model.GetSymbolInfo(invocation3).Symbol.ToTestDisplayString(includeNonNullable: true));
+                model.GetSymbolInfo(invocation1).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -26051,6 +26051,8 @@ partial class Program
                 }
                 """;
 
+            // We're missing a diagnostic for the `where T : notnull` constraint on the Create method
+            // Tracked by https://github.com/dotnet/roslyn/issues/68786
             CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
                 // (9,1): warning CS8602: Dereference of a possibly null reference.
                 // M(ref maybeNull, [maybeNull]).ToString();

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -27498,6 +27498,26 @@ partial class Program
         }
 
         [Fact]
+        public void ElementNullability_Inference_TODO2()
+        {
+            string src = """
+                #nullable enable
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        byte[] a = [1, 2];
+                        a.AsSpan().SequenceEqual([0, 1]);
+                    }
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics();
+        }
+
+        [Fact]
         public void SpreadNullability()
         {
             string src = """

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -10209,17 +10209,14 @@ static class Program
                     }
                 }
                 """;
+
+            // Missing diagnostics for conversion of element to iteration type in Add scenario.
+            // Tracked by https://github.com/dotnet/roslyn/issues/68786
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         x[0].ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x[0]").WithLocation(8, 9),
-                // (9,27): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         List<object> y = [null]; // 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 27),
-                // (11,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         y = [2, null]; // 3
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 17));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x[0]").WithLocation(8, 9));
         }
 
         [Fact]
@@ -10240,9 +10237,9 @@ static class Program
                     {
                         S<object?> x = [1];
                         x[0].ToString(); // 1
-                        S<object> y = [null]; // 2
+                        S<object> y = [null];
                         y[0].ToString();
-                        y = [2, null]; // 3
+                        y = [2, null];
                         y[1].ToString();
                     }
                 }
@@ -10251,13 +10248,7 @@ static class Program
             comp.VerifyEmitDiagnostics(
                 // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         x[0].ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x[0]").WithLocation(14, 9),
-                // (15,24): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         S<object> y = [null]; // 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(15, 24),
-                // (17,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         y = [2, null]; // 3
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(17, 17));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x[0]").WithLocation(14, 9));
         }
 
         [Fact]
@@ -25279,6 +25270,36 @@ partial class Program
         }
 
         [Fact]
+        public void ElementNullability_ArrayCollection_InferredLocal()
+        {
+            string src = """
+                #nullable enable
+                var x1 = M1();
+                x1 = [null]; // 1
+
+                var x2 = M2();
+                x2 = [null];
+
+                var x3 = M3();
+                x3 = [null];
+
+                string[] M1() => throw null!;
+                string?[] M2() => throw null!;
+
+                #nullable disable
+                string[]
+                #nullable enable
+                    M3() => throw null!;
+                """;
+
+            CreateCompilation(src).VerifyEmitDiagnostics(
+                // (3,7): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                // x1 = [null]; // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(3, 7)
+                );
+        }
+
+        [Fact]
         public void ElementNullability_ArrayCollection_Nested()
         {
             string src = """
@@ -25317,15 +25338,9 @@ partial class Program
                 // (2,13): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
                 // int[] x1 = [null];
                 Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(2, 13),
-                // (2,13): warning CS8619: Nullability of reference types in value of type '<null>' doesn't match target type 'int'.
-                // int[] x1 = [null];
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "null").WithArguments("<null>", "int").WithLocation(2, 13),
                 // (8,11): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
                 //     x3 = [null];
-                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(8, 11),
-                // (8,11): warning CS8619: Nullability of reference types in value of type '<null>' doesn't match target type 'int'.
-                //     x3 = [null];
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "null").WithArguments("<null>", "int").WithLocation(8, 11)
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(8, 11)
                 );
         }
 
@@ -25589,18 +25604,13 @@ partial class Program
                 }
                 """;
 
-            // Note: we warn on x3 because the of type substitution rules for oblivious type argument
-            //   into Create method with MyCollection<T!> return type
             CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
                 // (7,28): warning CS8714: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)'. Nullability of type argument 'string?' doesn't match 'notnull' constraint.
                 // MyCollection<string?> x1 = [null];
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "[null]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "string?").WithLocation(7, 28),
                 // (8,28): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 // MyCollection<string> x2 = [null];
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 28),
-                // (13,11): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //     x3 = [null];
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 11)
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 28)
                 );
         }
 
@@ -25643,12 +25653,15 @@ partial class Program
             CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
                 // (7,28): warning CS8714: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T?>)'. Nullability of type argument 'string?' doesn't match 'notnull' constraint.
                 // MyCollection<string?> x1 = [null];
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "[null]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T?>)", "T", "string?").WithLocation(7, 28)
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "[null]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T?>)", "T", "string?").WithLocation(7, 28),
+                // (8,28): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                // MyCollection<string> x2 = [null];
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 28)
                 );
         }
 
         [Fact]
-        public void ElementNullability_CollectionBuilderCollection_InInference()
+        public void ElementNullability_Inference_CollectionBuilderCollection()
         {
             string src = """
                 using System;
@@ -25686,14 +25699,66 @@ partial class Program
             var model = comp.GetSemanticModel(tree);
             var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
 
-            // https://github.com/dotnet/roslyn/issues/68786: Incorrect symbols (nullability wasn't updated)
             Assert.Equal("""M("hi", [null])""", invocations[0].ToString());
-            Assert.Equal("void M<System.String>(System.String t, MyCollection<System.String> mc)",
+            Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?> mc)",
                 model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
 
             Assert.Equal("M((string?)null, [null])", invocations[1].ToString());
             Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?> mc)",
                 model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_CollectionBuilderCollection_NullableValueType()
+        {
+            string src = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+
+                #nullable enable
+                M("hi", [null]);
+                M((string?)null, [null]);
+                M((string?)null, null);
+
+                void M<T>(T t, MyCollection<T>? mc) { }
+
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create))]
+                public struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    public MyCollection(List<T> list) { _list = list; }
+                    public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+
+                public class MyCollectionBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items)
+                    {
+                        return new MyCollection<T>(new List<T>(items.ToArray()));
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+
+            Assert.Equal("""M("hi", [null])""", invocations[0].ToString());
+            Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?>? mc)",
+                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("M((string?)null, [null])", invocations[1].ToString());
+            Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?>? mc)",
+                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("M((string?)null, null)", invocations[2].ToString());
+            Assert.Equal("void M<System.String?>(System.String? t, MyCollection<System.String?>? mc)",
+                model.GetSymbolInfo(invocations[2]).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
         [Fact]
@@ -25732,15 +25797,18 @@ partial class Program
                 }
                 """;
 
-            // https://github.com/dotnet/roslyn/issues/68786: missing diagnostics
-            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics();
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (8,7): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                // M(ref notNull, [null]); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(8, 7)
+                );
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
             var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
 
             Assert.Equal("M(ref notNull, [null])", invocations[0].ToString());
-            Assert.Equal("void M<System.String!>(ref System.String! t, MyCollection<System.String!> mc)",
+            Assert.Equal("void M<System.String?>(ref System.String? t, MyCollection<System.String?> mc)",
                 model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
 
             Assert.Equal("M(ref maybeNull, [null])", invocations[1].ToString());
@@ -25793,12 +25861,15 @@ partial class Program
                 }
                 """;
 
-            // https://github.com/dotnet/roslyn/issues/68786: Missing diagnostic for 1
-            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics();
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (9,12): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                // notNull = [null]; // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 12)
+                );
         }
 
         [Fact]
-        public void ElementNullability_CollectionBuilderCollection_InInference_SingleParameter()
+        public void ElementNullability_Inference_CollectionBuilderCollection_SingleParameter()
         {
             string src = """
                 using System;
@@ -25836,17 +25907,16 @@ partial class Program
             var model = comp.GetSemanticModel(tree);
             var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
 
-            // https://github.com/dotnet/roslyn/issues/68786: Incorrect symbols (nullability wasn't updated)
             Assert.Equal("M([(string?)null])", invocations[0].ToString());
-            Assert.Equal("void M<System.String>(MyCollection<System.String> mc)",
+            Assert.Equal("void M<System.String?>(MyCollection<System.String?> mc)",
                 model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
 
             Assert.Equal("""M(["hi"])""", invocations[1].ToString());
-            Assert.Equal("void M<System.String>(MyCollection<System.String> mc)",
+            Assert.Equal("void M<System.String!>(MyCollection<System.String!> mc)",
                 model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
 
             Assert.Equal("""M(["hi", null])""", invocations[2].ToString());
-            Assert.Equal("void M<System.String>(MyCollection<System.String> mc)",
+            Assert.Equal("void M<System.String?>(MyCollection<System.String?> mc)",
                 model.GetSymbolInfo(invocations[2]).Symbol.ToTestDisplayString(includeNonNullable: true));
         }
 
@@ -25900,6 +25970,141 @@ partial class Program
         }
 
         [Fact]
+        public void ElementNullability_Inference_CollectionBuilderCollection_NullReturningCreate()
+        {
+            string src = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+
+                #nullable enable
+                string? maybeNull = null;
+                string notNull = "";
+
+                M(ref maybeNull, [maybeNull]); // 1
+                M(ref notNull, [maybeNull]); // 2
+                M(ref maybeNull, [notNull]); // 3
+
+                void M<T>(ref T t, MyCollection<T> c) { }
+
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create))]
+                public class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    public MyCollection(List<T> list) { _list = list; }
+                    public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+
+                public class MyCollectionBuilder
+                {
+                    public static MyCollection<T>? Create<T>(ReadOnlySpan<T> items)
+                    {
+                        return new MyCollection<T>(new List<T>(items.ToArray()!));
+                    }
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (10,18): warning CS8604: Possible null reference argument for parameter 'c' in 'void M<string?>(ref string? t, MyCollection<string?> c)'.
+                // M(ref maybeNull, [maybeNull]); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "[maybeNull]").WithArguments("c", "void M<string?>(ref string? t, MyCollection<string?> c)").WithLocation(10, 18),
+                // (11,7): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                // M(ref notNull, [maybeNull]); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(11, 7),
+                // (11,16): warning CS8604: Possible null reference argument for parameter 'c' in 'void M<string?>(ref string? t, MyCollection<string?> c)'.
+                // M(ref notNull, [maybeNull]); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "[maybeNull]").WithArguments("c", "void M<string?>(ref string? t, MyCollection<string?> c)").WithLocation(11, 16),
+                // (12,18): warning CS8604: Possible null reference argument for parameter 'c' in 'void M<string?>(ref string? t, MyCollection<string?> c)'.
+                // M(ref maybeNull, [notNull]); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "[notNull]").WithArguments("c", "void M<string?>(ref string? t, MyCollection<string?> c)").WithLocation(12, 18)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_CollectionBuilderCollection_ConstrainedCreate()
+        {
+            string src = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+
+                #nullable enable
+                string? maybeNull = null;
+
+                M(ref maybeNull, [maybeNull]).ToString();
+
+                T M<T>(ref T t, MyCollection<T> c) => throw null!;
+
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create))]
+                public class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    public MyCollection(List<T> list) { _list = list; }
+                    public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+
+                public class MyCollectionBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) where T : notnull
+                    {
+                        return new MyCollection<T>(new List<T>(items.ToArray()!));
+                    }
+                }
+                """;
+
+            // We don't analyze the Add methods
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (9,1): warning CS8602: Dereference of a possibly null reference.
+                // M(ref maybeNull, [maybeNull]).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M(ref maybeNull, [maybeNull])").WithLocation(9, 1));
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_CollectionBuilderCollection_ConstrainedCreate_NullableValueType()
+        {
+            string src = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+
+                #nullable enable
+                string? maybeNull = null;
+
+                M(ref maybeNull, [maybeNull]).ToString();
+
+                T M<T>(ref T t, MyCollection<T>? c) => throw null!;
+
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create))]
+                public class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    public MyCollection(List<T> list) { _list = list; }
+                    public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+
+                public class MyCollectionBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) where T : notnull
+                    {
+                        return new MyCollection<T>(new List<T>(items.ToArray()!));
+                    }
+                }
+                """;
+
+            // We don't analyze the Add methods
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (9,1): warning CS8602: Dereference of a possibly null reference.
+                // M(ref maybeNull, [maybeNull]).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M(ref maybeNull, [maybeNull])").WithLocation(9, 1));
+        }
+
+        [Fact]
         public void ElementNullability_CollectionBuilderCollection_NullReturningCreate_WithAttribute()
         {
             string src = """
@@ -25944,14 +26149,14 @@ partial class Program
         }
 
         [Fact]
-        public void ElementNullability_CollectionInitializerCollection()
+        public void ElementNullability_IEnumerableCollection()
         {
             string src = """
                 using System.Collections;
 
                 #nullable enable
 
-                CNotNull x1 = [null]; // 1
+                CNotNull x1 = [null];
                 CNullable x2 = [null];
                 COblivious x3 = [null];
 
@@ -25978,11 +26183,255 @@ partial class Program
                 }
                 """;
 
-            CreateCompilation(src).VerifyEmitDiagnostics(
-                // (5,16): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                // CNotNull x1 = [null]; // 1
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(5, 16)
-                );
+            // We don't analyze the Add methods
+            CreateCompilation(src).VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_IEnumerableCollection_AnalyzeAddMethods()
+        {
+            string source = """
+                using System.Collections;
+
+                #nullable enable
+
+                object? maybeNull = null;
+                object? notNull = new object();
+
+                M(CreateAnnotated(maybeNull), [maybeNull]);
+                M(CreateAnnotated(maybeNull), [notNull]);
+
+                M(CreateAnnotated(notNull), [maybeNull]);
+                M(CreateAnnotated(notNull), [notNull]);
+
+                M(CreateUnannotated(maybeNull), [maybeNull]);
+                M(CreateUnannotated(maybeNull), [notNull]);
+
+                M(CreateUnannotated(notNull), [maybeNull]); // 1
+                M(CreateUnannotated(notNull), [notNull]);
+
+                void M<T>(T t1, T t2) { }
+
+                CAnnotated<T> CreateAnnotated<T>(T t) => throw null!;
+                CUnannotated<T> CreateUnannotated<T>(T t) => throw null!;
+
+                class CAnnotated<T> : IEnumerable
+                {
+                    IEnumerator IEnumerable.GetEnumerator() => throw null!;
+                    public void Add(T? t) { }
+                }
+
+                class CUnannotated<T> : IEnumerable
+                {
+                    IEnumerator IEnumerable.GetEnumerator() => throw null!;
+                    public void Add(T t) { }
+                }
+                """;
+
+            // We don't analyze the Add methods
+            CreateCompilation(source).VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_IEnumerableCollection_AnalyzeAddMethods_Constraints()
+        {
+            string source = """
+                using System.Collections;
+
+                #nullable enable
+
+                object? maybeNull = null;
+                object? notNull = new object();
+
+                M(new C(), [maybeNull]);
+                C c1 = [maybeNull];
+
+                M(new C(), [notNull]);
+                C c2 = [notNull];
+
+                void M<T>(T t1, T t2) { }
+
+                class C : IEnumerable
+                {
+                    IEnumerator IEnumerable.GetEnumerator() => throw null!;
+                    public void Add<T>(T t) where T : notnull { }
+                }
+                """;
+
+            // We don't analyze the Add methods
+            CreateCompilation(source).VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_IEnumerableTCollection_AnalyzeAddMethods()
+        {
+            string source = """
+                using System.Collections.Generic;
+
+                #nullable enable
+
+                object? maybeNull = null;
+                object? notNull = new object();
+
+                M(CreateAnnotated(maybeNull), [maybeNull]);
+                M(CreateAnnotated(maybeNull), [notNull]);
+
+                M(CreateAnnotated(notNull), [maybeNull]);
+                M(CreateAnnotated(notNull), [notNull]);
+
+                M(CreateUnannotated(maybeNull), [maybeNull]);
+                M(CreateUnannotated(maybeNull), [notNull]);
+
+                M(CreateUnannotated(notNull), [maybeNull]); // 1
+                M(CreateUnannotated(notNull), [notNull]);
+
+                void M<T>(T t1, T t2) { }
+
+                CAnnotated<T> CreateAnnotated<T>(T t) => throw null!;
+                CUnannotated<T> CreateUnannotated<T>(T t) => throw null!;
+
+                class CAnnotated<T> : IEnumerable<T>
+                {
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null!;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null!;
+                    public void Add(T? t) { }
+                }
+
+                class CUnannotated<T> : IEnumerable<T>
+                {
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null!;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null!;
+                    public void Add(T t) { }
+                }
+                """;
+
+            // Should we also produce W-warnings on `M(CreateAnnotated(notNull), [maybeNull])` and `M(CreateUnannotated(notNull), [maybeNull])`?
+            // Tracked by https://github.com/dotnet/roslyn/issues/68786
+
+            // We don't analyze the Add methods
+            CreateCompilation(source).VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_IEnumerableTCollection_AnalyzeAddMethods_Constraints()
+        {
+            string source = """
+                using System.Collections.Generic;
+
+                #nullable enable
+
+                object? maybeNull = null;
+                object? notNull = new object();
+
+                M(new C(), [maybeNull]);
+                C c1 = [maybeNull];
+
+                M(new C(), [notNull]);
+                C c2 = [notNull];
+
+                void M<T>(T t1, T t2) { }
+
+                class C : IEnumerable<object?>
+                {
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null!;
+                    IEnumerator<object?> IEnumerable<object?>.GetEnumerator() => throw null!;
+                    public void Add<T>(T t) where T : notnull { }
+                }
+                """;
+
+            // We don't analyze the Add methods
+            CreateCompilation(source).VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void ElementNullability_IEnumerableTCollection_AnalyzeAddMethods()
+        {
+            string source = """
+                using System.Collections.Generic;
+
+                #nullable enable
+
+                object? maybeNull = null;
+                object notNull = new object();
+
+                CAnnotated<object> c1 = [maybeNull]; // 1
+                CAnnotated<object?> c2 = [maybeNull];
+
+                CAnnotated<object> c3 = [notNull];
+                CAnnotated<object?> c4 = [notNull];
+
+                CUnannotated<object> c5 = [maybeNull]; // 2
+                CUnannotated<object?> c6 = [maybeNull];
+
+                CUnannotated<object> c7 = [notNull];
+                CUnannotated<object?> c8 = [notNull];
+
+                class CAnnotated<T> : IEnumerable<T>
+                {
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null!;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null!;
+                    public void Add(T? t) { }
+                }
+
+                class CUnannotated<T> : IEnumerable<T>
+                {
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null!;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null!;
+                    public void Add(T t) { }
+                }
+                """;
+
+            // We should produce W-warnings on `c1` and `c5` for implicit conversion from the element to the iteration type.
+            // Tracked by https://github.com/dotnet/roslyn/issues/68786
+            // We don't analyze the Add methods
+            CreateCompilation(source).VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_IEnumerableTCollection_AnalyzeAddMethods_GenericWithNotNullConstraint()
+        {
+            string source = """
+                using System.Collections.Generic;
+
+                #nullable enable
+
+                object? maybeNull = null;
+                object? notNull = new object();
+
+                M(CreateAnnotated(maybeNull), [maybeNull]);
+                M(CreateAnnotated(maybeNull), [notNull]);
+
+                M(CreateAnnotated(notNull), [maybeNull]);
+                M(CreateAnnotated(notNull), [notNull]);
+
+                M(CreateUnannotated(maybeNull), [maybeNull]);
+                M(CreateUnannotated(maybeNull), [notNull]);
+
+                M(CreateUnannotated(notNull), [maybeNull]);
+                M(CreateUnannotated(notNull), [notNull]);
+
+                void M<T>(T t1, T t2) { }
+
+                CAnnotated<T> CreateAnnotated<T>(T t) => throw null!;
+                CUnannotated<T> CreateUnannotated<T>(T t) => throw null!;
+
+                class CAnnotated<T> : IEnumerable<T>
+                {
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null!;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null!;
+                    public void Add(T? t) { }
+                }
+
+                class CUnannotated<T> : IEnumerable<T>
+                {
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null!;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null!;
+                    public void Add<U>(U u) where U : notnull { }
+                }
+                """;
+
+            // We don't analyze the Add methods
+            CreateCompilation(source).VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -26017,15 +26466,10 @@ partial class Program
                 int y = null;
                 """;
 
-            // Note: the nullability diagnostic is superfluous and results from the bound tree
-            //   not containing element conversions in the error case.
             CreateCompilation(src).VerifyEmitDiagnostics(
                 // (2,12): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
                 // int[] x = [null];
                 Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(2, 12),
-                // (2,12): warning CS8619: Nullability of reference types in value of type '<null>' doesn't match target type 'int'.
-                // int[] x = [null];
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "null").WithArguments("<null>", "int").WithLocation(2, 12),
                 // (3,9): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
                 // int y = null;
                 Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(3, 9)
@@ -26045,6 +26489,1011 @@ partial class Program
                 // (3,15): warning CS8602: Dereference of a possibly null reference.
                 // string[] x = [o.ToString()];
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(3, 15)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_MaybeNullElement()
+        {
+            string src = """
+                using System.Collections.Generic;
+
+                #nullable enable
+                string? element = null;
+                var collection = IdList([element]);
+                collection[0].ToString(); // 1
+
+                List<T> IdList<T>(List<T> l) => l;
+                """;
+
+            var comp = CreateCompilation(src).VerifyEmitDiagnostics(
+                // (6,1): warning CS8602: Dereference of a possibly null reference.
+                // collection[0].ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "collection[0]").WithLocation(6, 1)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            Assert.Equal("IdList([element])", invocation.ToFullString());
+
+            var model = comp.GetSemanticModel(tree);
+            Assert.Equal("System.Collections.Generic.List<System.String?> IdList<System.String?>(System.Collections.Generic.List<System.String?> l)",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+
+            var collection = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().Single();
+            Assert.Equal("[element]", collection.ToFullString());
+            var collectionConversion = model.GetConversion(collection);
+            Assert.True(collectionConversion.IsValid);
+            Assert.True(collectionConversion.IsCollectionExpression);
+
+            var element = collection.Elements.Single();
+            Assert.Equal("element", element.ToFullString());
+            var elementConversion = model.GetConversion(element);
+            Assert.True(elementConversion.IsValid);
+            Assert.True(elementConversion.IsIdentity);
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_NotNullElement()
+        {
+            string src = """
+                using System.Collections.Generic;
+
+                #nullable enable
+                string? element = "";
+                var collection = IdList([element]);
+                collection[0].ToString();
+
+                List<T> IdList<T>(List<T> l) => l;
+                """;
+
+            var comp = CreateCompilation(src).VerifyEmitDiagnostics();
+
+            var tree = comp.SyntaxTrees.First();
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            Assert.Equal("IdList([element])", invocation.ToFullString());
+
+            var model = comp.GetSemanticModel(tree);
+            Assert.Equal("System.Collections.Generic.List<System.String> IdList<System.String>(System.Collections.Generic.List<System.String> l)",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_TwoElements()
+        {
+            string src = """
+                using System.Collections.Generic;
+
+                #nullable enable
+                string? element1 = null;
+                string element2 = "hi";
+                var collection = IdList([element1, element2]);
+                collection[0].ToString(); // 1
+
+                List<T> IdList<T>(List<T> l) => l;
+                """;
+
+            var comp = CreateCompilation(src).VerifyEmitDiagnostics(
+                // (7,1): warning CS8602: Dereference of a possibly null reference.
+                // collection[0].ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "collection[0]").WithLocation(7, 1)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            Assert.Equal("IdList([element1, element2])", invocation.ToFullString());
+
+            var model = comp.GetSemanticModel(tree);
+            Assert.Equal("System.Collections.Generic.List<System.String?> IdList<System.String?>(System.Collections.Generic.List<System.String?> l)",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_TwoElements_DifferentTypes()
+        {
+            string src = """
+                using System.Collections.Generic;
+
+                #nullable enable
+                string? element1 = null;
+                object element2 = "hi";
+                var collection = IdList([element1, element2]);
+                collection[0].ToString(); // 1
+
+                List<T> IdList<T>(List<T> l) => l;
+                """;
+
+            var comp = CreateCompilation(src).VerifyEmitDiagnostics(
+                // (7,1): warning CS8602: Dereference of a possibly null reference.
+                // collection[0].ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "collection[0]").WithLocation(7, 1)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            Assert.Equal("IdList([element1, element2])", invocation.ToFullString());
+
+            var model = comp.GetSemanticModel(tree);
+            Assert.Equal("System.Collections.Generic.List<System.Object?> IdList<System.Object?>(System.Collections.Generic.List<System.Object?> l)",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+
+            var collection = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().Single();
+
+            var element1 = collection.Elements.First();
+            Assert.Equal("element1", element1.ToFullString());
+            var elementConversion1 = model.GetConversion(element1);
+            Assert.True(elementConversion1.IsValid);
+            Assert.True(elementConversion1.IsIdentity);
+
+            var element2 = collection.Elements.Last();
+            Assert.Equal("element2", element2.ToFullString());
+            var elementConversion2 = model.GetConversion(element2);
+            Assert.True(elementConversion2.IsValid);
+            Assert.True(elementConversion2.IsIdentity);
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_TwoElements_DifferentTypes_ExplicitConversions()
+        {
+            string src = """
+                using System.Collections.Generic;
+
+                #nullable enable
+                object? element1 = (string?)null;
+                object element2 = "hi";
+                var collection = IdList([(string?)element1, element2]);
+                collection[0].ToString(); // 1
+
+                List<T> IdList<T>(List<T> l) => l;
+                """;
+
+            var comp = CreateCompilation(src).VerifyEmitDiagnostics(
+                // (7,1): warning CS8602: Dereference of a possibly null reference.
+                // collection[0].ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "collection[0]").WithLocation(7, 1)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            Assert.Equal("IdList([(string?)element1, element2])", invocation.ToFullString());
+
+            var model = comp.GetSemanticModel(tree);
+            Assert.Equal("System.Collections.Generic.List<System.Object?> IdList<System.Object?>(System.Collections.Generic.List<System.Object?> l)",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+
+            var collection = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().Single();
+
+            var element1 = collection.Elements.First();
+            Assert.Equal("(string?)element1", element1.ToFullString());
+            var elementConversion1 = model.GetConversion(element1);
+            Assert.True(elementConversion1.IsValid);
+            Assert.True(elementConversion1.IsIdentity);
+
+            var element2 = collection.Elements.Last();
+            Assert.Equal("element2", element2.ToFullString());
+            var elementConversion2 = model.GetConversion(element2);
+            Assert.True(elementConversion2.IsValid);
+            Assert.True(elementConversion2.IsIdentity);
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_TwoElements_DifferentGenericTypes()
+        {
+            string src = """
+                using System.Collections.Generic;
+
+                #nullable enable
+                var element1 = new Container<string?>();
+                var element2 = new Container<string>();
+                var collection = IdList([element1, element2]); // 1
+                collection[0].Element.ToString();
+
+                List<T> IdList<T>(List<T> l) => l;
+
+                public class Container<T>
+                {
+                    public T Element;
+                }
+                """;
+
+            // Missing diagnostics for conversion of element to iteration type in Add scenario.
+            // Tracked by https://github.com/dotnet/roslyn/issues/68786
+            var comp = CreateCompilation(src).VerifyEmitDiagnostics(
+                // (13,14): warning CS8618: Non-nullable field 'Element' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
+                //     public T Element;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Element").WithArguments("field", "Element").WithLocation(13, 14)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            Assert.Equal("IdList([element1, element2])", invocation.ToFullString());
+
+            var model = comp.GetSemanticModel(tree);
+            Assert.Equal("System.Collections.Generic.List<Container<System.String>> IdList<Container<System.String>>(System.Collections.Generic.List<Container<System.String>> l)",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+
+            var collection = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().Single();
+
+            var element1 = collection.Elements.First();
+            Assert.Equal("element1", element1.ToFullString());
+            var elementConversion1 = model.GetConversion(element1);
+            Assert.True(elementConversion1.IsValid);
+            Assert.True(elementConversion1.IsIdentity);
+
+            var element2 = collection.Elements.Last();
+            Assert.Equal("element2", element2.ToFullString());
+            var elementConversion2 = model.GetConversion(element2);
+            Assert.True(elementConversion2.IsValid);
+            Assert.True(elementConversion2.IsIdentity);
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection()
+        {
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [null]); // 1
+                    }
+                    void M2(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [maybeNull]); // 2
+                    }
+                    void M3(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [notNull, ""]);
+                    }
+                    void M4(string? maybeNull, string notNull)
+                    {
+                        M(ref maybeNull, [notNull, maybeNull, ""]);
+                    }
+                    void M<T>(ref T t, T[] a) { }
+                }
+                """;
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (6,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [null]); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(6, 15),
+                // (10,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull]); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 15)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+            var model = comp.GetSemanticModel(tree);
+
+            Assert.Equal("M(ref notNull, [null])", invocations[0].ToString());
+            Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]! a)",
+                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("M(ref notNull, [maybeNull])", invocations[1].ToString());
+            Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]! a)",
+                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("""M(ref notNull, [notNull, ""])""", invocations[2].ToString());
+            Assert.Equal("void C.M<System.String!>(ref System.String! t, System.String![]! a)",
+                model.GetSymbolInfo(invocations[2]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("""M(ref maybeNull, [notNull, maybeNull, ""])""", invocations[3].ToString());
+            Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]! a)",
+                model.GetSymbolInfo(invocations[3]).Symbol.ToTestDisplayString(includeNonNullable: true));
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_ExplicitCast()
+        {
+            string src = """
+                #nullable enable
+                string? element1 = null;
+                string element2 = "hi";
+                var collection = IdList((string[])[element1, element2]); // 1
+                collection[0].ToString();
+
+                var collection2 = IdList([element1, element2]);
+                collection2[0].ToString(); // 2
+
+                T[] IdList<T>(T[] l) => l;
+                """;
+
+            CreateCompilation(src).VerifyEmitDiagnostics(
+                // (4,36): warning CS8601: Possible null reference assignment.
+                // var collection = IdList((string[])[element1, element2]); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "element1").WithLocation(4, 36),
+                // (8,1): warning CS8602: Dereference of a possibly null reference.
+                // collection2[0].ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "collection2[0]").WithLocation(8, 1)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_Nested()
+        {
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [[null]]); // 1
+                    }
+                    void M2(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [[maybeNull]]); // 2
+                    }
+                    void M3(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [[notNull, ""]]);
+                    }
+                    void M4(string? maybeNull, string notNull)
+                    {
+                        M(ref maybeNull, [[notNull, maybeNull, ""]]);
+                    }
+                    void M<T>(ref T t, T[][] a) { }
+                }
+                """;
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (6,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [null]); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(6, 15),
+                // (10,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull]); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 15)
+            );
+
+            var tree = comp.SyntaxTrees.First();
+            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+            var model = comp.GetSemanticModel(tree);
+
+            Assert.Equal("M(ref notNull, [[null]])", invocations[0].ToString());
+            Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]![]! a)",
+                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("M(ref notNull, [[maybeNull]])", invocations[1].ToString());
+            Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]![]! a)",
+                model.GetSymbolInfo(invocations[1]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("""M(ref notNull, [[notNull, ""]])""", invocations[2].ToString());
+            Assert.Equal("void C.M<System.String!>(ref System.String! t, System.String![]![]! a)",
+                model.GetSymbolInfo(invocations[2]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("""M(ref maybeNull, [[notNull, maybeNull, ""]])""", invocations[3].ToString());
+            Assert.Equal("void C.M<System.String?>(ref System.String? t, System.String?[]![]! a)",
+                model.GetSymbolInfo(invocations[3]).Symbol.ToTestDisplayString(includeNonNullable: true));
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_WithNotNullConstraint()
+        {
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string notNull)
+                    {
+                        M(ref notNull, [null]); // 1, 2
+                    }
+                    void M2(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [maybeNull]); // 3, 4
+                    }
+                    void M3(string notNull)
+                    {
+                        M(ref notNull, [notNull, ""]);
+                    }
+                    void M4(string? maybeNull, string notNull)
+                    {
+                        M(ref maybeNull, [notNull, maybeNull, ""]); // 5
+                    }
+                    void M<T>(ref T t, T[] a) where T : notnull { }
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (6,9): warning CS8714: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.M<T>(ref T, T[])'. Nullability of type argument 'string?' doesn't match 'notnull' constraint.
+                //         M(ref notNull, [null]); // 1, 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "M").WithArguments("C.M<T>(ref T, T[])", "T", "string?").WithLocation(6, 9),
+                // (6,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [null]); // 1, 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(6, 15),
+                // (10,9): warning CS8714: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.M<T>(ref T, T[])'. Nullability of type argument 'string?' doesn't match 'notnull' constraint.
+                //         M(ref notNull, [maybeNull]); // 3, 4
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "M").WithArguments("C.M<T>(ref T, T[])", "T", "string?").WithLocation(10, 9),
+                // (10,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull]); // 3, 4
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 15),
+                // (18,9): warning CS8714: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.M<T>(ref T, T[])'. Nullability of type argument 'string?' doesn't match 'notnull' constraint.
+                //         M(ref maybeNull, [notNull, maybeNull, ""]); // 5
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "M").WithArguments("C.M<T>(ref T, T[])", "T", "string?").WithLocation(18, 9)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_Lambda()
+        {
+            // Analyze captured variables at the location lambda is converted to a delegate
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? s)
+                    {
+                        Method([() => s]).ToString(); // 1
+                        if (s is null) return;
+                        Method([() => s]).ToString();
+                    }
+                    void M2(string? s)
+                    {
+                        Method2(s = "", [() => s]).ToString();
+                        Method2(s = null, [() => s]).ToString(); // 2
+                    }
+                    void M3(string? s)
+                    {
+                        s = "";
+                        Method([Method3(s = null), () => s.ToString()]); // 3
+                    }
+
+                    T Method<T>(System.Func<T>[] a) => throw null!;
+                    U Method2<T, U>(T t, System.Func<U>[] a) => throw null!;
+                    System.Func<string> Method3<T>(T t) => throw null!;
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
+                //         Method([() => s]).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Method([() => s])").WithLocation(6, 9),
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
+                //         Method2(s = null, [() => s]).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Method2(s = null, [() => s])").WithLocation(13, 9),
+                // (18,42): warning CS8602: Dereference of a possibly null reference.
+                //         Method([Method3(s = null), () => s.ToString()]); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 42)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_Lambda_WithConditional()
+        {
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? s)
+                    {
+                        bool b = true;
+                        Method([b ? (() => s) : (() => s)]).ToString(); // 1
+                    }
+
+                    T Method<T>(System.Func<T>[] a) => throw null!;
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (7,9): error CS0411: The type arguments for method 'C.Method<T>(Func<T>[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Method([b ? (() => s) : (() => s)]).ToString(); // 1
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Method").WithArguments("C.Method<T>(System.Func<T>[])").WithLocation(7, 9)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_Lambda_WithSwitch()
+        {
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? s)
+                    {
+                        bool b = true;
+                        Method([b switch { true => () => s, _ => () => s }]).ToString(); // 1
+                        Method2(b switch { true => () => s, _ => () => s }).ToString(); // 2
+                    }
+
+                    T Method<T>(System.Func<T>[] a) => throw null!;
+                    T Method2<T>(System.Func<T> a) => throw null!;
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (7,9): error CS0411: The type arguments for method 'C.Method<T>(Func<T>[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Method([b switch { true => () => s, _ => () => s }]).ToString(); // 1
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Method").WithArguments("C.Method<T>(System.Func<T>[])").WithLocation(7, 9),
+                // (8,9): error CS0411: The type arguments for method 'C.Method2<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Method2(b switch { true => () => s, _ => () => s }).ToString(); // 2
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Method2").WithArguments("C.Method2<T>(System.Func<T>)").WithLocation(8, 9)
+                );
+        }
+
+        [Fact]
+        public void TupleElementNullability_Inference_Lambda()
+        {
+            // Analyze captured variables at the location lambda is converted to a delegate
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? s)
+                    {
+                        Method((42, () => s)).ToString(); // 1
+                        if (s is null) return;
+                        Method((42, () => s)).ToString();
+                    }
+                    void M2(string? s)
+                    {
+                        Method2(s = "", (42, () => s)).ToString();
+                        Method2(s = null, (42, () => s)).ToString(); // 2
+                    }
+                    void M3(string? s)
+                    {
+                        s = "";
+                        Method((Method3(s = null), () => s.ToString())); // 3
+                        Method((Method3(s = ""), () => s.ToString()));
+                    }
+
+                    T Method<T>((int, System.Func<T>) a) => throw null!;
+                    U Method2<T, U>(T t, (int, System.Func<U>) a) => throw null!;
+                    int Method3<T>(T t) => throw null!;
+                }
+                """;
+
+            // Tuples should be analyzed as-if they were flattened (but they current are not)
+            // Tracked by https://github.com/dotnet/roslyn/issues/71242
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (18,42): warning CS8602: Dereference of a possibly null reference.
+                //         Method((Method3(s = null), () => s.ToString())); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 42)
+                );
+
+            string src2 = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? s)
+                    {
+                        Method(42, () => s).ToString(); // 1
+                        if (s is null) return;
+                        Method(42, () => s).ToString();
+                    }
+                    void M2(string? s)
+                    {
+                        Method2(s = "", 42, () => s).ToString();
+                        Method2(s = null, 42, () => s).ToString(); // 2
+                    }
+                    void M3(string? s)
+                    {
+                        s = "";
+                        Method(Method3(s = null), () => s.ToString()); // 3
+                        Method(Method3(s = ""), () => s.ToString());
+                    }
+
+                    T Method<T>(int a, System.Func<T> b) => throw null!;
+                    U Method2<T, U>(T t, int a, System.Func<U> b) => throw null!;
+                    int Method3<T>(T t) => throw null!;
+                }
+                """;
+
+            CreateCompilation(src2, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
+                //         Method(42, () => s).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Method(42, () => s)").WithLocation(6, 9),
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
+                //         Method2(s = null, 42, () => s).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Method2(s = null, 42, () => s)").WithLocation(13, 9),
+                // (18,41): warning CS8602: Dereference of a possibly null reference.
+                //         Method(Method3(s = null), () => s.ToString()); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 41)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_Lambda_ContainingTuples()
+        {
+            // Analyze captured variables at the location lambda is converted to a delegate
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? s)
+                    {
+                        Method([(42, () => s)]).ToString(); // 1
+                        if (s is null) return;
+                        Method([(42, () => s)]).ToString();
+                    }
+                    void M2(string? s)
+                    {
+                        Method2(s = "", [(42, () => s)]).ToString();
+                        Method2(s = null, [(42, () => s)]).ToString(); // 2
+                    }
+                    void M3(string? s)
+                    {
+                        s = "";
+                        Method([(42, Method3(s = null)), (42, () => s.ToString())]); // 3
+                    }
+
+                    T Method<T>((int, System.Func<T>)[] a) => throw null!;
+                    U Method2<T, U>(T t, (int, System.Func<U>)[] a) => throw null!;
+                    System.Func<string> Method3<T>(T t) => throw null!;
+                }
+                """;
+
+            // Tuples should be analyzed as-if they were flattened (but they current are not)
+            // Tracked by https://github.com/dotnet/roslyn/issues/71242
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (18,53): warning CS8602: Dereference of a possibly null reference.
+                //         Method([(42, Method3(s = null)), (42, () => s.ToString())]); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 53)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_Lambda_InsideTuples()
+        {
+            // Analyze captured variables at the location lambda is converted to a delegate
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? s)
+                    {
+                        Method((42, [() => s])).ToString(); // 1
+                        if (s is null) return;
+                        Method((42, [() => s])).ToString();
+                    }
+                    void M2(string? s)
+                    {
+                        Method2(s = "", (42, [() => s])).ToString();
+                        Method2(s = null, (42, [() => s])).ToString(); // 2
+                    }
+                    void M3(string? s)
+                    {
+                        s = "";
+                        Method((42, [Method3(s = null), () => s.ToString()])); // 3
+                    }
+
+                    T Method<T>((int, System.Func<T>[]) a) => throw null!;
+                    U Method2<T, U>(T t, (int, System.Func<U>[]) a) => throw null!;
+                    System.Func<string> Method3<T>(T t) => throw null!;
+                }
+                """;
+
+            // Tuples should be analyzed as-if they were flattened (but they current are not)
+            // Tracked by https://github.com/dotnet/roslyn/issues/71242
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (18,47): warning CS8602: Dereference of a possibly null reference.
+                //         Method((42, [Method3(s = null), () => s.ToString()])); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 47)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_Lambda_Constraint()
+        {
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string notNull)
+                    {
+                        M([() => notNull]).ToString();
+                    }
+                    void M2(string? maybeNull)
+                    {
+                        M([() => maybeNull]).ToString(); // 1, 2, 3
+                    }
+                    T M<T>(System.Func<T>[] a) where T : notnull => throw null!;
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (10,9): warning CS8714: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.M<T>(Func<T>[])'. Nullability of type argument 'string?' doesn't match 'notnull' constraint.
+                //         M([() => maybeNull]).ToString(); // 1, 2, 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint, "M").WithArguments("C.M<T>(System.Func<T>[])", "T", "string?").WithLocation(10, 9),
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
+                //         M([() => maybeNull]).ToString(); // 1, 2, 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M([() => maybeNull])").WithLocation(10, 9),
+                // (10,12): warning CS8621: Nullability of reference types in return type of 'lambda expression' doesn't match the target delegate 'Func<string?>' (possibly because of nullability attributes).
+                //         M([() => maybeNull]).ToString(); // 1, 2, 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate, "() =>").WithArguments("lambda expression", "System.Func<string?>").WithLocation(10, 12)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ArrayCollection_Chained()
+        {
+            string src = """
+                #nullable enable
+                public class C
+                {
+                    void M1(string? maybeNull)
+                    {
+                        var result = M([Copy(maybeNull, out var maybeNull2), maybeNull2]);
+                        result.ToString();
+                    }
+                    void M2(string? maybeNull)
+                    {
+                        M([Copy(maybeNull, out var maybeNull2), maybeNull2.ToString()]);
+                    }
+                    T M<T>(T[] a) => throw null!;
+                    object Copy<T>(T t, out T t2) => throw null!;
+                }
+                """;
+
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
+                //         result.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "result").WithLocation(7, 9),
+                // (11,49): warning CS8602: Dereference of a possibly null reference.
+                //         M([Copy(maybeNull, out var maybeNull2), maybeNull2.ToString()]);
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "maybeNull2").WithLocation(11, 49)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var invocations = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+            var model = comp.GetSemanticModel(tree);
+
+            Assert.Equal("M([Copy(maybeNull, out var maybeNull2), maybeNull2])", invocations[0].ToString());
+            Assert.Equal("System.Object? C.M<System.Object?>(System.Object?[]! a)",
+                model.GetSymbolInfo(invocations[0]).Symbol.ToTestDisplayString(includeNonNullable: true));
+
+            Assert.Equal("M([Copy(maybeNull, out var maybeNull2), maybeNull2.ToString()])", invocations[3].ToString());
+            Assert.Equal("System.Object! C.M<System.Object!>(System.Object![]! a)",
+                model.GetSymbolInfo(invocations[3]).Symbol.ToTestDisplayString(includeNonNullable: true));
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ImmutableArrayCollection()
+        {
+            string src = """
+                using System.Collections.Immutable;
+
+                #nullable enable
+                public class C
+                {
+                    void M1(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [null]); // 1
+                    }
+                    void M2(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [maybeNull]); // 2
+                    }
+                    void M3(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [notNull, ""]);
+                    }
+                    void M4(string? maybeNull, string notNull)
+                    {
+                        M(ref maybeNull, [notNull, maybeNull, ""]);
+                    }
+                    void M<T>(ref T t, ImmutableArray<T> a) { }
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (8,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [null]); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(8, 15),
+                // (12,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull]); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(12, 15)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ImmutableArrayCollection_NestedInArray()
+        {
+            string src = """
+                using System.Collections.Immutable;
+
+                #nullable enable
+                public class C
+                {
+                    void M1(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [[null]]); // 1
+                    }
+                    void M2(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [[maybeNull]]); // 2
+                    }
+                    void M3(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [[notNull, ""]]);
+                    }
+                    void M4(string? maybeNull, string notNull)
+                    {
+                        M(ref maybeNull, [[notNull, maybeNull, ""]]);
+                    }
+                    void M<T>(ref T t, ImmutableArray<T>[] a) { }
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (8,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [null]); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(8, 15),
+                // (12,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull]); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(12, 15)
+                );
+        }
+
+        [Theory, CombinatorialData]
+        public void ElementNullability_Inference_SpanCollection([CombinatorialValues("Span", "ReadOnlySpan")] string spanType)
+        {
+            string src = $$"""
+                using System;
+
+                #nullable enable
+                public class C
+                {
+                    void M1(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [null]); // 1
+                    }
+                    void M2(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [maybeNull]); // 2
+                    }
+                    void M3(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [notNull, ""]);
+                    }
+                    void M4(string? maybeNull, string notNull)
+                    {
+                        M(ref maybeNull, [notNull, maybeNull, ""]);
+                    }
+                    void M<T>(ref T t, {{spanType}}<T> a) { }
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (8,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [null]); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(8, 15),
+                // (12,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull]); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(12, 15)
+                );
+        }
+
+        [Fact]
+        public void ElementNullability_Inference_ListCollection()
+        {
+            string src = """
+                using System.Collections.Generic;
+
+                #nullable enable
+                public class C
+                {
+                    void M1(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [null]).ToString(); // 1
+                    }
+                    void M2(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [maybeNull]).ToString(); // 2
+                    }
+                    void M3(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [notNull, ""]).ToString();
+                    }
+                    void M4(string? maybeNull, string notNull)
+                    {
+                        M(ref maybeNull, [notNull, maybeNull, ""]).ToString(); // 3
+                    }
+                    T M<T>(ref T t, List<T> a) => throw null!;
+                }
+                """;
+
+            // The diagnostics on `notNull` are a bit unclear, but they match the behavior
+            // for non-collection expression scenarios (see below).
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
+                //         M(ref notNull, [null]).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M(ref notNull, [null])").WithLocation(8, 9),
+                // (8,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [null]).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(8, 15),
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
+                //         M(ref notNull, [maybeNull]).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M(ref notNull, [maybeNull])").WithLocation(12, 9),
+                // (12,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull]).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(12, 15),
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
+                //         M(ref maybeNull, [notNull, maybeNull, ""]).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, @"M(ref maybeNull, [notNull, maybeNull, """"])").WithLocation(20, 9));
+
+            src = """
+                #nullable enable
+                public class C
+                {
+                    void MA(string? maybeNull, string notNull)
+                    {
+                        M1(ref notNull, null).ToString(); // 1
+                    }
+                    void MB(string? maybeNull, string notNull)
+                    {
+                        M1(ref notNull, maybeNull).ToString(); // 2
+                    }
+                    void MC(string? maybeNull, string notNull)
+                    {
+                        M2(ref notNull, notNull, "").ToString();
+                    }
+                    void MD(string? maybeNull, string notNull)
+                    {
+                        M3(ref maybeNull, notNull, maybeNull, "").ToString(); // 3
+                    }
+                    T M1<T>(ref T t, T a) => throw null!;
+                    T M2<T>(ref T t, T a, T b) => throw null!;
+                    T M3<T>(ref T t, T a, T b, T c) => throw null!;
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
+                //         M1(ref notNull, null).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(ref notNull, null)").WithLocation(6, 9),
+                // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M1(ref notNull, null).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(6, 16),
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
+                //         M1(ref notNull, maybeNull).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(ref notNull, maybeNull)").WithLocation(10, 9),
+                // (10,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M1(ref notNull, maybeNull).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 16),
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
+                //         M3(ref maybeNull, notNull, maybeNull, "").ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, @"M3(ref maybeNull, notNull, maybeNull, """")").WithLocation(18, 9));
+        }
+
+        [Theory]
+        [InlineData("System.Collections.Generic.IEnumerable")]
+        [InlineData("System.Collections.Generic.IReadOnlyCollection")]
+        [InlineData("System.Collections.Generic.IReadOnlyList")]
+        [InlineData("System.Collections.Generic.ICollection")]
+        [InlineData("System.Collections.Generic.IList")]
+        public void ElementNullability_Inference_InterfaceCollection(string interfaceType)
+        {
+            string src = $$"""
+                #nullable enable
+                public class C
+                {
+                    void M1(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [null]); // 1
+                    }
+                    void M2(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [maybeNull]); // 2
+                    }
+                    void M3(string? maybeNull, string notNull)
+                    {
+                        M(ref notNull, [notNull, ""]);
+                    }
+                    void M4(string? maybeNull, string notNull)
+                    {
+                        M(ref maybeNull, [notNull, maybeNull, ""]);
+                    }
+                    void M<T>(ref T t, {{interfaceType}}<T> a) { }
+                }
+                """;
+
+            CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(
+                // (6,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [null]); // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(6, 15),
+                // (10,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         M(ref notNull, [maybeNull]); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "notNull").WithLocation(10, 15)
                 );
         }
 


### PR DESCRIPTION
Implements part of https://github.com/dotnet/roslyn/issues/68786

Overview of the change:
- Track which nodes are actually target-typed (this helps not register some completion continuations that later trigger assertions).
- Add `NestedVisitResults` and `StateForLambda` to `VisitResult`. 
  - `NestedVisitResults` allows to gather the `VisitResults` for elements, so that they can contribute to method type inference (`MethodTypeInferrer` handles unconverted collection expressions by making inferences from the elements directly). `GetArgumentsForMethodTypeInference` uses those nested visit results to prepare suitable arguments for method type inference.
  - `StateForLambda` allows tracking the State just prior to visiting a lambda expression. Previously, this was done with `VisitArgumentResult`, but that only works at the argument level. Now we need this for elements too.
- Left for follow-ups (marked with tracking link to https://github.com/dotnet/roslyn/issues/68786):
  - Analysis of spreads
  - Check the conversion of elements to some iteration type in Add/initializer scenario (we need to determine the element type, but there may be multiple `IEnumerable<T>` interfaces). Code below should help once that element type is determined.
 
 Update: there is one IDE test failure, for which I added a corresponding compiler repro. The problem is that the logic in `NullableWalker.VisitArguments` to get corresponding parameter types doesn't match the logic in `Binder.BuildArgumentsForErrorRecovery`. When we have a bad call, the binder tries to find corresponding parameter types across the various candidates, but the nullable walker logic only consider the method stored in `BoundCall.Method` (which is an `ErrorMethodSymbol`).
 Because of this mismatch, the binder was able to convert the collection expression to a parameter type, but the nullable walker isn't, so it asserts because we detect that a converted target-typed collection wasn't fully processed.
 As a workaround, the last commit softens an assertion (which was incorrect in `main`) and allows us to recover without triggering assertions. We could file a follow-up bug for this.