### PR TITLE
Fix infinite loop in tagging

### DIFF
--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
         public IList<ITagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
             => SegmentedListPool.ComputeList(
-                static (args, tags) => args.@this.AddIntersectingSpansInSortedOrder(args.snapshotSpan, tags),
+                static (args, tags) => args.@this.AppendIntersectingSpansInSortedOrder(args.snapshotSpan, tags),
                 (@this: this, snapshotSpan),
                 _: (ITagSpan<TTag>?)null);
 
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         /// <paramref name="result"/>.  Note the sorted chunk of items are appended to <paramref name="result"/>.  This
         /// means that <paramref name="result"/> may not be sorted if there were already items in them.
         /// </summary>
-        private void AddIntersectingSpansInSortedOrder(SnapshotSpan snapshotSpan, SegmentedList<ITagSpan<TTag>> result)
+        private void AppendIntersectingSpansInSortedOrder(SnapshotSpan snapshotSpan, SegmentedList<ITagSpan<TTag>> result)
         {
             var snapshot = snapshotSpan.Snapshot;
             Debug.Assert(snapshot.TextBuffer == _textBuffer);
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             // Special case the case where there is only one requested span.  In that case, we don't
             // need to allocate any intermediate collections
             if (requestedSpans.Count == 1)
-                AddIntersectingSpansInSortedOrder(requestedSpans[0], tags);
+                AppendIntersectingSpansInSortedOrder(requestedSpans[0], tags);
             else if (requestedSpans.Count < MaxNumberOfRequestedSpans)
                 AddTagsForSmallNumberOfSpans(requestedSpans, tags);
             else
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             SegmentedList<ITagSpan<TTag>> tags)
         {
             foreach (var span in requestedSpans)
-                AddIntersectingSpansInSortedOrder(span, tags);
+                AppendIntersectingSpansInSortedOrder(span, tags);
         }
 
         private void AddTagsForLargeNumberOfSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<ITagSpan<TTag>> tags)
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
             using var _1 = SegmentedListPool.GetPooledList<ITagSpan<TTag>>(out var tempList);
 
-            AddIntersectingSpansInSortedOrder(mergedSpan, tempList);
+            AppendIntersectingSpansInSortedOrder(mergedSpan, tempList);
             if (tempList.Count == 0)
                 return;
 

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             if (tempList.Count == 0)
                 return;
 
-            // Note: from this point on, both 'requstedSpans' and 'tempList' are in sorted
+            // Note: both 'requstedSpans' and 'tempList' are in sorted order.
 
             using var enumerator = tempList.GetEnumerator();
 

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -27,7 +27,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging;
 
 [UseExportProvider]
-public sealed class AsynchronousTaggerTests : TestBase
+public sealed class AsynchronousTaggerTests
 {
     /// <summary>
     /// This hits a special codepath in the product that is optimized for more than 100 spans.

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -71,7 +71,7 @@ public sealed class AsynchronousTaggerTests : TestBase
             workspace.GetService<IThreadingContext>(),
             (s, c) => Enumerable
                 .Range(0, tagsProduced)
-                .Select(i => (ITagSpan<TestTag>)new TagSpan<TestTag>(new SnapshotSpan(s.Snapshot, new Span(50 + i * 2, 1)), new TestTag())),
+                .Select(i => new TagSpan<TestTag>(new SnapshotSpan(s.Snapshot, new Span(50 + i * 2, 1)), new TestTag())),
             eventSource,
             workspace.GetService<IGlobalOptionService>(),
             asyncListener);

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -67,7 +67,7 @@ public sealed class AsynchronousTaggerTests
         WpfTestRunner.RequireWpfFact($"{nameof(AsynchronousTaggerTests)}.{nameof(LargeNumberOfSpans)} creates asynchronous taggers");
 
         var eventSource = CreateEventSource();
-        var taggerProvider = new TextMarkerTaggerProvider(
+        var taggerProvider = new TestTaggerProvider(
             workspace.GetService<IThreadingContext>(),
             (s, c) => Enumerable
                 .Range(0, tagsProduced)
@@ -141,10 +141,10 @@ public sealed class AsynchronousTaggerTests
         Assert.Equal(2, tags.Count());
     }
 
-    private static TextMarkerTaggerEventSource CreateEventSource()
+    private static TestTaggerEventSource CreateEventSource()
         => new();
 
-    private sealed class TextMarkerTaggerProvider(
+    private sealed class TestTaggerProvider(
         IThreadingContext threadingContext,
         Func<SnapshotSpan, CancellationToken, IEnumerable<ITagSpan<TextMarkerTag>>> callback,
         ITaggerEventSource eventSource,
@@ -171,7 +171,7 @@ public sealed class AsynchronousTaggerTests
             => tag1 == tag2;
     }
 
-    private sealed class TextMarkerTaggerEventSource() : AbstractTaggerEventSource
+    private sealed class TestTaggerEventSource() : AbstractTaggerEventSource
     {
         public void SendUpdateEvent()
             => this.RaiseChanged();

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -82,8 +82,8 @@ public sealed class AsynchronousTaggerTests : TestBase
         using var tagger = taggerProvider.CreateTagger(textBuffer);
         Contract.ThrowIfNull(tagger);
 
-        var spans = Enumerable.Range(0, 101).Select(i => new Span(i * 4, 1));
-        var snapshotSpans = new NormalizedSnapshotSpanCollection(snapshot, spans);
+        var snapshotSpans = new NormalizedSnapshotSpanCollection(
+            snapshot, Enumerable.Range(0, 101).Select(i => new Span(i * 4, 1)));
 
         eventSource.SendUpdateEvent();
 

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -99,6 +99,74 @@ public class AsynchronousTaggerTests : TestBase
 
         Assert.Equal(tagsProduced, tags.Count());
     }
+    /// <summary>
+    /// This hits a special codepath in the product that is optimized for more than 100 spans.
+    /// I'm leaving this test here because it covers that code path (as shown by code coverage)
+    /// </summary>
+    [WpfTheory]
+    [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530368")]
+    [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1927519")]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(101)]
+    public async Task LargeNumberOfSpans2(int tagsProduced)
+    {
+        using var workspace = TestWorkspace.CreateCSharp("""
+            class Program
+            {
+                void M()
+                {
+                    int z = 0;
+                    z = z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z +
+                        z + z + z + z + z + z + z + z + z + z;
+                }
+            }
+            """);
+
+        List<ITagSpan<TestTag>> tagProducer(SnapshotSpan span, CancellationToken cancellationToken)
+        {
+            return Enumerable
+                .Range(0, tagsProduced)
+                .Select(i => (ITagSpan<TestTag>)new TagSpan<TestTag>(new SnapshotSpan(span.Snapshot, new Span(50 + i * 2, 1)), new TestTag()))
+                .ToList();
+        }
+
+        var asyncListener = new AsynchronousOperationListener();
+
+        WpfTestRunner.RequireWpfFact($"{nameof(AsynchronousTaggerTests)}.{nameof(LargeNumberOfSpans)} creates asynchronous taggers");
+
+        var eventSource = CreateEventSource();
+        var taggerProvider = new TestTaggerProvider(
+            workspace.GetService<IThreadingContext>(),
+            tagProducer,
+            eventSource,
+            workspace.GetService<IGlobalOptionService>(),
+            asyncListener);
+
+        var document = workspace.Documents.First();
+        var textBuffer = document.GetTextBuffer();
+        var snapshot = textBuffer.CurrentSnapshot;
+        using var tagger = taggerProvider.CreateTagger(textBuffer);
+        Contract.ThrowIfNull(tagger);
+
+        var spans = Enumerable.Range(0, 101).Select(i => new Span(i * 4, 1));
+        var snapshotSpans = new NormalizedSnapshotSpanCollection(snapshot, spans);
+
+        eventSource.SendUpdateEvent();
+
+        await asyncListener.ExpeditedWaitAsync();
+
+        var tags = tagger.GetTags(snapshotSpans);
+    }
 
     [WpfFact]
     public void TestNotSynchronousOutlining()


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1927519

Introduced with https://github.com/dotnet/roslyn/pull/70884.  I accidentally moved an index that was outside of a loop into the loop.