### PR TITLE
Semantic snippets: fix inline statement snippets in a "qualified name" edge case

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
@@ -580,5 +580,113 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        public async Task InsertInlineSnippetWhenDottingBeforeContextualKeywordTest1()
+        {
+            var markupBeforeCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool flag)
+                    {
+                        flag.$$
+                        var a = 0;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool flag)
+                    {
+                        {{ItemToCommit}} (flag)
+                        {
+                            $$
+                        }
+                        var a = 0;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        public async Task InsertInlineSnippetWhenDottingBeforeContextualKeywordTest2()
+        {
+            var markupBeforeCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool flag, Task t)
+                    {
+                        flag.$$
+                        await t;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool flag, Task t)
+                    {
+                        {{ItemToCommit}} (flag)
+                        {
+                            $$
+                        }
+                        await t;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("Task")]
+        [InlineData("Task<int>")]
+        [InlineData("System.Threading.Tasks.Task<int>")]
+        public async Task InsertInlineSnippetWhenDottingBeforeNameSyntaxTest(string nameSyntax)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool flag)
+                    {
+                        flag.$$
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool flag)
+                    {
+                        {{ItemToCommit}} (flag)
+                        {
+                            $$
+                        }
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
@@ -697,6 +697,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
         [InlineData("Task")]
         [InlineData("Task<int>")]
+        [InlineData("System.Threading.Tasks.Task<int>")]
         public async Task InsertInlineForEachSnippetWhenDottingBeforeNameSyntaxTest(string nameSyntax)
         {
             var markupBeforeCommit = $$"""
@@ -812,6 +813,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
         [InlineData("Task")]
         [InlineData("Task<int>")]
+        [InlineData("System.Threading.Tasks.Task<int>")]
         public async Task InsertInlineAwaitForEachSnippetWhenDottingBeforeNameSyntaxTest(string nameSyntax)
         {
             var markupBeforeCommit = $$"""

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
@@ -623,5 +623,231 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        public async Task InsertInlineForEachSnippetWhenDottingBeforeContextualKeywordTest1()
+        {
+            var markupBeforeCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IEnumerable<int> ints)
+                    {
+                        ints.$$
+                        var a = 0;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IEnumerable<int> ints)
+                    {
+                        foreach (var item in ints)
+                        {
+                            $$
+                        }
+                        var a = 0;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        public async Task InsertInlineForEachSnippetWhenDottingBeforeContextualKeywordTest2()
+        {
+            var markupBeforeCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IEnumerable<int> ints, Task t)
+                    {
+                        ints.$$
+                        await t;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IEnumerable<int> ints, Task t)
+                    {
+                        foreach (var item in ints)
+                        {
+                            $$
+                        }
+                        await t;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("Task")]
+        [InlineData("Task<int>")]
+        public async Task InsertInlineForEachSnippetWhenDottingBeforeNameSyntaxTest(string nameSyntax)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IEnumerable<int> ints)
+                    {
+                        ints.$$
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IEnumerable<int> ints)
+                    {
+                        foreach (var item in ints)
+                        {
+                            $$
+                        }
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        public async Task InsertInlineAwaitForEachSnippetWhenDottingBeforeContextualKeywordTest1()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" CommonReferencesNet7="true">
+                        <Document>using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(IAsyncEnumerable&lt;int&gt; asyncInts)
+                    {
+                        asyncInts.$$
+                        var a = 0;
+                    }
+                }</Document>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IAsyncEnumerable<int> asyncInts)
+                    {
+                        await foreach (var item in asyncInts)
+                        {
+                            $$
+                        }
+                        var a = 0;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        public async Task InsertInlineAwaitForEachSnippetWhenDottingBeforeContextualKeywordTest2()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" CommonReferencesNet7="true">
+                        <Document>using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(IAsyncEnumerable&lt;int&gt; asyncInts, Task t)
+                    {
+                        asyncInts.$$
+                        await t;
+                    }
+                }</Document>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IAsyncEnumerable<int> asyncInts, Task t)
+                    {
+                        await foreach (var item in asyncInts)
+                        {
+                            $$
+                        }
+                        await t;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("Task")]
+        [InlineData("Task<int>")]
+        public async Task InsertInlineAwaitForEachSnippetWhenDottingBeforeNameSyntaxTest(string nameSyntax)
+        {
+            var markupBeforeCommit = $$"""
+                <Workspace>
+                    <Project Language="C#" CommonReferencesNet7="true">
+                        <Document>using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(IAsyncEnumerable&lt;int&gt; asyncInts)
+                    {
+                        asyncInts.$$
+                        {{nameSyntax.Replace("<", "&lt;").Replace(">", "&gt;")}} t = null;
+                    }
+                }</Document>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(IAsyncEnumerable<int> asyncInts)
+                    {
+                        await foreach (var item in asyncInts)
+                        {
+                            $$
+                        }
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForSnippetCompletionProviderTests.cs
@@ -520,5 +520,133 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("byte")]
+        [InlineData("sbyte")]
+        [InlineData("short")]
+        [InlineData("ushort")]
+        [InlineData("int")]
+        [InlineData("uint")]
+        [InlineData("long")]
+        [InlineData("ulong")]
+        [InlineData("nint")]
+        [InlineData("nuint")]
+        public async Task InsertInlineForSnippetWhenDottingBeforeContextualKeywordTest1(string intType)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M({{intType}} @int)
+                    {
+                        @int.$$
+                        var a = 0;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M({{intType}} @int)
+                    {
+                        for ({{intType}} i = 0; i < @int; i++)
+                        {
+                            $$
+                        }
+                        var a = 0;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("byte")]
+        [InlineData("sbyte")]
+        [InlineData("short")]
+        [InlineData("ushort")]
+        [InlineData("int")]
+        [InlineData("uint")]
+        [InlineData("long")]
+        [InlineData("ulong")]
+        [InlineData("nint")]
+        [InlineData("nuint")]
+        public async Task InsertInlineForSnippetWhenDottingBeforeContextualKeywordTest2(string intType)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M({{intType}} @int, Task t)
+                    {
+                        @int.$$
+                        await t;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M({{intType}} @int, Task t)
+                    {
+                        for ({{intType}} i = 0; i < @int; i++)
+                        {
+                            $$
+                        }
+                        await t;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("Task")]
+        [InlineData("Task<int>")]
+        [InlineData("System.Threading.Tasks.Task<int>")]
+        public async Task InsertInlineForSnippetWhenDottingBeforeNameSyntaxTest(string nameSyntax)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(int @int)
+                    {
+                        @int.$$
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(int @int)
+                    {
+                        for (int i = 0; i < @int; i++)
+                        {
+                            $$
+                        }
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForrSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForrSnippetCompletionProviderTests.cs
@@ -522,5 +522,133 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("byte")]
+        [InlineData("sbyte")]
+        [InlineData("short")]
+        [InlineData("ushort")]
+        [InlineData("int")]
+        [InlineData("uint")]
+        [InlineData("long")]
+        [InlineData("ulong")]
+        [InlineData("nint")]
+        [InlineData("nuint")]
+        public async Task InsertInlineForrSnippetWhenDottingBeforeContextualKeywordTest1(string intType)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M({{intType}} @int)
+                    {
+                        @int.$$
+                        var a = 0;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M({{intType}} @int)
+                    {
+                        for ({{intType}} i = @int - 1; i >= 0; i--)
+                        {
+                            $$
+                        }
+                        var a = 0;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("byte")]
+        [InlineData("sbyte")]
+        [InlineData("short")]
+        [InlineData("ushort")]
+        [InlineData("int")]
+        [InlineData("uint")]
+        [InlineData("long")]
+        [InlineData("ulong")]
+        [InlineData("nint")]
+        [InlineData("nuint")]
+        public async Task InsertInlineForrSnippetWhenDottingBeforeContextualKeywordTest2(string intType)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M({{intType}} @int, Task t)
+                    {
+                        @int.$$
+                        await t;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M({{intType}} @int, Task t)
+                    {
+                        for ({{intType}} i = @int - 1; i >= 0; i--)
+                        {
+                            $$
+                        }
+                        await t;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
+        [InlineData("Task")]
+        [InlineData("Task<int>")]
+        [InlineData("System.Threading.Tasks.Task<int>")]
+        public async Task InsertInlineForrSnippetWhenDottingBeforeNameSyntaxTest(string nameSyntax)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(int @int)
+                    {
+                        @int.$$
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(int @int)
+                    {
+                        for (int i = @int - 1; i >= 0; i--)
+                        {
+                            $$
+                        }
+                        {{nameSyntax}} t = null;
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected abstract void AddSpecificPlaceholders(MultiDictionary<string, int> placeholderBuilder, ExpressionSyntax initializer, ExpressionSyntax rightOfCondition);
 
-        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
+        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
         {
             var semanticModel = syntaxContext.SemanticModel;
             var compilation = semanticModel.Compilation;
@@ -48,18 +48,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
             TypeSyntax? iteratorTypeSyntax = null;
 
-            if (inlineExpression is null)
+            if (inlineExpressionInfo is null)
             {
                 iteratorTypeSyntax = compilation.GetSpecialType(SpecialType.System_Int32).GenerateTypeSyntax();
             }
             else
             {
-                var inlineExpressionType = semanticModel.GetTypeInfo(inlineExpression).Type;
+                var inlineExpressionType = inlineExpressionInfo.TypeInfo.Type;
                 Debug.Assert(inlineExpressionType is not null && (inlineExpressionType.IsIntegralType() || inlineExpressionType.IsNativeIntegerType));
                 iteratorTypeSyntax = inlineExpressionType.GenerateTypeSyntax();
             }
 
-            inlineExpression = inlineExpression?.WithoutLeadingTrivia();
+            var inlineExpression = inlineExpressionInfo?.Node.WithoutLeadingTrivia();
 
             var variableDeclaration = SyntaxFactory.VariableDeclaration(
                 iteratorTypeSyntax,

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -49,13 +49,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             return await base.IsValidSnippetLocationAsync(document, position, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
+        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
         {
             var semanticModel = syntaxContext.SemanticModel;
             var position = syntaxContext.Position;
 
             var varIdentifier = SyntaxFactory.IdentifierName("var");
-            var collectionIdentifier = (ExpressionSyntax?)inlineExpression;
+            var collectionIdentifier = (ExpressionSyntax?)inlineExpressionInfo?.Node;
 
             if (collectionIdentifier is null)
             {
@@ -73,8 +73,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
             ForEachStatementSyntax forEachStatement;
 
-            if (inlineExpression is not null &&
-                semanticModel.GetTypeInfo(inlineExpression).Type!.CanBeAsynchronouslyEnumerated(semanticModel.Compilation))
+            if (inlineExpressionInfo is { TypeInfo: var typeInfo } &&
+                typeInfo.Type!.CanBeAsynchronouslyEnumerated(semanticModel.Compilation))
             {
                 forEachStatement = SyntaxFactory.ForEachStatement(
                     SyntaxFactory.Token(SyntaxKind.AwaitKeyword),

--- a/src/Features/Core/Portable/Snippets/InlineExpressionInfo.cs
+++ b/src/Features/Core/Portable/Snippets/InlineExpressionInfo.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Snippets;
+
+/// <summary>
+/// Information about inline expression for inline statement snippets
+/// </summary>
+internal sealed class InlineExpressionInfo(SyntaxNode node, TypeInfo typeInfo)
+{
+    /// <summary>
+    /// Right-hand side of an accessing expression.
+    /// Must be an expression node.
+    /// Do NOT use it to obtain semantic info.
+    /// If you need type information about this node use <see cref="TypeInfo" /> property
+    /// </summary>
+    public SyntaxNode Node { get; } = node;
+
+    /// <summary>
+    /// Type information of an accessing expression
+    /// </summary>
+    public TypeInfo TypeInfo { get; } = typeInfo;
+}

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsIfStatement;
 
-        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
-            => generator.IfStatement(inlineExpression?.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
+        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
+            => generator.IfStatement(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -117,6 +117,18 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
             return false;
         }
 
+        /// <summary>
+        /// There are some edge cases when user intent is to write a member access expression,
+        /// but due to the current state of the document parser ends up parsing it as a qualified name, e.g.
+        /// <code>
+        /// ...
+        /// flag.$$
+        /// var a = 0;
+        /// ...
+        /// </code>
+        /// Here <c>flag.var</c> is parsed as a qualified name. Since we normally query for member access expressions this case requires its own handling
+        /// </summary>
+        /// <param name="expression">Left-hand side of a qualified name</param>
         private static bool TryGetInlineExpressionInQualifiedNameEdgeCases(SyntaxToken targetToken, ISyntaxFactsService syntaxFacts, [NotNullWhen(true)] out SyntaxNode? expression)
         {
             var parentNode = targetToken.Parent;

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsWhileStatement;
 
-        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
-            => generator.WhileStatement(inlineExpression?.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
+        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
+            => generator.WhileStatement(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/69598