### PR TITLE
Fix null ref exception in Symbol.CanBeReferencedByName for VB

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
@@ -1022,6 +1022,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Case BoundKind.Local
                     Dim local As LocalSymbol = DirectCast(node, BoundLocal).LocalSymbol
+
+                    If local.IsCompilerGenerated AndAlso Not Me.ProcessCompilerGeneratedLocals Then
+                        ' For consistency with Assign behavior, which does not process compiler generated temporary locals.
+                        Return True
+                    End If
+
                     If local.DeclarationKind <> LocalDeclarationKind.AmbiguousLocals Then
                         unassignedSlot = VariableSlot(local)
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -589,8 +589,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public ReadOnly Property CanBeReferencedByName As Boolean
             Get
                 Select Case Me.Kind
-                    Case SymbolKind.Local,
-                         SymbolKind.Label,
+                    Case SymbolKind.Local
+                        Return If(Me.Name?.Length, 0) > 0
+
+                    Case SymbolKind.Label,
                          SymbolKind.Alias
                         ' Can't be imported, but might have syntax errors in which case we use an empty name:
                         Return Me.Name.Length > 0


### PR DESCRIPTION
Fixes #71115.