### PR TITLE
Remove extra backslash from IBC script

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -248,7 +248,7 @@ function BuildSolution() {
   $msbuildWarnAsError = if ($warnAsError) { "/warnAsError" } else { "" }
 
   # Workaround for some machines in the AzDO pool not allowing long paths
-  $ibcDir = Join-Path $RepoRoot
+  $ibcDir = $RepoRoot
 
   # Set DotNetBuildFromSource to 'true' if we're simulating building for source-build.
   $buildFromSource = if ($sourceBuild) { "/p:DotNetBuildFromSource=true" } else { "" }

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -247,8 +247,8 @@ function BuildSolution() {
   # that MSBuild output as well as ones that custom tasks output.
   $msbuildWarnAsError = if ($warnAsError) { "/warnAsError" } else { "" }
 
-  # Workaround for some machines in the AzDO pool not allowing long paths (%5c is msbuild escaped backslash)
-  $ibcDir = Join-Path $RepoRoot ".o%5c"
+  # Workaround for some machines in the AzDO pool not allowing long paths
+  $ibcDir = Join-Path $RepoRoot
 
   # Set DotNetBuildFromSource to 'true' if we're simulating building for source-build.
   $buildFromSource = if ($sourceBuild) { "/p:DotNetBuildFromSource=true" } else { "" }


### PR DESCRIPTION
This should not be necessary and can cause problems with the inner build in Vertical Build by escaping a trailing quote. RepoRoot is already passed with a trailing slash.