### PR TITLE
Revert "Restore using dotnet CLI to ensure NuGet environment variables are used"

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -101,8 +101,15 @@ stages:
         useGlobalJson: true
         workingDirectory: '$(Build.SourcesDirectory)'
 
-    - script: dotnet restore eng\common\internal\Tools.csproj
+    # Needed to restore the Microsoft.DevDiv.Optimization.Data.PowerShell package
+    - task: NuGetCommand@2
       displayName: Restore internal tools
+      inputs:
+        command: restore
+        feedsToUse: config
+        restoreSolution: 'eng\common\internal\Tools.csproj'
+        nugetConfigPath: 'NuGet.config'
+        restoreDirectory: '$(Build.SourcesDirectory)\.packages'
 
     - task: MicroBuildSigningPlugin@2
       inputs:


### PR DESCRIPTION
It seems whatever had caused the previous error is now reverted back to previous behavior.
val build: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=8814005&view=results

This reverts commit f29d7f96042cba689cfdce05313d25018c125815.