### PR TITLE
Do not call Unsubst if it is not available due to argument processing

### DIFF
--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -15,6 +15,7 @@ $nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { $false }
 $bootstrapDir = if (Test-Path variable:bootstrapDir) { $bootstrapDir } else { "" }
 $bootstrapConfiguration = if (Test-Path variable:bootstrapConfiguration) { $bootstrapConfiguration } else { "Release" }
 $properties = if (Test-Path variable:properties) { $properties } else { @() }
+$originalTemp = $env:TEMP;
 
 function GetProjectOutputBinary([string]$fileName, [string]$projectName = "", [string]$configuration = $script:configuration, [string]$tfm = "net472", [string]$rid = "", [bool]$published = $false) {
   $projectName = if ($projectName -ne "") { $projectName } else { [System.IO.Path]::GetFileNameWithoutExtension($fileName) }
@@ -358,5 +359,9 @@ function Subst-TempDir() {
 function Unsubst-TempDir() {
   if ($ci) {
     Exec-Command "subst" "T: /d"
+
+    # Restore the original temp directory
+    $env:TEMP=$originalTemp
+    $env:TMP=$originalTemp
   }
 }

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -798,6 +798,8 @@ finally {
     Stop-Processes
   }
 
-  Unsubst-TempDir
+  if (Test-Path Function:\Unsubst-TempDir) {
+    Unsubst-TempDir
+  }
   Pop-Location
 }


### PR DESCRIPTION
If argument processing fails, the script will not import the utility methods, and Subst won't be called. This will cause the script to fail in non-helpful ways. In addition, fix an issue where the TEMP dir remains at T: after unsubst is called.