### PR TITLE
Call GetURI when getting a URI for a document

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -453,7 +453,7 @@ namespace Roslyn.Test.Utilities
                     Contract.ThrowIfNull(document.FilePath);
 
                     var locationsForName = locations.GetValueOrDefault(name, new List<LSP.Location>());
-                    locationsForName.AddRange(spans.Select(span => ConvertTextSpanWithTextToLocation(span, text, ProtocolConversions.CreateAbsoluteUri(document.FilePath))));
+                    locationsForName.AddRange(spans.Select(span => ConvertTextSpanWithTextToLocation(span, text, document.GetURI())));
 
                     // Linked files will return duplicate annotated Locations for each document that links to the same file.
                     // Since the test output only cares about the actual file, make sure we de-dupe before returning.

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -476,7 +476,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 CancellationToken cancellationToken)
             {
                 Debug.Assert(document.FilePath != null);
-                var uri = CreateAbsoluteUri(document.FilePath);
+                var uri = document.GetURI();
 
                 var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
                 if (isStale)

--- a/src/Features/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
@@ -73,7 +73,7 @@ comment */|}";
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
             var request = new LSP.FoldingRangeParams()
             {
-                TextDocument = CreateTextDocumentIdentifier(ProtocolConversions.CreateAbsoluteUri(document.FilePath))
+                TextDocument = CreateTextDocumentIdentifier(document.GetURI())
             };
 
             return await testLspServer.ExecuteRequestAsync<LSP.FoldingRangeParams, LSP.FoldingRange[]>(LSP.Methods.TextDocumentFoldingRangeName,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
@@ -128,7 +128,7 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
         // Open a file that is part of a registered workspace and verify it is not present in the misc workspace.
-        var fileInWorkspaceUri = ProtocolConversions.CreateAbsoluteUri(testLspServer.GetCurrentSolution().Projects.Single().Documents.Single().FilePath!);
+        var fileInWorkspaceUri = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single().GetURI();
         await testLspServer.OpenDocumentAsync(fileInWorkspaceUri).ConfigureAwait(false);
         Assert.Null(GetMiscellaneousDocument(testLspServer));
     }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Symbols
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
             var request = new LSP.DocumentSymbolParams
             {
-                TextDocument = CreateTextDocumentIdentifier(ProtocolConversions.CreateAbsoluteUri(document.FilePath))
+                TextDocument = CreateTextDocumentIdentifier(document.GetURI())
             };
 
             return await testLspServer.ExecuteRequestAsync<LSP.DocumentSymbolParams, TReturn>(LSP.Methods.TextDocumentDocumentSymbolName,

--- a/src/Tools/ExternalAccess/Razor/RazorUri.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorUri.cs
@@ -15,9 +15,6 @@ internal static class RazorUri
 
     public static Uri CreateUri(this TextDocument document)
     {
-        Contract.ThrowIfNull(document.FilePath);
-        return document is SourceGeneratedDocument
-            ? ProtocolConversions.CreateUriFromSourceGeneratedFilePath(document.FilePath)
-            : ProtocolConversions.CreateAbsoluteUri(document.FilePath);
+        return document.GetURI();
     }
 }


### PR DESCRIPTION
We had some code that slipped in that was calling `ProtocolConversions.CreateAbsoluteUri(document.FilePath)`, which is fine for regular documents but skips the special handling around source generated files, so we'd break in those cases.

This "fixes" the UriFormatExceptions people are getting, in the sense that you won't get a UriFormatException anymore. If you try to actually go to a source generated document, that'll still be broken until we merge https://github.com/dotnet/vscode-csharp/pull/5858, but at least this means something like a find reference won't completely break if it has a location somewhere in a source generated file.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1922993