### PR TITLE
Fix snippet change text

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -50,12 +50,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
             var lspSnippet = await RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(allChangesDocument, snippet.CursorPosition, snippet.Placeholders, change, item.Span.Start, cancellationToken).ConfigureAwait(false);
 
             // If the TextChanges retrieved starts after the trigger point of the CompletionItem,
-            // then we need to move the bounds backwards and encapsulate the trigger point.
+            // then we need to move the bounds backwards and encapsulate the trigger point and adjust the changed text.
             if (change.Span.Start > item.Span.Start)
             {
                 var textSpan = TextSpan.FromBounds(item.Span.Start, change.Span.End);
-                var snippetText = change.NewText;
-                Contract.ThrowIfNull(snippetText);
+                var snippetText = allChangesText.GetSubText(textSpan).ToString();
                 change = new TextChange(textSpan, snippetText);
             }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -355,15 +355,13 @@ link text";
                 using System;
                 public class Program
                 {
-                    svm{|caret:|}
+                    {|editRange:svm|}{|caret:|}
                 }
                 """;
-
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, new LSP.VSInternalClientCapabilities { SupportsVisualStudioExtensions = true });
             testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.CSharp, SnippetsRule.AlwaysInclude);
             testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp, true);
 
-            var caret = testLspServer.GetLocations("caret").Single();
             var clientCompletionItem = await GetCompletionItemToResolveAsync<LSP.VSInternalCompletionItem>(testLspServer, label: "svm").ConfigureAwait(false);
 
             Assert.True(clientCompletionItem.VsResolveTextEditOnCommit);
@@ -375,13 +373,8 @@ link text";
             Assert.Null(results.InsertText);
             Assert.Equal("static void Main(string[] args)\r\n    {\r\n        \r\n    }", results.TextEdit.Value.First.NewText);
 
-            var range = new LSP.Range
-            {
-                Start = new LSP.Position { Line = 3, Character = 4 },
-                End = new LSP.Position { Line = 3, Character = 7 }
-            };
-            Assert.Equal(range, results.TextEdit.Value.First.Range);
-
+            var editRange = testLspServer.GetLocations("editRange").Single().Range;
+            Assert.Equal(editRange, results.TextEdit.Value.First.Range);
         }
 
         private static async Task<LSP.CompletionItem> RunResolveCompletionItemAsync(TestLspServer testLspServer, LSP.CompletionItem completionItem)

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -9,20 +9,20 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text.Adornments;
 using Newtonsoft.Json;
+using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 using LSP = Roslyn.LanguageServer.Protocol;
-using Microsoft.CodeAnalysis.Extensions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
 {
@@ -345,6 +345,43 @@ link text";
                 testLspServer, clientCompletionItem).ConfigureAwait(false);
             Assert.Equal("(byte)", results.Label);
             Assert.NotNull(results.Description);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestSemanticSnippetChangeAsync(bool mutatingLspWorkspace)
+        {
+            var markup =
+                """
+                using System;
+                public class Program
+                {
+                    svm{|caret:|}
+                }
+                """;
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, new LSP.VSInternalClientCapabilities { SupportsVisualStudioExtensions = true });
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.CSharp, SnippetsRule.AlwaysInclude);
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp, true);
+
+            var caret = testLspServer.GetLocations("caret").Single();
+            var clientCompletionItem = await GetCompletionItemToResolveAsync<LSP.VSInternalCompletionItem>(testLspServer, label: "svm").ConfigureAwait(false);
+
+            Assert.True(clientCompletionItem.VsResolveTextEditOnCommit);
+
+            var results = (LSP.VSInternalCompletionItem)await RunResolveCompletionItemAsync(
+                testLspServer, clientCompletionItem).ConfigureAwait(false);
+
+            Assert.NotNull(results.TextEdit);
+            Assert.Null(results.InsertText);
+            Assert.Equal("static void Main(string[] args)\r\n    {\r\n        \r\n    }", results.TextEdit.Value.First.NewText);
+
+            var range = new LSP.Range
+            {
+                Start = new LSP.Position { Line = 3, Character = 4 },
+                End = new LSP.Position { Line = 3, Character = 7 }
+            };
+            Assert.Equal(range, results.TextEdit.Value.First.Range);
+
         }
 
         private static async Task<LSP.CompletionItem> RunResolveCompletionItemAsync(TestLspServer testLspServer, LSP.CompletionItem completionItem)


### PR DESCRIPTION
in LSP mode, when the full change shares a common prefix with filter text. e.g.

`svm<tab>`
 
 
![43572537-9fc3-420d-8ff8-a7e1af449d69](https://github.com/dotnet/roslyn/assets/788783/146cee84-db4d-438a-923b-beadbf6cc64b)

 
is producing:
 
![3f65aeb1-66b9-4f80-81fe-c5db78d86c40](https://github.com/dotnet/roslyn/assets/788783/77fafb07-1e56-4b6c-89d4-0a2f383e0d9a)

non-LSP mode (asyncCompletion) is not affected because it uses the LSP snippet string directly which always contains the full change. See: https://github.com/dotnet/roslyn/blob/main/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs#L263