### PR TITLE
[Inline Rename] Cosmetic improvements to Rename Suggestions

### DIFF
--- a/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
+++ b/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
@@ -159,4 +159,10 @@
   <data name="Generating_suggestions" xml:space="preserve">
     <value>Generating suggestions...</value>
   </data>
+  <data name="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion" xml:space="preserve">
+    <value>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</value>
+  </data>
+  <data name="Get_AI_suggestions" xml:space="preserve">
+    <value>Get AI-powered rename suggestions</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
+++ b/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
@@ -163,6 +163,6 @@
     <value>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</value>
   </data>
   <data name="Get_AI_suggestions" xml:space="preserve">
-    <value>Get AI-powered rename suggestions</value>
+    <value>Get AI-powered rename suggestions (Ctrl+Space)</value>
   </data>
 </root>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -92,7 +92,7 @@
                 <imaging:CrispImage Grid.Column="0" Moniker="{Binding StatusImageMoniker}" />
                 <TextBlock Grid.Column="1" Text="{Binding StatusText}" />
             </Grid>
-            
+
             <TextBlock 
                 Text="{Binding SearchText}" 
                 Visibility="{Binding ShowSearchText, Converter={StaticResource BooleanToVisibilityConverter}}"

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -32,7 +32,7 @@
         BorderThickness="1"
         x:Name="Outline">
         <StackPanel x:Name="MainPanel" Orientation="Vertical" Margin="5" >
-            <Grid x:Name="IdentifierAndExpandButtonGrid" Margin="0 0 0 10">
+            <Grid x:Name="IdentifierAndExpandButtonGrid" Margin="0 0 0 5">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="22" />

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -127,7 +127,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public string ApplyRename => EditorFeaturesResources.Apply1;
         public string CancelRename => EditorFeaturesResources.Cancel;
         public string PreviewChanges => EditorFeaturesResources.Preview_changes1;
-        public string SubmitText => EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
+        public string SubmitText
+            => _viewModel.SmartRenameViewModel is not null
+            ? EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion
+            : EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
 #pragma warning restore CA1822 // Mark members as static
 
         private void TextView_ViewPortChanged(object sender, EventArgs e)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -6,6 +6,7 @@
           xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
           xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
           xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+          xmlns:sr="clr-namespace:Microsoft.CodeAnalysis.InlineRename.UI.SmartRename"
           mc:Ignorable="d"
           GotKeyboardFocus="ComboBox_GotKeyboardFocus"
           Unloaded="ComboBox_Unloaded"
@@ -115,7 +116,7 @@
                         <Button x:Name="GetSuggestionsButton"
                                 Grid.Column="1"
                                 Style="{StaticResource GetSuggestionButtonStyle}"
-                                ToolTip="{Binding GetSuggestionsTooltip}"
+                                ToolTip="{x:Static sr:SmartRenameViewModel.GetSuggestionsTooltip}"
                                 Command="{Binding GetSuggestionsCommand}">
                             <Button.Content>
                                 <Canvas Width="16" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -9,6 +9,7 @@
           xmlns:sr="clr-namespace:Microsoft.CodeAnalysis.InlineRename.UI.SmartRename"
           mc:Ignorable="d"
           GotKeyboardFocus="ComboBox_GotKeyboardFocus"
+          LostKeyboardFocus="ComboBox_LostKeyboardFocus"
           Unloaded="ComboBox_Unloaded"
           PreviewKeyUp="ComboBox_PreviewKeyUp"
           SelectionChanged="ComboBox_SelectionChanged"
@@ -16,7 +17,9 @@
           ItemsSource="{Binding SuggestedNames}"
           StaysOpenOnEdit="True"
           IsEditable="True"
-          Style="{StaticResource {x:Static vsfx:VsResourceKeys.ComboBoxStyleKey}}">
+          Style="{StaticResource {x:Static vsfx:VsResourceKeys.ComboBoxStyleKey}}"
+          VirtualizingStackPanel.IsVirtualizing="True"
+          VirtualizingStackPanel.VirtualizationMode="Recycling">
     <ComboBox.Resources>
         <ResourceDictionary>
             <vsui:BooleanToHiddenVisibilityConverter x:Key="BooleanToHiddenVisibilityConverter"/>
@@ -91,9 +94,11 @@
                                               RenderOptions.BitmapScalingMode="{x:Static vsui:DpiHelper.BitmapScalingMode}"
                                               Background="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBackgroundGradientBrushKey}}">
                                             <ItemsPresenter x:Name="ItemsPresenter"
+                                                            VirtualizingStackPanel.IsVirtualizing="True"
                                                             KeyboardNavigation.DirectionalNavigation="Contained"
                                                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                            PreviewMouseUp="ItemsPresenter_PreviewMouseUp"/>
+                                                            PreviewMouseUp="ItemsPresenter_PreviewMouseUp">
+                                            </ItemsPresenter>
                                         </Grid>
                                     </ScrollViewer>
                                 </Border>
@@ -201,4 +206,12 @@
             </ControlTemplate.Triggers>
         </ControlTemplate>
     </ComboBox.Template>
+    <ComboBox.ItemsPanel>
+        <ItemsPanelTemplate>
+            <VirtualizingStackPanel
+                IsItemsHost="True"
+                IsVirtualizing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(VirtualizingStackPanel.IsVirtualizing)}"
+                VirtualizationMode="{Binding RelativeSource={RelativeSource TemplatedParent},Path=(VirtualizingStackPanel.VirtualizationMode)}" />
+        </ItemsPanelTemplate>
+    </ComboBox.ItemsPanel>
 </ComboBox>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -18,7 +18,7 @@
           Style="{StaticResource {x:Static vsfx:VsResourceKeys.ComboBoxStyleKey}}">
     <ComboBox.Resources>
         <ResourceDictionary>
-            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <vsui:BooleanToHiddenVisibilityConverter x:Key="BooleanToHiddenVisibilityConverter"/>
             <SolidColorBrush x:Key="copilotBranding" Color="#6F66E3"/>
 
             <Style x:Key="ComboBoxEditableTextBox" TargetType="{x:Type TextBox}">
@@ -36,6 +36,21 @@
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
+            </Style>
+
+            <Style x:Key="GetSuggestionButtonStyle" BasedOn="{StaticResource {x:Static vsfx:VsResourceKeys.ButtonStyleKey}}" TargetType="Button">
+                <Setter Property="Padding" Value="4,3,2,1"/>
+                <Setter Property="MinHeight" Value="0"/>
+                <Setter Property="MinWidth" Value="0"/>
+                <Setter Property="BorderBrush" Value="Transparent"/>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="true">
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderHoverBrushKey}}"/>
+                    </Trigger>
+                    <Trigger Property="IsKeyboardFocused" Value="true">
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderFocusedBrushKey}}"/>
+                    </Trigger>
+                </Style.Triggers>
             </Style>
         </ResourceDictionary>
     </ComboBox.Resources>
@@ -99,12 +114,8 @@
                                  PreviewKeyDown="InnerTextBox_PreviewKeyDown"/>
                         <Button x:Name="GetSuggestionsButton"
                                 Grid.Column="1"
-                                MinWidth="0"
-                                MinHeight="0"
-                                Background="Transparent"
-                                BorderBrush="Transparent"
-                                Style="{StaticResource {x:Static vsfx:VsResourceKeys.ButtonStyleKey}}"
-                                Padding="4,3,2,1"
+                                Style="{StaticResource GetSuggestionButtonStyle}"
+                                ToolTip="{Binding GetSuggestionsTooltip}"
                                 Command="{Binding GetSuggestionsCommand}">
                             <Button.Content>
                                 <Canvas Width="16" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center">
@@ -148,8 +159,9 @@
                 </Border>
                 <ProgressBar x:Name="ProgressBar"
                              Grid.Row="1"
+                             Margin="{TemplateBinding BorderThickness}"
                              IsIndeterminate="{Binding IsInProgress}"
-                             Visibility="{Binding IsInProgress, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
+                             Visibility="{Binding IsInProgress, Converter={StaticResource BooleanToHiddenVisibilityConverter}, Mode=OneWay}"
                              Foreground="{StaticResource copilotBranding}"
                              Background="{DynamicResource {x:Static vsfx:VsBrushes.CommandBarMenuBackgroundGradientBeginKey}}" />
             </Grid>
@@ -161,12 +173,10 @@
                     <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxFocusedTextBrushKey}}" />
                     <Setter TargetName="border" Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxFocusedBackgroundBrushKey}}" />
                     <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxFocusedBorderBrushKey}}" />
-                    <Setter TargetName="GetSuggestionsButton" Property="BorderBrush" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxFocusedButtonSeparatorBrushKey}}" />
                     <Setter TargetName="GetSuggestionsButton" Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxFocusedButtonBackgroundBrushKey}}" />
                     <Setter TargetName="GetSuggestionsButton" Property="TextElement.Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxFocusedGlyphBrushKey}}" />
                 </Trigger>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter TargetName="GetSuggestionsButton" Property="BorderBrush" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxButtonMouseOverSeparatorBrushKey}}" />
                     <Setter TargetName="GetSuggestionsButton" Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxButtonMouseOverBackgroundBrushKey}}" />
                     <Setter TargetName="GetSuggestionsButton" Property="TextElement.Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxMouseOverGlyphBrushKey}}" />
                     <Setter TargetName="border" Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxMouseOverBackgroundGradientBrushKey}}" />

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -112,6 +112,12 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
         e.Handled = true;
     }
 
+    private void ComboBox_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        Assumes.NotNull(_dropDownPopup);
+        _dropDownPopup.IsOpen = false;
+    }
+
     private void ComboBox_PreviewKeyUp(object sender, KeyEventArgs e)
     {
         if ((e.Key is Key.Up or Key.Down) && Items.Count > 0)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -64,6 +64,10 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
         }
     }
 
+#pragma warning disable CA1822 // Mark members as static - used in xaml
+    public string GetSuggestionsTooltip => EditorFeaturesWpfResources.Get_AI_suggestions;
+#pragma warning restore CA1822 // Mark members as static
+
     public ICommand GetSuggestionsCommand { get; }
 
     public SmartRenameViewModel(
@@ -102,11 +106,16 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
         // _smartRenameSession.SuggestedNames is a normal list. We need to convert it to ObservableCollection to bind to UI Element.
         if (e.PropertyName == nameof(_smartRenameSession.SuggestedNames))
         {
+            var textInputBackup = BaseViewModel.IdentifierText;
+
             SuggestedNames.Clear();
             foreach (var name in _smartRenameSession.SuggestedNames)
             {
                 SuggestedNames.Add(name);
             }
+
+            // Changing the list may have changed the text in the text box. We need to restore it.
+            BaseViewModel.IdentifierText = textInputBackup;
 
             return;
         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -64,9 +64,7 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
         }
     }
 
-#pragma warning disable CA1822 // Mark members as static - used in xaml
-    public string GetSuggestionsTooltip => EditorFeaturesWpfResources.Get_AI_suggestions;
-#pragma warning restore CA1822 // Mark members as static
+    public static string GetSuggestionsTooltip => EditorFeaturesWpfResources.Get_AI_suggestions;
 
     public ICommand GetSuggestionsCommand { get; }
 

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Stisknutím klávesy Enter přejmenujete, stisknutím kombinace kláves Shift+Enter zobrazíte náhled</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Nepovedlo se provést přejmenování: {0}</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Eingabetaste zum Umbenennen, Umschalt+Eingabetaste zur Vorschau</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Fehler beim Umbenennen: "{0}"</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Entrar para cambiar el nombre, Mayús+Entrar para la vista previa</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Error al realizar el cambio de nombre: "{0}"</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Entrez pour renommer, Maj+Entrée pour afficher un aperçu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Erreur au moment du renommage : '{0}'</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">INVIO per rinominare, MAIUSC+INVIO per visualizzare l'anteprima</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Si è verificato un errore durante la ridenominazione: '{0}'</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Enter キーを押して名前を変更、Shift + Enter キーを押してプレビュー</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">名前変更の実行でエラーが発生しました: '{0}'</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">이름을 바꾸려면 Enter 키를, 미리 보려면 Shift+Enter 키를 누르세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">이름 바꾸기 수행 중 오류 발생: '{0}'</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Naciśnij klawisz Enter, aby zmienić nazwę, Shift+Enter, aby wyświetlić podgląd</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Błąd podczas wykonywania operacji zmiany nazwy: „{0}”</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Pressionar Enter para renomear, Shift+Enter para visualizar</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Erro ao executar a renomeação: '{0}'</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Нажмите ВВОД для переименования. Нажмите SHIFT+ВВОД для предварительного просмотра.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Ошибка при выполнении переименования: "{0}"</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Yeniden adlandırmak için Enter, önizleme için Shift+Enter</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Yeniden adlandırma işlemi gerçekleştirilirken hata oluştu: '{0}'</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Enter 重命名，Shift+Enter 预览</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">执行重命名时出错:“{0}”</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Enter 鍵以重新命名，Shift+Enter 以預覽</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion">
+        <source>Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</source>
+        <target state="new">Enter to rename, Shift+Enter to preview, Ctrl+Space for rename suggestions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">執行重新命名時發生錯誤: '{0}'</target>
@@ -30,6 +35,11 @@
       <trans-unit id="Generating_suggestions">
         <source>Generating suggestions...</source>
         <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Get_AI_suggestions">
+        <source>Get AI-powered rename suggestions</source>
+        <target state="new">Get AI-powered rename suggestions</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Get_AI_suggestions">
-        <source>Get AI-powered rename suggestions</source>
-        <target state="new">Get AI-powered rename suggestions</target>
+        <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
+        <target state="new">Get AI-powered rename suggestions (Ctrl+Space)</target>
         <note />
       </trans-unit>
       <trans-unit id="Interactive_host_process_platform">


### PR DESCRIPTION
This PR addresses a few cosmetic issues in Rename Suggestions.

1. In Blue theme, the Rename Suggestion button had a border constantly. It's better to have a border only on focus or on mouse over.
![image](https://github.com/dotnet/roslyn/assets/3747805/c0d94e15-3ba9-4cf1-9d1c-bffb52deed39)

2. Progress bar was a tad off on the left and right. 
![image](https://github.com/dotnet/roslyn/assets/3747805/d473ac8c-4041-4766-879a-2fd3847c5bab)

3. The keyboard shortcut to trigger Rename Suggestion wasn't displayed anywhere.
4. The progress bar would shift the other UI element below when getting visible / invisible. 
5. Updating the suggestion list caused the text box to clear and lose its text.

Screenshots of the new experience:

![image](https://github.com/dotnet/roslyn/assets/3747805/db1d9ccf-4f52-45cb-9c70-c0dfbb260804)
![image](https://github.com/dotnet/roslyn/assets/3747805/a4e4e75c-4f48-479f-a596-da383d38bda4)
![image](https://github.com/dotnet/roslyn/assets/3747805/00a44a8e-e738-43b4-8c5d-404215912e5c)

![image](https://github.com/dotnet/roslyn/assets/3747805/92418ec0-17d0-48a8-8c8d-479fb4e65f19)

![image](https://github.com/dotnet/roslyn/assets/3747805/1888105e-6482-4cd9-a7e7-3df6ba3a3bf8)

![image](https://github.com/dotnet/roslyn/assets/3747805/a137cab4-2d81-49d4-ad74-75438bfc1ece)

![image](https://github.com/dotnet/roslyn/assets/3747805/291649d7-eabb-49e3-965d-639c8fb9688a)

 