### PR TITLE
Update to new version of NuGetAuthenticate task as v0 is being deprecated

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -138,7 +138,7 @@ stages:
         versionSpec: '4.9.2'
 
     # Authenticate with service connections to be able to publish packages to external nuget feeds.
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
       inputs:
         nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, devdiv/dotnet-core-internal-tooling
 

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -89,7 +89,7 @@ stages:
         versionSpec: '4.9.2'
 
     # Authenticate with service connections to be able to publish packages to external nuget feeds.
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
       inputs:
         nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
 


### PR DESCRIPTION
```
##[warning]Task 'NuGet authenticate' version 0 (NuGetAuthenticate@0) is deprecated. This task will be removed. From January 31, 2024, onwards it may no longer be available. Please see https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/nuget-authenticate-v0 for more information about this task.
```