### PR TITLE
Don't hard select promoted default item if there's filter text

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -938,9 +938,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 if (bestPromotedItemSoFar < 0)
                     return initialSelection;
 
-                // If user hasn't typed anything, we'd like to hard select the default item.
-                // This way, they can easily commit the default item which matches what WLC shows.
-                var selectionHint = _filterText.Length == 0 ? UpdateSelectionHint.Selected : initialSelection.SelectionHint;
+                // If user hasn't typed anything, we'd like to soft select the default item.
+                // This way, the selection won't get in the way of typing.
+                var selectionHint = _filterText.Length == 0 ? UpdateSelectionHint.SoftSelected : initialSelection.SelectionHint;
                 return initialSelection with { SelectedItemIndex = bestPromotedItemSoFar, SelectionHint = selectionHint };
             }
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
@@ -614,10 +614,10 @@ public class Program
                 }
 
                 AssertCompletionItemsInRelativeOrder(state, expectedItems1)
-                Await state.AssertSelectedCompletionItem("★ Title", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("★ Title", isHardSelected:=False)
 
                 state.SendTypeChars("""")
-                Await state.AssertLineTextAroundCaret("        sb.Append(Title""", "")
+                Await state.AssertLineTextAroundCaret("        sb.Append(""", "")
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
@@ -586,6 +586,41 @@ $$
             End Using
         End Function
 
+        <WpfFact>
+        Public Async Function TestSelectionOfPromotedDefaultItemWithEmptyFilterText() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+using System.Text;
+public class Program
+{
+    static string Title { get; } = "";
+    static void Main(string[] args)
+    {
+        var sb = new StringBuilder();
+        sb.Append$$
+    }
+}
+                </Document>,
+                showCompletionInArgumentLists:=True,
+                extraExportedTypes:={GetType(MockDefaultSource)}.ToList())
+
+                MockDefaultSource.Defaults = ImmutableArray.Create("Title")
+                state.SendTypeChars("(")
+
+                Dim expectedItems1 = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ Title", isPromoted:=True),
+                    CreateExpectedItem("Title", isPromoted:=False)
+                }
+
+                AssertCompletionItemsInRelativeOrder(state, expectedItems1)
+                Await state.AssertSelectedCompletionItem("★ Title", isHardSelected:=True)
+
+                state.SendTypeChars("""")
+                Await state.AssertLineTextAroundCaret("        sb.Append(Title""", "")
+            End Using
+        End Function
+
         <ExportLanguageServiceFactory(GetType(CompletionService), LanguageNames.CSharp), [Shared], PartNotDiscoverable>
         Private Class MockCompletionServiceFactory
             Implements ILanguageServiceFactory

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
@@ -6,14 +6,14 @@ Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Completion.Providers
+Imports Microsoft.CodeAnalysis.CSharp.Completion
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Options
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.PooledObjects
-Imports Microsoft.CodeAnalysis.CSharp.Completion
-Imports Microsoft.CodeAnalysis.Completion.Providers
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion
 Imports Microsoft.VisualStudio.Text.Editor
 
@@ -127,7 +127,7 @@ class C
 
                 AssertCompletionItemsInRelativeOrder(state, expectedItems)
 
-                Await state.AssertSelectedCompletionItem("★ MyAB", isHardSelected:=True) ' hard-selected since filter text is empty
+                Await state.AssertSelectedCompletionItem("★ MyAB", isHardSelected:=False)
             End Using
         End Function
 
@@ -342,7 +342,7 @@ class Test
                 }
 
                 AssertCompletionItemsInRelativeOrder(state, expectedItems1)
-                Await state.AssertSelectedCompletionItem("★ FirstDefault", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("★ FirstDefault", isHardSelected:=False)
 
                 Dim expectedItems2 = New List(Of ValueTuple(Of String, Boolean)) From {
                     CreateExpectedItem("★ FirstDefault", isPromoted:=True),
@@ -398,7 +398,7 @@ class Test
                 }
 
                 AssertCompletionItemsInRelativeOrder(state, expectedItems1)
-                Await state.AssertSelectedCompletionItem("★ SecondStarred", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("★ SecondStarred", isHardSelected:=False)
 
                 Dim expectedItems2 = New List(Of ValueTuple(Of String, Boolean)) From {
                     CreateExpectedItem("★ FirstStarred", isPromoted:=False),
@@ -465,7 +465,7 @@ class Test
                 }
 
                 AssertCompletionItemsInRelativeOrder(state, expectedItems1)
-                Await state.AssertSelectedCompletionItem("★ if", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("★ if", isHardSelected:=False)
 
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
@@ -587,7 +587,7 @@ $$
         End Function
 
         <WpfFact>
-        Public Async Function TestSelectionOfPromotedDefaultItemWithEmptyFilterText() As Task
+        Public Async Function TestSelectionOfPromotedDefaultItemWithEmptyFilterTextTriggeredOnArgument() As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document>
 using System;


### PR DESCRIPTION
Hard-selecting item suggested by WLC might be disrutive for typing. As shown in the screenshot, typing `"` would commit "Ttile", which is undesired.

![image](https://github.com/dotnet/roslyn/assets/788783/e35fe61d-c89b-4d4a-80f5-d0f5f44c9ebe)
