### PR TITLE
Wrap up all the refection and linq expression usage in try-catch 

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             IThreadingContext threadingContext,
             IAsynchronousOperationListenerProvider listenerProvider,
 #pragma warning disable CS0618 // Editor team use Obsolete attribute to mark potential changing API
-            Lazy<ISmartRenameSessionFactoryWrapper>? smartRenameSessionFactory)
+            Lazy<ISmartRenameSessionFactoryWrapper?>? smartRenameSessionFactory)
 #pragma warning restore CS0618 
         {
             _session = session;
@@ -55,8 +55,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _session.ReferenceLocationsChanged += OnReferenceLocationsChanged;
             StartingSelection = selectionSpan;
             InitialTrackingSpan = session.TriggerSpan.CreateTrackingSpan(SpanTrackingMode.EdgeInclusive);
-            var smartRenameSession = smartRenameSessionFactory?.Value.CreateSmartRenameSession(_session.TriggerSpan);
-            if (smartRenameSession is not null)
+            var smartRenameSession = smartRenameSessionFactory?.Value?.CreateSmartRenameSession(_session.TriggerSpan);
+            if (smartRenameSession.HasValue)
             {
                 SmartRenameViewModel = new SmartRenameViewModel(threadingContext, listenerProvider, smartRenameSession.Value, this);
             }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private readonly IInlineRenameColorUpdater? _dashboardColorUpdater;
         private readonly IThreadingContext _threadingContext;
 #pragma warning disable CS0618 // Editor team use Obsolete attribute to mark potential changing API
-        private readonly Lazy<ISmartRenameSessionFactoryWrapper>? _smartRenameSessionFactory;
+        private readonly Lazy<ISmartRenameSessionFactoryWrapper?>? _smartRenameSessionFactory;
 #pragma warning restore CS0618
 
         private readonly IAdornmentLayer _adornmentLayer;
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             IAsynchronousOperationListenerProvider listenerProvider,
             IThreadingContext threadingContext,
 #pragma warning disable CS0618  // Editor team use Obsolete attribute to mark potential changing API
-            Lazy<ISmartRenameSessionFactoryWrapper>? smartRenameSessionFactory)
+            Lazy<ISmartRenameSessionFactoryWrapper?>? smartRenameSessionFactory)
 #pragma warning restore CS0618
         {
             _renameService = renameService;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private readonly IThreadingContext _threadingContext;
 
 #pragma warning disable CS0618 // Editor team use Obsolete attribute to mark potential changing API
-        private readonly Lazy<ISmartRenameSessionFactoryWrapper>? _smartRenameSessionFactory;
+        private readonly Lazy<ISmartRenameSessionFactoryWrapper?>? _smartRenameSessionFactory;
 #pragma warning restore CS0618
 
         public const string AdornmentLayerName = "RoslynRenameDashboard";
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _listenerProvider = listenerProvider;
             if (smartRenameSessionFactory is not null)
             {
-                _smartRenameSessionFactory = new Lazy<ISmartRenameSessionFactoryWrapper>(() => ISmartRenameSessionFactoryWrapper.FromInstance(smartRenameSessionFactory.Value));
+                _smartRenameSessionFactory = new Lazy<ISmartRenameSessionFactoryWrapper?>(() => ISmartRenameSessionFactoryWrapper.FromInstance(smartRenameSessionFactory.Value));
             }
 
             _threadingContext = threadingContext;

--- a/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionFactoryWrapper.cs
+++ b/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionFactoryWrapper.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
@@ -14,16 +15,22 @@ namespace Microsoft.CodeAnalysis.EditorFeatures.Lightup;
 internal readonly struct ISmartRenameSessionFactoryWrapper
 {
     internal const string WrappedTypeName = "Microsoft.VisualStudio.Text.Editor.SmartRename.ISmartRenameSessionFactory";
-    private static readonly Type s_wrappedType;
+    private static readonly Type? s_wrappedType;
 
-    private static readonly Func<object, SnapshotSpan, object?> s_createSmartRenameSession;
+    private static readonly Func<object, SnapshotSpan, object?>? s_createSmartRenameSession;
 
     private readonly object _instance;
 
     static ISmartRenameSessionFactoryWrapper()
     {
-        s_wrappedType = typeof(AggregateFocusInterceptor).Assembly.GetType(WrappedTypeName, throwOnError: false, ignoreCase: false);
-        s_createSmartRenameSession = LightupHelpers.CreateFunctionAccessor<object, SnapshotSpan, object?>(s_wrappedType, nameof(CreateSmartRenameSession), typeof(SnapshotSpan), SpecializedTasks.Null<object>());
+        try
+        {
+            s_wrappedType = typeof(AggregateFocusInterceptor).Assembly.GetType(WrappedTypeName, throwOnError: false, ignoreCase: false);
+            s_createSmartRenameSession = LightupHelpers.CreateFunctionAccessor<object, SnapshotSpan, object?>(s_wrappedType, nameof(CreateSmartRenameSession), typeof(SnapshotSpan), SpecializedTasks.Null<object>());
+        }
+        catch (Exception e) when (FatalError.ReportAndCatch(e))
+        {
+        }
     }
 
     private ISmartRenameSessionFactoryWrapper(object instance)
@@ -31,16 +38,17 @@ internal readonly struct ISmartRenameSessionFactoryWrapper
         this._instance = instance;
     }
 
-    public static ISmartRenameSessionFactoryWrapper FromInstance(object? instance)
+    public static ISmartRenameSessionFactoryWrapper? FromInstance(object? instance)
     {
-        if (instance == null)
+        if (instance is null || s_wrappedType is null || s_createSmartRenameSession is null)
         {
-            return default;
+            return null;
         }
 
         if (!IsInstance(instance))
         {
-            throw new InvalidCastException($"Cannot cast '{instance.GetType().FullName}' to '{WrappedTypeName}'");
+            FatalError.ReportNonFatalError(new InvalidCastException($"Cannot cast '{instance.GetType().FullName}' to '{WrappedTypeName}'"));
+            return null;
         }
 
         return new ISmartRenameSessionFactoryWrapper(instance);
@@ -48,11 +56,14 @@ internal readonly struct ISmartRenameSessionFactoryWrapper
 
     public static bool IsInstance([NotNullWhen(true)] object? instance)
     {
-        return instance != null && LightupHelpers.CanWrapObject(instance, s_wrappedType);
+        return instance != null && s_wrappedType != null && LightupHelpers.CanWrapObject(instance, s_wrappedType);
     }
 
     public ISmartRenameSessionWrapper? CreateSmartRenameSession(SnapshotSpan renamedIdentifier)
     {
+        if (s_createSmartRenameSession == null)
+            return null;
+
         var session = s_createSmartRenameSession(_instance, renamedIdentifier);
         if (!ISmartRenameSessionWrapper.IsInstance(session))
             return null;

--- a/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionFactoryWrapper.cs
+++ b/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionFactoryWrapper.cs
@@ -30,6 +30,7 @@ internal readonly struct ISmartRenameSessionFactoryWrapper
         }
         catch (Exception e) when (FatalError.ReportAndCatch(e))
         {
+            // Editor side might change the interface, catch all exceptions when use reflection & composing linq expression so user could use the normal rename UI.
         }
     }
 

--- a/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionWrapper.cs
+++ b/src/EditorFeatures/Core.Wpf/Lightup/ISmartRenameSessionWrapper.cs
@@ -53,6 +53,7 @@ internal readonly struct ISmartRenameSessionWrapper : INotifyPropertyChanged, ID
         }
         catch (Exception e) when (FatalError.ReportAndCatch(e))
         {
+            // Editor side might change the interface, catch all exceptions when use reflection & composing linq expression so user could use the normal rename UI.
         }
     }
 


### PR DESCRIPTION
A regression is introduced in 17.9 P2 because of the AI rename.
We use reflection & linq expression to build the interface wrapper, however, this path is fragile, if editor folks change anything, it will end up breaks us, cause the user can't use the normal inline rename.

This PR wraps all these calls with try-catch, and only build `SmartRenameViewModel` when things are correct. In case there are errors, user would still fall back to the normal UI