### PR TITLE
Disable 'use collection expression' when it would introduce an allocation

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
@@ -69,6 +69,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
             semanticModel,
             expression,
             expressionType,
+            isSingletonInstance: false,
             allowInterfaceConversion,
             static e => e.Type,
             static e => e.Initializer,
@@ -78,7 +79,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
             return default;
 
         if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
-                semanticModel, expression, expressionType, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics))
+                semanticModel, expression, expressionType, isSingletonInstance: false, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics))
         {
             return default;
         }
@@ -97,7 +98,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
         // if we have `new[] { ... }` we have no subsequent matches to add to the collection. All values come
         // from within the initializer.
         if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
-                semanticModel, expression, expressionType, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics))
+                semanticModel, expression, expressionType, isSingletonInstance: false, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics))
         {
             return default;
         }
@@ -135,7 +136,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
         var allowInterfaceConversion = option.Value is CollectionExpressionPreference.WhenTypesLooselyMatch;
         if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
                 semanticModel, arrayCreationExpression, replacementCollectionExpression,
-                expressionType, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken,
+                expressionType, isSingletonInstance: false, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken,
                 out var changesSemantics))
         {
             return;

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderDiagnosticAnalyzer.cs
@@ -193,7 +193,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderDiagnosticA
 
             // Make sure we can actually use a collection expression in place of the created collection.
             if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
-                    semanticModel, creationExpression, expressionType, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
+                    semanticModel, creationExpression, expressionType, isSingletonInstance: false, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
             {
                 return null;
             }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
@@ -45,8 +45,11 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
 
         // Make sure we can actually use a collection expression in place of the full invocation.
         var allowInterfaceConversion = option.Value is CollectionExpressionPreference.WhenTypesLooselyMatch;
-        if (!CanReplaceWithCollectionExpression(semanticModel, invocationExpression, expressionType, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
+        if (!CanReplaceWithCollectionExpression(
+                semanticModel, invocationExpression, expressionType, isSingletonInstance: false, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
+        {
             return;
+        }
 
         var locations = ImmutableArray.Create(invocationExpression.GetLocation());
         var properties = unwrapArgument ? s_unwrapArgumentProperties : ImmutableDictionary<string, string?>.Empty;

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer.cs
@@ -46,8 +46,11 @@ internal sealed partial class CSharpUseCollectionExpressionForEmptyDiagnosticAna
             return;
 
         var allowInterfaceConversion = option.Value is CollectionExpressionPreference.WhenTypesLooselyMatch;
-        if (!CanReplaceWithCollectionExpression(semanticModel, nodeToReplace, expressionType, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
+        if (!CanReplaceWithCollectionExpression(
+                semanticModel, nodeToReplace, expressionType, isSingletonInstance: true, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
+        {
             return;
+        }
 
         context.ReportDiagnostic(DiagnosticHelper.Create(
             Descriptor,

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
@@ -131,8 +131,11 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
         if (!AnalyzeInvocation(text, state, invocation, addMatches ? matchesInReverse : null, out var existingInitializer, cancellationToken))
             return null;
 
-        if (!CanReplaceWithCollectionExpression(state.SemanticModel, invocation, expressionType, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
+        if (!CanReplaceWithCollectionExpression(
+                state.SemanticModel, invocation, expressionType, isSingletonInstance: false, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out var changesSemantics))
+        {
             return null;
+        }
 
         matchesInReverse.ReverseContents();
         return new AnalysisResult(existingInitializer, invocation, matchesInReverse.ToImmutable(), changesSemantics);

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs
@@ -49,7 +49,7 @@ internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnost
 
         // Stack alloc can never be wrapped in an interface, so don't even try.
         if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
-                semanticModel, expression, expressionType, allowInterfaceConversion: false, skipVerificationForReplacedNode: true, cancellationToken, out _))
+                semanticModel, expression, expressionType, isSingletonInstance: false, allowInterfaceConversion: false, skipVerificationForReplacedNode: true, cancellationToken, out _))
         {
             return;
         }
@@ -124,6 +124,7 @@ internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnost
             semanticModel,
             expression,
             expressionType,
+            isSingletonInstance: false,
             allowInterfaceConversion,
             static e => e.Type,
             static e => e.Initializer,

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -41,5 +41,5 @@ internal sealed class CSharpUseCollectionInitializerDiagnosticAnalyzer :
         => compilation.LanguageVersion().SupportsCollectionExpressions();
 
     protected override bool CanUseCollectionExpression(SemanticModel semanticModel, BaseObjectCreationExpressionSyntax objectCreationExpression, INamedTypeSymbol? expressionType, bool allowInterfaceConversion, CancellationToken cancellationToken, out bool changesSemantics)
-        => UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(semanticModel, objectCreationExpression, expressionType, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics);
+        => UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(semanticModel, objectCreationExpression, expressionType, isSingletonInstance: false, allowInterfaceConversion, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics);
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -4410,6 +4410,43 @@ public class UseCollectionExpressionForArrayTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70996")]
+    public async Task TestInterfaceOn_ReadWriteDestination()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode =
+                """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq.Expressions;
+
+                class C
+                {
+                    IList<int> M()
+                    {
+                        return [|[|new|] int[]|] { 1, 2, 3 };
+                    }
+                }
+                """,
+            FixedCode =
+                """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq.Expressions;
+
+                class C
+                {
+                    IList<int> M()
+                    {
+                        return [1, 2, 3];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70996")]
     public async Task TestInterfaceOff()
     {
         await new VerifyCS.Test

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForEmptyTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForEmptyTests.cs
@@ -1620,19 +1620,19 @@ public class UseCollectionExpressionForEmptyTests
                     }
                 }
                 """,
-            FixedCode = """
-                    using System;
-                    using System.Collections.Generic;
-                    using System.Collections.Immutable;
+            FixedCode = $$"""
+                using System;
+                using System.Collections.Generic;
+                using System.Collections.Immutable;
 
-                    class C
+                class C
+                {
+                    void M()
                     {
-                        void M()
-                        {
-                            {{type}} v = [];
-                        }
+                        {{type}} v = [];
                     }
-                    """,
+                }
+                """,
             LanguageVersion = LanguageVersion.CSharp12,
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForEmptyTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForEmptyTests.cs
@@ -1634,6 +1634,27 @@ public class UseCollectionExpressionForEmptyTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70996")]
+    public async Task TestInterfaceOn_ReadWriteDestination()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M()
+                    {
+                        IList<int> v = Array.Empty<int>();
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70996")]
     public async Task TestInterfaceOff()
     {
         await new VerifyCS.Test

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForEmptyTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForEmptyTests.cs
@@ -1600,57 +1600,66 @@ public class UseCollectionExpressionForEmptyTests
         }.RunAsync();
     }
 
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70996")]
-    public async Task TestInterfaceOn()
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/70996")]
+    public async Task TestInterfaceOn(
+        [CombinatorialValues("IEnumerable<int>", "IReadOnlyCollection<int>", "IReadOnlyList<int>")] string type,
+        [CombinatorialValues("Array.[|Empty|]<int>()", "ImmutableArray<int>.[|Empty|]")] string expression)
     {
         await new VerifyCS.Test
         {
-            TestCode = """
-            using System;
-            using System.Collections.Generic;
-
-            class C
-            {
-                void M()
-                {
-                    IEnumerable<int> v = Array.[|Empty|]<int>();
-                }
-            }
-            """,
-            FixedCode = """
-            using System;
-            using System.Collections.Generic;
-
-            class C
-            {
-                void M()
-                {
-                    IEnumerable<int> v = [];
-                }
-            }
-            """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70996")]
-    public async Task TestInterfaceOn_ReadWriteDestination()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
+            TestCode = $$"""
                 using System;
                 using System.Collections.Generic;
+                using System.Collections.Immutable;
 
                 class C
                 {
                     void M()
                     {
-                        IList<int> v = Array.Empty<int>();
+                        {{type}} v = {{expression}};
+                    }
+                }
+                """,
+            FixedCode = """
+                    using System;
+                    using System.Collections.Generic;
+                    using System.Collections.Immutable;
+
+                    class C
+                    {
+                        void M()
+                        {
+                            {{type}} v = [];
+                        }
+                    }
+                    """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/70996")]
+    public async Task TestInterfaceOn_ReadWriteDestination(
+        [CombinatorialValues("IList<int>", "ICollection<int>")] string type,
+        [CombinatorialValues("Array.Empty<int>()", "ImmutableArray<int>.Empty")] string expression)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Collections.Generic;
+                using System.Collections.Immutable;
+
+                class C
+                {
+                    void M()
+                    {
+                        {{type}} v = {{expression}};
                     }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
 


### PR DESCRIPTION
Reported by Stephen when trying out the updated analyzers.

Specifically, in code like `IList<T> v = Array.Empty<T>();` we don't want to convert to `IList<T> v = [];` as the language dictates that you get a fresh, mutable, instance when targeting IList/ICollection.

See also https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#empty-collection-literal