### PR TITLE
Separate the process of creating an event accessor parameter and the process of figuring out its type.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class LambdaParameterSymbol : SourceComplexParameterSymbolBase
     {
+        private readonly TypeWithAnnotations _parameterType;
         private readonly SyntaxList<AttributeListSyntax> _attributeLists;
 
         public LambdaParameterSymbol(
@@ -24,11 +25,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
            bool isDiscard,
            bool isParams,
            Location location)
-           : base(owner, ordinal, parameterType, refKind, name, location, syntaxRef, isParams, isExtensionMethodThis: false, scope)
+           : base(owner, ordinal, refKind, name, location, syntaxRef, isParams, isExtensionMethodThis: false, scope)
         {
+            _parameterType = parameterType;
             _attributeLists = attributeLists;
             IsDiscard = isDiscard;
         }
+
+        public override TypeWithAnnotations TypeWithAnnotations => _parameterType;
 
         public override bool IsDiscard { get; }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -39,7 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected SourceComplexParameterSymbolBase(
             Symbol owner,
             int ordinal,
-            TypeWithAnnotations parameterType,
             RefKind refKind,
             string name,
             Location location,
@@ -47,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool isParams,
             bool isExtensionMethodThis,
             ScopedKind scope)
-            : base(owner, parameterType, ordinal, refKind, scope, name, location)
+            : base(owner, ordinal, refKind, scope, name, location)
         {
             Debug.Assert((syntaxRef == null) || (syntaxRef.GetSyntax().IsKind(SyntaxKind.Parameter)));
 
@@ -393,9 +392,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (convertedExpression.ConstantValueOpt == null && convertedExpression.Kind == BoundKind.Conversion &&
                 ((BoundConversion)convertedExpression).ConversionKind != ConversionKind.DefaultLiteral)
             {
-                if (parameterType.Type.IsNullableType())
+                if (Type.IsNullableType())
                 {
-                    convertedExpression = binder.GenerateConversionForAssignment(parameterType.Type.GetNullableUnderlyingType(),
+                    convertedExpression = binder.GenerateConversionForAssignment(Type.GetNullableUnderlyingType(),
                         valueBeforeConversion, diagnostics, Binder.ConversionForAssignmentFlags.DefaultParameter);
                 }
             }
@@ -1516,6 +1515,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
     internal sealed class SourceComplexParameterSymbol : SourceComplexParameterSymbolBase
     {
+        private readonly TypeWithAnnotations _parameterType;
+
         internal SourceComplexParameterSymbol(
             Symbol owner,
             int ordinal,
@@ -1527,16 +1528,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool isParams,
             bool isExtensionMethodThis,
             ScopedKind scope)
-            : base(owner, ordinal, parameterType, refKind, name, location, syntaxRef, isParams, isExtensionMethodThis, scope)
+            : base(owner, ordinal, refKind, name, location, syntaxRef, isParams, isExtensionMethodThis, scope)
         {
+            _parameterType = parameterType;
         }
 
+        public override TypeWithAnnotations TypeWithAnnotations => _parameterType;
         public override ImmutableArray<CustomModifier> RefCustomModifiers => ImmutableArray<CustomModifier>.Empty;
     }
 
     internal sealed class SourceComplexParameterSymbolWithCustomModifiersPrecedingRef : SourceComplexParameterSymbolBase
     {
         private readonly ImmutableArray<CustomModifier> _refCustomModifiers;
+        private readonly TypeWithAnnotations _parameterType;
 
         internal SourceComplexParameterSymbolWithCustomModifiersPrecedingRef(
             Symbol owner,
@@ -1550,15 +1554,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool isParams,
             bool isExtensionMethodThis,
             ScopedKind scope)
-            : base(owner, ordinal, parameterType, refKind, name, location, syntaxRef, isParams, isExtensionMethodThis, scope)
+            : base(owner, ordinal, refKind, name, location, syntaxRef, isParams, isExtensionMethodThis, scope)
         {
             Debug.Assert(!refCustomModifiers.IsEmpty);
 
+            _parameterType = parameterType;
             _refCustomModifiers = refCustomModifiers;
 
             Debug.Assert(refKind != RefKind.None || _refCustomModifiers.IsEmpty);
         }
 
+        public override TypeWithAnnotations TypeWithAnnotations => _parameterType;
         public override ImmutableArray<CustomModifier> RefCustomModifiers => _refCustomModifiers;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly string _name;
         private readonly ImmutableArray<MethodSymbol> _explicitInterfaceImplementations;
 
-        private ImmutableArray<ParameterSymbol> _lazyParameters;
+        private readonly ImmutableArray<ParameterSymbol> _parameters;
         private TypeWithAnnotations _lazyReturnType;
 
         public SourceEventAccessorSymbol(
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                 hasThisInitializer: false)))
         {
             _event = @event;
+            _parameters = ImmutableArray.Create<ParameterSymbol>(new SynthesizedEventAccessorValueParameterSymbol(this, 0));
 
             string name;
             ImmutableArray<MethodSymbol> explicitInterfaceImplementations;
@@ -97,8 +98,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected sealed override void MethodChecks(BindingDiagnosticBag diagnostics)
         {
-            Debug.Assert(_lazyParameters.IsDefault != _lazyReturnType.HasType);
-
             // CONSIDER: currently, we're copying the custom modifiers of the event overridden
             // by this method's associated event (by using the associated event's type, which is
             // copied from the overridden event).  It would be more correct to copy them from
@@ -122,9 +121,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         _lazyReturnType = TypeWithAnnotations.Create(eventTokenType);
                         this.SetReturnsVoid(returnsVoid: false);
-
-                        var parameter = new SynthesizedAccessorValueParameterSymbol(this, _event.TypeWithAnnotations, 0);
-                        _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
                     }
                     else
                     {
@@ -136,9 +132,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         Binder.ReportUseSite(voidType, diagnostics, this.Location);
                         _lazyReturnType = TypeWithAnnotations.Create(voidType);
                         this.SetReturnsVoid(returnsVoid: true);
-
-                        var parameter = new SynthesizedAccessorValueParameterSymbol(this, TypeWithAnnotations.Create(eventTokenType), 0);
-                        _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
                     }
                 }
                 else
@@ -150,9 +143,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     Binder.ReportUseSite(voidType, diagnostics, this.Location);
                     _lazyReturnType = TypeWithAnnotations.Create(voidType);
                     this.SetReturnsVoid(returnsVoid: true);
-
-                    var parameter = new SynthesizedAccessorValueParameterSymbol(this, _event.TypeWithAnnotations, 0);
-                    _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
                 }
             }
         }
@@ -189,9 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                LazyMethodChecks();
-                Debug.Assert(!_lazyParameters.IsDefault);
-                return _lazyParameters;
+                return _parameters;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal abstract class SourceParameterSymbol : SourceParameterSymbolBase
     {
         protected SymbolCompletionState state;
-        protected readonly TypeWithAnnotations parameterType;
         private readonly string _name;
         private readonly Location? _location;
         private readonly RefKind _refKind;
@@ -98,7 +97,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected SourceParameterSymbol(
             Symbol owner,
-            TypeWithAnnotations parameterType,
             int ordinal,
             RefKind refKind,
             ScopedKind scope,
@@ -107,7 +105,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             : base(owner, ordinal)
         {
             Debug.Assert((owner.Kind == SymbolKind.Method) || (owner.Kind == SymbolKind.Property));
-            this.parameterType = parameterType;
             _refKind = refKind;
             _scope = scope;
             _name = name;
@@ -258,14 +255,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return IsImplicitlyDeclared ?
                     ImmutableArray<SyntaxReference>.Empty :
                     GetDeclaringSyntaxReferenceHelper<ParameterSyntax>(this.Locations);
-            }
-        }
-
-        public sealed override TypeWithAnnotations TypeWithAnnotations
-        {
-            get
-            {
-                return this.parameterType;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -760,7 +760,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!isGetMethod)
             {
-                parameters.Add(new SynthesizedAccessorValueParameterSymbol(this, _property.TypeWithAnnotations, parameters.Count));
+                parameters.Add(new SynthesizedPropertyAccessorValueParameterSymbol(this, parameters.Count));
             }
 
             return parameters.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceSimpleParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceSimpleParameterSymbol.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class SourceSimpleParameterSymbol : SourceParameterSymbol
     {
+        private readonly TypeWithAnnotations _parameterType;
+
         public SourceSimpleParameterSymbol(
             Symbol owner,
             TypeWithAnnotations parameterType,
@@ -36,9 +38,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ScopedKind scope,
             string name,
             Location? location)
-            : base(owner, parameterType, ordinal, refKind, scope, name, location)
+            : base(owner, ordinal, refKind, scope, name, location)
         {
+            _parameterType = parameterType;
         }
+
+        public override TypeWithAnnotations TypeWithAnnotations => _parameterType;
 
         public override bool IsDiscard => false;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
@@ -17,10 +17,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// This parameter has no source location/syntax, but may have attributes.
     /// Attributes with 'param' target specifier on the accessor must be applied to the this parameter.
     /// </summary>
-    internal sealed class SynthesizedAccessorValueParameterSymbol : SourceComplexParameterSymbolBase
+    internal abstract class SynthesizedAccessorValueParameterSymbol : SourceComplexParameterSymbolBase
     {
-        public SynthesizedAccessorValueParameterSymbol(SourceMemberMethodSymbol accessor, TypeWithAnnotations paramType, int ordinal)
-            : base(accessor, ordinal, paramType, RefKind.None, ParameterSymbol.ValueParameterName, accessor.TryGetFirstLocation(),
+        public SynthesizedAccessorValueParameterSymbol(SourceMemberMethodSymbol accessor, int ordinal)
+            : base(accessor, ordinal, RefKind.None, ParameterSymbol.ValueParameterName, accessor.TryGetFirstLocation(),
                    syntaxRef: null,
                    isParams: false,
                    isExtensionMethodThis: false,
@@ -91,6 +91,55 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     AddSynthesizedAttribute(ref attributes, SynthesizedAttributeData.Create(property.AllowNullAttributeIfExists));
                 }
+            }
+        }
+    }
+
+    internal sealed class SynthesizedPropertyAccessorValueParameterSymbol : SynthesizedAccessorValueParameterSymbol
+    {
+        public SynthesizedPropertyAccessorValueParameterSymbol(SourcePropertyAccessorSymbol accessor, int ordinal)
+            : base(accessor, ordinal)
+        {
+            Debug.Assert(accessor.Locations.Length <= 1);
+        }
+
+        public override TypeWithAnnotations TypeWithAnnotations => ((PropertySymbol)((SourcePropertyAccessorSymbol)ContainingSymbol).AssociatedSymbol).TypeWithAnnotations;
+    }
+
+    internal sealed class SynthesizedEventAccessorValueParameterSymbol : SynthesizedAccessorValueParameterSymbol
+    {
+        private SingleInitNullable<TypeWithAnnotations> _lazyParameterType;
+
+        public SynthesizedEventAccessorValueParameterSymbol(SourceEventAccessorSymbol accessor, int ordinal)
+            : base(accessor, ordinal)
+        {
+            Debug.Assert(accessor.Locations.Length <= 1);
+        }
+
+        public override TypeWithAnnotations TypeWithAnnotations
+        {
+            get
+            {
+                return _lazyParameterType.Initialize(static (SourceEventAccessorSymbol accessor) =>
+                                                     {
+                                                         SourceEventSymbol @event = accessor.AssociatedEvent;
+
+                                                         if (accessor.MethodKind == MethodKind.EventAdd)
+                                                         {
+                                                             return @event.TypeWithAnnotations;
+                                                         }
+                                                         else if (@event.IsWindowsRuntimeEvent)
+                                                         {
+                                                             TypeSymbol eventTokenType = @event.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken);
+                                                             // Use-site info is collected by SourceEventAccessorSymbol.MethodChecks
+                                                             return TypeWithAnnotations.Create(eventTokenType);
+                                                         }
+                                                         else
+                                                         {
+                                                             return @event.TypeWithAnnotations;
+                                                         }
+                                                     },
+                                                     (SourceEventAccessorSymbol)this.ContainingSymbol);
             }
         }
     }


### PR DESCRIPTION
This allows us to perform lookup operations within the accessor without triggering the process of determining whether the event is a WINMD event. That process could request the list of containing type members while we are building the list, thus causing an unexpected circularity and an unexpected reentrancy into  SourceMemberMethodSymbol.LazyMethodChecks on the same thread.

Fixes #71400.