### PR TITLE
Do not offer to make a member readonly if it potentially writes into an inline-array field.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -344,6 +344,15 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
                 return IsPotentiallyMutatingMethod(owningMethod, invocationOperation.Instance, invocationOperation.TargetMethod);
             }
 
+            // Converting an inline-array into a Span<T> allows the array to be written into.  As such, we have to
+            // consider this a potential future mutation of 'this'.
+            if (operation is IConversionOperation conversionOperation)
+            {
+                var conversion = conversionOperation.GetConversion();
+                if (conversion.IsInlineArray && conversionOperation.Type.IsSpan())
+                    return true;
+            }
+
             // Wasn't something that mutates this instance.  Go onto the next instance expression.
             break;
         }

--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -329,6 +329,17 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
                 return false;
             }
 
+            if (operation is IInlineArrayAccessOperation)
+            {
+                // If we're writing into an inline-array off of 'this'.  Then we can't make this `readonly`.
+                if (CSharpSemanticFacts.Instance.IsWrittenTo(semanticModel, operation.Syntax, cancellationToken))
+                    return true;
+
+                // We're reading a value from inside the inline-array.  Have to keep looking upwards to see how the
+                // value is treated.
+                continue;
+            }
+
             // See if we're accessing or invoking a method.
             if (operation is IMethodReferenceOperation methodRefOperation)
             {

--- a/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
@@ -2345,6 +2345,152 @@ public sealed class MakeStructMemberReadOnlyTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71500")]
+    public async Task TestOnInlineArrayRead()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Runtime.CompilerServices;
+
+                internal struct Repro
+                {
+                    private Values _values;
+
+                    public void [|Populate|]()
+                    {
+                        var v = _values[0];
+                    }
+                }
+
+                [InlineArray(4)]
+                internal struct Values
+                {
+                    private int _field;
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Runtime.CompilerServices;
+                
+                internal struct Repro
+                {
+                    private Values _values;
+                
+                    public readonly void Populate()
+                    {
+                        var v = _values[0];
+                    }
+                }
+                
+                [InlineArray(4)]
+                internal struct Values
+                {
+                    private int _field;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71500")]
+    public async Task TestOnInlineArrayReadSafe()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Runtime.CompilerServices;
+
+                internal struct Repro
+                {
+                    private Values _values;
+
+                    public void [|Populate|]()
+                    {
+                        _values[0].Safe();
+                    }
+                }
+
+                [InlineArray(4)]
+                internal struct Values
+                {
+                    private S _field;
+                }
+
+                internal struct S
+                {
+                    public readonly void Safe() { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Runtime.CompilerServices;
+                
+                internal struct Repro
+                {
+                    private Values _values;
+                
+                    public readonly void Populate()
+                    {
+                        _values[0].Safe();
+                    }
+                }
+                
+                [InlineArray(4)]
+                internal struct Values
+                {
+                    private S _field;
+                }
+                
+                internal struct S
+                {
+                    public readonly void Safe() { }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71500")]
+    public async Task TestOnInlineArrayReadUnsafe()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Runtime.CompilerServices;
+
+                internal struct Repro
+                {
+                    private Values _values;
+
+                    public void Populate()
+                    {
+                        _values[0].Unsafe();
+                    }
+                }
+
+                [InlineArray(4)]
+                internal struct Values
+                {
+                    private S _field;
+                }
+
+                internal struct S
+                {
+                    private int i;
+                    public void Unsafe() { i++; }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71500")]
     public async Task TestNotOnInlineArrayCapturedIntoSpan()
     {
         await new VerifyCS.Test
@@ -2360,6 +2506,36 @@ public sealed class MakeStructMemberReadOnlyTests
                     public void Populate()
                     {
                         Span<int> values = _values;
+                    }
+                }
+
+                [InlineArray(4)]
+                internal struct Values
+                {
+                    private int _field;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71500")]
+    public async Task TestNotOnInlineArrayWrittenInfo()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Runtime.CompilerServices;
+
+                internal struct Repro
+                {
+                    private Values _values;
+
+                    public void Populate()
+                    {
+                        _values[0] = 1;
                     }
                 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/71500