### PR TITLE
Address UIDelays in AbstractGraphProvider.GetCommands

### DIFF
--- a/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
@@ -400,18 +400,6 @@ internal abstract class AbstractGraphProvider : IGraphProvider
     private static bool HasExplicitInterfaces(GraphNode node)
         => ((IList<SymbolKey>)node[RoslynGraphProperties.ExplicitInterfaceImplementations]).Count > 0;
 
-    private static bool IsRoslynNode(GraphNode node)
-    {
-        return node[RoslynGraphProperties.SymbolKind] != null
-            && node[RoslynGraphProperties.TypeKind] != null;
-    }
-
-    private static bool IsAnySymbolKind(GraphNode node, params SymbolKind[] symbolKinds)
-        => symbolKinds.Any(k => k.Equals(node[RoslynGraphProperties.SymbolKind]));
-
-    private static bool IsAnyTypeKind(GraphNode node, params TypeKind[] typeKinds)
-        => typeKinds.Any(k => node[RoslynGraphProperties.TypeKind].Equals(k));
-
     private static readonly GraphCommandDefinition s_overridesCommandDefinition =
         new("Overrides", ServicesVSResources.Overrides_, GraphContextDirection.Target, 700);
 


### PR DESCRIPTION
The .Any calls in this method are showing up in prism uidelays (not particularly high though as there are only 124 expressed hits in 17.8). This PR reduces some duplicated calls in this method, reducing the number of linear searches through nodes in about half in most codepaths.

I don't have much context on this code, so I'm also looking into whether both the VB and C# derivations of this class should be getting called all the time, but any changes in that regard would be separate from this.

Partially addresses [AB#1936654](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1936654)