### PR TITLE
Fix unwrapping of null synchronization context during xunit test execution

### DIFF
--- a/src/Workspaces/CoreTestUtilities/TestExportJoinableTaskContext.cs
+++ b/src/Workspaces/CoreTestUtilities/TestExportJoinableTaskContext.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             SynchronizationContext synchronizationContext;
 
             var currentContext = SynchronizationContext.Current;
-            if (currentContext is not null and not AsyncTestSyncContext)
+            if (currentContext is not null)
             {
                 Contract.ThrowIfFalse(dispatcherTaskJoiner?.IsDispatcherSynchronizationContext(currentContext) == true);
 
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     },
                     null);
 
-                return innerSynchronizationContext;
+                return innerSynchronizationContext == asyncTestSyncContext ? null : innerSynchronizationContext;
             }
             else
             {


### PR DESCRIPTION
AsyncTestSyncContext only executes calls on the inner synchronization context when the inner context is non-null. In other cases, it simply executes the call on itself. We now detect the latter case and return a value indicating that the inner synchronization context is null.

Follow-up to #71392