### PR TITLE
Update ILVerify bits

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,7 @@
          but not higher than our minimum dogfoodable Visual Studio version, or else
          the generators we build would load on the command line but not load in IDEs. -->
     <SourceGeneratorMicrosoftCodeAnalysisVersion>4.1.0</SourceGeneratorMicrosoftCodeAnalysisVersion>
-    <MicrosoftILVerificationVersion>7.0.0-alpha.1.22060.1</MicrosoftILVerificationVersion>
+    <MicrosoftILVerificationVersion>8.0.0-rtm.23523.3</MicrosoftILVerificationVersion>
     <MicrosoftVisualStudioThreadingPackagesVersion>17.8.14</MicrosoftVisualStudioThreadingPackagesVersion>
     <MicrosoftVisualStudioThreadingAnalyzersPackagesVersion>17.9.12-alpha</MicrosoftVisualStudioThreadingAnalyzersPackagesVersion>
     <MicrosoftTestPlatformVersion>17.4.1</MicrosoftTestPlatformVersion>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3274,7 +3274,85 @@ public class AsyncBug {
 }
 ";
 
-            var v = CompileAndVerify(source, "System.Int32");
+            var verifier = CompileAndVerify(source, expectedOutput: "System.Int32",
+                verify: Verification.FailsILVerify with { ILVerifyMessage = "[MoveNext]: Unrecognized arguments for delegate .ctor. { Offset = 0x6d }" });
+
+            verifier.VerifyIL("AsyncBug.<Boom>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", """
+{
+  // Code size      169 (0xa9)
+  .maxstack  3
+  .locals init (int V_0,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_1,
+                System.Exception V_2)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "int AsyncBug.<Boom>d__1.<>1__state"
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_003f
+    IL_000a:  ldc.i4.1
+    IL_000b:  call       "System.Threading.Tasks.Task<int> System.Threading.Tasks.Task.FromResult<int>(int)"
+    IL_0010:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()"
+    IL_0015:  stloc.1
+    IL_0016:  ldloca.s   V_1
+    IL_0018:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get"
+    IL_001d:  brtrue.s   IL_005b
+    IL_001f:  ldarg.0
+    IL_0020:  ldc.i4.0
+    IL_0021:  dup
+    IL_0022:  stloc.0
+    IL_0023:  stfld      "int AsyncBug.<Boom>d__1.<>1__state"
+    IL_0028:  ldarg.0
+    IL_0029:  ldloc.1
+    IL_002a:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<int> AsyncBug.<Boom>d__1.<>u__1"
+    IL_002f:  ldarg.0
+    IL_0030:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncBug.<Boom>d__1.<>t__builder"
+    IL_0035:  ldloca.s   V_1
+    IL_0037:  ldarg.0
+    IL_0038:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, AsyncBug.<Boom>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref AsyncBug.<Boom>d__1)"
+    IL_003d:  leave.s    IL_00a8
+    IL_003f:  ldarg.0
+    IL_0040:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<int> AsyncBug.<Boom>d__1.<>u__1"
+    IL_0045:  stloc.1
+    IL_0046:  ldarg.0
+    IL_0047:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<int> AsyncBug.<Boom>d__1.<>u__1"
+    IL_004c:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<int>"
+    IL_0052:  ldarg.0
+    IL_0053:  ldc.i4.m1
+    IL_0054:  dup
+    IL_0055:  stloc.0
+    IL_0056:  stfld      "int AsyncBug.<Boom>d__1.<>1__state"
+    IL_005b:  ldloca.s   V_1
+    IL_005d:  call       "int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()"
+    IL_0062:  box        "int"
+    IL_0067:  ldftn      "System.Type object.GetType()"
+    IL_006d:  newobj     "System.Func<System.Type>..ctor(object, System.IntPtr)"
+    IL_0072:  callvirt   "System.Type System.Func<System.Type>.Invoke()"
+    IL_0077:  call       "void System.Console.WriteLine(object)"
+    IL_007c:  leave.s    IL_0095
+  }
+  catch System.Exception
+  {
+    IL_007e:  stloc.2
+    IL_007f:  ldarg.0
+    IL_0080:  ldc.i4.s   -2
+    IL_0082:  stfld      "int AsyncBug.<Boom>d__1.<>1__state"
+    IL_0087:  ldarg.0
+    IL_0088:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncBug.<Boom>d__1.<>t__builder"
+    IL_008d:  ldloc.2
+    IL_008e:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+    IL_0093:  leave.s    IL_00a8
+  }
+  IL_0095:  ldarg.0
+  IL_0096:  ldc.i4.s   -2
+  IL_0098:  stfld      "int AsyncBug.<Boom>d__1.<>1__state"
+  IL_009d:  ldarg.0
+  IL_009e:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncBug.<Boom>d__1.<>t__builder"
+  IL_00a3:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+  IL_00a8:  ret
+}
+""");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3274,6 +3274,7 @@ public class AsyncBug {
 }
 ";
 
+            // See tracking issue https://github.com/dotnet/runtime/issues/96695
             var verifier = CompileAndVerify(source, expectedOutput: "System.Int32",
                 verify: Verification.FailsILVerify with { ILVerifyMessage = "[MoveNext]: Unrecognized arguments for delegate .ctor. { Offset = 0x6d }" });
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -6245,7 +6245,7 @@ public static class Extensions
                 options: TestOptions.DebugExe,
                 parseOptions: TestOptions.Regular9);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "123", verify: Verification.FailsILVerify);
+            CompileAndVerify(comp, expectedOutput: "123");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
@@ -3244,6 +3244,7 @@ class Program
         Console.Write(f.Invoke());
     }
 }";
+            // See tracking issue https://github.com/dotnet/runtime/issues/96695
             var verifier = CompileAndVerify(source, expectedOutput: "42",
                 verify: Verification.FailsILVerify with { ILVerifyMessage = "[Main]: Unrecognized arguments for delegate .ctor. { Offset = 0xe }" });
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
@@ -3243,9 +3243,24 @@ class Program
         Func<string> f = x.ToString;
         Console.Write(f.Invoke());
     }
-}"
-;
-            CompileAndVerify(source, expectedOutput: "42");
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "42",
+                verify: Verification.FailsILVerify with { ILVerifyMessage = "[Main]: Unrecognized arguments for delegate .ctor. { Offset = 0xe }" });
+
+            verifier.VerifyIL("Program.Main", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  2
+  IL_0000:  ldc.i4.s   42
+  IL_0002:  box        "int"
+  IL_0007:  dup
+  IL_0008:  ldvirtftn  "string object.ToString()"
+  IL_000e:  newobj     "System.Func<string>..ctor(object, System.IntPtr)"
+  IL_0013:  callvirt   "string System.Func<string>.Invoke()"
+  IL_0018:  call       "void System.Console.Write(string)"
+  IL_001d:  ret
+}
+""");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
@@ -1619,6 +1619,7 @@ public class Test
             var peVerifyMessage = "[ : Test::Main][offset 0x00000002] Cannot modify an imaged based (RVA) static";
 
             var ilVerifyMessage = """
+                [Main]: Cannot change initonly field outside its .ctor. { Offset = 0x2 }
                 [Main]: Unexpected type on the stack. { Offset = 0x8, Found = address of '<PrivateImplementationDetails>+__StaticArrayInitTypeSize=3', Expected = Native Int }
                 """;
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
@@ -1619,8 +1619,6 @@ public class Test
             var peVerifyMessage = "[ : Test::Main][offset 0x00000002] Cannot modify an imaged based (RVA) static";
 
             var ilVerifyMessage = """
-                [Main]: Cannot change initonly field outside its .ctor. { Offset = 0x2 }
-                [Main]: Field is not visible. { Offset = 0x2 }
                 [Main]: Unexpected type on the stack. { Offset = 0x8, Found = address of '<PrivateImplementationDetails>+__StaticArrayInitTypeSize=3', Expected = Native Int }
                 """;
 
@@ -2686,8 +2684,8 @@ class Test
                     "__StaticArrayInitTypeSize=32_Align=8",
                 };
 
-                // .class nested private explicit ansi sealed 'TYPENAME'
-                string[] actual = Regex.Matches(il, @"\.class nested private explicit ansi sealed '([^']*?)'").Cast<Match>().Select(m => m.Groups[1].Value).ToArray();
+                // .class nested assembly explicit ansi sealed 'TYPENAME'
+                string[] actual = Regex.Matches(il, @"\.class nested assembly explicit ansi sealed '([^']*?)'").Cast<Match>().Select(m => m.Groups[1].Value).ToArray();
 
                 Assert.Equal(expected, actual);
             });

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -259,8 +259,7 @@ class Program
     }
 }
 ";
-            // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of '[...]S1', Expected = address of '[...]S1' }
-            var compilation = CompileAndVerify(source, verify: Verification.FailsILVerify, expectedOutput: @"");
+            var compilation = CompileAndVerify(source, expectedOutput: @"");
 
             compilation.VerifyIL("S1.Equals(object)",
 @"
@@ -449,8 +448,7 @@ namespace NS
     }
 }
 ";
-            // ILVerify: Unexpected type on the stack. { Offset = 31, Found = readonly address of '[...]NS.N2.S`2<string,uint8>', Expected = address of '[...]NS.N2.S`2<string,uint8>' }
-            var compilation = CompileAndVerify(source, verify: Verification.FailsILVerify, expectedOutput: @"
+            var compilation = CompileAndVerify(source, expectedOutput: @"
 Abc
 255
 q");
@@ -2368,8 +2366,7 @@ public class Test
     }
 
 ";
-            // ILVerify: Unexpected type on the stack. { Offset = 10, Found = readonly address of '[...]C1', Expected = address of '[...]C1' }
-            var compilation = CompileAndVerify(source, verify: Verification.FailsILVerify, expectedOutput: "0");
+            var compilation = CompileAndVerify(source, expectedOutput: "0");
 
             compilation.VerifyIL("Program.Main",
 @"

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -62,27 +62,27 @@ class Program
             Assert.False(predefined.IsPossibleMatch(typeIdentifier, QuickAttributes.None));
 
             var alias1 = SyntaxFactory.Attribute(SyntaxFactory.ParseName("alias1"));
-            var checker1 = WithAliases(predefined, "using alias1 = TypeForwardedToAttribute;");
+            var checker1 = withAliases(predefined, "using alias1 = TypeForwardedToAttribute;");
             Assert.True(checker1.IsPossibleMatch(alias1, QuickAttributes.TypeForwardedTo));
             Assert.False(checker1.IsPossibleMatch(alias1, QuickAttributes.TypeIdentifier));
 
-            var checker1a = WithAliases(checker1, "using alias1 = TypeIdentifierAttribute;");
+            var checker1a = withAliases(checker1, "using alias1 = TypeIdentifierAttribute;");
             Assert.True(checker1a.IsPossibleMatch(alias1, QuickAttributes.TypeForwardedTo));
             Assert.True(checker1a.IsPossibleMatch(alias1, QuickAttributes.TypeIdentifier));
 
-            var checker1b = WithAliases(checker1, "using alias2 = TypeIdentifierAttribute;");
+            var checker1b = withAliases(checker1, "using alias2 = TypeIdentifierAttribute;");
             var alias2 = SyntaxFactory.Attribute(SyntaxFactory.ParseName("alias2"));
             Assert.True(checker1b.IsPossibleMatch(alias1, QuickAttributes.TypeForwardedTo));
             Assert.False(checker1b.IsPossibleMatch(alias1, QuickAttributes.TypeIdentifier));
             Assert.False(checker1b.IsPossibleMatch(alias2, QuickAttributes.TypeForwardedTo));
             Assert.True(checker1b.IsPossibleMatch(alias2, QuickAttributes.TypeIdentifier));
 
-            var checker3 = WithAliases(predefined, "using alias3 = TypeForwardedToAttribute; using alias3 = TypeIdentifierAttribute;");
+            var checker3 = withAliases(predefined, "using alias3 = TypeForwardedToAttribute; using alias3 = TypeIdentifierAttribute;");
             var alias3 = SyntaxFactory.Attribute(SyntaxFactory.ParseName("alias3"));
             Assert.True(checker3.IsPossibleMatch(alias3, QuickAttributes.TypeForwardedTo));
             Assert.True(checker3.IsPossibleMatch(alias3, QuickAttributes.TypeIdentifier));
 
-            QuickAttributeChecker WithAliases(QuickAttributeChecker checker, string aliases)
+            QuickAttributeChecker withAliases(QuickAttributeChecker checker, string aliases)
             {
                 var nodes = Parse(aliases).GetRoot().DescendantNodes().OfType<UsingDirectiveSyntax>();
                 var list = new SyntaxList<UsingDirectiveSyntax>().AddRange(nodes);

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenMethodGroupConversionCachingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenMethodGroupConversionCachingTests.cs
@@ -147,8 +147,7 @@ static class E
     public static void Target(this C that) { Console.WriteLine(""FAIL""); }
 }
 ";
-        // ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 14 }
-        var verifier = CompileAndVerify(source, expectedOutput: PASS, symbolValidator: VerifyNoCacheContainersIn("C"), verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(source, expectedOutput: PASS, symbolValidator: VerifyNoCacheContainersIn("C"));
         verifier.VerifyIL("C.Main", @"
 {
   // Code size       37 (0x25)
@@ -190,8 +189,7 @@ static class E
     public static void Target(this C that) { Console.WriteLine(""FAIL""); }
 }
 ";
-        // ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 14 }
-        var verifier = CompileAndVerify(source, expectedOutput: PASS, symbolValidator: VerifyNoCacheContainersIn("C"), verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(source, expectedOutput: PASS, symbolValidator: VerifyNoCacheContainersIn("C"));
         verifier.VerifyIL("C.Main", @"
 {
   // Code size       37 (0x25)

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -10657,12 +10657,13 @@ partial class Program
             var comp = CreateCompilation(new[] { src, s_collectionExtensions }, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics();
 
-            var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("[1, 2, 3],"), verify: Verification.Fails);
+            var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("[1, 2, 3],"),
+                verify: Verification.Fails with { ILVerifyMessage = """
+                    [M]: Cannot change initonly field outside its .ctor. { Offset = 0x0 }
+                    [M]: Field is not visible. { Offset = 0x0 }
+                    [M]: Unexpected type on the stack. { Offset = 0x6, Found = address of '<PrivateImplementationDetails>+__StaticArrayInitTypeSize=3', Expected = Native Int }
+                    """ });
 
-            // ILVerify:
-            // [M]: Cannot change initonly field outside its .ctor. { Offset = 0x0 }
-            // [M]: Field is not visible. { Offset = 0x0 }
-            // [M]: Unexpected type on the stack. { Offset = 0x6, Found = address of '[78cb4f30-abc1-41ca-b5d2-939830104c72]<PrivateImplementationDetails>+__StaticArrayInitTypeSize=3', Expected = Native Int }
             verifier.VerifyIL("Program.M", """
 {
   // Code size       22 (0x16)

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -10659,6 +10659,7 @@ partial class Program
 
             var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("[1, 2, 3],"),
                 verify: Verification.Fails with { ILVerifyMessage = """
+                    [M]: Cannot change initonly field outside its .ctor. { Offset = 0x0 }
                     [M]: Unexpected type on the stack. { Offset = 0x6, Found = address of '<PrivateImplementationDetails>+__StaticArrayInitTypeSize=3', Expected = Native Int }
                     """ });
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -10659,8 +10659,6 @@ partial class Program
 
             var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("[1, 2, 3],"),
                 verify: Verification.Fails with { ILVerifyMessage = """
-                    [M]: Cannot change initonly field outside its .ctor. { Offset = 0x0 }
-                    [M]: Field is not visible. { Offset = 0x0 }
                     [M]: Unexpected type on the stack. { Offset = 0x6, Found = address of '<PrivateImplementationDetails>+__StaticArrayInitTypeSize=3', Expected = Native Int }
                     """ });
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests_ListPatterns.cs
@@ -278,9 +278,8 @@ public class X
     }
 }
 ";
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
         var verifier = CompileAndVerify(new[] { source, TestSources.Index, TestSources.Range }, parseOptions: TestOptions.RegularWithListPatterns,
-            options: TestOptions.ReleaseDll, verify: Verification.FailsILVerify);
+            options: TestOptions.ReleaseDll);
         verifier.VerifyDiagnostics();
         AssertEx.Multiple(
             () => verifier.VerifyIL("X.Test1", @"
@@ -2596,10 +2595,9 @@ class X
     } 
 }
 ";
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
         var compilation = CreateCompilation(new[] { source, TestSources.Index }, options: TestOptions.ReleaseExe);
         compilation.VerifyEmitDiagnostics();
-        CompileAndVerify(compilation, expectedOutput: "123", verify: Verification.FailsILVerify);
+        CompileAndVerify(compilation, expectedOutput: "123");
     }
 
     [Fact]
@@ -3961,8 +3959,7 @@ public class C
 ";
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         compilation.VerifyDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.FailsILVerify);
+        CompileAndVerify(compilation, expectedOutput: expectedOutput);
     }
 
     [Fact]
@@ -5538,8 +5535,7 @@ public class C
 ";
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         compilation.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        var verifier = CompileAndVerify(compilation, expectedOutput: "(item value, rest value)", verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(compilation, expectedOutput: "(item value, rest value)");
 
         verifier.VerifyIL("C.M", @"
 {
@@ -5627,8 +5623,7 @@ public class C
 ";
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         compilation.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        var verifier = CompileAndVerify(compilation, expectedOutput: "(item value, rest value)", verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(compilation, expectedOutput: "(item value, rest value)");
 
         verifier.VerifyIL("C.M", @"
 {
@@ -5717,8 +5712,7 @@ class C
             Console.Write((x, y));
     }
 }";
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(new[] { src, TestSources.Index, TestSources.Range }, expectedOutput: "Index Range (42, 43)", verify: Verification.FailsILVerify);
+        CompileAndVerify(new[] { src, TestSources.Index, TestSources.Range }, expectedOutput: "Index Range (42, 43)");
     }
 
     [Fact]
@@ -5757,8 +5751,7 @@ if (""abc"" is [var first, ..var rest])
     System.Console.Write((first, rest).ToString());
 }
 ";
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(new[] { src, TestSources.Index, TestSources.Range }, expectedOutput: "(a, bc)", verify: Verification.FailsILVerify);
+        CompileAndVerify(new[] { src, TestSources.Index, TestSources.Range }, expectedOutput: "(a, bc)");
     }
 
     [Fact]
@@ -7648,8 +7641,7 @@ class C : Base
     }
 }
 ";
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        var verifier = CompileAndVerify(new[] { source, TestSources.Index }, options: TestOptions.DebugDll, verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(new[] { source, TestSources.Index }, options: TestOptions.DebugDll);
         verifier.VerifyIL("C.M", @"
 {
   // Code size      105 (0x69)
@@ -7746,8 +7738,7 @@ class C : Base
     }
 }
 ";
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        var verifier = CompileAndVerify(new[] { source, TestSources.Index }, verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(new[] { source, TestSources.Index });
         verifier.VerifyIL("C.M", @"
 {
   // Code size       78 (0x4e)
@@ -7899,8 +7890,7 @@ public class C
             );
 
         compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        var verifier = CompileAndVerify(compilation, expectedOutput: "(2, 3)", verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(compilation, expectedOutput: "(2, 3)");
         verifier.VerifyDiagnostics();
         // Note: no Index or Range involved
         verifier.VerifyIL("C.M", @"
@@ -8066,7 +8056,7 @@ record ConsList(object Head, ConsList? Tail)
         // Note: this pattern doesn't work well because list-patterns needs a functional Length
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, IsExternalInitTypeDefinition });
         compilation.VerifyDiagnostics();
-        var verifier = CompileAndVerify(compilation, verify: Verification.Fails);
+        var verifier = CompileAndVerify(compilation, verify: Verification.FailsPEVerify);
         verifier.VerifyIL("ConsList.Print", @"
 {
   // Code size       84 (0x54)
@@ -8137,7 +8127,7 @@ record ConsList(object Head, ConsList? Tail)
 ";
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, IsExternalInitTypeDefinition });
         compilation.VerifyDiagnostics();
-        var verifier = CompileAndVerify(compilation, expectedOutput: "1 2 3", verify: Verification.Fails);
+        var verifier = CompileAndVerify(compilation, expectedOutput: "1 2 3", verify: Verification.FailsPEVerify);
         verifier.VerifyIL("ConsList.Print", @"
 {
   // Code size       44 (0x2c)
@@ -8181,8 +8171,7 @@ class C
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(comp, expectedOutput: "(42, 42)", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "(42, 42)");
     }
 
     [Fact]
@@ -8228,8 +8217,7 @@ class C
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(comp, expectedOutput: "(42, 42)", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "(42, 42)");
     }
 
     [Fact]
@@ -8243,8 +8231,7 @@ if (""42"" is [var x, var y])
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(comp, expectedOutput: "(4, 2)", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "(4, 2)");
     }
 
     [Fact]
@@ -8259,8 +8246,7 @@ if (new[] { 4, 2 } is [var x, _])
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(comp, expectedOutput: "(4, 2)", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "(4, 2)");
     }
 
     [Theory]
@@ -8281,8 +8267,7 @@ if (new[] {data} is {pattern})
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(comp, expectedOutput: "(4, 4)", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "(4, 4)");
     }
 
     [Fact]
@@ -8303,8 +8288,7 @@ class C
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(comp, expectedOutput: "(42, 42)", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "(42, 42)");
     }
 
     [Fact]
@@ -8325,8 +8309,7 @@ class C
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(comp, expectedOutput: "(42, 42)", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "(42, 42)");
     }
 
     [Fact]
@@ -8340,8 +8323,7 @@ if (""0420"" is [_, .. var x, _])
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' } 
-        CompileAndVerify(comp, expectedOutput: "42", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "42");
     }
 
     [Fact, WorkItem(57728, "https://github.com/dotnet/roslyn/issues/57728")]
@@ -8362,8 +8344,7 @@ class C
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray }, options: TestOptions.ReleaseExe);
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        var verifier = CompileAndVerify(comp, expectedOutput: "(4, 2, 4, 2)", verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(comp, expectedOutput: "(4, 2, 4, 2)");
         // we use Array.Length to get the length, but should be using ldlen
         // Tracked by https://github.com/dotnet/roslyn/issues/57728
         verifier.VerifyIL("C.Main", @"
@@ -8455,8 +8436,7 @@ if (new[] {data} is {pattern})
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray });
         comp.VerifyEmitDiagnostics();
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of 'System.Index', Expected = address of 'System.Index' }
-        CompileAndVerify(comp, expectedOutput: "(4, 2, 2, 4, 2, 2)", verify: Verification.FailsILVerify);
+        CompileAndVerify(comp, expectedOutput: "(4, 2, 2, 4, 2, 2)");
     }
 
     [Fact]
@@ -8477,8 +8457,7 @@ class C
 }
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray }, options: TestOptions.ReleaseDll);
-        // ILVerify: Unexpected type on the stack. { Offset = 20, Found = readonly address of '[...]System.Index', Expected = address of '[...]System.Index' }
-        var verifier = CompileAndVerify(comp, verify: Verification.FailsILVerify).VerifyDiagnostics();
+        var verifier = CompileAndVerify(comp).VerifyDiagnostics();
 
         verifier.VerifyIL("C.M", @"
 {
@@ -8557,7 +8536,7 @@ class C : Interface
 }
 ";
         var comp = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
-        var verifier = CompileAndVerify(comp, expectedOutput: "(42, 43)", verify: Verification.FailsILVerify);
+        var verifier = CompileAndVerify(comp, expectedOutput: "(42, 43)");
         verifier.VerifyDiagnostics();
     }
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -7240,7 +7240,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             delegate void X(ref readonly int p);
             delegate void Y({{modifier}} int p);
             """;
-        CompileAndVerify(source, expectedOutput: "X1 Y1 Y1 X1 Y2 X2", verify: Verification.FailsILVerify).VerifyDiagnostics(
+        CompileAndVerify(source, expectedOutput: "X1 Y1 Y1 X1 Y2 X2").VerifyDiagnostics(
             // (9,5): warning CS9198: Reference kind modifier of parameter 'in int p' doesn't match the corresponding parameter 'ref readonly int p' in target.
             // x = c.Y1;
             Diagnostic(ErrorCode.WRN_TargetDifferentRefness, "c.Y1").WithArguments($"{modifier} int p", "ref readonly int p").WithLocation(9, 5),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BetterCandidates.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BetterCandidates.cs
@@ -860,10 +860,8 @@ namespace System.Runtime.CompilerServices
                 //         M(new Z().Q);
                 Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(D1)", "Program.M(D2)").WithLocation(5, 9)
                 );
-            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
-                );
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(compilation, verify: Verification.FailsILVerify, expectedOutput: "2");
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "2");
         }
 
         // Test suggested by @VSadov

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -1326,8 +1326,7 @@ static class B
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
             if (expectedDiagnostics is null)
             {
-                // ILVerify: Unrecognized arguments for delegate .ctor.
-                CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: $"{expectedMethod}: {expectedType}");
+                CompileAndVerify(comp, expectedOutput: $"{expectedMethod}: {expectedType}");
             }
             else
             {
@@ -1371,8 +1370,7 @@ static class B
 }
 """;
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "RAN(42) A.F: System.Action<System.Object>", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "RAN(42) A.F: System.Action<System.Object>");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -1415,8 +1413,7 @@ static class B
 }
 """;
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "RAN B.F: System.Action", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "RAN B.F: System.Action");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -1551,8 +1548,7 @@ namespace N
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.Regular12, options: TestOptions.ReleaseExe);
             if (expectedDiagnostics is null)
             {
-                // ILVerify: Unrecognized arguments for delegate .ctor.
-                CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: $"{expectedMethod}: {expectedType}");
+                CompileAndVerify(comp, expectedOutput: $"{expectedMethod}: {expectedType}");
             }
             else
             {
@@ -1632,8 +1628,7 @@ namespace N
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseExe);
             if (expectedDiagnostics is null)
             {
-                // ILVerify: Unrecognized arguments for delegate .ctor.
-                CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: $"{expectedMethod}: {expectedType}");
+                CompileAndVerify(comp, expectedOutput: $"{expectedMethod}: {expectedType}");
             }
             else
             {
@@ -1688,8 +1683,7 @@ namespace N
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1)
                 );
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "A.F: System.Action");
+            CompileAndVerify(comp, expectedOutput: "A.F: System.Action");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -1739,8 +1733,7 @@ namespace N
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1)
                 );
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "A.F: System.Action<System.Object>");
+            CompileAndVerify(comp, expectedOutput: "A.F: System.Action<System.Object>");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -1790,8 +1783,7 @@ namespace N
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1)
                 );
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "A.F: <>A{00000001}<System.Object>");
+            CompileAndVerify(comp, expectedOutput: "A.F: <>A{00000001}<System.Object>");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -1841,8 +1833,7 @@ namespace N
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1)
                 );
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "A.F: System.Func<System.Object>");
+            CompileAndVerify(comp, expectedOutput: "A.F: System.Func<System.Object>");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -1892,8 +1883,7 @@ namespace N
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1)
                 );
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "A.F: <>F{00000001}<System.Object>");
+            CompileAndVerify(comp, expectedOutput: "A.F: <>F{00000001}<System.Object>");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -1943,8 +1933,7 @@ namespace N
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1)
                 );
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "A.F: System.Action<System.Object>");
+            CompileAndVerify(comp, expectedOutput: "A.F: System.Action<System.Object>");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -1989,8 +1978,7 @@ namespace N
 }
 """;
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "RAN N.B.F: System.Action", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "RAN N.B.F: System.Action");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -2093,8 +2081,7 @@ public static class E
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "C.M E.M C.M");
+            CompileAndVerify(comp, expectedOutput: "C.M E.M C.M");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2280,8 +2267,7 @@ namespace N
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1)
                 );
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "E1.M E1.M");
+            CompileAndVerify(comp, expectedOutput: "E1.M E1.M");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2330,8 +2316,7 @@ namespace N
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "E2.M E2.M");
+            CompileAndVerify(comp, expectedOutput: "E2.M E2.M");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2370,8 +2355,7 @@ public static class E
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "E.M");
+            CompileAndVerify(comp, expectedOutput: "E.M");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2414,8 +2398,7 @@ public static class E
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "E.M E.M");
+            CompileAndVerify(comp, expectedOutput: "E.M E.M");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2507,8 +2490,7 @@ public static class E
                 );
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "E.M", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "E.M");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -2556,8 +2538,7 @@ namespace N
                 );
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "E2.M E2.M", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "E2.M E2.M");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -2605,8 +2586,7 @@ namespace N
                 );
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "E1.M E1.M", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "E1.M E1.M");
             verifier.VerifyDiagnostics(
                 // (1,1): hidden CS8019: Unnecessary using directive.
                 // using N;
@@ -2657,8 +2637,7 @@ public static class E
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "E.M<T, U> E.M<T, U>");
+            CompileAndVerify(comp, expectedOutput: "E.M<T, U> E.M<T, U>");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2706,8 +2685,7 @@ namespace N
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "E2.M<T, U> E2.M<T, U>");
+            CompileAndVerify(comp, expectedOutput: "E2.M<T, U> E2.M<T, U>");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2796,8 +2774,7 @@ public static class DExt
 """;
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics();
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, expectedOutput: "ran11", verify: Verification.FailsILVerify);
+            CompileAndVerify(comp, expectedOutput: "ran11");
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
@@ -2851,8 +2828,7 @@ static class E
 }
 """;
             var comp = CreateCompilation(source);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "ran");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -2880,8 +2856,7 @@ static class E
 }
 """;
             var comp = CreateCompilation(source);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "ran");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -3035,8 +3010,7 @@ static class E2
 }
 """;
             var comp = CreateCompilation(source);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "ran");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -3067,8 +3041,7 @@ static class E2
 }
 """;
             var comp = CreateCompilation(source);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "ran");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -3103,8 +3076,7 @@ static class A
                 Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new object().F").WithLocation(1, 9));
 
             var comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, expectedOutput: "A.F", verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(comp, expectedOutput: "A.F");
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -3630,8 +3602,7 @@ class Program
     }
 }";
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: "System.Action<System.Int32>, System.Action");
+            CompileAndVerify(comp, expectedOutput: "System.Action<System.Int32>, System.Action");
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -10245,8 +10216,7 @@ static class E
             var comp = CreateCompilation(source, options: TestOptions.ReleaseExe);
             comp.VerifyDiagnostics();
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(comp, verify: Verification.FailsILVerify, expectedOutput: @"(41, 42)");
+            var verifier = CompileAndVerify(comp, expectedOutput: @"(41, 42)");
             verifier.VerifyIL("Program.M1",
 @"{
   // Code size       20 (0x14)
@@ -10825,13 +10795,27 @@ class Program
             var comp = CreateCompilation(source, options: TestOptions.ReleaseExe);
             comp.VerifyDiagnostics();
 
-            // ILVerify: Return type is ByRef, TypedReference, ArgHandle, or ArgIterator. { Offset = 24 }
-            CompileAndVerify(comp, expectedOutput:
+            var verifier = CompileAndVerify(comp, expectedOutput:
 @"0
 System.Object
 <>f__AnonymousDelegate0
 <>f__AnonymousDelegate1
-", verify: Verification.FailsILVerify);
+", verify: Verification.FailsILVerify with { ILVerifyMessage = "[F2]: Return type is ByRef, TypedReference, ArgHandle, or ArgIterator. { Offset = 0x18 }" });
+
+            verifier.VerifyIL("Program.F2<T>()", """
+{
+  // Code size       25 (0x19)
+  .maxstack  1
+  .locals init (S<T> V_0)
+  IL_0000:  ldtoken    "T"
+  IL_0005:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+  IL_000a:  call       "void System.Console.WriteLine(object)"
+  IL_000f:  ldloca.s   V_0
+  IL_0011:  initobj    "S<T>"
+  IL_0017:  ldloc.0
+  IL_0018:  ret
+}
+""");
         }
 
         [Fact]
@@ -15366,8 +15350,7 @@ public class Program
 }
 """;
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            var verifier = CompileAndVerify(source, verify: Verification.FailsILVerify);
+            var verifier = CompileAndVerify(source);
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("Program.Main",
 @"
@@ -15497,8 +15480,7 @@ public class Program
 }
 """;
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(source, verify: Verification.FailsILVerify, expectedOutput:
+            CompileAndVerify(source, expectedOutput:
 @"<>f__AnonymousDelegate0`4[Program,System.String,System.Int64,System.String]
 <>f__AnonymousDelegate1`3[System.String,System.Int64,System.String]
 20 b 1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -4662,7 +4662,9 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
-            var verifier = CompileAndVerify(comp, expectedOutput:
+            var verifier = CompileAndVerify(comp,
+                verify: Verification.FailsILVerify with { ILVerifyMessage = "[GetHashCode]: Unrecognized arguments for delegate .ctor. { Offset = 0x12 }" },
+                expectedOutput:
 $@"42
 {42.GetHashCode()}
 False

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -4662,6 +4662,7 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            // See tracking issue https://github.com/dotnet/runtime/issues/96695
             var verifier = CompileAndVerify(comp,
                 verify: Verification.FailsILVerify with { ILVerifyMessage = "[GetHashCode]: Unrecognized arguments for delegate .ctor. { Offset = 0x12 }" },
                 expectedOutput:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -9022,8 +9022,7 @@ public static class Class
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(compilation, verify: Verification.FailsILVerify, expectedOutput:
+            CompileAndVerify(compilation, expectedOutput:
 @"RemoveDetail
 RemoveDetail
 RemoveDetail
@@ -11709,8 +11708,7 @@ public static class Extensions
         throw new NotImplementedException();
 }";
 
-            // ILVerify: Unrecognized arguments for delegate .ctor.
-            CompileAndVerify(code, verify: Verification.FailsILVerify, expectedOutput: @"2");
+            CompileAndVerify(code, expectedOutput: @"2");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
@@ -3328,7 +3328,11 @@ class C
 }
 ";
             var comp = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
-            var verifier = CompileAndVerify(comp, verify: Verification.Fails).VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = """
+[Test3]: Unexpected type on the stack. { Offset = 0x6, Found = address of Int32, Expected = Native Int }
+[Test3]: Return type is ByRef, TypedReference, ArgHandle, or ArgIterator. { Offset = 0xb }
+""" });
+            verifier.VerifyDiagnostics();
 
             string blobId = ExecutionConditionUtil.IsWindows ?
                 "I_000026F8" :
@@ -3342,7 +3346,7 @@ class C
 		01 00 00 00
 	)
 	// Fields
-	.field assembly static initonly int32 F3D4280708A6C4BEA1BAEB5AD5A4B659E705A90BDD448840276EA20CB151BE57 at " + blobId + @"
+	.field assembly static int32 F3D4280708A6C4BEA1BAEB5AD5A4B659E705A90BDD448840276EA20CB151BE57 at " + blobId + @"
 	.data cil " + blobId + @" = bytearray (
 		63 61 74 00
 	)
@@ -3388,7 +3392,7 @@ class C
 		01 00 00 00
 	)
 	// Fields
-	.field assembly static initonly uint8 '6E340B9CFFB37A989CA544E6BB780A2C78901D3FB33738768511A30617AFA01D' at " + blobId + @"
+	.field assembly static uint8 '6E340B9CFFB37A989CA544E6BB780A2C78901D3FB33738768511A30617AFA01D' at " + blobId + @"
 	.data cil " + blobId + @" = bytearray ( 00
 	)
 } // end of class <PrivateImplementationDetails>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
@@ -3329,6 +3329,7 @@ class C
 ";
             var comp = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             var verifier = CompileAndVerify(comp, verify: Verification.Fails with { ILVerifyMessage = """
+[Test3]: Cannot change initonly field outside its .ctor. { Offset = 0x0 }
 [Test3]: Unexpected type on the stack. { Offset = 0x6, Found = address of Int32, Expected = Native Int }
 [Test3]: Return type is ByRef, TypedReference, ArgHandle, or ArgIterator. { Offset = 0xb }
 """ });
@@ -3357,7 +3358,7 @@ class C
 		01 00 00 00
 	)
 	// Fields
-	.field assembly static int32 F3D4280708A6C4BEA1BAEB5AD5A4B659E705A90BDD448840276EA20CB151BE57 at " + blobId + @"
+	.field assembly static initonly int32 F3D4280708A6C4BEA1BAEB5AD5A4B659E705A90BDD448840276EA20CB151BE57 at " + blobId + @"
 	.data cil " + blobId + @" = bytearray (
 		63 61 74 00
 	)
@@ -3403,7 +3404,7 @@ class C
 		01 00 00 00
 	)
 	// Fields
-	.field assembly static uint8 '6E340B9CFFB37A989CA544E6BB780A2C78901D3FB33738768511A30617AFA01D' at " + blobId + @"
+	.field assembly static initonly uint8 '6E340B9CFFB37A989CA544E6BB780A2C78901D3FB33738768511A30617AFA01D' at " + blobId + @"
 	.data cil " + blobId + @" = bytearray ( 00
 	)
 } // end of class <PrivateImplementationDetails>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
@@ -3334,6 +3334,17 @@ class C
 """ });
             verifier.VerifyDiagnostics();
 
+            verifier.VerifyIL("C.Test3", """
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldsflda    "int <PrivateImplementationDetails>.F3D4280708A6C4BEA1BAEB5AD5A4B659E705A90BDD448840276EA20CB151BE57"
+  IL_0005:  ldc.i4.3
+  IL_0006:  newobj     "System.ReadOnlySpan<byte>..ctor(void*, int)"
+  IL_000b:  ret
+}
+""");
+
             string blobId = ExecutionConditionUtil.IsWindows ?
                 "I_000026F8" :
                 "I_00002738";

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -290,12 +290,11 @@ static class Program
         Console.WriteLine(x);
     }
 }";
-            // ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 21 }
             CompileAndVerify(source, expectedOutput:
 @"ABC
 123
 123
-xyz", verify: Verification.FailsILVerify);
+xyz");
         }
 
         [WorkItem(541143, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541143")]
@@ -377,8 +376,7 @@ static class Program
     static void Goo<T>(this T x) { }
 }
 ";
-            // ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 7 }
-            CompileAndVerify(source, expectedOutput: "2", verify: Verification.FailsILVerify);
+            CompileAndVerify(source, expectedOutput: "2");
         }
 
         [WorkItem(528426, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528426")]
@@ -875,8 +873,7 @@ static class B
     internal static void F(this object x, object y) { }
     internal static void G(this object x, object y) { }
 }";
-            // ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 8 }
-            var compilation = CompileAndVerify(source, verify: Verification.FailsILVerify);
+            var compilation = CompileAndVerify(source);
             compilation.VerifyIL("N.C.M",
 @"{
   // Code size       71 (0x47)
@@ -942,8 +939,7 @@ static class S2
     internal static void F3(this object x, int y) { }
     internal static void F4(this object x, object y) { }
 }";
-            // ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 8 }
-            var compilation = CompileAndVerify(source, verify: Verification.FailsILVerify);
+            var compilation = CompileAndVerify(source);
             compilation.VerifyIL("N.C.M",
 @"
 {
@@ -1927,8 +1923,7 @@ static class S
         System.Console.Write(c.P * i);
     }
 }";
-            // ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 11 }
-            CompileAndVerify(source, expectedOutput: "6", verify: Verification.FailsILVerify);
+            CompileAndVerify(source, expectedOutput: "6");
         }
 
         [Fact]
@@ -2379,13 +2374,12 @@ static class E
         Console.WriteLine(""{0}"", o.GetType());
     }
 }";
-            // ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 12 }
             var compilation = CompileAndVerify(source, expectedOutput:
 @"System.Object
 System.Object
 System.Int32
 B
-B", verify: Verification.FailsILVerify);
+B");
             compilation.VerifyIL("C.M<T1, T2, T3, T4, T5>",
 @"{
   // Code size      112 (0x70)
@@ -4031,7 +4025,7 @@ public static class C
     public static void M2(in this int p) { }
 }";
 
-            void Validator(ModuleSymbol module)
+            void validator(ModuleSymbol module)
             {
                 var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
@@ -4048,7 +4042,7 @@ public static class C
                 Assert.Equal(RefKind.In, parameter.RefKind);
             }
 
-            CompileAndVerify(source, validator: Validator, options: TestOptions.ReleaseDll);
+            CompileAndVerify(source, validator: validator, options: TestOptions.ReleaseDll);
         }
 
         [Fact]
@@ -4061,7 +4055,7 @@ public static class C
     public static void M2(ref this int p) { }
 }";
 
-            void Validator(ModuleSymbol module)
+            void validator(ModuleSymbol module)
             {
                 var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
@@ -4078,7 +4072,7 @@ public static class C
                 Assert.Equal(RefKind.Ref, parameter.RefKind);
             }
 
-            CompileAndVerify(source, validator: Validator, options: TestOptions.ReleaseDll);
+            CompileAndVerify(source, validator: validator, options: TestOptions.ReleaseDll);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -20783,10 +20783,22 @@ namespace C
 }";
             var referenceD = CreateCompilation(codeD, assemblyName: "D").EmitToImageReference();
 
-            CompileAndVerify(
+            var verifier = CompileAndVerify(
                 source: codeA,
                 references: new MetadataReference[] { referenceB, referenceC2, referenceD },
-                expectedOutput: "obj is null");
+                expectedOutput: "obj is null",
+                verify: Verification.FailsILVerify with { ILVerifyMessage = "[Main]: Unable to resolve token. { Offset = 0x1, Token = 167772167 }" });
+
+            verifier.VerifyIL("A.ClassA.Main", """
+{
+  // Code size       12 (0xc)
+  .maxstack  1
+  IL_0000:  ldnull
+  IL_0001:  call       "string B.ClassB.MethodB(C.ClassC)"
+  IL_0006:  call       "void System.Console.WriteLine(string)"
+  IL_000b:  ret
+}
+""");
         }
 
         [Fact, WorkItem(16484, "https://github.com/dotnet/roslyn/issues/16484")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -20783,6 +20783,7 @@ namespace C
 }";
             var referenceD = CreateCompilation(codeD, assemblyName: "D").EmitToImageReference();
 
+            // ECMA-335 "II.22.14 ExportedType : 0x27" rule 14: "Ignoring nested Types, there shall be no duplicate rows, based upon FullName [ERROR]".
             var verifier = CompileAndVerify(
                 source: codeA,
                 references: new MetadataReference[] { referenceB, referenceC2, referenceD },

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -576,7 +576,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public Cci.ITypeDefinition ContainingTypeDefinition => _containingType;
 
-        public Cci.TypeMemberVisibility Visibility => Cci.TypeMemberVisibility.Private;
+        public Cci.TypeMemberVisibility Visibility => Cci.TypeMemberVisibility.Assembly;
 
         public override bool IsValueType => true;
 
@@ -727,7 +727,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
         }
 
         public override ImmutableArray<byte> MappedData => _block;
-        public override bool IsReadOnly => true;
+        public override bool IsReadOnly => false;
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -727,7 +727,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
         }
 
         public override ImmutableArray<byte> MappedData => _block;
-        public override bool IsReadOnly => false;
+        public override bool IsReadOnly => true;
     }
 
     /// <summary>

--- a/src/Compilers/Test/Core/CommonTestBase.cs
+++ b/src/Compilers/Test/Core/CommonTestBase.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public static readonly Verification PassesOrFailFast = new() { Status = VerificationStatus.PassesOrFailFast };
 
         public Verification WithILVerifyMessage(string message)
-            => new Verification() { Status = Status, ILVerifyMessage = message, PEVerifyMessage = PEVerifyMessage, IncludeTokensAndModuleIds = IncludeTokensAndModuleIds };
+            => this with { ILVerifyMessage = message };
     }
 
 #nullable disable

--- a/src/Compilers/Test/Core/CommonTestBase.cs
+++ b/src/Compilers/Test/Core/CommonTestBase.cs
@@ -57,6 +57,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public static readonly Verification FailsILVerify = new() { Status = VerificationStatus.FailsILVerify };
         public static readonly Verification Fails = new() { Status = VerificationStatus.Fails };
         public static readonly Verification PassesOrFailFast = new() { Status = VerificationStatus.PassesOrFailFast };
+
+        public Verification WithILVerifyMessage(string message)
+            => new Verification() { Status = Status, ILVerifyMessage = message, PEVerifyMessage = PEVerifyMessage, IncludeTokensAndModuleIds = IncludeTokensAndModuleIds };
     }
 
 #nullable disable

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -300,20 +300,30 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
-        private sealed class Resolver : ILVerify.ResolverBase
+        private sealed class Resolver : ILVerify.IResolver
         {
-            private readonly Dictionary<string, ImmutableArray<byte>> _imagesByName;
+            private readonly Dictionary<string, PEReader> _readersByName;
 
-            internal Resolver(Dictionary<string, ImmutableArray<byte>> imagesByName)
+            internal Resolver(Dictionary<string, PEReader> readersByName)
             {
-                _imagesByName = imagesByName;
+                _readersByName = readersByName;
             }
 
-            protected override PEReader ResolveCore(string simpleName)
+            public PEReader ResolveAssembly(AssemblyName assemblyName)
             {
-                if (_imagesByName.TryGetValue(simpleName, out var image))
+                return Resolve(assemblyName.Name);
+            }
+
+            public PEReader ResolveModule(AssemblyName referencingAssembly, string fileName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public PEReader Resolve(string simpleName)
+            {
+                if (_readersByName.TryGetValue(simpleName, out var reader))
                 {
-                    return new PEReader(image);
+                    return reader;
                 }
 
                 throw new Exception($"ILVerify was not able to resolve a module named '{simpleName}'");
@@ -327,11 +337,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 return;
             }
 
-            var imagesByName = new Dictionary<string, ImmutableArray<byte>>(StringComparer.OrdinalIgnoreCase);
+            var readersByName = new Dictionary<string, PEReader>(StringComparer.OrdinalIgnoreCase);
             foreach (var module in _allModuleData)
             {
                 string name = module.SimpleName;
-                if (imagesByName.ContainsKey(name))
+                if (readersByName.ContainsKey(name))
                 {
                     if (verification.Status.HasFlag(VerificationStatus.FailsILVerify) && verification.ILVerifyMessage is null)
                     {
@@ -340,10 +350,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
                     throw new Exception($"Multiple modules named '{name}' were found");
                 }
-                imagesByName.Add(name, module.Image);
+                readersByName.Add(name, new PEReader(module.Image));
             }
 
-            var resolver = new Resolver(imagesByName);
+            var resolver = new Resolver(readersByName);
             var verifier = new ILVerify.Verifier(resolver);
             var mscorlibModule = _allModuleData.SingleOrDefault(m => m.IsCorLib);
             if (mscorlibModule is null)
@@ -359,7 +369,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             // Main module is the first one
             var mainModuleReader = resolver.Resolve(_allModuleData[0].SimpleName);
 
-            var (actualSuccess, actualMessage) = verify(verifier, mscorlibModule.SimpleName, mainModuleReader);
+            var (actualSuccess, actualMessage) = verify(verifier, mscorlibModule.FullName, mainModuleReader);
             var expectedSuccess = !verification.Status.HasFlag(VerificationStatus.FailsILVerify);
 
             if (actualSuccess != expectedSuccess)

--- a/src/Compilers/Test/Core/Platform/Desktop/DesktopRuntimeEnvironment.cs
+++ b/src/Compilers/Test/Core/Platform/Desktop/DesktopRuntimeEnvironment.cs
@@ -341,7 +341,7 @@ namespace Roslyn.Test.Utilities.Desktop
                 if (expectedMessage != null && !IsEnglishLocal.Instance.ShouldSkip)
                 {
                     var actualMessage = ex.Output;
-                    
+
                     if (!verification.IncludeTokensAndModuleIds)
                     {
                         actualMessage = Regex.Replace(ex.Output, @"\[mdToken=0x[0-9a-fA-F]+\]", "");

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -6,6 +6,7 @@ Imports System.IO
 Imports System.Text.RegularExpressions
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Emit
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Roslyn.Test.Utilities
@@ -9917,8 +9918,11 @@ End Class
             Dim expectedOutput = <![CDATA[System.Int32]]>
 
             Dim compilation = CompilationUtils.CreateEmptyCompilationWithReferences(source, references:=LatestVbReferences, options:=TestOptions.DebugExe)
-            CompileAndVerify(compilation, expectedOutput:=expectedOutput)
-            CompileAndVerify(compilation.WithOptions(TestOptions.ReleaseExe), expectedOutput:=expectedOutput)
+            CompileAndVerify(compilation, expectedOutput:=expectedOutput,
+                             verify:=Verification.FailsILVerify.WithILVerifyMessage("[MoveNext]: Unrecognized arguments for delegate .ctor. { Offset = 0x86 }"))
+
+            CompileAndVerify(compilation.WithOptions(TestOptions.ReleaseExe), expectedOutput:=expectedOutput,
+                             verify:=Verification.FailsILVerify.WithILVerifyMessage("[MoveNext]: Unrecognized arguments for delegate .ctor. { Offset = 0x75 }"))
         End Sub
 
         <Fact, WorkItem(13734, "https://github.com/dotnet/roslyn/issues/13734")>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenDelegateCreation.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenDelegateCreation.vb
@@ -2342,7 +2342,8 @@ End Structure
         </file>
     </compilation>
 
-            CompileAndVerify(source,
+            Dim verifier = CompileAndVerify(source,
+                         verify:=Verification.FailsILVerify.WithILVerifyMessage("[Test15]: Unrecognized arguments for delegate .ctor. { Offset = 0x1f }"),
                          expectedOutput:=<![CDATA[
 -- Test1 --
 SideEffect1
@@ -2399,6 +2400,29 @@ P1
 1
 2
 ]]>)
+
+            verifier.VerifyIL("Module1.Test15", "
+{
+  // Code size       58 (0x3a)
+  .maxstack  2
+  .locals init (S1 V_0)
+  IL_0000:  ldstr      ""-- Test15 --""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  ldloca.s   V_0
+  IL_000c:  initobj    ""S1""
+  IL_0012:  ldloc.0
+  IL_0013:  box        ""S1""
+  IL_0018:  dup
+  IL_0019:  ldvirtftn  ""Function Object.GetHashCode() As Integer""
+  IL_001f:  newobj     ""Sub System.Func(Of Integer)..ctor(Object, System.IntPtr)""
+  IL_0024:  dup
+  IL_0025:  callvirt   ""Function System.Func(Of Integer).Invoke() As Integer""
+  IL_002a:  call       ""Sub System.Console.WriteLine(Integer)""
+  IL_002f:  callvirt   ""Function System.Func(Of Integer).Invoke() As Integer""
+  IL_0034:  call       ""Sub System.Console.WriteLine(Integer)""
+  IL_0039:  ret
+}
+")
 
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenForeach.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenForeach.vb
@@ -2400,7 +2400,6 @@ End Class
 
         <Fact>
         Public Sub NoObjectCopyForGetCurrent()
-            ' ILVerify: Unexpected type on the stack. { Offset = 25, Found = readonly address of '[...]C2+S1', Expected = address of '[...]C2+S1' }
             Dim TEMP = CompileAndVerify(
 <compilation>
     <file name="a.vb">      
@@ -2437,7 +2436,7 @@ End Class
 </compilation>, expectedOutput:=<![CDATA[
 23
 42
-]]>, verify:=Verification.FailsILVerify).VerifyIL("C2.DoStuff", <![CDATA[
+]]>).VerifyIL("C2.DoStuff", <![CDATA[
 {
   // Code size       66 (0x42)
   .maxstack  1

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
@@ -3483,7 +3483,13 @@ End Module
                     </file>
                 </compilation>
 
-            CompileAndVerify(source).VerifyDiagnostics().VerifyIL("Program.Main", <![CDATA[
+            Dim verifier = CompileAndVerify(source, verify:=Verification.FailsILVerify.WithILVerifyMessage("
+[Main]: Unrecognized arguments for delegate .ctor. { Offset = 0x16 }
+[Main]: Unrecognized arguments for delegate .ctor. { Offset = 0x2e }
+[Main]: Unrecognized arguments for delegate .ctor. { Offset = 0x46 }
+[Main]: Unrecognized arguments for delegate .ctor. { Offset = 0x5d }"))
+
+            verifier.VerifyDiagnostics().VerifyIL("Program.Main", <![CDATA[
 {
   // Code size      124 (0x7c)
   .maxstack  3

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -130,7 +130,6 @@ End Class
 
         <Fact()>
         Public Sub Bug776642a_ref()
-            ' ILVerify: Unexpected type on the stack. { Offset = 30, Found = readonly address of '[...]OuterStruct', Expected = address of '[...]OuterStruct' }
             CompileAndVerify(
 <compilation>
     <file name="a.vb">
@@ -165,7 +164,7 @@ Structure OuterStruct
     Public z As DoubleAndStruct
 End Structure
     </file>
-</compilation>, verify:=Verification.FailsILVerify).
+</compilation>).
             VerifyIL("Program.M",
             <![CDATA[
 {

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -3664,7 +3664,6 @@ Lambda(
 
         <Fact>
         Public Sub ExprTree_LegacyTests02_v40()
-            ' ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 1223 }
             Dim file = <file name="expr.vb"><![CDATA[
 Option Strict Off 
 Imports System
@@ -3705,12 +3704,11 @@ Module Form1
     End Sub
 End Module
 ]]></file>
-            TestExpressionTrees(file, ExpTreeTestResources.ExprTree_LegacyTests02_v40_Result, verify:=Verification.FailsILVerify)
+            TestExpressionTrees(file, ExpTreeTestResources.ExprTree_LegacyTests02_v40_Result)
         End Sub
 
         <Fact>
         Public Sub ExprTree_LegacyTests02_v45()
-            ' ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 1167 }
             Dim file = <file name="expr.vb"><![CDATA[
 Option Strict Off 
 Imports System
@@ -3748,7 +3746,7 @@ Module Form1
     End Sub
 End Module
 ]]></file>
-            TestExpressionTrees(file, ExpTreeTestResources.ExprTree_LegacyTests02_v45_Result, latestReferences:=True, verify:=Verification.FailsILVerify)
+            TestExpressionTrees(file, ExpTreeTestResources.ExprTree_LegacyTests02_v45_Result, latestReferences:=True)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/XmlLiteralTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/XmlLiteralTests.vb
@@ -2916,7 +2916,6 @@ End Module
         <WorkItem(544461, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544461")>
         <Fact()>
         Public Sub ValueExtensionProperty()
-            ' ILVerify: Unexpected type on the stack. { Offset = 117, Found = ref '[mscorlib]System.Collections.Generic.IEnumerable`1<T0>', Expected = ref '[mscorlib]System.Collections.Generic.IEnumerable`1<System.Xml.Linq.XElement>' }
             Dim compilation = CompileAndVerify(
 <compilation>
     <file name="c.vb"><![CDATA[
@@ -2969,7 +2968,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, references:=Net40XmlReferences, verify:=Verification.FailsILVerify)
+</compilation>, references:=Net40XmlReferences)
             compilation.VerifyIL("M.M(Of T)", <![CDATA[
 {
   // Code size      166 (0xa6)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalAccessTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalAccessTests.vb
@@ -3997,7 +3997,6 @@ BC41999: Implicit conversion from 'I1' to 'C1' in copying the value of 'ByRef' p
         ~
 ]]></expected>)
 
-            ' ILVerify: Unexpected type on the stack. { Offset = 39, Found = readonly address of '[...]S1', Expected = address of '[...]S1' }
             Dim verifier = CompileAndVerify(compilation, expectedOutput:=
             <![CDATA[
  ---------
@@ -4060,7 +4059,7 @@ C1
 Ext4
 C1
 ---------
-]]>, verify:=Verification.FailsILVerify)
+]]>)
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/AddressOf.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/AddressOf.vb
@@ -202,7 +202,6 @@ End Namespace
 </compilation>
 
             CompileAndVerify(compilationDef,
-                             verify:=Verification.FailsILVerify,
                              expectedOutput:=
             <![CDATA[
 -- Test1 --
@@ -633,7 +632,6 @@ End Namespace
 </compilation>
 
             CompileAndVerify(compilationDef,
-                             verify:=Verification.FailsILVerify,
                              expectedOutput:=
             <![CDATA[
 M2.F1
@@ -941,9 +939,7 @@ Namespace System.Runtime.CompilerServices
 End Namespace
     </file>
 </compilation>
-            ' ILVerify: Unrecognized arguments for delegate .ctor. { Offset = 8 }
             CompileAndVerify(compilationDef,
-                             verify:=Verification.FailsILVerify,
                              expectedOutput:=
             <![CDATA[
 2

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -24344,6 +24344,7 @@ End Namespace"
                 options:=New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
                 assemblyName:="D").EmitToImageReference()
 
+            ' ECMA-335 "II.22.14 ExportedType : 0x27" rule 14: "Ignoring nested Types, there shall be no duplicate rows, based upon FullName [ERROR]".
             Dim verifier = CompileAndVerify(
                 source:=codeA,
                 references:={referenceB, referenceC2, referenceD},

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -24344,10 +24344,22 @@ End Namespace"
                 options:=New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
                 assemblyName:="D").EmitToImageReference()
 
-            CompileAndVerify(
+            Dim verifier = CompileAndVerify(
                 source:=codeA,
                 references:={referenceB, referenceC2, referenceD},
-                expectedOutput:="obj is nothing")
+                expectedOutput:="obj is nothing",
+                verify:=Verification.FailsILVerify.WithILVerifyMessage("[Main]: Unable to resolve token. { Offset = 0x1, Token = 167772166 }"))
+
+            verifier.VerifyIL("A.ClassA.Main()", "
+{
+  // Code size       12 (0xc)
+  .maxstack  1
+  IL_0000:  ldnull
+  IL_0001:  call       ""Function B.ClassB.MethodB(C.ClassC) As String""
+  IL_0006:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000b:  ret
+}
+")
         End Sub
 
         <Fact>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69860

The second commit changes codegen for a private implementation field (~~it should not be readonly and~~ its type should be internal instead of private). That resolves some verification issues documented in the linked bug.