### PR TITLE
Update MSBuild.StructuredLogger

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -205,7 +205,7 @@
     <MicrosoftVisualStudioWorkspaceVSIntegrationVersion>17.1.11-preview-0002</MicrosoftVisualStudioWorkspaceVSIntegrationVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
-    <MSBuildStructuredLoggerVersion>2.2.100</MSBuildStructuredLoggerVersion>
+    <MSBuildStructuredLoggerVersion>2.2.158</MSBuildStructuredLoggerVersion>
     <MDbgVersion>0.1.0</MDbgVersion>
     <MonoOptionsVersion>6.6.0.161</MonoOptionsVersion>
     <MoqVersion>4.10.1</MoqVersion>


### PR DESCRIPTION
FYI @KirillOsenkov 


### Context

This is update to the latest version of MSBuild.StructuredLogger, that contains the forward compatibility reading support.
The initial MSBuild change to forward compatible logs reading is **breaking** (log data format needs to be adjusted in order to allow forward compatibile reading for the future) - hence updating the reading code ahead of MSBuild pushing the updated version of binlog writing (https://github.com/dotnet/msbuild/pull/9307) is advisable.