### PR TITLE
Fix rethrowing in nested async catch

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -2335,5 +2335,142 @@ class Driver
             CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput).VerifyDiagnostics();
             CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput).VerifyDiagnostics();
         }
+
+        [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/71569")]
+        public void NestedRethrow(bool await1, bool await2)
+        {
+            var source = $$"""
+                using System;
+                using System.Threading.Tasks;
+
+                try
+                {
+                    await Test1();
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.GetType().Name);
+                }
+
+                try
+                {
+                    await Test2();
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.GetType().Name);
+                }
+
+                static async Task Test1()
+                {
+                    try
+                    {
+                        throw new Exception1();
+                    }
+                    catch (Exception1)
+                    {
+                        try
+                        {
+                            await Task.FromException(new Exception2());
+                        }
+                        catch (Exception2)
+                        {
+                            {{(await1 ? "await Task.Yield();" : "")}}
+                            throw;
+                        }
+                    }
+                }
+
+                static async Task Test2()
+                {
+                    try
+                    {
+                        throw new Exception1();
+                    }
+                    catch (Exception1)
+                    {
+                        try
+                        {
+                            await Task.FromException(new Exception2());
+                        }
+                        catch (Exception2 ex)
+                        {
+                            {{(await2 ? "await Task.Yield();" : "")}}
+                            throw ex;
+                        }
+                    }
+                }
+
+                class Exception1 : Exception { }
+                class Exception2 : Exception { }
+                """;
+
+            var expectedOutput = """
+                Exception2
+                Exception2
+                """;
+
+            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput,
+                targetFramework: TargetFramework.Mscorlib46).VerifyDiagnostics();
+            CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput,
+                targetFramework: TargetFramework.Mscorlib46).VerifyDiagnostics();
+        }
+
+        [Theory, CombinatorialData]
+        public void NestedRethrow_02(bool await1, bool await2, bool await3)
+        {
+            var source = $$"""
+                #pragma warning disable 1998 // async method lacks 'await' operators
+                using System;
+                using System.Threading.Tasks;
+
+                try
+                {
+                    await Run();
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.GetType().Name);
+                }
+
+                static async Task Run()
+                {
+                    try
+                    {
+                        throw new Exception1();
+                    }
+                    catch (Exception1)
+                    {
+                        try
+                        {
+                            {{(await1 ? "await Task.Yield();" : "")}}
+                            throw new Exception2();
+                        }
+                        catch (Exception2)
+                        {
+                            try
+                            {
+                                {{(await2 ? "await Task.Yield();" : "")}}
+                                throw new Exception3();
+                            }
+                            catch (Exception3)
+                            {
+                                {{(await3 ? "await Task.Yield();" : "")}}
+                                throw;
+                            }
+                        }
+                    }
+                }
+
+                class Exception1 : Exception { }
+                class Exception2 : Exception { }
+                class Exception3 : Exception { }
+                """;
+
+            var expectedOutput = "Exception3";
+
+            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+            CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput).VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/71569.

The async catch rewriter was handling each rethrow via `_currentAwaitCatchFrame` but that might not be the current catch frame, that's only the nearest catch frame with awaits.