### PR TITLE
Remove properties from DocumentSpan

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptFindUsagesContext.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Navigation;
 
@@ -54,6 +55,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
                    ImmutableArray<TaggedText>.Empty,
                    originationParts: default,
                    sourceSpans: default,
+                   classifiedSpans: default,
                    properties: null,
                    displayIfNoReferences: true)
         {
@@ -84,8 +86,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             bool displayIfNoReferences = true)
         {
             return new(DefinitionItem.Create(
-                tags, displayParts, sourceSpans.SelectAsArray(span => span.ToDocumentSpan()), nameDisplayParts,
-                properties: null, displayableProperties: ImmutableDictionary<string, string>.Empty, displayIfNoReferences: displayIfNoReferences));
+                tags, displayParts, sourceSpans.SelectAsArray(span => span.ToDocumentSpan()), sourceSpans.SelectAsArray(_ => (ClassifiedSpansAndHighlightSpan?)null),
+                nameDisplayParts, properties: null, displayableProperties: ImmutableDictionary<string, string>.Empty, displayIfNoReferences: displayIfNoReferences));
         }
 
         public static VSTypeScriptDefinitionItem CreateExternal(
@@ -120,7 +122,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         VSTypeScriptDocumentSpan sourceSpan,
         VSTypeScriptSymbolUsageInfo symbolUsageInfo)
     {
-        internal readonly SourceReferenceItem UnderlyingObject = new SourceReferenceItem(definition.UnderlyingObject, sourceSpan.ToDocumentSpan(), symbolUsageInfo.UnderlyingObject);
+        internal readonly SourceReferenceItem UnderlyingObject = new SourceReferenceItem(
+            definition.UnderlyingObject, sourceSpan.ToDocumentSpan(), classifiedSpans: null, symbolUsageInfo.UnderlyingObject);
 
         public VSTypeScriptDocumentSpan GetSourceSpan()
             => new(UnderlyingObject.SourceSpan);

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -46,6 +46,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
 
                 Dim spansAndHighlightSpan = Await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
                     New DocumentSpan(document, referenceSpan),
+                    classifiedSpans:=Nothing,
                     ClassificationOptions.Default, CancellationToken.None)
 
                 ' This is the classification of the line, starting at the beginning of the highlight, and going to the end of that line.
@@ -219,6 +220,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
 
                 Dim spansAndHighlightSpan = Await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
                     New DocumentSpan(document, referenceSpan),
+                    classifiedSpans:=Nothing,
                     ClassificationOptions.Default, CancellationToken.None)
 
                 ' string classification should not overlap u8 classification.

--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
@@ -15,29 +15,23 @@ namespace Microsoft.CodeAnalysis.Classification
 {
     internal static class ClassifiedSpansAndHighlightSpanFactory
     {
-        public static async Task<DocumentSpan> GetClassifiedDocumentSpanAsync(
-            Document document, TextSpan sourceSpan, ClassificationOptions options, CancellationToken cancellationToken)
-        {
-            var classifiedSpans = await ClassifyAsync(
-                document, sourceSpan, options, cancellationToken).ConfigureAwait(false);
+        //public static async Task<ClassifiedSpansAndHighlightSpan> GetClassifiedDocumentSpanAsync(
+        //    Document document, TextSpan sourceSpan, ClassificationOptions options, CancellationToken cancellationToken)
+        //{
+        //    var classifiedSpans = await ClassifyAsync(
+        //        document, sourceSpan, options, cancellationToken).ConfigureAwait(false);
 
-            var properties = ImmutableDictionary<string, object>.Empty.Add(
-                ClassifiedSpansAndHighlightSpan.Key, classifiedSpans);
-
-            return new DocumentSpan(document, sourceSpan, properties);
-        }
+        //    return classifiedSpans;
+        //}
 
         public static async Task<ClassifiedSpansAndHighlightSpan> ClassifyAsync(
-            DocumentSpan documentSpan, ClassificationOptions options, CancellationToken cancellationToken)
+            DocumentSpan documentSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, ClassificationOptions options, CancellationToken cancellationToken)
         {
             // If the document span is providing us with the classified spans up front, then we
             // can just use that.  Otherwise, go back and actually classify the text for the line
             // the document span is on.
-            if (documentSpan.Properties != null &&
-                documentSpan.Properties.TryGetValue(ClassifiedSpansAndHighlightSpan.Key, out var value))
-            {
-                return (ClassifiedSpansAndHighlightSpan)value;
-            }
+            if (classifiedSpans != null)
+                return classifiedSpans.Value;
 
             return await ClassifyAsync(
                 documentSpan.Document, documentSpan.SourceSpan, options, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
@@ -15,15 +15,6 @@ namespace Microsoft.CodeAnalysis.Classification
 {
     internal static class ClassifiedSpansAndHighlightSpanFactory
     {
-        //public static async Task<ClassifiedSpansAndHighlightSpan> GetClassifiedDocumentSpanAsync(
-        //    Document document, TextSpan sourceSpan, ClassificationOptions options, CancellationToken cancellationToken)
-        //{
-        //    var classifiedSpans = await ClassifyAsync(
-        //        document, sourceSpan, options, cancellationToken).ConfigureAwait(false);
-
-        //    return classifiedSpans;
-        //}
-
         public static async Task<ClassifiedSpansAndHighlightSpan> ClassifyAsync(
             DocumentSpan documentSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, ClassificationOptions options, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/DocumentSpan.cs
+++ b/src/Features/Core/Portable/DocumentSpan.cs
@@ -17,10 +17,10 @@ namespace Microsoft.CodeAnalysis
         public Document Document { get; }
         public TextSpan SourceSpan { get; }
 
-        /// <summary>
-        /// Additional information attached to a document span by it creator.
-        /// </summary>
-        public ImmutableDictionary<string, object>? Properties { get; }
+        ///// <summary>
+        ///// Additional information attached to a document span by it creator.
+        ///// </summary>
+        //public ImmutableDictionary<string, object>? Properties { get; }
 
         public DocumentSpan(
             Document document,
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis
         {
             Document = document;
             SourceSpan = sourceSpan;
-            Properties = properties ?? ImmutableDictionary<string, object>.Empty;
+            // Properties = properties ?? ImmutableDictionary<string, object>.Empty;
         }
 
         public DocumentSpan(Document document, TextSpan sourceSpan)

--- a/src/Features/Core/Portable/DocumentSpan.cs
+++ b/src/Features/Core/Portable/DocumentSpan.cs
@@ -2,47 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis
-{
-    /// <summary>
-    /// Represents a <see cref="TextSpan"/> location in a <see cref="Document"/>.
-    /// </summary>
-    internal readonly record struct DocumentSpan
-    {
-        public Document Document { get; }
-        public TextSpan SourceSpan { get; }
+namespace Microsoft.CodeAnalysis;
 
-        ///// <summary>
-        ///// Additional information attached to a document span by it creator.
-        ///// </summary>
-        //public ImmutableDictionary<string, object>? Properties { get; }
-
-        public DocumentSpan(
-            Document document,
-            TextSpan sourceSpan,
-            ImmutableDictionary<string, object>? properties)
-        {
-            Document = document;
-            SourceSpan = sourceSpan;
-            // Properties = properties ?? ImmutableDictionary<string, object>.Empty;
-        }
-
-        public DocumentSpan(Document document, TextSpan sourceSpan)
-            : this(document, sourceSpan, properties: null)
-        {
-        }
-
-        public bool Equals(DocumentSpan obj)
-            => Document == obj.Document && SourceSpan == obj.SourceSpan;
-
-        public override int GetHashCode()
-            => Hash.Combine(
-                Document,
-                SourceSpan.GetHashCode());
-    }
-}
+/// <summary>
+/// Represents a <see cref="TextSpan"/> location in a <see cref="Document"/>.
+/// </summary>
+internal readonly record struct DocumentSpan(Document Document, TextSpan SourceSpan);

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDefinitionItemBase.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDefinitionItemBase.cs
@@ -4,25 +4,22 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindUsages;
-using Microsoft.CodeAnalysis.Navigation;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
+
+[Obsolete]
+internal abstract class VSTypeScriptDefinitionItemBase : DefinitionItem
 {
-    [Obsolete]
-    internal abstract class VSTypeScriptDefinitionItemBase : DefinitionItem
+    protected VSTypeScriptDefinitionItemBase(ImmutableArray<string> tags, ImmutableArray<TaggedText> displayParts)
+        : base(tags,
+              displayParts,
+              ImmutableArray<TaggedText>.Empty,
+              originationParts: default,
+              sourceSpans: default,
+              classifiedSpans: default,
+              properties: null,
+              displayIfNoReferences: true)
     {
-        protected VSTypeScriptDefinitionItemBase(ImmutableArray<string> tags, ImmutableArray<TaggedText> displayParts)
-            : base(tags,
-                  displayParts,
-                  ImmutableArray<TaggedText>.Empty,
-                  originationParts: default,
-                  sourceSpans: default,
-                  properties: null,
-                  displayIfNoReferences: true)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -37,11 +37,12 @@ namespace Microsoft.CodeAnalysis.FindUsages
             {
                 var options = await _context.GetOptionsAsync(document.Project.Language, cancellationToken).ConfigureAwait(false);
 
-                var documentSpan = await ClassifiedSpansAndHighlightSpanFactory.GetClassifiedDocumentSpanAsync(
-                    document, span, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
+                var documentSpan = new DocumentSpan(document, span);
+                var classifiedSpans = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
+                    documentSpan, classifiedSpans: null, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
 
                 await _context.OnReferenceFoundAsync(
-                    new SourceReferenceItem(_definition, documentSpan, SymbolUsageInfo.None), cancellationToken).ConfigureAwait(false);
+                    new SourceReferenceItem(_definition, documentSpan, classifiedSpans, SymbolUsageInfo.None), cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -25,10 +26,12 @@ namespace Microsoft.CodeAnalysis.FindUsages
             ImmutableArray<TaggedText> nameDisplayParts,
             ImmutableArray<TaggedText> originationParts,
             ImmutableArray<DocumentSpan> sourceSpans,
+            ImmutableArray<ClassifiedSpansAndHighlightSpan?> classifiedSpans,
             ImmutableDictionary<string, string>? properties,
             ImmutableDictionary<string, string>? displayableProperties,
-            bool displayIfNoReferences) : DefinitionItem(tags, displayParts, nameDisplayParts, originationParts,
-                   sourceSpans, properties, displayableProperties, displayIfNoReferences)
+            bool displayIfNoReferences) : DefinitionItem(
+                tags, displayParts, nameDisplayParts, originationParts,
+                sourceSpans, classifiedSpans, properties, displayableProperties, displayIfNoReferences)
         {
             internal sealed override bool IsExternal => false;
 

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DetachedDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DetachedDefinitionItem.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.FindUsages.DefinitionItem;
@@ -76,6 +77,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
         public async Task<DefaultDefinitionItem?> TryRehydrateAsync(Solution solution, CancellationToken cancellationToken)
         {
             using var converted = TemporaryArray<DocumentSpan>.Empty;
+            using var convertedClassifiedSpans = TemporaryArray<ClassifiedSpansAndHighlightSpan?>.Empty;
             foreach (var ss in SourceSpans)
             {
                 var documentSpan = await ss.TryRehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
@@ -83,11 +85,14 @@ namespace Microsoft.CodeAnalysis.FindUsages
                     return null;
 
                 converted.Add(documentSpan.Value);
+
+                // todo: consider serializing this data.
+                convertedClassifiedSpans.Add(null);
             }
 
             return new DefaultDefinitionItem(
                 Tags, DisplayParts, NameDisplayParts, OriginationParts,
-                converted.ToImmutableAndClear(),
+                converted.ToImmutableAndClear(), convertedClassifiedSpans.ToImmutableAndClear(),
                 Properties, DisplayableProperties, DisplayIfNoReferences);
         }
     }

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
@@ -163,6 +163,8 @@ namespace Microsoft.CodeAnalysis.FindUsages
             DisplayableProperties = displayableProperties ?? ImmutableDictionary<string, string>.Empty;
             DisplayIfNoReferences = displayIfNoReferences;
 
+            Contract.ThrowIfTrue(sourceSpans.Length != classifiedSpans.Length);
+
             if (Properties.ContainsKey(MetadataSymbolKey))
             {
                 Contract.ThrowIfFalse(Properties.ContainsKey(MetadataSymbolOriginatingProjectIdGuid));

--- a/src/Features/Core/Portable/FindUsages/IDefinitionsAndReferencesFactory.cs
+++ b/src/Features/Core/Portable/FindUsages/IDefinitionsAndReferencesFactory.cs
@@ -112,7 +112,13 @@ namespace Microsoft.CodeAnalysis.FindUsages
             FindReferencesSearchOptions options,
             bool isPrimary)
         {
-            return ToDefinitionItem(definition, sourceLocations, sourceLocations.SelectAsArray(d => (ClassifiedSpansAndHighlightSpan?)null), solution, options, isPrimary);
+            return ToDefinitionItem(
+                definition,
+                sourceLocations,
+                sourceLocations.IsDefault ? default : sourceLocations.SelectAsArray(d => (ClassifiedSpansAndHighlightSpan?)null),
+                solution,
+                options,
+                isPrimary);
         }
 
         private static DefinitionItem ToDefinitionItem(

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -9,6 +9,7 @@ using System.Composition;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -232,6 +233,8 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 NameDisplayParts,
                 OriginationParts,
                 sourceSpans,
+                // todo: consider serializing this over.
+                classifiedSpans: sourceSpans.SelectAsArray(ss => (ClassifiedSpansAndHighlightSpan?)null),
                 Properties,
                 DisplayableProperties,
                 DisplayIfNoReferences);
@@ -266,6 +269,8 @@ namespace Microsoft.CodeAnalysis.FindUsages
         public async Task<SourceReferenceItem> RehydrateAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)
             => new(definition,
                    await SourceSpan.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false),
+                   // Todo: consider serializing this over.
+                   classifiedSpans: null,
                    SymbolUsageInfo,
                    AdditionalProperties.ToImmutableDictionary(t => t.Key, t => t.Value));
     }

--- a/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
+++ b/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Classification;
 
 namespace Microsoft.CodeAnalysis.FindUsages
 {
@@ -23,6 +24,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// The location of the source item.
         /// </summary>
         public DocumentSpan SourceSpan { get; }
+
+        /// <summary>
+        /// Precomputed classified spans for the corresponding <see cref="SourceSpan"/>.
+        /// </summary>
+        public ClassifiedSpansAndHighlightSpan? ClassifiedSpans { get; }
 
         /// <summary>
         /// If this reference is a location where the definition is written to.
@@ -45,31 +51,33 @@ namespace Microsoft.CodeAnalysis.FindUsages
         private SourceReferenceItem(
             DefinitionItem definition,
             DocumentSpan sourceSpan,
+            ClassifiedSpansAndHighlightSpan? classifiedSpans,
             SymbolUsageInfo symbolUsageInfo,
             ImmutableDictionary<string, string> additionalProperties,
             bool isWrittenTo)
         {
             Definition = definition;
             SourceSpan = sourceSpan;
+            ClassifiedSpans = classifiedSpans;
             SymbolUsageInfo = symbolUsageInfo;
             IsWrittenTo = isWrittenTo;
             AdditionalProperties = additionalProperties ?? ImmutableDictionary<string, string>.Empty;
         }
 
         // Used by F#
-        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan)
-            : this(definition, sourceSpan, SymbolUsageInfo.None)
+        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans)
+            : this(definition, sourceSpan, classifiedSpans, SymbolUsageInfo.None)
         {
         }
 
         // Used by TypeScript
-        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, SymbolUsageInfo symbolUsageInfo)
-            : this(definition, sourceSpan, symbolUsageInfo, additionalProperties: ImmutableDictionary<string, string>.Empty)
+        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, SymbolUsageInfo symbolUsageInfo)
+            : this(definition, sourceSpan, classifiedSpans, symbolUsageInfo, additionalProperties: ImmutableDictionary<string, string>.Empty)
         {
         }
 
-        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, SymbolUsageInfo symbolUsageInfo, ImmutableDictionary<string, string> additionalProperties)
-            : this(definition, sourceSpan, symbolUsageInfo, additionalProperties, isWrittenTo: symbolUsageInfo.IsWrittenTo())
+        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, SymbolUsageInfo symbolUsageInfo, ImmutableDictionary<string, string> additionalProperties)
+            : this(definition, sourceSpan, classifiedSpans, symbolUsageInfo, additionalProperties, isWrittenTo: symbolUsageInfo.IsWrittenTo())
         {
         }
     }

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -248,7 +248,8 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                     {
                         var item = DefinitionItem.Create(
                             ImmutableArray<string>.Empty, ImmutableArray<TaggedText>.Empty,
-                            new DocumentSpan(destinationDocument, import.DeclaringSyntaxReference!.Span));
+                            new DocumentSpan(destinationDocument, import.DeclaringSyntaxReference!.Span),
+                            classifiedSpans: null);
                         targetItems.Add(new InheritanceTargetItem(
                             InheritanceRelationship.InheritedImport, item.Detach(), Glyph.None, languageGlyph,
                             import.NamespaceOrType.ToDisplayString(), projectName));
@@ -725,11 +726,11 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                     var document = solution.GetDocument(location.SourceTree);
                     if (document != null)
                     {
-                        var documentSpan = new DocumentSpan(document, location.SourceSpan);
                         return DefinitionItem.Create(
                             tags: ImmutableArray<string>.Empty,
                             displayParts: ImmutableArray<TaggedText>.Empty,
-                            documentSpan,
+                            new DocumentSpan(document, location.SourceSpan),
+                            classifiedSpans: null,
                             nameDisplayParts: ImmutableArray<TaggedText>.Empty);
                     }
                 }

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 var options = await GetOptionsAsync(document.Project.Language, cancellationToken).ConfigureAwait(false);
 
                 var classifiedSpansAndHighlightSpan = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
-                    documentSpan.Value, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
+                    documentSpan.Value, classifiedSpans: null, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
 
                 var classifiedSpans = classifiedSpansAndHighlightSpan.ClassifiedSpans;
                 var docText = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Tools/ExternalAccess/FSharp/FSharpDocumentSpan.cs
+++ b/src/Tools/ExternalAccess/FSharp/FSharpDocumentSpan.cs
@@ -22,21 +22,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
         /// <summary>
         /// Additional information attached to a document span by it creator.
         /// </summary>
-        public ImmutableDictionary<string, object> Properties { get; }
+        public ImmutableDictionary<string, object> Properties { get; } = ImmutableDictionary<string, object>.Empty;
 
         public FSharpDocumentSpan(Document document, TextSpan sourceSpan)
-            : this(document, sourceSpan, properties: null)
-        {
-        }
-
-        public FSharpDocumentSpan(
-            Document document,
-            TextSpan sourceSpan,
-            ImmutableDictionary<string, object> properties)
         {
             Document = document;
             SourceSpan = sourceSpan;
-            Properties = properties ?? ImmutableDictionary<string, object>.Empty;
         }
 
         public override bool Equals(object obj)
@@ -56,9 +47,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
                 this.Document,
                 this.SourceSpan.GetHashCode());
 
-        internal Microsoft.CodeAnalysis.DocumentSpan ToRoslynDocumentSpan()
+        internal DocumentSpan ToRoslynDocumentSpan()
         {
-            return new Microsoft.CodeAnalysis.DocumentSpan(this.Document, this.SourceSpan, this.Properties);
+            return new DocumentSpan(this.Document, this.SourceSpan);
         }
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/FindUsages/FSharpDefinitionItem.cs
+++ b/src/Tools/ExternalAccess/FSharp/FindUsages/FSharpDefinitionItem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.FindUsages
 
         public static FSharpDefinitionItem Create(ImmutableArray<string> tags, ImmutableArray<TaggedText> displayParts, FSharpDocumentSpan sourceSpan)
         {
-            return new FSharpDefinitionItem(Microsoft.CodeAnalysis.FindUsages.DefinitionItem.Create(tags, displayParts, sourceSpan.ToRoslynDocumentSpan()));
+            return new FSharpDefinitionItem(Microsoft.CodeAnalysis.FindUsages.DefinitionItem.Create(tags, displayParts, sourceSpan.ToRoslynDocumentSpan(), classifiedSpans: null));
         }
 
         public static FSharpDefinitionItem CreateNonNavigableItem(ImmutableArray<string> tags, ImmutableArray<TaggedText> displayParts, ImmutableArray<TaggedText> originationParts)

--- a/src/Tools/ExternalAccess/FSharp/FindUsages/FSharpSourceReferenceItem.cs
+++ b/src/Tools/ExternalAccess/FSharp/FindUsages/FSharpSourceReferenceItem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.FindUsages
 
         public FSharpSourceReferenceItem(FSharpDefinitionItem definition, FSharpDocumentSpan sourceSpan)
         {
-            _roslynSourceReferenceItem = new Microsoft.CodeAnalysis.FindUsages.SourceReferenceItem(definition.RoslynDefinitionItem, sourceSpan.ToRoslynDocumentSpan());
+            _roslynSourceReferenceItem = new Microsoft.CodeAnalysis.FindUsages.SourceReferenceItem(definition.RoslynDefinitionItem, sourceSpan.ToRoslynDocumentSpan(), classifiedSpans: null);
         }
 
         internal Microsoft.CodeAnalysis.FindUsages.SourceReferenceItem RoslynSourceReferenceItem

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/WithReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/WithReferencesFindUsagesContext.cs
@@ -71,10 +71,13 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
                 using var _1 = ArrayBuilder<Entry>.GetInstance(out var declarations);
                 using var _2 = PooledHashSet<(string? filePath, TextSpan span)>.GetInstance(out var seenLocations);
-                foreach (var declarationLocation in definition.SourceSpans)
+
+                for (int i = 0, n = definition.SourceSpans.Length; i < n; i++)
                 {
+                    var declarationLocation = definition.SourceSpans[i];
+                    var classifiedSpans = definition.ClassifiedSpans[i];
                     var definitionEntry = await TryCreateDocumentSpanEntryAsync(
-                        definitionBucket, declarationLocation, HighlightSpanKind.Definition, SymbolUsageInfo.None,
+                        definitionBucket, declarationLocation, classifiedSpans, HighlightSpanKind.Definition, SymbolUsageInfo.None,
                         additionalProperties: definition.DisplayableProperties, cancellationToken).ConfigureAwait(false);
                     declarations.AddIfNotNull(definitionEntry);
                 }
@@ -116,7 +119,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 return OnEntryFoundAsync(
                     reference.Definition,
                     bucket => TryCreateDocumentSpanEntryAsync(
-                        bucket, reference.SourceSpan,
+                        bucket, reference.SourceSpan, reference.ClassifiedSpans,
                         reference.IsWrittenTo ? HighlightSpanKind.WrittenReference : HighlightSpanKind.Reference,
                         reference.SymbolUsageInfo,
                         reference.AdditionalProperties,

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
@@ -98,11 +98,15 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     // DocumentSpanEntry for each.  That way we can easily see the source
                     // code where each location is to help the user decide which they want
                     // to navigate to.
-                    foreach (var sourceSpan in definition.SourceSpans)
+                    for (int i = 0, n = definition.SourceSpans.Length; i < n; i++)
                     {
+                        var sourceSpan = definition.SourceSpans[i];
+                        var classifiedSpans = definition.ClassifiedSpans[i];
+
                         var entry = await TryCreateDocumentSpanEntryAsync(
                             definitionBucket,
                             sourceSpan,
+                            classifiedSpans,
                             HighlightSpanKind.Definition,
                             symbolUsageInfo: SymbolUsageInfo.None,
                             additionalProperties: definition.DisplayableProperties,

--- a/src/VisualStudio/Core/Def/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
@@ -104,6 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.FindReferences
                        nameDisplayParts: ImmutableArray<TaggedText>.Empty,
                        originationParts: default,
                        sourceSpans: default,
+                       classifiedSpans: default,
                        properties: null,
                        displayableProperties: null,
                        displayIfNoReferences: true)

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
@@ -105,8 +105,9 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             var fileName = document.FilePath ?? document.Name;
 
             var options = globalOptions.GetClassificationOptions(document.Project.Language);
-            var documentSpan = await ClassifiedSpansAndHighlightSpanFactory.GetClassifiedDocumentSpanAsync(document, item.Span, options, cancellationToken).ConfigureAwait(false);
-            var classificationResult = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(documentSpan, options, cancellationToken).ConfigureAwait(false);
+            var documentSpan = new DocumentSpan(document, item.Span);
+            var classificationResult = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
+                documentSpan, classifiedSpans: null, options, cancellationToken).ConfigureAwait(false);
             var classifiedSpans = classificationResult.ClassifiedSpans;
 
             return new ValueTrackedTreeItemViewModel(


### PR DESCRIPTION
This was always a nasty hack used to pass some information around in Find-References.  Moved to passing the data around explicitly, and making DocumentSpan a simple Document+TextSpan value.