### PR TITLE
Preserve the whitespaces when rewriting an inheritdoc

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Inheritdoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests_Inheritdoc.vb
@@ -197,6 +197,52 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Function
 
         <WpfFact>
+        Public Async Function ExplicitInheritedQuickInfoForSummary3() As Task
+            Dim workspace =
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+                            using System.Threading;
+
+                            /// &lt;summary&gt;
+                            /// &lt;code&gt;
+                            /// Dim test = 0
+                            /// &lt;/code&gt;
+                            /// &lt;/summary&gt;
+                            class BaseClass
+                            {
+                            }
+
+                            /// &lt;inheritdoc cref="BaseClass"/&gt;
+                            class My$$Class {
+                            }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+            Dim intellisenseQuickInfo = Await GetQuickInfoItemAsync(workspace, LanguageNames.CSharp)
+            Assert.NotNull(intellisenseQuickInfo)
+
+            Dim container = Assert.IsType(Of ContainerElement)(intellisenseQuickInfo.Item)
+
+            Dim expected = New ContainerElement(
+                ContainerElementStyle.Stacked Or ContainerElementStyle.VerticalPadding,
+                New ContainerElement(
+                    ContainerElementStyle.Stacked,
+                    New ContainerElement(
+                        ContainerElementStyle.Wrapped,
+                        New ImageElement(New ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.ClassInternal)),
+                        New ClassifiedTextElement(
+                            New ClassifiedTextRun(ClassificationTypeNames.Keyword, "class"),
+                            New ClassifiedTextRun(ClassificationTypeNames.WhiteSpace, " "),
+                            New ClassifiedTextRun(ClassificationTypeNames.ClassName, "MyClass", navigationAction:=Sub() Return, "MyClass"))),
+                    New ClassifiedTextElement(
+                        New ClassifiedTextRun(ClassificationTypeNames.Text, "Dim test = 0", ClassifiedTextRunStyle.UseClassificationFont))))
+
+            ToolTipAssert.EqualContent(expected, container)
+        End Function
+
+        <WpfFact>
         Public Async Function InheritedQuickInfoForParameterButNotSummary1() As Task
             Dim workspace =
                 <Workspace>

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -394,7 +394,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return Array.Empty<XNode>();
                 }
 
-                var document = XDocument.Parse(inheritedDocumentation.FullXmlFragment);
+                var document = XDocument.Parse(inheritedDocumentation.FullXmlFragment, LoadOptions.PreserveWhitespace);
                 string xpathValue;
                 if (string.IsNullOrEmpty(pathAttribute?.Value))
                 {


### PR DESCRIPTION
Fixes #67180 

I explain what's going on in my latest comment on the issue, but the basic idea is the newline between the summary opening tag and a code opening one gets lost during this parse which causes indentation changes since the original had the newline. As I was debugging this, it seemed the whole pipeline cared a lot about preserving whitespaces during (de)serialisation so this one seemed to have been a small oversight when inheritdoc became supported in QuickInfo. 