### PR TITLE
Include buildhost deps.json

### DIFF
--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -56,11 +56,11 @@
   </ItemGroup>
 
   <!--
-    This target is used by Microsoft.CodeAnalysis.Workspaces.MSBuild to copy the .deps.json file into its BuildHost subfolder.
+    This target is used by Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj to copy the .deps.json file into its BuildHost subfolder.
     The .deps.json file is required for the BuildHost to resolve assemblies using the directory as a binding path
     -->
-  <Target Name="OutputProjectDepsJsonFile" Returns="@(ProjectDepsJsonFile)">
-    <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+  <Target Name="GetProjectDepsJsonFile" Returns="@(ProjectDepsJsonFile)">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
       <ProjectDepsJsonFile Include="$(ProjectDepsFilePath)">
         <TargetPath>$(ProjectDepsFileName)</TargetPath>
       </ProjectDepsJsonFile>

--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -54,8 +54,16 @@
   <ItemGroup>
     <EmbeddedResource Update="WorkspaceMSBuildBuildHostResources.resx" GenerateSource="true" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Force a deps.json to be included when packaging the language server, so we get proper assembly resolution using the directory as a binding path -->
-    <_UseBuildDependencyFile>true</_UseBuildDependencyFile>
-  </PropertyGroup>
+
+  <!--
+    This target is used by Microsoft.CodeAnalysis.Workspaces.MSBuild to copy the .deps.json file into its BuildHost subfolder.
+    The .deps.json file is required for the BuildHost to resolve assemblies using the directory as a binding path
+    -->
+  <Target Name="OutputProjectDepsJsonFile" Returns="@(ProjectDepsJsonFile)">
+    <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+      <ProjectDepsJsonFile Include="$(ProjectDepsFilePath)">
+        <TargetPath>$(ProjectDepsFileName)</TargetPath>
+      </ProjectDepsJsonFile>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Workspaces/Core/MSBuild/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/BuildHostProcessManager.cs
@@ -162,14 +162,19 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         AddArgument(processStartInfo, "--roll-forward");
         AddArgument(processStartInfo, "LatestMajor");
 
-        // The .NET Core build host is deployed as a content folder next to the application into the BuildHost-netcore path
-        var netCoreBuildHostPath = Path.Combine(Path.GetDirectoryName(typeof(BuildHostProcessManager).Assembly.Location)!, "BuildHost-netcore", "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll");
+        var netCoreBuildHostPath = GetNetCoreBuildHostPath();
 
         AddArgument(processStartInfo, netCoreBuildHostPath);
 
         AppendBuildHostCommandLineArgumentsConfigureProcess(processStartInfo);
 
         return processStartInfo;
+    }
+
+    internal static string GetNetCoreBuildHostPath()
+    {
+        // The .NET Core build host is deployed as a content folder next to the application into the BuildHost-netcore path
+        return Path.Combine(Path.GetDirectoryName(typeof(BuildHostProcessManager).Assembly.Location)!, "BuildHost-netcore", "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll");
     }
 
     private ProcessStartInfo CreateDotNetFrameworkBuildHostStartInfo()

--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -117,7 +117,7 @@
     </ItemGroup>
 
     <!-- We include Build as a target we invoke to work around https://github.com/dotnet/msbuild/issues/5433  -->
-    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)" Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup;OutputProjectDepsJsonFile" Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework)">
+    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)" Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup;GetProjectDepsJsonFile" Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework)">
       <Output TaskParameter="TargetOutputs" ItemName="NetFrameworkBuildHostAssets" />
     </MSBuild>
 

--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -117,7 +117,7 @@
     </ItemGroup>
 
     <!-- We include Build as a target we invoke to work around https://github.com/dotnet/msbuild/issues/5433  -->
-    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)" Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup" Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework)">
+    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)" Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup;OutputProjectDepsJsonFile" Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework)">
       <Output TaskParameter="TargetOutputs" ItemName="NetFrameworkBuildHostAssets" />
     </MSBuild>
 

--- a/src/Workspaces/MSBuildTest/NetCoreTests.cs
+++ b/src/Workspaces/MSBuildTest/NetCoreTests.cs
@@ -496,5 +496,12 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
                 Assert.Equal(projectRefFilePath, project.Solution.GetProject(projectRefId).FilePath);
             }
         }
+
+        [Fact]
+        public void BuildHostShipsDepsJsonFile()
+        {
+            var depsJsonFile = Path.ChangeExtension(BuildHostProcessManager.GetNetCoreBuildHostPath(), "deps.json");
+            Assert.True(File.Exists(depsJsonFile), $"{depsJsonFile} should exist, or it won't load on some runtimes.");
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6801

The .deps.json file in the build host was missing, leading to incorrect assembly resolution.  It happened to work as long as the buildhost runtime was .net7