### PR TITLE
Ensure thread-safety in aggregated telemetry

### DIFF
--- a/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLog.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLog.cs
@@ -29,9 +29,9 @@ namespace Microsoft.CodeAnalysis.Telemetry
         private readonly string _eventName;
         private readonly FunctionId _functionId;
         private readonly AggregatingTelemetryLogManager _aggregatingTelemetryLogManager;
-        private readonly object _lock;
+        private readonly object _flushLock;
 
-        private ImmutableDictionary<string, (IHistogram<long> Histogram, TelemetryEvent TelemetryEvent)> _histograms = ImmutableDictionary<string, (IHistogram<long>, TelemetryEvent)>.Empty;
+        private ImmutableDictionary<string, (IHistogram<long> Histogram, TelemetryEvent TelemetryEvent, object Lock)> _histograms = ImmutableDictionary<string, (IHistogram<long>, TelemetryEvent, object)>.Empty;
 
         /// <summary>
         /// Creates a new aggregating telemetry log
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Telemetry
             _eventName = TelemetryLogger.GetEventName(functionId);
             _functionId = functionId;
             _aggregatingTelemetryLogManager = aggregatingTelemetryLogManager;
-            _lock = new();
+            _flushLock = new();
 
             if (bucketBoundaries != null)
             {
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Telemetry
             if (!logMessage.Properties.TryGetValue(TelemetryLogging.KeyValue, out var valueValue) || valueValue is not int value)
                 throw ExceptionUtilities.Unreachable();
 
-            (var histogram, _) = ImmutableInterlocked.GetOrAdd(ref _histograms, name, name =>
+            (var histogram, _, var histogramLock) = ImmutableInterlocked.GetOrAdd(ref _histograms, name, name =>
             {
                 var telemetryEvent = new TelemetryEvent(_eventName);
 
@@ -95,11 +95,15 @@ namespace Microsoft.CodeAnalysis.Telemetry
                 }
 
                 var histogram = _meter.CreateHistogram<long>(metricName, _histogramConfiguration);
+                var histogramLock = new object();
 
-                return (histogram, telemetryEvent);
+                return (histogram, telemetryEvent, histogramLock);
             });
 
-            histogram.Record(value);
+            lock (histogramLock)
+            {
+                histogram.Record(value);
+            }
 
             _aggregatingTelemetryLogManager.EnsureTelemetryWorkQueued();
         }
@@ -119,16 +123,25 @@ namespace Microsoft.CodeAnalysis.Telemetry
 
         public void Flush()
         {
-            lock (_lock)
+            // This lock ensures that multiple calls to Flush cannot occur simultaneously.
+            //  Without this lock, we would could potentially call PostMetricEvent multiple
+            //  times for the same histogram.
+            lock (_flushLock)
             {
-                foreach (var (histogram, telemetryEvent) in _histograms.Values)
+                foreach (var (histogram, telemetryEvent, histogramLock) in _histograms.Values)
                 {
-                    var histogramEvent = new TelemetryHistogramEvent<long>(telemetryEvent, histogram);
+                    // This fine-grained lock ensures that the histogram isn't modified (via a Record call)
+                    //  during the creation of the TelemetryHistogramEvent or the PostMetricEvent
+                    //  call that operates on it.
+                    lock (histogramLock)
+                    {
+                        var histogramEvent = new TelemetryHistogramEvent<long>(telemetryEvent, histogram);
 
-                    _session.PostMetricEvent(histogramEvent);
+                        _session.PostMetricEvent(histogramEvent);
+                    }
                 }
 
-                _histograms = ImmutableDictionary<string, (IHistogram<long>, TelemetryEvent)>.Empty;
+                _histograms = ImmutableDictionary<string, (IHistogram<long>, TelemetryEvent, object)>.Empty;
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLog.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLog.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Telemetry
         private readonly string _eventName;
         private readonly FunctionId _functionId;
         private readonly AggregatingTelemetryLogManager _aggregatingTelemetryLogManager;
-        private static readonly object s_lock = new object();
+        private readonly object _lock;
 
         private ImmutableDictionary<string, (IHistogram<long> Histogram, TelemetryEvent TelemetryEvent)> _histograms = ImmutableDictionary<string, (IHistogram<long>, TelemetryEvent)>.Empty;
 
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.Telemetry
             _eventName = TelemetryLogger.GetEventName(functionId);
             _functionId = functionId;
             _aggregatingTelemetryLogManager = aggregatingTelemetryLogManager;
+            _lock = new();
 
             if (bucketBoundaries != null)
             {
@@ -118,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Telemetry
 
         public void Flush()
         {
-            lock (s_lock)
+            lock (_lock)
             {
                 foreach (var (histogram, telemetryEvent) in _histograms.Values)
                 {


### PR DESCRIPTION
We've recently had several forms of exceptions come through due to threading issues in our interaction with the vstelemetry api. Specifically, we need to be more cautious around our use of TelemetrySession.PostMetricEvent.

This PR adds two locks with the following intent:

_flushLock:
  This lock is intended to ensure that concurrent iterations over _histograms is not allowed. Such concurrent iterations could potentially invoke TelemetrySession.PostMetricEvent multiple times with the same histogramEvent .

histogramLock:
  This lock is intended to ensure that overlapping calls of IHistogram.Record and TelemetrySession.PostMetricEvent for that histogram are not allowed. A separate lock is allocated for each histogram to reduce the likelihood of contention during Log calls. This lock also prevents concurrent Record calls on the same histogram.

In addition to preventing these concurrency issues, a primary goal here was not to add much overhead via these lock calls. I considered just using a single lock, but opted instead for this approach to prevent contention as much as possible during the much more frequent Log calls.

Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1934204