### PR TITLE
Handle the 'WSL is not installed' error

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/DebuggerInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/DebuggerInProcess.cs
@@ -6,6 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Extensibility.Testing;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -66,6 +67,19 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             var debugger = await GetDebuggerAsync(cancellationToken);
+
+            // Dismiss the unexpected WSL error if it appears, since it will cause test hangs otherwise
+            using var _ = TestServices.MessageBox.HandleMessageBox((text, caption) =>
+            {
+                if (text.Contains("WSL is not installed."))
+                {
+                    // We do not understand why WSL is being selected as the active debugger
+                    return DialogResult.OK;
+                }
+
+                return DialogResult.None;
+            });
+
             debugger.Go(waitForBreakMode);
         }
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MessageBoxInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MessageBoxInProcess.cs
@@ -129,6 +129,9 @@ internal partial class MessageBoxInProcess
                 }
             }
 
+            // Make sure to set pidButton to a non-zero value or it will fall back to showing a dialog.
+            pidButton = (int)DialogResult.Cancel;
+
             Assert.True(
                 false,
                 $"""


### PR DESCRIPTION
Example integration test deadlock:
![image](https://github.com/dotnet/roslyn/assets/1408396/099481b8-6ba4-4aa7-904a-239d728e4a4c)
