### PR TITLE
Ignore the exception from IntraTextAdornmentTagger

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestSetup/TestExtensionErrorHandler.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/TestExtensionErrorHandler.cs
@@ -38,6 +38,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Setup
                 return;
             }
 
+            if (exception is ObjectDisposedException objectDisposedException
+                && objectDisposedException.StackTrace.Contains("Microsoft.VisualStudio.Text.IntraTextTaggerAggregator.Implementation.IntraTextAdornmentTagger"))
+            {
+                // Workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1935805
+                return;
+            }
+
             FatalError.ReportAndPropagate(exception);
             TestTraceListener.Instance.AddException(exception);
         }


### PR DESCRIPTION
Test only fix.

Editor side bug causing our integration tests to fail on 17.9. Affects all interactive window tests. I think the real test is not affected. (tested locally, our tests are still running)
It is shown in the golden bar so just ignore it. 