### PR TITLE
Only use ReadyToRun on Release builds

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -44,7 +44,7 @@
     <!-- List of runtime identifiers that we want to publish an executable for -->
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;linux-arm64;alpine-x64;alpine-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
-    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != ''">true</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>
   </PropertyGroup>
 
   <!-- When we are packing each RID, we set PackRuntimeIdentifier; by default this will also get passed to the builds of all ResolveProjectReferences

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
@@ -2,6 +2,8 @@
   <!-- We are defining our own Pack target, so opt out of the SDK version. -->
   <PropertyGroup>
     <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
+    <_RoslynPublishReadyToRun>false</_RoslynPublishReadyToRun>
+    <_RoslynPublishReadyToRun Condition="'$(Configuration)' == 'Release'">true</_RoslynPublishReadyToRun>
   </PropertyGroup>
 
   <Target Name="Pack">
@@ -12,7 +14,7 @@
         We also pass the RestoreUseStaticGraphEvaluation=false flag to workaround a long path issue when calling the restore target.
         See https://github.com/NuGet/Home/issues/11968
     -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="PublishReadyToRun=true;RestoreUseStaticGraphEvaluation=false" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="PublishReadyToRun=t$(_RoslynPublishReadyToRun);RestoreUseStaticGraphEvaluation=false" />
 
     <ItemGroup>
       <!-- Transform RuntimeIdentifiers property to item -->

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
@@ -14,7 +14,7 @@
         We also pass the RestoreUseStaticGraphEvaluation=false flag to workaround a long path issue when calling the restore target.
         See https://github.com/NuGet/Home/issues/11968
     -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="PublishReadyToRun=t$(_RoslynPublishReadyToRun);RestoreUseStaticGraphEvaluation=false" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="PublishReadyToRun=$(_RoslynPublishReadyToRun);RestoreUseStaticGraphEvaluation=false" />
 
     <ItemGroup>
       <!-- Transform RuntimeIdentifiers property to item -->


### PR DESCRIPTION
Creating the ready to run images is an expensive optimization. Disabling this during debug builds to help inner loop dev settings.

On my local machine this saved 2:30 from a `Build.cmd -restore -bl -pack` command.