### PR TITLE
Verify SyntaxList length in SyntaxNodeCache.TryGetNode()

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeCacheTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeCacheTests.cs
@@ -14,6 +14,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class SyntaxNodeCacheTests : CSharpTestBase
     {
         [Fact]
+        public void TryGetNode_With1Child()
+        {
+            var child0 = new SyntaxTokenWithTrivia(SyntaxKind.IntKeyword, null, null);
+            SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
+
+            var listOf1 = new Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.PredefinedTypeSyntax(SyntaxKind.PredefinedType, child0);
+            SyntaxNodeCache.AddNode(listOf1, listOf1.GetCacheHash());
+
+            var listCached = SyntaxNodeCache.TryGetNode(listOf1.RawKind, child0, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+            Assert.NotNull(listCached);
+        }
+
+        [Fact]
         public void TryGetNode_With1Of2Children()
         {
             const int nIterations = 1_000_000;
@@ -22,13 +35,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 var child0 = new SyntaxTokenWithTrivia(SyntaxKind.InternalKeyword, null, null);
                 var child1 = new SyntaxTokenWithTrivia(SyntaxKind.StaticKeyword, null, null);
-
                 SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
                 SyntaxNodeCache.AddNode(child1, child1.GetCacheHash());
 
                 var listOf2 = new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithTwoChildren(child0, child1);
-                int hashOf2 = listOf2.GetCacheHash();
-                SyntaxNodeCache.AddNode(listOf2, hashOf2);
+                SyntaxNodeCache.AddNode(listOf2, listOf2.GetCacheHash());
 
                 var listCached = SyntaxNodeCache.TryGetNode(listOf2.RawKind, child0, child1, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
                 Assert.NotNull(listCached);
@@ -48,14 +59,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 var child0 = new SyntaxTokenWithTrivia(SyntaxKind.InternalKeyword, null, null);
                 var child1 = new SyntaxTokenWithTrivia(SyntaxKind.StaticKeyword, null, null);
                 var child2 = new SyntaxTokenWithTrivia(SyntaxKind.ReadOnlyKeyword, null, null);
-
                 SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
                 SyntaxNodeCache.AddNode(child1, child1.GetCacheHash());
                 SyntaxNodeCache.AddNode(child2, child2.GetCacheHash());
 
                 var listOf3 = new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithThreeChildren(child0, child1, child2);
-                int hashOf3 = listOf3.GetCacheHash();
-                SyntaxNodeCache.AddNode(listOf3, hashOf3);
+                SyntaxNodeCache.AddNode(listOf3, listOf3.GetCacheHash());
 
                 var listCached = SyntaxNodeCache.TryGetNode(listOf3.RawKind, child0, child1, child2, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
                 Assert.NotNull(listCached);

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeCacheTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeCacheTests.cs
@@ -4,7 +4,8 @@
 
 #nullable disable
 
-using SyntaxNodeCache = Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxNodeCache;
+using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax;
 using SyntaxTokenWithTrivia = Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxToken.SyntaxTokenWithTrivia;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Xunit;
@@ -19,10 +20,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var child0 = new SyntaxTokenWithTrivia(SyntaxKind.IntKeyword, null, null);
             SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
 
-            var listOf1 = new Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.PredefinedTypeSyntax(SyntaxKind.PredefinedType, child0);
+            var listOf1 = new PredefinedTypeSyntax(SyntaxKind.PredefinedType, child0);
             SyntaxNodeCache.AddNode(listOf1, listOf1.GetCacheHash());
 
-            var listCached = SyntaxNodeCache.TryGetNode(listOf1.RawKind, child0, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+            var listCached = (PredefinedTypeSyntax)SyntaxNodeCache.TryGetNode(listOf1.RawKind, child0, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
             Assert.NotNull(listCached);
         }
 
@@ -38,10 +39,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
                 SyntaxNodeCache.AddNode(child1, child1.GetCacheHash());
 
-                var listOf2 = new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithTwoChildren(child0, child1);
+                var listOf2 = new SyntaxList.WithTwoChildren(child0, child1);
                 SyntaxNodeCache.AddNode(listOf2, listOf2.GetCacheHash());
 
-                var listCached = SyntaxNodeCache.TryGetNode(listOf2.RawKind, child0, child1, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                var listCached = (SyntaxList.WithTwoChildren)SyntaxNodeCache.TryGetNode(listOf2.RawKind, child0, child1, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
                 Assert.NotNull(listCached);
 
                 var listOf1 = SyntaxNodeCache.TryGetNode(listOf2.RawKind, child0, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
@@ -63,10 +64,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 SyntaxNodeCache.AddNode(child1, child1.GetCacheHash());
                 SyntaxNodeCache.AddNode(child2, child2.GetCacheHash());
 
-                var listOf3 = new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithThreeChildren(child0, child1, child2);
+                var listOf3 = new SyntaxList.WithThreeChildren(child0, child1, child2);
                 SyntaxNodeCache.AddNode(listOf3, listOf3.GetCacheHash());
 
-                var listCached = SyntaxNodeCache.TryGetNode(listOf3.RawKind, child0, child1, child2, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                var listCached = (SyntaxList.WithThreeChildren)SyntaxNodeCache.TryGetNode(listOf3.RawKind, child0, child1, child2, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
                 Assert.NotNull(listCached);
 
                 var listOf2 = SyntaxNodeCache.TryGetNode(listOf3.RawKind, child0, child1, SyntaxNodeCache.GetDefaultNodeFlags(), out _);

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeCacheTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeCacheTests.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using SyntaxNodeCache = Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxNodeCache;
+using SyntaxTokenWithTrivia = Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxToken.SyntaxTokenWithTrivia;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class SyntaxNodeCacheTests : CSharpTestBase
+    {
+        [Fact]
+        public void TryGetNode_With1Of2Children()
+        {
+            const int nIterations = 1_000_000;
+
+            for (int i = 0; i < nIterations; i++)
+            {
+                var child0 = new SyntaxTokenWithTrivia(SyntaxKind.InternalKeyword, null, null);
+                var child1 = new SyntaxTokenWithTrivia(SyntaxKind.StaticKeyword, null, null);
+
+                SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
+                SyntaxNodeCache.AddNode(child1, child1.GetCacheHash());
+
+                var listOf2 = new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithTwoChildren(child0, child1);
+                int hashOf2 = listOf2.GetCacheHash();
+                SyntaxNodeCache.AddNode(listOf2, hashOf2);
+
+                var listCached = SyntaxNodeCache.TryGetNode(listOf2.RawKind, child0, child1, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                Assert.NotNull(listCached);
+
+                var listOf1 = SyntaxNodeCache.TryGetNode(listOf2.RawKind, child0, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                Assert.True(listOf2 != listOf1, $"{i} iterations");
+            }
+        }
+
+        [Fact]
+        public void TryGetNode_With2Of3Children()
+        {
+            const int nIterations = 1_000_000;
+
+            for (int i = 0; i < nIterations; i++)
+            {
+                var child0 = new SyntaxTokenWithTrivia(SyntaxKind.InternalKeyword, null, null);
+                var child1 = new SyntaxTokenWithTrivia(SyntaxKind.StaticKeyword, null, null);
+                var child2 = new SyntaxTokenWithTrivia(SyntaxKind.ReadOnlyKeyword, null, null);
+
+                SyntaxNodeCache.AddNode(child0, child0.GetCacheHash());
+                SyntaxNodeCache.AddNode(child1, child1.GetCacheHash());
+                SyntaxNodeCache.AddNode(child2, child2.GetCacheHash());
+
+                var listOf3 = new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithThreeChildren(child0, child1, child2);
+                int hashOf3 = listOf3.GetCacheHash();
+                SyntaxNodeCache.AddNode(listOf3, hashOf3);
+
+                var listCached = SyntaxNodeCache.TryGetNode(listOf3.RawKind, child0, child1, child2, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                Assert.NotNull(listCached);
+
+                var listOf2 = SyntaxNodeCache.TryGetNode(listOf3.RawKind, child0, child1, SyntaxNodeCache.GetDefaultNodeFlags(), out _);
+                Assert.True(listOf3 != listOf2, $"{i} iterations");
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -927,6 +927,7 @@ namespace Microsoft.CodeAnalysis
 
             return this.RawKind == kind &&
                 this.flags == flags &&
+                this.SlotCount == 1 &&
                 this.GetSlot(0) == child1;
         }
 
@@ -936,6 +937,7 @@ namespace Microsoft.CodeAnalysis
 
             return this.RawKind == kind &&
                 this.flags == flags &&
+                this.SlotCount == 2 &&
                 this.GetSlot(0) == child1 &&
                 this.GetSlot(1) == child2;
         }
@@ -946,6 +948,7 @@ namespace Microsoft.CodeAnalysis
 
             return this.RawKind == kind &&
                 this.flags == flags &&
+                this.SlotCount == 3 &&
                 this.GetSlot(0) == child1 &&
                 this.GetSlot(1) == child2 &&
                 this.GetSlot(2) == child3;


### PR DESCRIPTION
Verify `node.SlotCount` matches expected length in `SyntaxNodeCache.TryGetNode()`.

Fixes infrequent `InvalidCastException` in [`SyntaxList.List()`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.cs#L35).