### PR TITLE
IDE0051: Consider a record's private constructor as used

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -1137,6 +1137,30 @@ class MyClass
         }
 
         [Fact]
+        public async Task InstanceConstructorIsUsed_RecordCopyConstructor()
+        {
+            var code = """
+                       var a = new A();
+                       
+                       sealed record A()
+                       {
+                           private A(A other) => throw new System.NotImplementedException();
+                       }
+                       """;
+
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { code },
+                    OutputKind = OutputKind.ConsoleApplication
+                },
+                FixedCode = code,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task PropertyIsRead()
         {
             var code = """

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -722,6 +722,16 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                                         return false;
                                     }
 
+                                    // Having a private copy constructor in a record means it's implicitly used by
+                                    // the record's clone method
+                                    if (methodSymbol.ContainingType.IsRecord &&
+                                        methodSymbol.Parameters.Length == 1 &&
+                                        methodSymbol.Parameters[0].RefKind == RefKind.None &&
+                                        methodSymbol.Parameters[0].Type.Equals(memberSymbol.ContainingType))
+                                    {
+                                        return false;
+                                    }
+
                                     // ISerializable constructor is invoked by the runtime for deserialization
                                     // and it is a common pattern to have a private serialization constructor
                                     // that is not explicitly referenced in code.


### PR DESCRIPTION
Fixes #67910 

I added an exception case just like the one for a private parameterless constructor. We can be sure the clone method would use it as it's made clear in the specifications here: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/records#copy-and-clone-members
