### PR TITLE
Fix intercepting a struct or enum base method

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -272,7 +272,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (needToReduce)
             {
                 Debug.Assert(methodThisParameter is not null);
-                arguments = arguments.Insert(0, receiverOpt!);
+                Debug.Assert(receiverOpt?.Type is not null);
+                Debug.Assert(receiverOpt.Type.Equals(interceptor.Parameters[0].Type, TypeCompareKind.AllIgnoreOptions)
+                    || (receiverOpt.Type.IsValueType && !interceptor.Parameters[0].Type.IsValueType));
+                receiverOpt = MakeConversionNode(receiverOpt, interceptor.Parameters[0].Type, @checked: false, markAsChecked: true);
+                arguments = arguments.Insert(0, receiverOpt);
                 receiverOpt = null;
 
                 // CodeGenerator.EmitArguments requires that we have a fully-filled-out argumentRefKindsOpt for any ref/in/out arguments.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(methodThisParameter is not null);
                 Debug.Assert(receiverOpt?.Type is not null);
                 Debug.Assert(receiverOpt.Type.Equals(interceptor.Parameters[0].Type, TypeCompareKind.AllIgnoreOptions)
-                    || (receiverOpt.Type.IsValueType && !interceptor.Parameters[0].Type.IsValueType));
+                    || (!receiverOpt.Type.IsReferenceType && interceptor.Parameters[0].Type.IsReferenceType));
                 receiverOpt = MakeConversionNode(receiverOpt, interceptor.Parameters[0].Type, @checked: false, markAsChecked: true);
                 arguments = arguments.Insert(0, receiverOpt);
                 receiverOpt = null;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -3424,6 +3424,36 @@ public class InterceptorsTests : CSharpTestBase
     }
 
     [Fact]
+    public void SignatureMismatch_10()
+    {
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            struct Program
+            {
+                public void InterceptableMethod() => Console.Write("Original");
+
+                public static void Main()
+                {
+                    new Program().InterceptableMethod();
+                }
+            }
+
+            static class D
+            {
+                [InterceptsLocation("Program.cs", 10, 23)]
+                public static void Interceptor(this in Program x) => Console.Write("Intercepted");
+            }
+            """;
+        var comp = CreateCompilation(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: RegularWithInterceptors);
+        comp.VerifyEmitDiagnostics(
+            // Program.cs(16,6): error CS9148: Interceptor must have a 'this' parameter matching parameter 'ref Program this' on 'Program.InterceptableMethod()'.
+            //     [InterceptsLocation("Program.cs", 10, 23)]
+            Diagnostic(ErrorCode.ERR_InterceptorMustHaveMatchingThisParameter, @"InterceptsLocation(""Program.cs"", 10, 23)").WithArguments("ref Program this", "Program.InterceptableMethod()").WithLocation(16, 6));
+    }
+
+    [Fact]
     public void ScopedMismatch_01()
     {
         // Unsafe 'scoped' difference
@@ -4826,5 +4856,202 @@ partial struct CustomHandler
                 // Program.cs(14,6): error CS9161: An interceptor cannot be marked with 'UnmanagedCallersOnlyAttribute'.
                 //     [InterceptsLocation("Program.cs", 5, 3)]
                 Diagnostic(ErrorCode.ERR_InterceptorCannotUseUnmanagedCallersOnly, @"InterceptsLocation(""Program.cs"", 5, 3)").WithLocation(14, 6));
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70841")]
+    public void InterceptorEnumBaseMethod()
+    {
+        var program = ("""
+            using System;
+
+            var value = MyEnum.Second;
+            Console.WriteLine(value.ToString());
+
+            public enum MyEnum
+            {
+                First,
+                Second,
+            }
+            """, "Program.cs");
+
+        var interceptor = ("""
+            using System.Runtime.CompilerServices;
+
+            namespace MyInterceptors
+            {
+                public static class Interceptors
+                {
+                    [InterceptsLocation(@"Program.cs", 4, 25)]
+                    public static string OtherToString(this System.Enum value)
+                        => "Wrong Value" + value;
+                }
+            }
+            """, "Interceptor.cs");
+
+        var verifier = CompileAndVerify(new[] { program, s_attributesSource }, parseOptions: RegularWithInterceptors, expectedOutput: "Second");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("<top-level-statements-entry-point>", """
+            {
+              // Code size       21 (0x15)
+              .maxstack  1
+              .locals init (MyEnum V_0) //value
+              IL_0000:  ldc.i4.1
+              IL_0001:  stloc.0
+              IL_0002:  ldloca.s   V_0
+              IL_0004:  constrained. "MyEnum"
+              IL_000a:  callvirt   "string object.ToString()"
+              IL_000f:  call       "void System.Console.WriteLine(string)"
+              IL_0014:  ret
+            }
+            """);
+
+        verifier = CompileAndVerify(new[] { program, interceptor, s_attributesSource }, parseOptions: RegularWithInterceptors, expectedOutput: "Wrong ValueSecond");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("<top-level-statements-entry-point>", """
+            {
+              // Code size       17 (0x11)
+              .maxstack  1
+              IL_0000:  ldc.i4.1
+              IL_0001:  box        "MyEnum"
+              IL_0006:  call       "string MyInterceptors.Interceptors.OtherToString(System.Enum)"
+              IL_000b:  call       "void System.Console.WriteLine(string)"
+              IL_0010:  ret
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70841")]
+    public void InterceptorStructBaseMethod()
+    {
+        var program = ("""
+            using System;
+
+            MyStruct value = default;
+            Console.WriteLine(value.Equals((object)1));
+
+            public struct MyStruct { }
+            """, "Program.cs");
+
+        var interceptor = ("""
+            using System.Runtime.CompilerServices;
+
+            namespace MyInterceptors
+            {
+                public static class Interceptors
+                {
+                    [InterceptsLocation(@"Program.cs", 4, 25)]
+                    public static bool Equals(this System.ValueType value, object other) => true;
+                }
+            }
+            """, "Interceptor.cs");
+
+        var verifier = CompileAndVerify(new[] { program, s_attributesSource }, parseOptions: RegularWithInterceptors, expectedOutput: "False");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("<top-level-statements-entry-point>", """
+            {
+              // Code size       33 (0x21)
+              .maxstack  2
+              .locals init (MyStruct V_0) //value
+              IL_0000:  ldloca.s   V_0
+              IL_0002:  initobj    "MyStruct"
+              IL_0008:  ldloca.s   V_0
+              IL_000a:  ldc.i4.1
+              IL_000b:  box        "int"
+              IL_0010:  constrained. "MyStruct"
+              IL_0016:  callvirt   "bool object.Equals(object)"
+              IL_001b:  call       "void System.Console.WriteLine(bool)"
+              IL_0020:  ret
+            }
+            """);
+
+        verifier = CompileAndVerify(new[] { program, interceptor, s_attributesSource }, parseOptions: RegularWithInterceptors, expectedOutput: "True");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("<top-level-statements-entry-point>", """
+            {
+              // Code size       31 (0x1f)
+              .maxstack  2
+              .locals init (MyStruct V_0)
+              IL_0000:  ldloca.s   V_0
+              IL_0002:  initobj    "MyStruct"
+              IL_0008:  ldloc.0
+              IL_0009:  box        "MyStruct"
+              IL_000e:  ldc.i4.1
+              IL_000f:  box        "int"
+              IL_0014:  call       "bool MyInterceptors.Interceptors.Equals(System.ValueType, object)"
+              IL_0019:  call       "void System.Console.WriteLine(bool)"
+              IL_001e:  ret
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70841")]
+    public void InterceptorStructConstrainedInterfaceMethod()
+    {
+        var program = ("""
+            using System;
+
+            C.M(default(MyStruct));
+
+            class C
+            {
+                public static void M<T>(T t) where T : struct, I
+                {
+                    t.IM();
+                }
+            }
+
+            public struct MyStruct : I
+            {
+                public void IM()
+                {
+                    Console.Write("Original");
+                }
+            }
+
+            public interface I
+            {
+                void IM();
+            }
+            """, "Program.cs");
+
+        var interceptor = ("""
+            using System.Runtime.CompilerServices;
+            using System;
+
+            namespace MyInterceptors
+            {
+                public static class Interceptors
+                {
+                    [InterceptsLocation(@"Program.cs", 9, 11)]
+                    public static void IM(this I @this) { Console.Write("Interceptor"); }
+                }
+            }
+            """, "Interceptor.cs");
+
+        var verifier = CompileAndVerify(new[] { program, s_attributesSource }, parseOptions: RegularWithInterceptors, expectedOutput: "Original");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("C.M<T>(T)", """
+            {
+              // Code size       14 (0xe)
+              .maxstack  1
+              IL_0000:  ldarga.s   V_0
+              IL_0002:  constrained. "T"
+              IL_0008:  callvirt   "void I.IM()"
+              IL_000d:  ret
+            }
+            """);
+
+        verifier = CompileAndVerify(new[] { program, interceptor, s_attributesSource }, parseOptions: RegularWithInterceptors, expectedOutput: "Interceptor");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("C.M<T>(T)", """
+            {
+              // Code size       12 (0xc)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  box        "T"
+              IL_0006:  call       "void MyInterceptors.Interceptors.IM(I)"
+              IL_000b:  ret
+            }
+            """);
     }
 }


### PR DESCRIPTION
Closes #70841

When the original method is an instance method and interceptor is an extension, we have to adjust the receiver argument to pass it for the extension 'this' parameter. Receiver emit strategies such as 'ConstrainedCallVirt' are not available for an extension 'this' parameter, so we may need to insert an additional (generally boxing) conversion, to make the receiver argument actually match the parameter type.

See https://github.com/dotnet/roslyn/blob/main/docs/features/interceptors.md#signature-matching
> When an interceptable instance method is compared to a static interceptor method (including a classic extension method), we use the method as if it is an extension in reduced form for comparison.

In test `InterceptorEnumBaseMethod`, for example, we lower the call `value.ToString()` as if it were calling `OtherToString` in reduced form. In that case, `value` must be boxed.
