### PR TITLE
Turn off auto surround in integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpArgumentProvider.cs
@@ -31,6 +31,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             var globalOptions = await TestServices.Shell.GetComponentModelServiceAsync<IGlobalOptionService>(HangMitigatingCancellationToken);
             globalOptions.SetGlobalOption(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.CSharp, true);
             globalOptions.SetGlobalOption(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, true);
+            await TestServices.Workarounds.DisableAutoSurroundAsync(HangMitigatingCancellationToken);
         }
 
         [IdeFact]

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpArgumentProvider.cs
@@ -144,7 +144,7 @@ public class Test
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString()$$;", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1940994")]
         public async Task TabTabCompletionWithArguments()
         {
             await SetUpEditorAsync(@"
@@ -452,7 +452,7 @@ $$
 ", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
-        [IdeTheory]
+        [IdeTheory(Skip = "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1940994")]
         [InlineData("\"<\"", Skip = "https://github.com/dotnet/roslyn/issues/29669")]
         [InlineData("\">\"")] // testing things that might break XML
         [InlineData("\"&\"")]

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpArgumentProvider.cs
@@ -144,7 +144,7 @@ public class Test
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString()$$;", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
-        [IdeFact(Skip = "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1940994")]
+        [IdeFact]
         public async Task TabTabCompletionWithArguments()
         {
             await SetUpEditorAsync(@"
@@ -452,7 +452,7 @@ $$
 ", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
-        [IdeTheory(Skip = "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1940994")]
+        [IdeTheory]
         [InlineData("\"<\"", Skip = "https://github.com/dotnet/roslyn/issues/29669")]
         [InlineData("\">\"")] // testing things that might break XML
         [InlineData("\"&\"")]


### PR DESCRIPTION
These tests would fail after CI update to 17.9 P2. 
Test failures are caused because of new editor side feature. https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes-preview#auto-surround-with-quotes-or-brackets

I have filed bug on their side