### PR TITLE
Revert "Remove properties from DocumentSpan"

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptFindUsagesContext.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Navigation;
 
@@ -55,7 +54,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
                    ImmutableArray<TaggedText>.Empty,
                    originationParts: default,
                    sourceSpans: default,
-                   classifiedSpans: default,
                    properties: null,
                    displayIfNoReferences: true)
         {
@@ -86,8 +84,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             bool displayIfNoReferences = true)
         {
             return new(DefinitionItem.Create(
-                tags, displayParts, sourceSpans.SelectAsArray(span => span.ToDocumentSpan()), sourceSpans.SelectAsArray(_ => (ClassifiedSpansAndHighlightSpan?)null),
-                nameDisplayParts, properties: null, displayableProperties: ImmutableDictionary<string, string>.Empty, displayIfNoReferences: displayIfNoReferences));
+                tags, displayParts, sourceSpans.SelectAsArray(span => span.ToDocumentSpan()), nameDisplayParts,
+                properties: null, displayableProperties: ImmutableDictionary<string, string>.Empty, displayIfNoReferences: displayIfNoReferences));
         }
 
         public static VSTypeScriptDefinitionItem CreateExternal(
@@ -122,8 +120,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         VSTypeScriptDocumentSpan sourceSpan,
         VSTypeScriptSymbolUsageInfo symbolUsageInfo)
     {
-        internal readonly SourceReferenceItem UnderlyingObject = new SourceReferenceItem(
-            definition.UnderlyingObject, sourceSpan.ToDocumentSpan(), classifiedSpans: null, symbolUsageInfo.UnderlyingObject);
+        internal readonly SourceReferenceItem UnderlyingObject = new SourceReferenceItem(definition.UnderlyingObject, sourceSpan.ToDocumentSpan(), symbolUsageInfo.UnderlyingObject);
 
         public VSTypeScriptDocumentSpan GetSourceSpan()
             => new(UnderlyingObject.SourceSpan);

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -46,7 +46,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
 
                 Dim spansAndHighlightSpan = Await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
                     New DocumentSpan(document, referenceSpan),
-                    classifiedSpans:=Nothing,
                     ClassificationOptions.Default, CancellationToken.None)
 
                 ' This is the classification of the line, starting at the beginning of the highlight, and going to the end of that line.
@@ -220,7 +219,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
 
                 Dim spansAndHighlightSpan = Await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
                     New DocumentSpan(document, referenceSpan),
-                    classifiedSpans:=Nothing,
                     ClassificationOptions.Default, CancellationToken.None)
 
                 ' string classification should not overlap u8 classification.

--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
@@ -15,14 +15,29 @@ namespace Microsoft.CodeAnalysis.Classification
 {
     internal static class ClassifiedSpansAndHighlightSpanFactory
     {
+        public static async Task<DocumentSpan> GetClassifiedDocumentSpanAsync(
+            Document document, TextSpan sourceSpan, ClassificationOptions options, CancellationToken cancellationToken)
+        {
+            var classifiedSpans = await ClassifyAsync(
+                document, sourceSpan, options, cancellationToken).ConfigureAwait(false);
+
+            var properties = ImmutableDictionary<string, object>.Empty.Add(
+                ClassifiedSpansAndHighlightSpan.Key, classifiedSpans);
+
+            return new DocumentSpan(document, sourceSpan, properties);
+        }
+
         public static async Task<ClassifiedSpansAndHighlightSpan> ClassifyAsync(
-            DocumentSpan documentSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, ClassificationOptions options, CancellationToken cancellationToken)
+            DocumentSpan documentSpan, ClassificationOptions options, CancellationToken cancellationToken)
         {
             // If the document span is providing us with the classified spans up front, then we
             // can just use that.  Otherwise, go back and actually classify the text for the line
             // the document span is on.
-            if (classifiedSpans != null)
-                return classifiedSpans.Value;
+            if (documentSpan.Properties != null &&
+                documentSpan.Properties.TryGetValue(ClassifiedSpansAndHighlightSpan.Key, out var value))
+            {
+                return (ClassifiedSpansAndHighlightSpan)value;
+            }
 
             return await ClassifyAsync(
                 documentSpan.Document, documentSpan.SourceSpan, options, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/DocumentSpan.cs
+++ b/src/Features/Core/Portable/DocumentSpan.cs
@@ -2,11 +2,47 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis;
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Represents a <see cref="TextSpan"/> location in a <see cref="Document"/>.
+    /// </summary>
+    internal readonly record struct DocumentSpan
+    {
+        public Document Document { get; }
+        public TextSpan SourceSpan { get; }
 
-/// <summary>
-/// Represents a <see cref="TextSpan"/> location in a <see cref="Document"/>.
-/// </summary>
-internal readonly record struct DocumentSpan(Document Document, TextSpan SourceSpan);
+        /// <summary>
+        /// Additional information attached to a document span by it creator.
+        /// </summary>
+        public ImmutableDictionary<string, object>? Properties { get; }
+
+        public DocumentSpan(
+            Document document,
+            TextSpan sourceSpan,
+            ImmutableDictionary<string, object>? properties)
+        {
+            Document = document;
+            SourceSpan = sourceSpan;
+            Properties = properties ?? ImmutableDictionary<string, object>.Empty;
+        }
+
+        public DocumentSpan(Document document, TextSpan sourceSpan)
+            : this(document, sourceSpan, properties: null)
+        {
+        }
+
+        public bool Equals(DocumentSpan obj)
+            => Document == obj.Document && SourceSpan == obj.SourceSpan;
+
+        public override int GetHashCode()
+            => Hash.Combine(
+                Document,
+                SourceSpan.GetHashCode());
+    }
+}

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDefinitionItemBase.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDefinitionItemBase.cs
@@ -4,22 +4,25 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.Navigation;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
-
-[Obsolete]
-internal abstract class VSTypeScriptDefinitionItemBase : DefinitionItem
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
-    protected VSTypeScriptDefinitionItemBase(ImmutableArray<string> tags, ImmutableArray<TaggedText> displayParts)
-        : base(tags,
-              displayParts,
-              ImmutableArray<TaggedText>.Empty,
-              originationParts: default,
-              sourceSpans: default,
-              classifiedSpans: default,
-              properties: null,
-              displayIfNoReferences: true)
+    [Obsolete]
+    internal abstract class VSTypeScriptDefinitionItemBase : DefinitionItem
     {
+        protected VSTypeScriptDefinitionItemBase(ImmutableArray<string> tags, ImmutableArray<TaggedText> displayParts)
+            : base(tags,
+                  displayParts,
+                  ImmutableArray<TaggedText>.Empty,
+                  originationParts: default,
+                  sourceSpans: default,
+                  properties: null,
+                  displayIfNoReferences: true)
+        {
+        }
     }
 }

--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -37,12 +37,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
             {
                 var options = await _context.GetOptionsAsync(document.Project.Language, cancellationToken).ConfigureAwait(false);
 
-                var documentSpan = new DocumentSpan(document, span);
-                var classifiedSpans = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
-                    documentSpan, classifiedSpans: null, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
+                var documentSpan = await ClassifiedSpansAndHighlightSpanFactory.GetClassifiedDocumentSpanAsync(
+                    document, span, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
 
                 await _context.OnReferenceFoundAsync(
-                    new SourceReferenceItem(_definition, documentSpan, classifiedSpans, SymbolUsageInfo.None), cancellationToken).ConfigureAwait(false);
+                    new SourceReferenceItem(_definition, documentSpan, SymbolUsageInfo.None), cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -26,12 +25,10 @@ namespace Microsoft.CodeAnalysis.FindUsages
             ImmutableArray<TaggedText> nameDisplayParts,
             ImmutableArray<TaggedText> originationParts,
             ImmutableArray<DocumentSpan> sourceSpans,
-            ImmutableArray<ClassifiedSpansAndHighlightSpan?> classifiedSpans,
             ImmutableDictionary<string, string>? properties,
             ImmutableDictionary<string, string>? displayableProperties,
-            bool displayIfNoReferences) : DefinitionItem(
-                tags, displayParts, nameDisplayParts, originationParts,
-                sourceSpans, classifiedSpans, properties, displayableProperties, displayIfNoReferences)
+            bool displayIfNoReferences) : DefinitionItem(tags, displayParts, nameDisplayParts, originationParts,
+                   sourceSpans, properties, displayableProperties, displayIfNoReferences)
         {
             internal sealed override bool IsExternal => false;
 

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DetachedDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DetachedDefinitionItem.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.FindUsages.DefinitionItem;
@@ -77,7 +76,6 @@ namespace Microsoft.CodeAnalysis.FindUsages
         public async Task<DefaultDefinitionItem?> TryRehydrateAsync(Solution solution, CancellationToken cancellationToken)
         {
             using var converted = TemporaryArray<DocumentSpan>.Empty;
-            using var convertedClassifiedSpans = TemporaryArray<ClassifiedSpansAndHighlightSpan?>.Empty;
             foreach (var ss in SourceSpans)
             {
                 var documentSpan = await ss.TryRehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
@@ -85,14 +83,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
                     return null;
 
                 converted.Add(documentSpan.Value);
-
-                // todo: consider serializing this data.
-                convertedClassifiedSpans.Add(null);
             }
 
             return new DefaultDefinitionItem(
                 Tags, DisplayParts, NameDisplayParts, OriginationParts,
-                converted.ToImmutableAndClear(), convertedClassifiedSpans.ToImmutableAndClear(),
+                converted.ToImmutableAndClear(),
                 Properties, DisplayableProperties, DisplayIfNoReferences);
         }
     }

--- a/src/Features/Core/Portable/FindUsages/IDefinitionsAndReferencesFactory.cs
+++ b/src/Features/Core/Portable/FindUsages/IDefinitionsAndReferencesFactory.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
             var unclassifiedSpans = TryGetSourceLocations(definition, solution, definition.Locations, includeHiddenLocations);
             var classifiedSpans = unclassifiedSpans.IsDefault ? default : await ClassifyDocumentSpansAsync(context, unclassifiedSpans, cancellationToken).ConfigureAwait(false);
 
-            return ToDefinitionItem(definition, unclassifiedSpans, classifiedSpans, solution, options, isPrimary);
+            return ToDefinitionItem(definition, classifiedSpans, solution, options, isPrimary);
         }
 
         public static async ValueTask<DefinitionItem> ToClassifiedDefinitionItemAsync(
@@ -102,29 +102,12 @@ namespace Microsoft.CodeAnalysis.FindUsages
             var unclassifiedSpans = TryGetSourceLocations(definition, solution, allLocations, includeHiddenLocations);
             var classifiedSpans = unclassifiedSpans.IsDefault ? default : await ClassifyDocumentSpansAsync(context, unclassifiedSpans, cancellationToken).ConfigureAwait(false);
 
-            return ToDefinitionItem(definition, unclassifiedSpans, classifiedSpans, solution, options, isPrimary);
+            return ToDefinitionItem(definition, classifiedSpans, solution, options, isPrimary);
         }
 
         private static DefinitionItem ToDefinitionItem(
             ISymbol definition,
             ImmutableArray<DocumentSpan> sourceLocations,
-            Solution solution,
-            FindReferencesSearchOptions options,
-            bool isPrimary)
-        {
-            return ToDefinitionItem(
-                definition,
-                sourceLocations,
-                sourceLocations.IsDefault ? default : sourceLocations.SelectAsArray(d => (ClassifiedSpansAndHighlightSpan?)null),
-                solution,
-                options,
-                isPrimary);
-        }
-
-        private static DefinitionItem ToDefinitionItem(
-            ISymbol definition,
-            ImmutableArray<DocumentSpan> sourceLocations,
-            ImmutableArray<ClassifiedSpansAndHighlightSpan?> classifiedSpans,
             Solution solution,
             FindReferencesSearchOptions options,
             bool isPrimary)
@@ -171,7 +154,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
             var displayableProperties = AbstractReferenceFinder.GetAdditionalFindUsagesProperties(definition);
 
             return DefinitionItem.Create(
-                tags, displayParts, sourceLocations, classifiedSpans,
+                tags, displayParts, sourceLocations,
                 nameDisplayParts, properties, displayableProperties, displayIfNoReferences);
         }
 
@@ -216,13 +199,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
             return sourceLocations.ToImmutableAndClear();
         }
 
-        private static ValueTask<ImmutableArray<ClassifiedSpansAndHighlightSpan?>> ClassifyDocumentSpansAsync(IFindUsagesContext context, ImmutableArray<DocumentSpan> unclassifiedSpans, CancellationToken cancellationToken)
+        private static ValueTask<ImmutableArray<DocumentSpan>> ClassifyDocumentSpansAsync(IFindUsagesContext context, ImmutableArray<DocumentSpan> unclassifiedSpans, CancellationToken cancellationToken)
             => unclassifiedSpans.SelectAsArrayAsync(async (documentSpan, context, cancellationToken) =>
             {
                 var options = await context.GetOptionsAsync(documentSpan.Document.Project.Language, cancellationToken).ConfigureAwait(false);
-                ClassifiedSpansAndHighlightSpan? result = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
-                    documentSpan, classifiedSpans: null, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
-                return result;
+                return await ClassifiedSpansAndHighlightSpanFactory.GetClassifiedDocumentSpanAsync(documentSpan.Document, documentSpan.SourceSpan, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
             }, context, cancellationToken);
 
         private static ImmutableDictionary<string, string> GetProperties(ISymbol definition, bool isPrimary)
@@ -275,12 +256,10 @@ namespace Microsoft.CodeAnalysis.FindUsages
 
             var options = await context.GetOptionsAsync(document.Project.Language, cancellationToken).ConfigureAwait(false);
 
-            var documentSpan = new DocumentSpan(document, sourceSpan);
-            var classifiedSpans = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
-                documentSpan, classifiedSpans: null, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
+            var documentSpan = await ClassifiedSpansAndHighlightSpanFactory.GetClassifiedDocumentSpanAsync(
+                document, sourceSpan, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
 
-            return new SourceReferenceItem(
-                definitionItem, documentSpan, classifiedSpans, referenceLocation.SymbolUsageInfo, referenceLocation.AdditionalProperties);
+            return new SourceReferenceItem(definitionItem, documentSpan, referenceLocation.SymbolUsageInfo, referenceLocation.AdditionalProperties);
         }
     }
 }

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -9,7 +9,6 @@ using System.Composition;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -233,8 +232,6 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 NameDisplayParts,
                 OriginationParts,
                 sourceSpans,
-                // todo: consider serializing this over.
-                classifiedSpans: sourceSpans.SelectAsArray(ss => (ClassifiedSpansAndHighlightSpan?)null),
                 Properties,
                 DisplayableProperties,
                 DisplayIfNoReferences);
@@ -269,8 +266,6 @@ namespace Microsoft.CodeAnalysis.FindUsages
         public async Task<SourceReferenceItem> RehydrateAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)
             => new(definition,
                    await SourceSpan.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false),
-                   // Todo: consider serializing this over.
-                   classifiedSpans: null,
                    SymbolUsageInfo,
                    AdditionalProperties.ToImmutableDictionary(t => t.Key, t => t.Value));
     }

--- a/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
+++ b/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Classification;
 
 namespace Microsoft.CodeAnalysis.FindUsages
 {
@@ -24,11 +23,6 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// The location of the source item.
         /// </summary>
         public DocumentSpan SourceSpan { get; }
-
-        /// <summary>
-        /// Precomputed classified spans for the corresponding <see cref="SourceSpan"/>.
-        /// </summary>
-        public ClassifiedSpansAndHighlightSpan? ClassifiedSpans { get; }
 
         /// <summary>
         /// If this reference is a location where the definition is written to.
@@ -51,33 +45,31 @@ namespace Microsoft.CodeAnalysis.FindUsages
         private SourceReferenceItem(
             DefinitionItem definition,
             DocumentSpan sourceSpan,
-            ClassifiedSpansAndHighlightSpan? classifiedSpans,
             SymbolUsageInfo symbolUsageInfo,
             ImmutableDictionary<string, string> additionalProperties,
             bool isWrittenTo)
         {
             Definition = definition;
             SourceSpan = sourceSpan;
-            ClassifiedSpans = classifiedSpans;
             SymbolUsageInfo = symbolUsageInfo;
             IsWrittenTo = isWrittenTo;
             AdditionalProperties = additionalProperties ?? ImmutableDictionary<string, string>.Empty;
         }
 
         // Used by F#
-        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans)
-            : this(definition, sourceSpan, classifiedSpans, SymbolUsageInfo.None)
+        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan)
+            : this(definition, sourceSpan, SymbolUsageInfo.None)
         {
         }
 
         // Used by TypeScript
-        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, SymbolUsageInfo symbolUsageInfo)
-            : this(definition, sourceSpan, classifiedSpans, symbolUsageInfo, additionalProperties: ImmutableDictionary<string, string>.Empty)
+        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, SymbolUsageInfo symbolUsageInfo)
+            : this(definition, sourceSpan, symbolUsageInfo, additionalProperties: ImmutableDictionary<string, string>.Empty)
         {
         }
 
-        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, SymbolUsageInfo symbolUsageInfo, ImmutableDictionary<string, string> additionalProperties)
-            : this(definition, sourceSpan, classifiedSpans, symbolUsageInfo, additionalProperties, isWrittenTo: symbolUsageInfo.IsWrittenTo())
+        internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, SymbolUsageInfo symbolUsageInfo, ImmutableDictionary<string, string> additionalProperties)
+            : this(definition, sourceSpan, symbolUsageInfo, additionalProperties, isWrittenTo: symbolUsageInfo.IsWrittenTo())
         {
         }
     }

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -248,8 +248,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                     {
                         var item = DefinitionItem.Create(
                             ImmutableArray<string>.Empty, ImmutableArray<TaggedText>.Empty,
-                            new DocumentSpan(destinationDocument, import.DeclaringSyntaxReference!.Span),
-                            classifiedSpans: null);
+                            new DocumentSpan(destinationDocument, import.DeclaringSyntaxReference!.Span));
                         targetItems.Add(new InheritanceTargetItem(
                             InheritanceRelationship.InheritedImport, item.Detach(), Glyph.None, languageGlyph,
                             import.NamespaceOrType.ToDisplayString(), projectName));
@@ -726,11 +725,11 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                     var document = solution.GetDocument(location.SourceTree);
                     if (document != null)
                     {
+                        var documentSpan = new DocumentSpan(document, location.SourceSpan);
                         return DefinitionItem.Create(
                             tags: ImmutableArray<string>.Empty,
                             displayParts: ImmutableArray<TaggedText>.Empty,
-                            new DocumentSpan(document, location.SourceSpan),
-                            classifiedSpans: null,
+                            documentSpan,
                             nameDisplayParts: ImmutableArray<TaggedText>.Empty);
                     }
                 }

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 var options = await GetOptionsAsync(document.Project.Language, cancellationToken).ConfigureAwait(false);
 
                 var classifiedSpansAndHighlightSpan = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
-                    documentSpan.Value, classifiedSpans: null, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
+                    documentSpan.Value, options.ClassificationOptions, cancellationToken).ConfigureAwait(false);
 
                 var classifiedSpans = classifiedSpansAndHighlightSpan.ClassifiedSpans;
                 var docText = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Tools/ExternalAccess/FSharp/FSharpDocumentSpan.cs
+++ b/src/Tools/ExternalAccess/FSharp/FSharpDocumentSpan.cs
@@ -22,12 +22,21 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
         /// <summary>
         /// Additional information attached to a document span by it creator.
         /// </summary>
-        public ImmutableDictionary<string, object> Properties { get; } = ImmutableDictionary<string, object>.Empty;
+        public ImmutableDictionary<string, object> Properties { get; }
 
         public FSharpDocumentSpan(Document document, TextSpan sourceSpan)
+            : this(document, sourceSpan, properties: null)
+        {
+        }
+
+        public FSharpDocumentSpan(
+            Document document,
+            TextSpan sourceSpan,
+            ImmutableDictionary<string, object> properties)
         {
             Document = document;
             SourceSpan = sourceSpan;
+            Properties = properties ?? ImmutableDictionary<string, object>.Empty;
         }
 
         public override bool Equals(object obj)
@@ -47,9 +56,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
                 this.Document,
                 this.SourceSpan.GetHashCode());
 
-        internal DocumentSpan ToRoslynDocumentSpan()
+        internal Microsoft.CodeAnalysis.DocumentSpan ToRoslynDocumentSpan()
         {
-            return new DocumentSpan(this.Document, this.SourceSpan);
+            return new Microsoft.CodeAnalysis.DocumentSpan(this.Document, this.SourceSpan, this.Properties);
         }
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/FindUsages/FSharpDefinitionItem.cs
+++ b/src/Tools/ExternalAccess/FSharp/FindUsages/FSharpDefinitionItem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.FindUsages
 
         public static FSharpDefinitionItem Create(ImmutableArray<string> tags, ImmutableArray<TaggedText> displayParts, FSharpDocumentSpan sourceSpan)
         {
-            return new FSharpDefinitionItem(Microsoft.CodeAnalysis.FindUsages.DefinitionItem.Create(tags, displayParts, sourceSpan.ToRoslynDocumentSpan(), classifiedSpans: null));
+            return new FSharpDefinitionItem(Microsoft.CodeAnalysis.FindUsages.DefinitionItem.Create(tags, displayParts, sourceSpan.ToRoslynDocumentSpan()));
         }
 
         public static FSharpDefinitionItem CreateNonNavigableItem(ImmutableArray<string> tags, ImmutableArray<TaggedText> displayParts, ImmutableArray<TaggedText> originationParts)

--- a/src/Tools/ExternalAccess/FSharp/FindUsages/FSharpSourceReferenceItem.cs
+++ b/src/Tools/ExternalAccess/FSharp/FindUsages/FSharpSourceReferenceItem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.FindUsages
 
         public FSharpSourceReferenceItem(FSharpDefinitionItem definition, FSharpDocumentSpan sourceSpan)
         {
-            _roslynSourceReferenceItem = new Microsoft.CodeAnalysis.FindUsages.SourceReferenceItem(definition.RoslynDefinitionItem, sourceSpan.ToRoslynDocumentSpan(), classifiedSpans: null);
+            _roslynSourceReferenceItem = new Microsoft.CodeAnalysis.FindUsages.SourceReferenceItem(definition.RoslynDefinitionItem, sourceSpan.ToRoslynDocumentSpan());
         }
 
         internal Microsoft.CodeAnalysis.FindUsages.SourceReferenceItem RoslynSourceReferenceItem

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -352,7 +352,6 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             protected async Task<Entry?> TryCreateDocumentSpanEntryAsync(
                 RoslynDefinitionBucket definitionBucket,
                 DocumentSpan documentSpan,
-                ClassifiedSpansAndHighlightSpan? classifiedSpans,
                 HighlightSpanKind spanKind,
                 SymbolUsageInfo symbolUsageInfo,
                 ImmutableDictionary<string, string> additionalProperties,
@@ -361,7 +360,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 var document = documentSpan.Document;
                 var options = _globalOptions.GetClassificationOptions(document.Project.Language);
                 var sourceText = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-                var (excerptResult, lineText) = await ExcerptAsync(sourceText, documentSpan, classifiedSpans, options, cancellationToken).ConfigureAwait(false);
+                var (excerptResult, lineText) = await ExcerptAsync(sourceText, documentSpan, options, cancellationToken).ConfigureAwait(false);
 
                 var mappedDocumentSpan = await AbstractDocumentSpanEntry.TryMapAndGetFirstAsync(documentSpan, sourceText, cancellationToken).ConfigureAwait(false);
                 if (mappedDocumentSpan == null)
@@ -390,7 +389,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             }
 
             private static async Task<(ExcerptResult, SourceText)> ExcerptAsync(
-                SourceText sourceText, DocumentSpan documentSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, ClassificationOptions options, CancellationToken cancellationToken)
+                SourceText sourceText, DocumentSpan documentSpan, ClassificationOptions options, CancellationToken cancellationToken)
             {
                 var excerptService = documentSpan.Document.Services.GetService<IDocumentExcerptService>();
                 if (excerptService != null)
@@ -402,8 +401,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     }
                 }
 
-                var classificationResult = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
-                    documentSpan, classifiedSpans, options, cancellationToken).ConfigureAwait(false);
+                var classificationResult = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(documentSpan, options, cancellationToken).ConfigureAwait(false);
 
                 // need to fix the span issue tracking here - https://github.com/dotnet/roslyn/issues/31001
                 var excerptResult = new ExcerptResult(

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/WithReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/WithReferencesFindUsagesContext.cs
@@ -71,13 +71,10 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
                 using var _1 = ArrayBuilder<Entry>.GetInstance(out var declarations);
                 using var _2 = PooledHashSet<(string? filePath, TextSpan span)>.GetInstance(out var seenLocations);
-
-                for (int i = 0, n = definition.SourceSpans.Length; i < n; i++)
+                foreach (var declarationLocation in definition.SourceSpans)
                 {
-                    var declarationLocation = definition.SourceSpans[i];
-                    var classifiedSpans = definition.ClassifiedSpans[i];
                     var definitionEntry = await TryCreateDocumentSpanEntryAsync(
-                        definitionBucket, declarationLocation, classifiedSpans, HighlightSpanKind.Definition, SymbolUsageInfo.None,
+                        definitionBucket, declarationLocation, HighlightSpanKind.Definition, SymbolUsageInfo.None,
                         additionalProperties: definition.DisplayableProperties, cancellationToken).ConfigureAwait(false);
                     declarations.AddIfNotNull(definitionEntry);
                 }
@@ -119,7 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 return OnEntryFoundAsync(
                     reference.Definition,
                     bucket => TryCreateDocumentSpanEntryAsync(
-                        bucket, reference.SourceSpan, reference.ClassifiedSpans,
+                        bucket, reference.SourceSpan,
                         reference.IsWrittenTo ? HighlightSpanKind.WrittenReference : HighlightSpanKind.Reference,
                         reference.SymbolUsageInfo,
                         reference.AdditionalProperties,

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
@@ -98,15 +98,11 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     // DocumentSpanEntry for each.  That way we can easily see the source
                     // code where each location is to help the user decide which they want
                     // to navigate to.
-                    for (int i = 0, n = definition.SourceSpans.Length; i < n; i++)
+                    foreach (var sourceSpan in definition.SourceSpans)
                     {
-                        var sourceSpan = definition.SourceSpans[i];
-                        var classifiedSpans = definition.ClassifiedSpans[i];
-
                         var entry = await TryCreateDocumentSpanEntryAsync(
                             definitionBucket,
                             sourceSpan,
-                            classifiedSpans,
                             HighlightSpanKind.Definition,
                             symbolUsageInfo: SymbolUsageInfo.None,
                             additionalProperties: definition.DisplayableProperties,

--- a/src/VisualStudio/Core/Def/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
@@ -104,7 +104,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.FindReferences
                        nameDisplayParts: ImmutableArray<TaggedText>.Empty,
                        originationParts: default,
                        sourceSpans: default,
-                       classifiedSpans: default,
                        properties: null,
                        displayableProperties: null,
                        displayIfNoReferences: true)

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
@@ -105,9 +105,8 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             var fileName = document.FilePath ?? document.Name;
 
             var options = globalOptions.GetClassificationOptions(document.Project.Language);
-            var documentSpan = new DocumentSpan(document, item.Span);
-            var classificationResult = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
-                documentSpan, classifiedSpans: null, options, cancellationToken).ConfigureAwait(false);
+            var documentSpan = await ClassifiedSpansAndHighlightSpanFactory.GetClassifiedDocumentSpanAsync(document, item.Span, options, cancellationToken).ConfigureAwait(false);
+            var classificationResult = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(documentSpan, options, cancellationToken).ConfigureAwait(false);
             var classifiedSpans = classificationResult.ClassifiedSpans;
 
             return new ValueTrackedTreeItemViewModel(


### PR DESCRIPTION
Reverts dotnet/roslyn#71587. This broke typescript. @genlu is working on a new version that does not.