### PR TITLE
Use VSCode compatible buildhost

### DIFF
--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -100,7 +100,7 @@
         <ContentFolderName>BuildHost-net472</ContentFolderName>
       </_NetFrameworkBuildHostProjectReference>
       <_NetFrameworkBuildHostProjectReference Include="..\..\..\Workspaces\Core\MSBuild.BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj">
-        <TargetFramework>$(NetVS)</TargetFramework>
+        <TargetFramework>$(NetVSCode)</TargetFramework>
         <ContentFolderName>BuildHost-netcore</ContentFolderName>
       </_NetFrameworkBuildHostProjectReference>
     </ItemGroup>


### PR DESCRIPTION
https://github.com/dotnet/vscode-csharp/pull/6813 is failing tests because we started pulling in a .net8 build host when we had no compatible runtime.
```
[BuildHost PID 5916] Message from Process: App: d:\a\_work\1\s\.roslyn\BuildHost-netcore\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll
[BuildHost PID 5916] Message from Process: Architecture: x64
[BuildHost PID 5916] Message from Process: Framework: 'Microsoft.NETCore.App', version '8.0.0' (x64)
[BuildHost PID 5916] Message from Process: .NET location: C:\hostedtoolcache\windows\dotnet\
[BuildHost PID 5916] Message from Process: 
[BuildHost PID 5916] Message from Process: The following frameworks were found:
[BuildHost PID 5916] Message from Process:   7.0.15 at [C:\hostedtoolcache\windows\dotnet\shared\Microsoft.NETCore.App]
[BuildHost PID 5916] Message from Process: 
[BuildHost PID 5916] Message from Process: Learn about framework resolution:
[BuildHost PID 5916] Message from Process: https://aka.ms/dotnet/app-launch-failed
[BuildHost PID 5916] Message from Process: 
[BuildHost PID 5916] Message from Process: To install missing framework, download:
[BuildHost PID 5916] Message from Process: https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=8.0.0&arch=x64&rid=win10-x64
```

Instead we should pull in the .net7 build host (the same runtime that the server uses).