### PR TITLE
[Razor Cohost] Pass TextDocuments to Razor for text sync LSP messages

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Cohost/IRazorCohostTextDocumentSyncHandler.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/IRazorCohostTextDocumentSyncHandler.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+internal interface IRazorCohostTextDocumentSyncHandler
+{
+    Task HandleAsync(int version, RazorCohostRequestContext context, CancellationToken cancellationToken);
+}
+
+internal static class IRazorCohostTextDocumentSyncHandlerExtensions
+{
+    public static async Task NotifyRazorAsync(this IRazorCohostTextDocumentSyncHandler? openOrChangeHandler, Uri uri, int version, RequestContext context, CancellationToken cancellationToken)
+    {
+        if (openOrChangeHandler is null)
+            return;
+
+        // Razor is a little special here, because when a .razor or .cshtml document is opened/changed, which is what this request is for,
+        // they need to generate a C# and/or Html document. To do this they use the Razor Source Generator, but to run the generator they
+        // need a TextDocument for the Razor file that this request is for. To facilitate that need we create a RequestContext here
+        // and pass it to Razor, which is essentially the same as the RequestContext they would get on the next request, but by providing it
+        // early here, they can do their generation before the didOpen/didChange/didClose mutating request is finished.
+        // This is a little hacky, but it's the best we can do for now. In future hopefully we can switch to a pull model where the source
+        // generator just provides C# source to the project/compilation as normal. Whether we need to maintain this system for the Html
+        // generated documents remains to be seen.
+        var clientCapabilitiesManager = context.GetRequiredService<IInitializeManager>();
+        var clientCapabilities = clientCapabilitiesManager.TryGetClientCapabilities();
+        var logger = context.GetRequiredService<AbstractLspLogger>();
+        var serverInfoProvider = context.GetRequiredService<ServerInfoProvider>();
+        var supportedLanguages = serverInfoProvider.SupportedLanguages;
+        var lspServices = context.GetRequiredService<ILspServices>();
+
+        var newContext = await RequestContext.CreateAsync(false, true, new TextDocumentIdentifier() { Uri = uri }, LanguageServer.WellKnownLspServerKinds.RazorCohostServer, clientCapabilities, supportedLanguages, lspServices, logger, context.Method, cancellationToken).ConfigureAwait(false);
+
+        var razorContext = new RazorCohostRequestContext(newContext);
+
+        await openOrChangeHandler.HandleAsync(version, razorContext, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostDidCloseEndpoint.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostDidCloseEndpoint.cs
@@ -17,7 +17,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 [ExportRazorStatelessLspService(typeof(RazorCohostDidCloseEndpoint)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class RazorCohostDidCloseEndpoint([Import(AllowDefault = true)] IRazorCohostDidCloseHandler? didCloseHandler) : ILspServiceNotificationHandler<DidCloseTextDocumentParams>, ITextDocumentIdentifierHandler<DidCloseTextDocumentParams, TextDocumentIdentifier>
+internal sealed class RazorCohostDidCloseEndpoint(
+    [Import(AllowDefault = true)] IRazorCohostTextDocumentSyncHandler? razorDocSyncHandler)
+    : ILspServiceNotificationHandler<DidCloseTextDocumentParams>, ITextDocumentIdentifierHandler<DidCloseTextDocumentParams, TextDocumentIdentifier>
 {
     public bool MutatesSolutionState => true;
     public bool RequiresLSPSolution => false;
@@ -32,13 +34,11 @@ internal sealed class RazorCohostDidCloseEndpoint([Import(AllowDefault = true)] 
         await context.StopTrackingAsync(request.TextDocument.Uri, cancellationToken).ConfigureAwait(false);
 
         // Razor can't handle this request because they don't have access to the RequestContext, but they might want to do something with it
-        if (didCloseHandler is not null)
-        {
-            await didCloseHandler.HandleAsync(request.TextDocument.Uri, cancellationToken).ConfigureAwait(false);
-        }
+        await razorDocSyncHandler.NotifyRazorAsync(request.TextDocument.Uri, version: -1, context, cancellationToken).ConfigureAwait(false);
     }
 }
 
+[Obsolete("This API is made of regret, no longer functions, and will be removed very soon")]
 internal interface IRazorCohostDidCloseHandler
 {
     Task HandleAsync(Uri uri, CancellationToken cancellationToken);

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostDidOpenEndpoint.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostDidOpenEndpoint.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class RazorCohostDidOpenEndpoint(
-    [Import(AllowDefault = true)] IRazorCohostDidOpenHandler? didOpenHandler)
+    [Import(AllowDefault = true)] IRazorCohostTextDocumentSyncHandler? razorDocSyncHandler)
     : ILspServiceNotificationHandler<DidOpenTextDocumentParams>, ITextDocumentIdentifierHandler<DidOpenTextDocumentParams, Uri>
 {
     public bool MutatesSolutionState => true;
@@ -36,14 +36,12 @@ internal sealed class RazorCohostDidOpenEndpoint(
 
         await context.StartTrackingAsync(request.TextDocument.Uri, sourceText, request.TextDocument.LanguageId, cancellationToken).ConfigureAwait(false);
 
-        // Razor can't handle this request because they don't have access to the RequestContext, but they might want to do something with it
-        if (didOpenHandler is not null)
-        {
-            await didOpenHandler.HandleAsync(request.TextDocument.Uri, request.TextDocument.Version, sourceText, cancellationToken).ConfigureAwait(false);
-        }
+        // Razor can't handle this request directly because they don't have access to the RequestContext, but they might want to do something with it
+        await razorDocSyncHandler.NotifyRazorAsync(request.TextDocument.Uri, request.TextDocument.Version, context, cancellationToken).ConfigureAwait(false);
     }
 }
 
+[Obsolete("This API is made of regret, no longer functions, and will be removed very soon")]
 internal interface IRazorCohostDidOpenHandler
 {
     Task HandleAsync(Uri uri, int version, SourceText sourceText, CancellationToken cancellationToken);


### PR DESCRIPTION
The original API I wrote for text sync for cohosting was sadly not sufficient to allow Razor to call the source generator. This fixes that by providing `TextDocument`s in the didOpen/didChange/didClose requests.