### PR TITLE
Ensure we find the right partial if we have multiple in one file

### DIFF
--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -418,7 +418,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 return null;
 
             // Find the syntax node that declared the symbol in the tree we're processing
-            var syntaxReference = declaredSymbol.DeclaringSyntaxReferences.FirstOrDefault(static (r, syntaxTree) => r.SyntaxTree == syntaxTree, arg: syntaxTree);
+            var syntaxReference = declaredSymbol.DeclaringSyntaxReferences.FirstOrDefault(static (r, arg) => r.SyntaxTree == arg.syntaxTree && r.Span.Contains(arg.SpanStart), arg: (syntaxTree, syntaxToken.SpanStart));
             var syntaxNode = syntaxReference?.GetSyntax(cancellationToken);
 
             if (syntaxNode is null)

--- a/src/Features/Lsif/GeneratorTest/DocumentSymbolTests.vb
+++ b/src/Features/Lsif/GeneratorTest/DocumentSymbolTests.vb
@@ -17,6 +17,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <InlineData("{|fullRange:struct [|S|] { }|}", CType(LSP.SymbolKind.Struct, Integer), "S")>
         <InlineData("class C { {|fullRange:void [|M|]() { }|} }", CType(LSP.SymbolKind.Method, Integer), "M")>
         <InlineData("class C { int {|fullRange:[|field|]|}; }", CType(LSP.SymbolKind.Field, Integer), "field")>
+        <InlineData("{|fullRange:partial class [|C|] { int a; }|} partial class C { int b; }", CType(LSP.SymbolKind.Class, Integer), "C")>
         Public Async Function TestDefinition(code As String, expectedSymbolKindInt As Integer, expectedText As String) As Task
             Dim expectedSymbolKind = CType(expectedSymbolKindInt, LSP.SymbolKind)
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(


### PR DESCRIPTION
If we had more than one partial in the same file, we might pick the wrong symbol span for a given token.