### PR TITLE
Include file names in the aggregate exception we create

### DIFF
--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -166,10 +166,11 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 {
                     if (tasks[i].IsFaulted)
                     {
+                        var documentExceptionMessage = $"Exception while processing {documents[i].FilePath}";
                         var exception = tasks[i].Exception!.InnerExceptions.Single();
-                        exceptions.Add(exception);
+                        exceptions.Add(new Exception(documentExceptionMessage, exception));
 
-                        _logger.LogError(exception, $"Exception while processing {documents[i].FilePath}");
+                        _logger.LogError(exception, documentExceptionMessage);
                     }
                 }
 


### PR DESCRIPTION
This just ensures we don't lose file path information when exceptions get thrown/caught, since sometimes those exceptions are easier to find than the underlying log.