### PR TITLE
Support lexing razor comments

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -1939,6 +1939,8 @@ LoopExit:
                         // not trivia
                         return;
                     case '@' when TextWindow.PeekChar(1) == '*':
+                        // Razor comment. We pretend that it's a multi-line comment for error recovery, but it's an error case.
+                        this.AddError(TextWindow.Position, width: 1, ErrorCode.ERR_UnexpectedCharacter, '@');
                         lexMultiLineComment(ref triviaList, '@');
                         onlyWhitespaceOnLine = false;
                         break;
@@ -1992,12 +1994,6 @@ LoopExit:
 
             void lexMultiLineComment(ref SyntaxListBuilder triviaList, char delimiter)
             {
-                if (delimiter == '@')
-                {
-                    // Razor comment. We pretend that it's a multi-line comment for error recovery, but it's an error case.
-                    this.AddError(TextWindow.Position, width: 1, ErrorCode.ERR_UnexpectedCharacter, '@');
-                }
-
                 bool isTerminated;
                 this.ScanMultiLineComment(out isTerminated, delimiter);
                 if (!isTerminated)

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -1931,22 +1931,17 @@ LoopExit:
                                 break;
                             }
 
-                            bool isTerminated;
-                            this.ScanMultiLineComment(out isTerminated);
-                            if (!isTerminated)
-                            {
-                                // The comment didn't end.  Report an error at the start point.
-                                this.AddError(ErrorCode.ERR_OpenEndedComment);
-                            }
-
-                            var text = TextWindow.GetText(false);
-                            this.AddTrivia(SyntaxFactory.Comment(text), ref triviaList);
+                            lexMultiLineComment(ref triviaList, '/');
                             onlyWhitespaceOnLine = false;
                             break;
                         }
 
                         // not trivia
                         return;
+                    case '@' when TextWindow.PeekChar(1) == '*':
+                        lexMultiLineComment(ref triviaList, '@');
+                        onlyWhitespaceOnLine = false;
+                        break;
                     case '\r':
                     case '\n':
                         var endOfLine = this.ScanEndOfLine();
@@ -1993,6 +1988,26 @@ LoopExit:
                     default:
                         return;
                 }
+            }
+
+            void lexMultiLineComment(ref SyntaxListBuilder triviaList, char delimiter)
+            {
+                if (delimiter == '@')
+                {
+                    // Razor comment. We pretend that it's a multi-line comment for error recovery, but it's an error case.
+                    this.AddError(TextWindow.Position, width: 1, ErrorCode.ERR_UnexpectedCharacter, '@');
+                }
+
+                bool isTerminated;
+                this.ScanMultiLineComment(out isTerminated, delimiter);
+                if (!isTerminated)
+                {
+                    // The comment didn't end.  Report an error at the start point.
+                    this.AddError(ErrorCode.ERR_OpenEndedComment);
+                }
+
+                var text = TextWindow.GetText(false);
+                this.AddTrivia(SyntaxFactory.Comment(text), ref triviaList);
             }
         }
 
@@ -2145,38 +2160,30 @@ LoopExit:
             list.Add(trivia);
         }
 
-        private bool ScanMultiLineComment(out bool isTerminated)
+        private void ScanMultiLineComment(out bool isTerminated, char delimiter)
         {
-            if (TextWindow.PeekChar() == '/' && TextWindow.PeekChar(1) == '*')
-            {
-                TextWindow.AdvanceChar(2);
+            Debug.Assert(delimiter is '/' or '@');
+            Debug.Assert(TextWindow.PeekChar() == delimiter && TextWindow.PeekChar(1) == '*');
+            TextWindow.AdvanceChar(2);
 
-                char ch;
-                while (true)
+            char ch;
+            while (true)
+            {
+                if ((ch = TextWindow.PeekChar()) == SlidingTextWindow.InvalidCharacter && TextWindow.IsReallyAtEnd())
                 {
-                    if ((ch = TextWindow.PeekChar()) == SlidingTextWindow.InvalidCharacter && TextWindow.IsReallyAtEnd())
-                    {
-                        isTerminated = false;
-                        break;
-                    }
-                    else if (ch == '*' && TextWindow.PeekChar(1) == '/')
-                    {
-                        TextWindow.AdvanceChar(2);
-                        isTerminated = true;
-                        break;
-                    }
-                    else
-                    {
-                        TextWindow.AdvanceChar();
-                    }
+                    isTerminated = false;
+                    break;
                 }
-
-                return true;
-            }
-            else
-            {
-                isTerminated = false;
-                return false;
+                else if (ch == '*' && TextWindow.PeekChar(1) == delimiter)
+                {
+                    TextWindow.AdvanceChar(2);
+                    isTerminated = true;
+                    break;
+                }
+                else
+                {
+                    TextWindow.AdvanceChar();
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -1931,7 +1931,7 @@ LoopExit:
                                 break;
                             }
 
-                            lexMultiLineComment(ref triviaList, '/');
+                            lexMultiLineComment(ref triviaList, delimiter: '/');
                             onlyWhitespaceOnLine = false;
                             break;
                         }
@@ -1941,7 +1941,7 @@ LoopExit:
                     case '@' when TextWindow.PeekChar(1) == '*':
                         // Razor comment. We pretend that it's a multi-line comment for error recovery, but it's an error case.
                         this.AddError(TextWindow.Position, width: 1, ErrorCode.ERR_UnexpectedCharacter, '@');
-                        lexMultiLineComment(ref triviaList, '@');
+                        lexMultiLineComment(ref triviaList, delimiter: '@');
                         onlyWhitespaceOnLine = false;
                         break;
                     case '\r':

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -1081,7 +1081,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 {
                                     // Razor comment. Handle for error recovery purposes. The parser will come along later to retokenize the inside of the string
                                     // and report a proper error.
-                                    _lexer.ScanMultiLineComment(isTerminated: out _, '@');
+                                    _lexer.ScanMultiLineComment(isTerminated: out _, delimiter: '@');
                                     continue;
                                 }
 

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -1077,6 +1077,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 if (_lexer.TryScanAtStringToken(ref discarded))
                                     continue;
 
+                                if (_lexer.TextWindow.PeekChar(1) == '*')
+                                {
+                                    // Razor comment. Handle for error recovery purposes. The parser will come along later to retokenize the inside of the string
+                                    // and report a proper error.
+                                    _lexer.ScanMultiLineComment(isTerminated: out _, '@');
+                                    continue;
+                                }
+
                                 // Wasn't an @"" or @$"" string.  Just consume this as normal code.
                                 goto default;
                             }
@@ -1087,7 +1095,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                     _lexer.ScanToEndOfLine();
                                     continue;
                                 case '*':
-                                    _lexer.ScanMultiLineComment(out _);
+                                    _lexer.ScanMultiLineComment(isTerminated: out _, '/');
                                     continue;
                                 default:
                                     _lexer.TextWindow.AdvanceChar();

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         internal static SyntaxTrivia Comment(string text)
         {
-            if (text.StartsWith("/*", StringComparison.Ordinal))
+            if (text is ['/' or '@', '*', ..])
             {
                 return SyntaxTrivia.Create(SyntaxKind.MultiLineCommentTrivia, text);
             }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
@@ -516,6 +516,62 @@ public class MainClass
             ParserErrorMessageTests.ParseAndValidate(test, Diagnostic(ErrorCode.ERR_OpenEndedComment, ""));
         }
 
+        [Fact]
+        public void CS1035ERR_OpenEndedComment_Razor()
+        {
+            var test = @"
+public class MainClass
+    {
+    public static int Main ()
+        {
+        return 1;
+        }
+    }
+//Comment lacks closing */
+@*    
+";
+
+            ParserErrorMessageTests.ParseAndValidate(test,
+                // (10,1): error CS1056: Unexpected character '@'
+                // @*    
+                Diagnostic(ErrorCode.ERR_UnexpectedCharacter, "@").WithArguments("@").WithLocation(10, 1),
+                // (10,1): error CS1035: End-of-file found, '*/' expected
+                // @*    
+                Diagnostic(ErrorCode.ERR_OpenEndedComment, "").WithLocation(10, 1));
+        }
+
+        [Fact]
+        public void CS1035ERR_OpenEndedComment_Razor_InterpolatedString()
+        {
+            var test = """
+                public class MainClass
+                    {
+                    public static int Main ()
+                        {
+                        return $"{1@*   
+                """;
+
+            ParserErrorMessageTests.ParseAndValidate(test,
+                // (5,17): error CS8076: Missing close delimiter '}' for interpolated expression started with '{'.
+                //         return $"{1@*   
+                Diagnostic(ErrorCode.ERR_UnclosedExpressionHole, @"""{").WithLocation(5, 17),
+                // (5,20): error CS1056: Unexpected character '@'
+                //         return $"{1@*   
+                Diagnostic(ErrorCode.ERR_UnexpectedCharacter, "@").WithArguments("@").WithLocation(5, 20),
+                // (5,20): error CS1035: End-of-file found, '*/' expected
+                //         return $"{1@*   
+                Diagnostic(ErrorCode.ERR_OpenEndedComment, "").WithLocation(5, 20),
+                // (5,25): error CS1002: ; expected
+                //         return $"{1@*   
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(5, 25),
+                // (5,25): error CS1513: } expected
+                //         return $"{1@*   
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 25),
+                // (5,25): error CS1513: } expected
+                //         return $"{1@*   
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 25));
+        }
+
         [Fact, WorkItem(526993, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/526993")]
         public void CS1039ERR_UnterminatedStringLit()
         {
@@ -767,6 +823,39 @@ class A
             });
 
             ParsingTests.ParseAndValidate(test, descriptions.ToArray());
+        }
+
+        [Fact]
+        public void CS1056ERR_RazorComment()
+        {
+            var test = """
+                @* comment *@
+                class C {}
+                """;
+
+            ParsingTests.ParseAndValidate(test,
+                // (1,1): error CS1056: Unexpected character '@'
+                // @* comment *@
+                Diagnostic(ErrorCode.ERR_UnexpectedCharacter, "@").WithArguments("@").WithLocation(1, 1));
+        }
+
+        [Fact]
+        public void CS1056ERR_RazorComment_InterpolatedString()
+        {
+            var test = """
+                $"{@* comment *@}"
+                """;
+
+            ParsingTests.ParseAndValidate(test,
+                // (1,4): error CS1056: Unexpected character '@'
+                // $"{@* comment *@}"
+                Diagnostic(ErrorCode.ERR_UnexpectedCharacter, "@").WithArguments("@").WithLocation(1, 4),
+                // (1,17): error CS1733: Expected expression
+                // $"{@* comment *@}"
+                Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(1, 17),
+                // (1,19): error CS1002: ; expected
+                // $"{@* comment *@}"
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 19));
         }
 
         [Fact, WorkItem(535937, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/535937")]

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -260,6 +260,96 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [Trait("Feature", "Comments")]
+        public void TestMultiLineCommentOnOneLine_Razor()
+        {
+            var text = "@* comment *@";
+            var token = LexToken(text);
+
+            Assert.NotEqual(default, token);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
+            Assert.Equal(text, token.ToFullString());
+            var errors = token.Errors();
+            errors.Verify(
+                // error CS1056: Unexpected character '@'
+                TestBase.Diagnostic(ErrorCode.ERR_UnexpectedCharacter).WithArguments("@").WithLocation(1, 1));
+            var trivia = token.GetLeadingTrivia().ToArray();
+            Assert.Equal(1, trivia.Length);
+            Assert.NotEqual(default, trivia[0]);
+            Assert.Equal(SyntaxKind.MultiLineCommentTrivia, trivia[0].Kind());
+        }
+
+        [Fact]
+        [Trait("Feature", "Comments")]
+        public void TestMultiLineCommentOnMultipleLines_Razor()
+        {
+            var text =
+@"@* 
+ comment 
+ on many lines
+*@";
+            var token = LexToken(text);
+
+            Assert.NotEqual(default, token);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
+            Assert.Equal(text, token.ToFullString());
+            var errors = token.Errors();
+            errors.Verify(
+                // error CS1056: Unexpected character '@'
+                TestBase.Diagnostic(ErrorCode.ERR_UnexpectedCharacter).WithArguments("@").WithLocation(1, 1));
+            var trivia = token.GetLeadingTrivia().ToArray();
+            Assert.Equal(1, trivia.Length);
+            Assert.NotEqual(default, trivia[0]);
+            Assert.Equal(SyntaxKind.MultiLineCommentTrivia, trivia[0].Kind());
+        }
+
+        [Fact]
+        [Trait("Feature", "Comments")]
+        public void TestMultiLineXmlCommentOnMultipleLines_Razor()
+        {
+            var text =
+@"@** 
+ xml comment 
+ on many lines
+**@";
+            var token = LexToken(text);
+
+            Assert.NotEqual(default, token);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
+            Assert.Equal(text, token.ToFullString());
+            var errors = token.Errors();
+            errors.Verify(
+                // error CS1056: Unexpected character '@'
+                TestBase.Diagnostic(ErrorCode.ERR_UnexpectedCharacter).WithArguments("@").WithLocation(1, 1));
+            var trivia = token.GetLeadingTrivia().ToArray();
+            Assert.Equal(1, trivia.Length);
+            Assert.NotEqual(default, trivia[0]);
+            Assert.Equal(SyntaxKind.MultiLineCommentTrivia, trivia[0].Kind());
+        }
+
+        [Fact]
+        [Trait("Feature", "Comments")]
+        public void TestUnterminatedMultiLineComment_Razor()
+        {
+            var text = "@* comment";
+            var token = LexToken(text);
+
+            Assert.NotEqual(default, token);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
+            Assert.Equal(text, token.ToFullString());
+            var errors = token.Errors();
+            errors.Verify(
+                // error CS1056: Unexpected character '@'
+                TestBase.Diagnostic(ErrorCode.ERR_UnexpectedCharacter).WithArguments("@").WithLocation(1, 1),
+                // error CS1035: End-of-file found, '*/' expected
+                TestBase.Diagnostic(ErrorCode.ERR_OpenEndedComment).WithLocation(1, 1));
+            var trivia = token.GetLeadingTrivia().ToArray();
+            Assert.Equal(1, trivia.Length);
+            Assert.NotEqual(default, trivia[0]);
+            Assert.Equal(SyntaxKind.MultiLineCommentTrivia, trivia[0].Kind());
+        }
+
+        [Fact]
+        [Trait("Feature", "Comments")]
         public void TestCommentWithTextWindowSentinel()
         {
             Assert.Equal('\uFFFF', SlidingTextWindow.InvalidCharacter);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -11,12 +11,13 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public class ParsingErrorRecoveryTests : CSharpTestBase
+    public class ParsingErrorRecoveryTests(ITestOutputHelper helper) : ParsingTests(helper)
     {
-        private CompilationUnitSyntax ParseTree(string text, CSharpParseOptions options = null)
+        private new CompilationUnitSyntax ParseTree(string text, CSharpParseOptions options = null)
         {
             return SyntaxFactory.ParseCompilationUnit(text, options: options);
         }
@@ -7226,6 +7227,85 @@ class c
             var ns = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().Single();
             Assert.False(ns.OpenBraceToken.IsMissing);
             Assert.False(ns.CloseBraceToken.IsMissing);
+        }
+
+        [Fact]
+        public void RazorCommentRecovery_Space()
+        {
+            UsingTree("""@ * *@""",
+                // (1,1): error CS1646: Keyword, identifier, or string expected after verbatim specifier: @
+                // @ * *@
+                Diagnostic(ErrorCode.ERR_ExpectedVerbatimLiteral, "").WithLocation(1, 1),
+                // (1,6): error CS1525: Invalid expression term ''
+                // @ * *@
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "@").WithArguments("").WithLocation(1, 6),
+                // (1,6): error CS1002: ; expected
+                // @ * *@
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "@").WithLocation(1, 6),
+                // (1,6): error CS1646: Keyword, identifier, or string expected after verbatim specifier: @
+                // @ * *@
+                Diagnostic(ErrorCode.ERR_ExpectedVerbatimLiteral, "").WithLocation(1, 6));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ExpressionStatement);
+                    {
+                        N(SyntaxKind.PointerIndirectionExpression);
+                        {
+                            N(SyntaxKind.AsteriskToken);
+                            N(SyntaxKind.PointerIndirectionExpression);
+                            {
+                                N(SyntaxKind.AsteriskToken);
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void RazorCommentRecovery_NoStart()
+        {
+            UsingTree("""*@""",
+                // (1,2): error CS1525: Invalid expression term ''
+                // *@
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "@").WithArguments("").WithLocation(1, 2),
+                // (1,2): error CS1002: ; expected
+                // *@
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "@").WithLocation(1, 2),
+                // (1,2): error CS1646: Keyword, identifier, or string expected after verbatim specifier: @
+                // *@
+                Diagnostic(ErrorCode.ERR_ExpectedVerbatimLiteral, "").WithLocation(1, 2));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ExpressionStatement);
+                    {
+                        N(SyntaxKind.PointerIndirectionExpression);
+                        {
+                            N(SyntaxKind.AsteriskToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
         }
     }
 }


### PR DESCRIPTION
In order to make it easier to use the roslyn lexer in Razor, it would be helpful if roslyn's parser had limited understanding of razor trivia types. Fortunately, since `@*` is always illegal in C#, we can simply lex this as if it were a multi-line comment, add an unconditional error, and continue, so this is exactly what this change does. I've copied relevant multi-line comment tests and changed them to `@*` formats for verification purposes.
