### PR TITLE
Add EA.Razor.Compiler back to publishData.json

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -74,6 +74,7 @@
       "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.AspNetCore": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.Razor": "vs-impl",
+      "Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.TypeScript": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.UnitTesting": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.Xamarin.Remote": "vs-impl",


### PR DESCRIPTION
It's still needed in main, because we always read `PublishData.json` from main. Otherwise other shipping branch won't be able to ship the packages. Given the project is deleted in main, it won't be shipped from main.