### PR TITLE
Revert deadlock mitigation that causes other deadlocks

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
@@ -7,16 +7,17 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Implementation.Suggestions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -107,18 +108,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         EnsureSuggestedActionsSourceProviderEnabled();
                     }
                 });
-            }
-
-            private async Task TryOpeningDocumentsForMonikerAndSetContextOnUIThreadAsync(string moniker, ITextBuffer textBuffer, IVsHierarchy? hierarchy, CancellationToken cancellationToken)
-            {
-                await _projectSystemProjectFactory.ApplyChangeToWorkspaceAsync(async w =>
-                {
-                    await _foregroundAffinitization.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                    if (TryOpeningDocumentsForFilePathCore(w, moniker, textBuffer, hierarchy))
-                    {
-                        EnsureSuggestedActionsSourceProviderEnabled();
-                    }
-                }, cancellationToken).ConfigureAwait(true);
             }
 
             private void EnsureSuggestedActionsSourceProviderEnabled()
@@ -405,15 +394,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 EnsureSuggestedActionsSourceProviderEnabled();
             }
 
-            internal async Task CheckForOpenFilesThatWeMissedAsync(CancellationToken cancellationToken)
+            internal void CheckForOpenFilesThatWeMissed()
             {
                 // It's possible that Roslyn is loading asynchronously after documents were already opened by the user; this is a one-time check for
                 // any of those -- after this point, we are subscribed to events so we'll know of anything else.
-                await _foregroundAffinitization.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                _foregroundAffinitization.AssertIsForeground();
 
                 foreach (var (filePath, textBuffer, hierarchy) in _openTextBufferProvider.EnumerateDocumentSet())
                 {
-                    await TryOpeningDocumentsForMonikerAndSetContextOnUIThreadAsync(filePath, textBuffer, hierarchy, cancellationToken).ConfigureAwait(true);
+                    TryOpeningDocumentsForMonikerAndSetContextOnUIThread(filePath, textBuffer, hierarchy);
                 }
             }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -216,9 +216,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _memoryListener = memoryListener;
             }
 
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(_threadingContext.DisposalToken);
+
             // This must be called after the _openFileTracker was assigned; this way we know that a file added from the project system either got checked
             // in CheckForAddedFileBeingOpenMaybeAsync, or we catch it here.
-            await openFileTracker.CheckForOpenFilesThatWeMissedAsync(_threadingContext.DisposalToken).ConfigureAwait(false);
+            openFileTracker.CheckForOpenFilesThatWeMissed();
 
             // Switch to a background thread to avoid loading option providers on UI thread (telemetry is reading options).
             await TaskScheduler.Default;


### PR DESCRIPTION
This reverts commit https://github.com/dotnet/roslyn/commit/e5edae4309aa6e94b42992f3f957b4f6ed9eab29; that change was made to blocking the UI thread while waiting for a lock at the same time as another operation holding the lock is attempting to complete work on the UI thread, but in the process it created another deadlock by implicitly switching to the main thread itself while holding the lock.

If/when the previous deadlock occurs again, a new fix should be created that fixes the issue at the source of the _other_ concurrent operation which is holding the workspace lock on a background thread, and the proper fix would be removing the cross-thread dependency which appears inside that lock.

Fixes [AB#1920741](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1920741)