### PR TITLE
Make the Roslyn code index CI use the LSIF generator just produced

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -46,13 +46,20 @@ jobs:
   timeoutInMinutes: ${{ parameters.timeout }}
   variables:
     EnableRichCodeNavigation: true
+    Configuration: Debug
 
   steps:
     - task: PowerShell@2
       displayName: Build
       inputs:
         filePath: eng/build.ps1
-        arguments: -ci -restore -build -configuration Debug -prepareMachine
+        arguments: -ci -restore -build -configuration $(Configuration) -prepareMachine -pack /p:DotNetUseShippingVersions=true
+
+    - task: PowerShell@2
+      displayName: Get LSIF Package Version
+      inputs:
+        filePath: eng/set-package-version-variable.ps1
+        arguments: -folder $(Build.SourcesDirectory)/artifacts/packages/$(Configuration)/NonShipping -packageName Microsoft.CodeAnalysis.Lsif.Generator
 
     - task: RichCodeNavIndexer@0
       displayName: RichCodeNav Upload
@@ -60,6 +67,9 @@ jobs:
         languages: 'csharp'
         environment: production
         richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        lsifToolFeed: $(Build.SourcesDirectory)/artifacts/packages/$(Configuration)/NonShipping
+        csharpVersion: $(MicrosoftCodeAnalysisLsifGeneratorPackageVersion)
+
       continueOnError: true
       env:
         DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet

--- a/eng/set-package-version-variable.ps1
+++ b/eng/set-package-version-variable.ps1
@@ -1,0 +1,18 @@
+# This searches a directory for a given package, and sets an Azure DevOps variable to the found version number,
+# which is useful if you need to pass that version to a later Azure DevOps build task. The variable set is
+# the name of the package, with periods removed, and "PackageVersion" appended. So for example, Microsoft.CodeAnalysis
+# would be "MicrosoftCodeAnalysisPackageVersion".
+
+[CmdletBinding(PositionalBinding=$false)]
+param (
+  [string]$folder,
+  [string]$packageName)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+$packageBaseName = (Get-ChildItem -Path $folder -Filter "$packageName*.nupkg").BaseName
+$packageVersion = $packageBaseName.Substring($packageName.Length + 1)
+$variableName = $packageName.Replace(".", "") + "PackageVersion"
+Write-Host "Found version $packageVersion of $packageName in $folder"
+Write-Host "##vso[task.setvariable variable=$variableName]$packageVersion"


### PR DESCRIPTION
Rather than having the CI download the widely-deployed LSIF generator, use the one we just built as a bootstrap. This acts as a quality gate by ensuring it can run on the Roslyn repo itself.