### PR TITLE
Fix SyntaxGenerator not generating event field modifiers correctly

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -5109,7 +5109,9 @@ namespace PushUpTest
 
     public class Testclass2 : Base2
     {
-        private event EventHandler Event1, Eve[||]nt3, Event4;
+        private event EventHandler Event1;
+        private override event EventHandler Eve[||]nt3;
+        private event EventHandler Event4;
     }
 }";
             await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("Event3", true) }, index: 1);

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1478,12 +1478,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             DeclarationModifiers.Virtual |
             DeclarationModifiers.Unsafe;
 
-        private static readonly DeclarationModifiers s_eventFieldModifiers =
-            DeclarationModifiers.New |
-            DeclarationModifiers.ReadOnly |
-            DeclarationModifiers.Static |
-            DeclarationModifiers.Unsafe;
-
         private static readonly DeclarationModifiers s_indexerModifiers =
             DeclarationModifiers.Abstract |
             DeclarationModifiers.Extern |
@@ -1577,8 +1571,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return s_indexerModifiers;
 
                 case SyntaxKind.EventFieldDeclaration:
-                    return s_eventFieldModifiers;
-
                 case SyntaxKind.EventDeclaration:
                     return s_eventModifiers;
 

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -3011,7 +3011,7 @@ public class C
                 Generator.GetModifiers(Generator.WithModifiers(Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("i") }, Generator.IdentifierName("t")), allModifiers)));
 
             Assert.Equal(
-                DeclarationModifiers.New | DeclarationModifiers.Static | DeclarationModifiers.Unsafe | DeclarationModifiers.ReadOnly,
+                DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual | DeclarationModifiers.Unsafe | DeclarationModifiers.ReadOnly,
                 Generator.GetModifiers(Generator.WithModifiers(Generator.EventDeclaration("ef", Generator.IdentifierName("t")), allModifiers)));
 
             Assert.Equal(


### PR DESCRIPTION
Fixes #66966