### PR TITLE
Allow Razor to register Json converters for functional tests

### DIFF
--- a/src/Tools/ExternalAccess/Razor/IRazorLanguageServerFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorLanguageServerFactory.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Newtonsoft.Json;
 using StreamJsonRpc;
@@ -16,9 +14,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
     /// </summary>
     internal interface IRazorLanguageServerFactoryWrapper
     {
-        [Obsolete("Use the overload that takes a IRazorTestCapabilitiesProvider")]
-        IRazorLanguageServerTarget CreateLanguageServer(JsonRpc jsonRpc, IRazorCapabilitiesProvider capabilitiesProvider, HostServices hostServices);
-
         IRazorLanguageServerTarget CreateLanguageServer(JsonRpc jsonRpc, IRazorTestCapabilitiesProvider capabilitiesProvider, HostServices hostServices);
 
         DocumentInfo CreateDocumentInfo(

--- a/src/Tools/ExternalAccess/Razor/IRazorLanguageServerFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorLanguageServerFactory.cs
@@ -6,10 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Newtonsoft.Json;
 using StreamJsonRpc;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
+    /// <summary>
+    /// NOTE: For Razor test usage only
+    /// </summary>
     internal interface IRazorLanguageServerFactoryWrapper
     {
         [Obsolete("Use the overload that takes a IRazorTestCapabilitiesProvider")]
@@ -27,5 +31,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             bool isGenerated = false,
             bool designTimeOnly = false,
             IRazorDocumentServiceProvider? razorDocumentServiceProvider = null);
+
+        /// <summary>
+        /// Supports the creation of a Roslyn LSP server for functional tests
+        /// </summary>
+        void AddJsonConverters(JsonSerializer jsonSerializer);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/IRazorTestCapabilitiesProvider.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorTestCapabilitiesProvider.cs
@@ -2,17 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Roslyn.LanguageServer.Protocol;
-
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
-    [Obsolete("Use IRazorTestCapabilitiesProvider")]
-    internal interface IRazorCapabilitiesProvider
-    {
-        ServerCapabilities GetCapabilities(ClientCapabilities clientCapabilities);
-    }
-
     /// <summary>
     /// A capabilities provider that should only be used from Razor tests
     /// </summary>

--- a/src/Tools/ExternalAccess/Razor/RazorLanguageServerFactoryWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorLanguageServerFactoryWrapper.cs
@@ -74,6 +74,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                 .WithDocumentServiceProvider(documentServiceProvider);
         }
 
+        public void AddJsonConverters(JsonSerializer jsonSerializer)
+        {
+            VSInternalExtensionUtilities.AddVSInternalExtensionConverters(jsonSerializer);
+        }
+
         private class RazorCapabilitiesProvider : ICapabilitiesProvider
         {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Tools/ExternalAccess/Razor/RazorLanguageServerFactoryWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorLanguageServerFactoryWrapper.cs
@@ -41,15 +41,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             return new RazorLanguageServerTargetWrapper(languageServer);
         }
 
-        [Obsolete("Use the overload that takes IRazorTestCapabilitiesProvider")]
-        public IRazorLanguageServerTarget CreateLanguageServer(JsonRpc jsonRpc, IRazorCapabilitiesProvider razorCapabilitiesProvider, HostServices hostServices)
-        {
-            var capabilitiesProvider = new RazorCapabilitiesProvider(razorCapabilitiesProvider);
-            var languageServer = _languageServerFactory.Create(jsonRpc, capabilitiesProvider, WellKnownLspServerKinds.RazorLspServer, NoOpLspLogger.Instance, hostServices);
-
-            return new RazorLanguageServerTargetWrapper(languageServer);
-        }
-
         public DocumentInfo CreateDocumentInfo(
             DocumentId id,
             string name,
@@ -81,42 +72,27 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
         private class RazorCapabilitiesProvider : ICapabilitiesProvider
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            private readonly IRazorCapabilitiesProvider? _razorCapabilitiesProvider;
-#pragma warning restore CS0618 // Type or member is obsolete
-            private readonly IRazorTestCapabilitiesProvider? _razorTestCapabilitiesProvider;
+            private readonly IRazorTestCapabilitiesProvider _razorTestCapabilitiesProvider;
 
             public RazorCapabilitiesProvider(IRazorTestCapabilitiesProvider razorTestCapabilitiesProvider)
             {
                 _razorTestCapabilitiesProvider = razorTestCapabilitiesProvider;
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            public RazorCapabilitiesProvider(IRazorCapabilitiesProvider razorCapabilitiesProvider)
-#pragma warning restore CS0618 // Type or member is obsolete
-            {
-                _razorCapabilitiesProvider = razorCapabilitiesProvider;
-            }
-
             public ServerCapabilities GetCapabilities(ClientCapabilities clientCapabilities)
             {
-                if (_razorTestCapabilitiesProvider is not null)
+                // To avoid exposing types from MS.VS.LanguageServer.Protocol types we serialize and deserialize the capabilities
+                // so we can just pass string around. This is obviously not great for perf, but it is only used in Razor tests.
+                var clientCapabilitiesJson = JsonConvert.SerializeObject(clientCapabilities);
+                var serverCapabilitiesJson = _razorTestCapabilitiesProvider.GetServerCapabilitiesJson(clientCapabilitiesJson);
+                var serverCapabilities = JsonConvert.DeserializeObject<VSInternalServerCapabilities>(serverCapabilitiesJson);
+
+                if (serverCapabilities is null)
                 {
-                    // To avoid exposing types from MS.VS.LanguageServer.Protocol types we serialize and deserialize the capabilities
-                    // so we can just pass string around. This is obviously not great for perf, but it is only used in Razor tests.
-                    var clientCapabilitiesJson = JsonConvert.SerializeObject(clientCapabilities);
-                    var serverCapabilitiesJson = _razorTestCapabilitiesProvider.GetServerCapabilitiesJson(clientCapabilitiesJson);
-                    var serverCapabilities = JsonConvert.DeserializeObject<VSInternalServerCapabilities>(serverCapabilitiesJson);
-
-                    if (serverCapabilities is null)
-                    {
-                        throw new InvalidOperationException("Could not deserialize server capabilities as VSInternalServerCapabilities");
-                    }
-
-                    return serverCapabilities;
+                    throw new InvalidOperationException("Could not deserialize server capabilities as VSInternalServerCapabilities");
                 }
 
-                return _razorCapabilitiesProvider!.GetCapabilities(clientCapabilities);
+                return serverCapabilities;
             }
         }
     }

--- a/src/Tools/ExternalAccess/Razor/RazorSemanticTokensAccessor.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorSemanticTokensAccessor.cs
@@ -2,21 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens;
-using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
     internal class RazorSemanticTokensAccessor
     {
-        [Obsolete("Use GetTokenTypes")]
-        public static ImmutableArray<string> RoslynTokenTypes => SemanticTokensSchema.LegacyTokenSchemaForRazor.AllTokenTypes;
-
-        [Obsolete("Use GetTokenTypes(bool)")]
-        public static ImmutableArray<string> GetTokenTypes(ClientCapabilities capabilities) => SemanticTokensSchema.GetSchema(capabilities is VSInternalClientCapabilities { SupportsVisualStudioExtensions: true }).AllTokenTypes;
-
         public static ImmutableArray<string> GetTokenTypes(bool clientSupportsVisualStudioExtensions) => SemanticTokensSchema.GetSchema(clientSupportsVisualStudioExtensions).AllTokenTypes;
 
         public static string[] GetTokenModifiers() => SemanticTokensSchema.TokenModifiers;


### PR DESCRIPTION
Razor creates a Roslyn LSP server for functional tests, but with Roslyn's move away from the VS Protocol DLL types, we need to be able to add the Json converters to our pipeline for tests to work. This PR allows us to do that without and replace this hack:
https://github.com/davidwengier/razor/blob/GenerationFromTextDocument/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServer.cs#L97-L101

Also took the opportunity to clean up the obsolete things that Razor has already moved away from.