### PR TITLE
Fix issue with 'use primary constructor' when an assignment uses a suppression operator

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
@@ -488,7 +488,12 @@ internal sealed class CSharpUsePrimaryConstructorDiagnosticAnalyzer()
 
                 // Left side looks good.  Now check the right side.  It cannot reference 'this' (as that is not
                 // legal once we move this to initialize the field/prop in the rewrite).
-                var rightOperation = semanticModel.GetOperation(assignmentExpression.Right);
+                //
+                // Note: we have to walk down suppressions as the IOp tree gives back nothing for them.
+                var rightOperation = semanticModel.GetOperation(assignmentExpression.Right.WalkDownSuppressions());
+                if (rightOperation is null)
+                    return false;
+
                 foreach (var operation in rightOperation.DescendantsAndSelf())
                 {
                     if (operation is IInstanceReferenceOperation)

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -3999,4 +3999,31 @@ public partial class UsePrimaryConstructorTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71749")]
+    public async Task TestNotOnSuppressedAssignmentToAnotherField()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Reflection;
+
+                public class C
+                {
+                    private readonly Type _type;
+                    private readonly Type _comparerType;
+                    private readonly object _defaultObject;
+
+                    public C(Type type)
+                    {
+                        _type = type;
+                        _comparerType = typeof(EqualityComparer<>).MakeGenericType(type);
+                        _defaultObject = _comparerType.GetProperty("Default", BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -4006,6 +4006,8 @@ public partial class UsePrimaryConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                using System;
+                using System.Collections.Generic;
                 using System.Reflection;
 
                 public class C

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -32,6 +32,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return expression;
         }
 
+        public static ExpressionSyntax WalkDownSuppressions(this ExpressionSyntax expression)
+        {
+            while (expression is PostfixUnaryExpressionSyntax(SyntaxKind.SuppressNullableWarningExpression) postfixExpression)
+                expression = postfixExpression.Operand;
+
+            return expression;
+        }
+
         public static bool IsQualifiedCrefName(this ExpressionSyntax expression)
             => expression.IsParentKind(SyntaxKind.NameMemberCref) && expression.Parent.IsParentKind(SyntaxKind.QualifiedCref);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/71749