### PR TITLE
Fix bootstrap log publish

### DIFF
--- a/eng/pipelines/build-bootstrap.yml
+++ b/eng/pipelines/build-bootstrap.yml
@@ -3,6 +3,9 @@ parameters:
 - name: bootstrapToolset
   type: string
   default: ''
+- name: bootstrapName
+  type: string
+  default: ''
 
 steps:
     - template: checkout-windows-task.yml
@@ -12,19 +15,19 @@ steps:
 
     - template: publish-logs.yml
       parameters:
-        jobName: Correctness_Bootstrap_Build
+        jobName: Correctness_Bootstrap_Build - ${{parameters.bootstrapName}}
         configuration: Release
 
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact Packages
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
-        ArtifactName: 'Bootstrap Packages - ${{parameters.bootstrapToolset}}'
+        ArtifactName: 'Bootstrap Packages - ${{parameters.bootstrapName}}'
         publishLocation: Container
 
     - task: PublishBuildArtifacts@1
       displayName: Publish VSIX Packages
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
-        ArtifactName: 'Bootstrap VSIX - ${{parameters.bootstrapToolset}}'
+        ArtifactName: 'Bootstrap VSIX - ${{parameters.bootstrapName}}'
         publishLocation: Container

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -31,6 +31,7 @@ try {
   }
 
   $ci = $true
+  $prepareMachine = $true
 
   . (Join-Path $PSScriptRoot "build-utils.ps1")
   Push-Location $RepoRoot


### PR DESCRIPTION
PR #71265 tried to unify machine cleanup on CI. It did not set the `$prepareMachine` value for our bootstrap builds. That meant that `VBCSCompiler` kept running after the build as `ExitWithExitCode` did not kill processes and it held onto log files that blocked publishing. That results in us being able to investigate bootstrap failures (see #71591).

The log file is opened with `FileShare.ReadWrite` but apparently that is not enough for publish artifacts to work