### PR TITLE
Fix VSIX asset inclusion

### DIFF
--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -16,6 +16,9 @@
          when we don't have one. -->
     <CopyVsixManifestToOutput>$(CreateVsixContainer)</CopyVsixManifestToOutput>
     <SetupProductArch Condition="'$(SetupProductArch)' == ''">Neutral</SetupProductArch>
+
+    <!-- Avoid auto-adding referenced dlls to VSIX -->
+    <IncludeCopyLocalReferencesInVSIXContainer>false</IncludeCopyLocalReferencesInVSIXContainer>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -47,57 +50,56 @@
     </ItemGroup>
   </Target>
 
-  <!-- Include some of our NuGet-consumed assets into VSIX projects
+  <!--
+    Disable auto-including referenced libraries by default.
+    Instead, explicitly list packages to include in NuGetPackageToIncludeInVsix items.
+  -->
 
-       This exists for two reasons:
-
-       1) In some cases, we need to include the contents of a NuGet package that is otherwise
-          contained within the SuppressFromVsix list, because we're actually the component
-          inside Visual Studio that ships that component
-
-       2) The SDK targets don't currently look at the ReferenceCopyLocalPaths produced
-          by the NuGet build task. -->
-
+  <PropertyGroup>
+    <IncludeCopyLocalReferencesInVSIXContainer>false</IncludeCopyLocalReferencesInVSIXContainer>
+  </PropertyGroup>
+  
   <Target Name="IncludeNuGetResolvedAssets"
           DependsOnTargets="ResolvePackageDependenciesForBuild"
           BeforeTargets="GeneratePkgDef"
           Condition="'@(NuGetPackageToIncludeInVsix)' != ''">
 
-    <!-- Calculate a list of packages ReferenceCopyLocalPaths originate from whose content should not be included in the VSIX -->
+    <!--
+      NuGetPackageToIncludeInVsix items are names of packages with metadata.
+      We join this list with ReferenceCopyLocalPaths items to get the list of dlls to include in the VSIX.
+    -->
     <ItemGroup>
-      <_ExcludedPackageId Include="@(ReferenceCopyLocalPaths->'%(NuGetPackageId)')" />
-      <_ExcludedPackageId Remove="@(NuGetPackageToIncludeInVsix)"/>
-    </ItemGroup>
-
-    <!-- Build a list assets to include in the VSIX keyed by package id -->
-    <ItemGroup>
-      <_AssetsByPackageId Include="@(ReferenceCopyLocalPaths->'%(NuGetPackageId)')">
+      <_RuntimeAssetsByPackageId Include="@(ReferenceCopyLocalPaths->'%(NuGetPackageId)')" Condition="%(ReferenceCopyLocalPaths.AssetType) == 'runtime'">
         <Path>%(ReferenceCopyLocalPaths.Identity)</Path>
-      </_AssetsByPackageId>
-
-      <_AssetsByPackageId Remove="@(_ExcludedPackageId)" />
+      </_RuntimeAssetsByPackageId>
     </ItemGroup>
 
-    <!-- Flow metadata set on NuGetPackageToIncludeInVsix to VSIXCopyLocalReferenceSourceItem -->
-    <JoinItems Left="@(_AssetsByPackageId)" LeftKey="" LeftMetadata="*"
+    <JoinItems Left="@(_RuntimeAssetsByPackageId)" LeftKey="" LeftMetadata="*"
                Right="@(NuGetPackageToIncludeInVsix)" RightKey="" RightMetadata="*">
-      <Output TaskParameter="JoinResult" ItemName="_AssetsWithMetadata" />
+      <Output TaskParameter="JoinResult" ItemName="_RuntimeAssetsWithMetadata" />
     </JoinItems>
 
     <ItemGroup>
       <!-- Include the assets in the VSIX -->
-      <VSIXCopyLocalReferenceSourceItem Include="@(_AssetsWithMetadata->'%(Path)')">
+      <VSIXCopyLocalReferenceSourceItem Include="@(_RuntimeAssetsWithMetadata->'%(Path)')">
         <ForceIncludeInVsix>true</ForceIncludeInVsix>
         <Private>true</Private>
-        <Ngen Condition="'%(_AssetsWithMetadata.Optimization)' == 'true'">true</Ngen>
-        <NgenArchitecture Condition="'%(_AssetsWithMetadata.Optimization)' == 'true'">All</NgenArchitecture>
-        <NgenPriority Condition="'%(_AssetsWithMetadata.Optimization)' == 'true'">3</NgenPriority>
+        <Ngen Condition="'%(_RuntimeAssetsWithMetadata.Optimization)' == 'true'">true</Ngen>
+        <NgenArchitecture Condition="'%(_RuntimeAssetsWithMetadata.Optimization)' == 'true'">All</NgenArchitecture>
+        <NgenPriority Condition="'%(_RuntimeAssetsWithMetadata.Optimization)' == 'true'">3</NgenPriority>
       </VSIXCopyLocalReferenceSourceItem>
 
       <!-- Add PkgDef* items for assets that specify PkgDefEntry -->
-      <PkgDefBindingRedirect Include="@(_AssetsWithMetadata->'%(Path)')" Condition="'%(_AssetsWithMetadata.PkgDefEntry)' == 'BindingRedirect' and %(_AssetsWithMetadata.AssetType) == 'runtime'" />
-      <PkgDefCodeBase Include="@(_AssetsWithMetadata->'%(Path)')" Condition="'%(_AssetsWithMetadata.PkgDefEntry)' == 'CodeBase' and %(_AssetsWithMetadata.AssetType) == 'runtime'" />
+      <PkgDefBindingRedirect Include="@(_RuntimeAssetsWithMetadata->'%(Path)')" Condition="'%(_RuntimeAssetsWithMetadata.PkgDefEntry)' == 'BindingRedirect'" />
+      <PkgDefCodeBase Include="@(_RuntimeAssetsWithMetadata->'%(Path)')" Condition="'%(_RuntimeAssetsWithMetadata.PkgDefEntry)' == 'CodeBase'" />
+
+      <!-- Check that NuGetPackageToIncludeInVsix doesn't list unreferenced package -->
+      <_UnknownAssets Include="@(NuGetPackageToIncludeInVsix)" />
+      <_UnknownAssets Remove="@(_RuntimeAssetsWithMetadata)" />
     </ItemGroup>
+
+    <Error Text="Packages specified by NuGetPackageToIncludeInVsix are not referenced by the project or have no runtime assets applicable to $(TargetFramework): @(_UnknownAssets)"
+           Condition="'@(_UnknownAssets)' != ''"/>
   </Target>
 
   <!-- Microsoft.VisualStudio.SDK.EmbedInteropTypes sets a bunch of EmbedInteropTypes attributes, but Roslyn is somewhat special

--- a/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
+++ b/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
@@ -29,7 +29,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader.Native" />
     <NuGetPackageToIncludeInVsix Include="System.Buffers" />
     <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" />
     <NuGetPackageToIncludeInVsix Include="System.Memory" />

--- a/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
+++ b/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
@@ -28,8 +28,6 @@
     <NuGetPackageToIncludeInVsix Include="System.Buffers" PkgDefEntry="BindingRedirect" />
     <NuGetPackageToIncludeInVsix Include="System.CodeDom" PkgDefEntry="BindingRedirect" />
     <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" PkgDefEntry="BindingRedirect" />
-    <NuGetPackageToIncludeInVsix Include="System.ComponentModel.Composition" PkgDefEntry="BindingRedirect" />
-    <NuGetPackageToIncludeInVsix Include="System.Composition" PkgDefEntry="BindingRedirect" />
     <NuGetPackageToIncludeInVsix Include="System.Configuration.ConfigurationManager" PkgDefEntry="BindingRedirect" />
     <NuGetPackageToIncludeInVsix Include="System.Drawing.Common" PkgDefEntry="BindingRedirect" />
     <NuGetPackageToIncludeInVsix Include="System.IO.Pipelines" PkgDefEntry="BindingRedirect" />
@@ -46,9 +44,6 @@
     <NuGetPackageToIncludeInVsix Include="Nerdbank.Streams" PkgDefEntry="BindingRedirect" />
     <NuGetPackageToIncludeInVsix Include="StreamJsonRpc" PkgDefEntry="BindingRedirect" />
     <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.Threading" PkgDefEntry="BindingRedirect" />
-    <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol" PkgDefEntry="CodeBase" />
-    <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" PkgDefEntry="CodeBase" />
-    <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" PkgDefEntry="CodeBase" />
   </ItemGroup>
   <ItemGroup>
     <None Include="source.extension.vsixmanifest">
@@ -57,5 +52,15 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
+
+    <!-- Required for NuGetPackageToIncludeInVsix -->
+    <PackageReference Include="Microsoft.DiaSymReader" />
+    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" />
+    <PackageReference Include="System.CodeDom" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
+    <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="System.Resources.Extensions" />
+    <PackageReference Include="System.Text.Encoding.CodePages" />
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 </Project>

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -333,14 +333,9 @@
     <NuGetPackageToIncludeInVsix Include="Microsoft.CodeAnalysis.AnalyzerUtilities" PkgDefEntry="CodeBase" />
     <NuGetPackageToIncludeInVsix Include="SQLitePCLRaw.core" PkgDefEntry="CodeBase" />
     <NuGetPackageToIncludeInVsix Include="SQLitePCLRaw.bundle_green" PkgDefEntry="CodeBase" />
-    <NuGetPackageToIncludeInVsix Include="SQLitePCLRaw.provider.e_sqlite3.net45" PkgDefEntry="CodeBase" />
     <NuGetPackageToIncludeInVsix Include="SQLitePCLRaw.provider.dynamic_cdecl" PkgDefEntry="CodeBase" />
     <NuGetPackageToIncludeInVsix Include="Microsoft.CodeAnalysis.Elfie" PkgDefEntry="BindingRedirect" />
     <NuGetPackageToIncludeInVsix Include="ICSharpCode.Decompiler" PkgDefEntry="CodeBase" />
-    <!-- Code base is provided by the LSP client for released VS versions in order to ensure only 1 version of these assemblies are loaded. -->
-    <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol" />
-    <NugetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" />
-    <NugetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(PkgSQLitePCLRaw_lib_e_sqlite3)\runtimes\win-x64\native\e_sqlite3.dll">


### PR DESCRIPTION
17.9 version of VSSDK includes all libraries referenced via package reference. Updating to that version included dlls in Roslyn setup VSIX that shouldn't have been.