### PR TITLE
Clean up the IntelliSense option pages

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -18,14 +18,12 @@
                     <CheckBox x:Uid="Show_completion_list_after_a_character_is_typed"
                               x:Name="Show_completion_list_after_a_character_is_typed"
                               Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_typed}" 
-                              Checked="Show_completion_list_after_a_character_is_typed_Checked" 
+                              Checked="Show_completion_list_after_a_character_is_typed_Checked"
                               Unchecked="Show_completion_list_after_a_character_is_typed_Unchecked"/>
                     <StackPanel Margin="15, 0, 0, 0">
                         <CheckBox x:Uid="Show_completion_list_after_a_character_is_deleted"
                                   x:Name="Show_completion_list_after_a_character_is_deleted"
-                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_deleted}" 
-                                  Checked="Show_completion_list_after_a_character_is_deleted_Checked" 
-                                  Unchecked="Show_completion_list_after_a_character_is_deleted_Unchecked"/>
+                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_deleted}" />
                     </StackPanel>
 
                     <CheckBox x:Uid="Automatically_show_completion_list_in_argument_lists"

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -74,27 +74,15 @@
 
                     <CheckBox x:Uid="Show_items_from_unimported_namespaces"
                                   x:Name="Show_items_from_unimported_namespaces"
-                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_items_from_unimported_namespaces}" 
-                              Checked="Show_items_from_unimported_namespaces_CheckedChanged"       
-                              Unchecked="Show_items_from_unimported_namespaces_CheckedChanged"
-                              Indeterminate="Show_items_from_unimported_namespaces_CheckedChanged"
-                              IsThreeState="True"/>
+                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_items_from_unimported_namespaces}" />
 
                     <CheckBox x:Uid="Tab_twice_to_insert_arguments"
                                   x:Name="Tab_twice_to_insert_arguments"
-                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Tab_twice_to_insert_arguments}" 
-                              Checked="Tab_twice_to_insert_arguments_CheckedChanged"
-                              Unchecked="Tab_twice_to_insert_arguments_CheckedChanged"
-                              Indeterminate="Tab_twice_to_insert_arguments_CheckedChanged"
-                              IsThreeState="True"/>
+                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Tab_twice_to_insert_arguments}" />
 
                     <CheckBox x:Uid="Show_new_snippet_experience"
                                   x:Name="Show_new_snippet_experience"
-                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_new_snippet_experience_experimental}"
-                              Checked="Show_new_snippet_experience_CheckedChanged"
-                              Unchecked="Show_new_snippet_experience_CheckedChanged"
-                              Indeterminate="Show_new_snippet_experience_CheckedChanged"
-                              IsThreeState="True"/>
+                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_new_snippet_experience_experimental}" />
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -52,7 +52,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked == true;
             Show_completion_list_after_a_character_is_deleted.IsChecked = false;
-            this.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, value: false);
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -19,9 +19,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             InitializeComponent();
 
             BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.CSharp);
-            Show_completion_list_after_a_character_is_deleted.IsChecked = this.OptionStore.GetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp) == true;
+            BindToOption(Show_completion_list_after_a_character_is_deleted, CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, onNullValue: () => false);
             Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked == true;
-            AddSearchHandler(Show_completion_list_after_a_character_is_deleted);
 
             BindToOption(Automatically_show_completion_list_in_argument_lists, CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp);
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.CSharp);
@@ -53,13 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked == true;
             Show_completion_list_after_a_character_is_deleted.IsChecked = false;
-            Show_completion_list_after_a_character_is_deleted_Unchecked(sender, e);
+            this.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, value: false);
         }
-
-        private void Show_completion_list_after_a_character_is_deleted_Checked(object sender, RoutedEventArgs e)
-            => this.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, value: true);
-
-        private void Show_completion_list_after_a_character_is_deleted_Unchecked(object sender, RoutedEventArgs e)
-            => this.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, value: false);
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             InitializeComponent();
 
             BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.CSharp);
-            BindToOption(Show_completion_list_after_a_character_is_deleted, CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, onNullValue: () => false);
+            BindToOption(Show_completion_list_after_a_character_is_deleted, CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, onNullValue: static () => false);
             Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked == true;
 
             BindToOption(Automatically_show_completion_list_in_argument_lists, CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, onNullValue: static () => true);
 
-            BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.CSharp, onNullValue: () => false);
+            BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.CSharp, onNullValue: static () => false);
             BindToOption(Show_new_snippet_experience, CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp,
                 onNullValue: () => this.OptionStore.GetOption(CompletionOptionsStorage.ShowNewSnippetExperienceFeatureFlag));
         }

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -8,7 +8,6 @@ using System.Windows;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement;
-using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
@@ -19,15 +18,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             InitializeComponent();
 
-            BindToOption(Automatically_complete_statement_on_semicolon, CompleteStatementOptionsStorage.AutomaticallyCompleteStatementOnSemicolon);
-
-            BindToOption(Show_completion_item_filters, CompletionViewOptionsStorage.ShowCompletionItemFilters, LanguageNames.CSharp);
-            BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.CSharp);
-
             BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.CSharp);
             Show_completion_list_after_a_character_is_deleted.IsChecked = this.OptionStore.GetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp) == true;
             Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked == true;
             AddSearchHandler(Show_completion_list_after_a_character_is_deleted);
+
+            BindToOption(Automatically_show_completion_list_in_argument_lists, CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp);
+            BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.CSharp);
+            BindToOption(Show_completion_item_filters, CompletionViewOptionsStorage.ShowCompletionItemFilters, LanguageNames.CSharp);
+
+            BindToOption(Automatically_complete_statement_on_semicolon, CompleteStatementOptionsStorage.AutomaticallyCompleteStatementOnSemicolon);
 
             BindToOption(Never_include_snippets, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.CSharp);
             BindToOption(Always_include_snippets, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.CSharp);
@@ -38,16 +38,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Always_add_new_line_on_enter, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.CSharp);
 
             BindToOption(Show_name_suggestions, CompletionOptionsStorage.ShowNameSuggestions, LanguageNames.CSharp);
-            BindToOption(Automatically_show_completion_list_in_argument_lists, CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp);
 
-            Show_items_from_unimported_namespaces.IsChecked = this.OptionStore.GetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp);
-            AddSearchHandler(Show_items_from_unimported_namespaces);
+            BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, onNullValue: static () => true);
 
-            Tab_twice_to_insert_arguments.IsChecked = this.OptionStore.GetOption(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.CSharp);
-            AddSearchHandler(Tab_twice_to_insert_arguments);
-
-            Show_new_snippet_experience.IsChecked = this.OptionStore.GetOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp);
-            AddSearchHandler(Show_new_snippet_experience);
+            BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.CSharp, onNullValue: () => false);
+            BindToOption(Show_new_snippet_experience, CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp,
+                onNullValue: () => this.OptionStore.GetOption(CompletionOptionsStorage.ShowNewSnippetExperienceFeatureFlag));
         }
 
         private void Show_completion_list_after_a_character_is_typed_Checked(object sender, RoutedEventArgs e)
@@ -65,23 +61,5 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         private void Show_completion_list_after_a_character_is_deleted_Unchecked(object sender, RoutedEventArgs e)
             => this.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, value: false);
-
-        private void Show_items_from_unimported_namespaces_CheckedChanged(object sender, RoutedEventArgs e)
-        {
-            Show_items_from_unimported_namespaces.IsThreeState = false;
-            this.OptionStore.SetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, value: Show_items_from_unimported_namespaces.IsChecked);
-        }
-
-        private void Tab_twice_to_insert_arguments_CheckedChanged(object sender, RoutedEventArgs e)
-        {
-            Tab_twice_to_insert_arguments.IsThreeState = false;
-            this.OptionStore.SetOption(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.CSharp, value: Tab_twice_to_insert_arguments.IsChecked);
-        }
-
-        private void Show_new_snippet_experience_CheckedChanged(object sender, RoutedEventArgs e)
-        {
-            Show_new_snippet_experience.IsThreeState = false;
-            this.OptionStore.SetOption(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp, value: Show_new_snippet_experience.IsChecked);
-        }
     }
 }

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -21,9 +21,7 @@
                     <StackPanel Margin="15, 0, 0, 0">
                         <CheckBox x:Uid="Show_completion_list_after_a_character_is_deleted"
                                 x:Name="Show_completion_list_after_a_character_is_deleted"
-                                Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_deleted}" 
-                                Checked="Show_completion_list_after_a_character_is_deleted_Checked" 
-                                Unchecked="Show_completion_list_after_a_character_is_deleted_Unchecked"/>
+                                Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_deleted}" />
                     </StackPanel>
 
                     <CheckBox x:Uid="Highlight_matching_portions_of_completion_list_items"

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -61,19 +61,11 @@
 
                     <CheckBox x:Uid="Show_items_from_unimported_namespaces"
                                   x:Name="Show_items_from_unimported_namespaces"
-                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_items_from_unimported_namespaces}" 
-                              Checked="Show_items_from_unimported_namespaces_CheckedChanged"       
-                              Unchecked="Show_items_from_unimported_namespaces_CheckedChanged"
-                              Indeterminate="Show_items_from_unimported_namespaces_CheckedChanged"
-                              IsThreeState="True"/>
+                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_items_from_unimported_namespaces}" />
 
                     <CheckBox x:Uid="Tab_twice_to_insert_arguments"
                                   x:Name="Tab_twice_to_insert_arguments"
-                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Tab_twice_to_insert_arguments}" 
-                              Checked="Tab_twice_to_insert_arguments_CheckedChanged"
-                              Unchecked="Tab_twice_to_insert_arguments_CheckedChanged"
-                              Indeterminate="Tab_twice_to_insert_arguments_CheckedChanged"
-                              IsThreeState="True"/>
+                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Tab_twice_to_insert_arguments}" />
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -18,8 +18,6 @@
                     <CheckBox x:Uid="Show_completion_list_after_a_character_is_typed"
                             x:Name="Show_completion_list_after_a_character_is_typed"
                             Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_typed}"
-                            Checked="Show_completion_list_after_a_character_is_typed_OnChecked"
-                            Unchecked="Show_completion_list_after_a_character_is_typed_OnUnchecked"/>
                     <StackPanel Margin="15, 0, 0, 0">
                         <CheckBox x:Uid="Show_completion_list_after_a_character_is_deleted"
                                 x:Name="Show_completion_list_after_a_character_is_deleted"

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -17,7 +17,9 @@
                 <StackPanel>
                     <CheckBox x:Uid="Show_completion_list_after_a_character_is_typed"
                             x:Name="Show_completion_list_after_a_character_is_typed"
-                            Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_typed}" />
+                            Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_typed}"
+                            Checked="Show_completion_list_after_a_character_is_typed_OnChecked"
+                            Unchecked="Show_completion_list_after_a_character_is_typed_OnUnchecked"/>
                     <StackPanel Margin="15, 0, 0, 0">
                         <CheckBox x:Uid="Show_completion_list_after_a_character_is_deleted"
                                 x:Name="Show_completion_list_after_a_character_is_deleted"

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -17,7 +17,7 @@
                 <StackPanel>
                     <CheckBox x:Uid="Show_completion_list_after_a_character_is_typed"
                             x:Name="Show_completion_list_after_a_character_is_typed"
-                            Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_typed}"
+                            Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_completion_list_after_a_character_is_typed}" />
                     <StackPanel Margin="15, 0, 0, 0">
                         <CheckBox x:Uid="Show_completion_list_after_a_character_is_deleted"
                                 x:Name="Show_completion_list_after_a_character_is_deleted"

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             InitializeComponent()
 
             BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.VisualBasic)
-            BindToOption(Show_completion_list_after_a_character_is_deleted, CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, function() True)
+            BindToOption(Show_completion_list_after_a_character_is_deleted, CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, onNullValue:=function() True)
 
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.VisualBasic)
             BindToOption(Show_completion_item_filters, CompletionViewOptionsStorage.ShowCompletionItemFilters, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -17,6 +17,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
             BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.VisualBasic)
             BindToOption(Show_completion_list_after_a_character_is_deleted, CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, function() True)
+            Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked.Value
 
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.VisualBasic)
             BindToOption(Show_completion_item_filters, CompletionViewOptionsStorage.ShowCompletionItemFilters, LanguageNames.VisualBasic)
@@ -31,6 +32,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
             BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, function() True)
             BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, function() False)
+        End Sub
+
+        Private Sub Show_completion_list_after_a_character_is_typed_OnChecked(sender As Object, e As RoutedEventArgs)
+            Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked.Value
+        End Sub
+
+        Private Sub Show_completion_list_after_a_character_is_typed_OnUnchecked(sender As Object, e As RoutedEventArgs)
+            Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked.Value
+            Show_completion_list_after_a_character_is_deleted.IsChecked = False
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -19,8 +19,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             Show_completion_list_after_a_character_is_deleted.IsChecked = Me.OptionStore.GetOption(
                 CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic) <> False
 
-            BindToOption(Show_completion_item_filters, CompletionViewOptionsStorage.ShowCompletionItemFilters, LanguageNames.VisualBasic)
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.VisualBasic)
+            BindToOption(Show_completion_item_filters, CompletionViewOptionsStorage.ShowCompletionItemFilters, LanguageNames.VisualBasic)
 
             BindToOption(Never_include_snippets, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.VisualBasic)
             BindToOption(Always_include_snippets, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.VisualBasic)
@@ -30,8 +30,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.VisualBasic)
             BindToOption(Always_add_new_line_on_enter, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.VisualBasic)
 
-            Show_items_from_unimported_namespaces.IsChecked = Me.OptionStore.GetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic)
-            Tab_twice_to_insert_arguments.IsChecked = Me.OptionStore.GetOption(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic)
+            BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, function() True)
+            BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, function() False)
         End Sub
 
         Private Sub Show_completion_list_after_a_character_is_deleted_Checked(sender As Object, e As RoutedEventArgs)
@@ -40,16 +40,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
         Private Sub Show_completion_list_after_a_character_is_deleted_Unchecked(sender As Object, e As RoutedEventArgs)
             Me.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, value:=False)
-        End Sub
-
-        Private Sub Show_items_from_unimported_namespaces_CheckedChanged(sender As Object, e As RoutedEventArgs)
-            Show_items_from_unimported_namespaces.IsThreeState = False
-            Me.OptionStore.SetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, Show_items_from_unimported_namespaces.IsChecked)
-        End Sub
-
-        Private Sub Tab_twice_to_insert_arguments_CheckedChanged(sender As Object, e As RoutedEventArgs)
-            Tab_twice_to_insert_arguments.IsThreeState = False
-            Me.OptionStore.SetOption(CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, Tab_twice_to_insert_arguments.IsChecked)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -2,7 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Windows
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options
@@ -17,7 +16,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
             BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.VisualBasic)
             BindToOption(Show_completion_list_after_a_character_is_deleted, CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, function() True)
-            Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked.Value
 
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.VisualBasic)
             BindToOption(Show_completion_item_filters, CompletionViewOptionsStorage.ShowCompletionItemFilters, LanguageNames.VisualBasic)
@@ -32,15 +30,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
             BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, function() True)
             BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, function() False)
-        End Sub
-
-        Private Sub Show_completion_list_after_a_character_is_typed_OnChecked(sender As Object, e As RoutedEventArgs)
-            Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked.Value
-        End Sub
-
-        Private Sub Show_completion_list_after_a_character_is_typed_OnUnchecked(sender As Object, e As RoutedEventArgs)
-            Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked.Value
-            Show_completion_list_after_a_character_is_deleted.IsChecked = False
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -28,8 +28,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.VisualBasic)
             BindToOption(Always_add_new_line_on_enter, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.VisualBasic)
 
-            BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, onNullValue := function() True)
-            BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, onNullValue := function() False)
+            BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, onNullValue:=function() True)
+            BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, onNullValue:=function() False)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -16,8 +16,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             InitializeComponent()
 
             BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.VisualBasic)
-            Show_completion_list_after_a_character_is_deleted.IsChecked = Me.OptionStore.GetOption(
-                CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic) <> False
+            BindToOption(Show_completion_list_after_a_character_is_deleted, CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, function() True)
 
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptionsStorage.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.VisualBasic)
             BindToOption(Show_completion_item_filters, CompletionViewOptionsStorage.ShowCompletionItemFilters, LanguageNames.VisualBasic)
@@ -32,14 +31,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
             BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, function() True)
             BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, function() False)
-        End Sub
-
-        Private Sub Show_completion_list_after_a_character_is_deleted_Checked(sender As Object, e As RoutedEventArgs)
-            Me.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, value:=True)
-        End Sub
-
-        Private Sub Show_completion_list_after_a_character_is_deleted_Unchecked(sender As Object, e As RoutedEventArgs)
-            Me.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, value:=False)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -28,8 +28,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.VisualBasic)
             BindToOption(Always_add_new_line_on_enter, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.VisualBasic)
 
-            BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, function() True)
-            BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, function() False)
+            BindToOption(Show_items_from_unimported_namespaces, CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, onNullValue := function() True)
+            BindToOption(Tab_twice_to_insert_arguments, CompletionViewOptionsStorage.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, onNullValue := function() False)
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
I am going to move the IntelliSense page to VS new Unified Settings.
Our old page would still be used because the new Unified Settings is in preview.
Before that happens, I would like to clean up our Intellisense page because it's in a strange stage now.
See my comments for detailed changes.