### PR TITLE
Disable OSX queue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -337,17 +337,19 @@ stages:
         testArguments: --testCoreClr
         poolParameters: ${{ parameters.ubuntuPool }}
 
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-    - template: eng/pipelines/test-unix-job.yml
-      parameters:
-        testRunName: 'Test macOS Debug'
-        jobName: Test_macOS_Debug
-        testArtifactName: Transport_Artifacts_Unix_Debug
-        configuration: Debug
-        testArguments: --testCoreClr 
-        helixQueueName: $(HelixMacOsQueueName)
-        helixApiAccessToken: $(HelixApiAccessToken)
-        poolParameters: ${{ parameters.ubuntuPool }}
+  # https://github.com/dotnet/runtime/issues/97186
+  # Disabled until runtime can track down the crash
+  # - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  #   - template: eng/pipelines/test-unix-job.yml
+  #     parameters:
+  #       testRunName: 'Test macOS Debug'
+  #       jobName: Test_macOS_Debug
+  #       testArtifactName: Transport_Artifacts_Unix_Debug
+  #       configuration: Debug
+  #       testArguments: --testCoreClr 
+  #       helixQueueName: $(HelixMacOsQueueName)
+  #       helixApiAccessToken: $(HelixApiAccessToken)
+  #       poolParameters: ${{ parameters.ubuntuPool }}
 
 - stage: Correctness
   dependsOn: []


### PR DESCRIPTION
The OSX queues are failing at virtually 100% right now. Shutting them down until .NET runtime makes progress on the issue.

https://github.com/dotnet/runtime/issues/97186