### PR TITLE
Change WriteEvent calls to WriteEventCore

### DIFF
--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -70,3 +70,4 @@ M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetPreviewOperationsAsync(System
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputeOperationsAsync(System.Threading.CancellationToken); Use overload that takes progress
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(CSystem.Threading.CancellationToken); Use overload that takes progress
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(CancellationToken); Use overload that takes progress
+M:System.Diagnostics.Tracing.EventSource.WriteEvent(System.Int32,System.Object[]); Use WriteEventCore instead

--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -68,6 +68,6 @@ M:Microsoft.CodeAnalysis.CodeActions.CodeActionWithOptions.GetOperationsAsync(Sy
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetOperationsAsync(System.Threading.CancellationToken); Use overload that takes a solution
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetPreviewOperationsAsync(System.Threading.CancellationToken); Use overload that takes a solution
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputeOperationsAsync(System.Threading.CancellationToken); Use overload that takes progress
-M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(System.Threading.CancellationToken); Use overload that takes progress
-M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(System.Threading.CancellationToken); Use overload that takes progress
+M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(CSystem.Threading.CancellationToken); Use overload that takes progress
+M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(CancellationToken); Use overload that takes progress
 M:System.Diagnostics.Tracing.EventSource.WriteEvent(System.Int32,System.Object[]); Use WriteEventCore instead

--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -68,6 +68,6 @@ M:Microsoft.CodeAnalysis.CodeActions.CodeActionWithOptions.GetOperationsAsync(Sy
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetOperationsAsync(System.Threading.CancellationToken); Use overload that takes a solution
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetPreviewOperationsAsync(System.Threading.CancellationToken); Use overload that takes a solution
 M:Microsoft.CodeAnalysis.CodeActions.CodeAction.ComputeOperationsAsync(System.Threading.CancellationToken); Use overload that takes progress
-M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(CSystem.Threading.CancellationToken); Use overload that takes progress
-M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(CancellationToken); Use overload that takes progress
+M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedSolutionAsync(System.Threading.CancellationToken); Use overload that takes progress
+M:Microsoft.CodeAnalysis.CodeActions.CodeAction.GetChangedDocumentAsync(System.Threading.CancellationToken); Use overload that takes progress
 M:System.Diagnostics.Tracing.EventSource.WriteEvent(System.Int32,System.Object[]); Use WriteEventCore instead

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -37,9 +37,9 @@ namespace Microsoft.CodeAnalysis
         internal void StartSingleGeneratorRunTime(string generatorName, string assemblyPath, string id) => WriteEvent(3, generatorName, assemblyPath, id);
 
         [Event(4, Message = "Generator {0} ran for {2} ticks", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.SingleGeneratorRunTime)]
-        internal void StopSingleGeneratorRunTime(string generatorName, string assemblyPath, long elapsedTicks, string id)
+        internal unsafe void StopSingleGeneratorRunTime(string generatorName, string assemblyPath, long elapsedTicks, string id)
         {
-            unsafe
+            if (IsEnabled())
             {
                 fixed (char* generatorNameBytes = generatorName)
                 fixed (char* assemblyPathBytes = assemblyPath)
@@ -65,9 +65,9 @@ namespace Microsoft.CodeAnalysis
         internal void GeneratorException(string generatorName, string exception) => WriteEvent(5, generatorName, exception);
 
         [Event(6, Message = "Node {0} transformed", Keywords = Keywords.Correctness, Level = EventLevel.Verbose, Task = Tasks.BuildStateTable)]
-        internal void NodeTransform(int nodeHashCode, string name, string tableType, int previousTable, string previousTableContent, int newTable, string newTableContent, int input1, int input2)
+        internal unsafe void NodeTransform(int nodeHashCode, string name, string tableType, int previousTable, string previousTableContent, int newTable, string newTableContent, int input1, int input2)
         {
-            unsafe
+            if (IsEnabled())
             {
                 fixed (char* nameBytes = name)
                 fixed (char* tableTypeBytes = tableType)

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         GetEventDataForString(generatorName, generatorNameBytes),
                         GetEventDataForString(assemblyPath, assemblyPathBytes),
-                        GetEventDataForLong(&elapsedTicks),
+                        GetEventDataForInt64(&elapsedTicks),
                         GetEventDataForString(id, idBytes),
                     };
 
@@ -76,15 +76,15 @@ namespace Microsoft.CodeAnalysis
                 {
                     Span<EventData> data = stackalloc EventData[]
                     {
-                        GetEventDataForInt(&nodeHashCode),
+                        GetEventDataForInt32(&nodeHashCode),
                         GetEventDataForString(name, nameBytes),
                         GetEventDataForString(tableType, tableTypeBytes),
-                        GetEventDataForInt(&previousTable),
+                        GetEventDataForInt32(&previousTable),
                         GetEventDataForString(previousTableContent, previousTableContentBytes),
-                        GetEventDataForInt(&newTable),
+                        GetEventDataForInt32(&newTable),
                         GetEventDataForString(newTableContent, newTableContentBytes),
-                        GetEventDataForInt(&input1),
-                        GetEventDataForInt(&input2),
+                        GetEventDataForInt32(&input1),
+                        GetEventDataForInt32(&input2),
                     };
 
                     fixed (EventSource.EventData* dataPtr = data)
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis
             };
         }
 
-        private static unsafe EventData GetEventDataForInt(int* ptr)
+        private static unsafe EventData GetEventDataForInt32(int* ptr)
         {
             return new EventData()
             {
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis
             };
         }
 
-        private static unsafe EventData GetEventDataForLong(long* ptr)
+        private static unsafe EventData GetEventDataForInt64(long* ptr)
         {
             return new EventData()
             {

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics.Tracing;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -38,12 +37,63 @@ namespace Microsoft.CodeAnalysis
         internal void StartSingleGeneratorRunTime(string generatorName, string assemblyPath, string id) => WriteEvent(3, generatorName, assemblyPath, id);
 
         [Event(4, Message = "Generator {0} ran for {2} ticks", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.SingleGeneratorRunTime)]
-        internal void StopSingleGeneratorRunTime(string generatorName, string assemblyPath, long elapsedTicks, string id) => WriteEvent(4, generatorName, assemblyPath, elapsedTicks, id);
+        internal void StopSingleGeneratorRunTime(string generatorName, string assemblyPath, long elapsedTicks, string id)
+        {
+            unsafe
+            {
+                fixed (char* generatorNameBytes = generatorName)
+                fixed (char* assemblyPathBytes = assemblyPath)
+                fixed (char* idBytes = id)
+                {
+                    EventSource.EventData* data = stackalloc EventSource.EventData[4];
+                    data[0].DataPointer = (IntPtr)generatorNameBytes;
+                    data[0].Size = ((generatorName.Length + 1) * 2);
+                    data[1].DataPointer = (IntPtr)assemblyPathBytes;
+                    data[1].Size = ((assemblyPath.Length + 1) * 2);
+                    data[2].DataPointer = (IntPtr)(&elapsedTicks);
+                    data[2].Size = 8;
+                    data[3].DataPointer = (IntPtr)idBytes;
+                    data[3].Size = ((id.Length + 1) * 2);
+                    WriteEventCore(4, 4, data);
+                }
+            }
+        }
 
         [Event(5, Message = "Generator '{0}' failed with exception: {1}", Level = EventLevel.Error)]
         internal void GeneratorException(string generatorName, string exception) => WriteEvent(5, generatorName, exception);
 
         [Event(6, Message = "Node {0} transformed", Keywords = Keywords.Correctness, Level = EventLevel.Verbose, Task = Tasks.BuildStateTable)]
-        internal void NodeTransform(int nodeHashCode, string name, string tableType, int previousTable, string previousTableContent, int newTable, string newTableContent, int input1, int input2) => WriteEvent(6, nodeHashCode, name, tableType, previousTable, previousTableContent, newTable, newTableContent, input1, input2);
+        internal void NodeTransform(int nodeHashCode, string name, string tableType, int previousTable, string previousTableContent, int newTable, string newTableContent, int input1, int input2)
+        {
+            unsafe
+            {
+                fixed (char* nameBytes = name)
+                fixed (char* tableTypeBytes = tableType)
+                fixed (char* previousTableContentBytes = previousTableContent)
+                fixed (char* newTableContentBytes = newTableContent)
+                {
+                    EventSource.EventData* data = stackalloc EventSource.EventData[9];
+                    data[0].DataPointer = (IntPtr)(&nodeHashCode);
+                    data[0].Size = 4;
+                    data[1].DataPointer = (IntPtr)nameBytes;
+                    data[1].Size = ((name.Length + 1) * 2);
+                    data[2].DataPointer = (IntPtr)tableTypeBytes;
+                    data[2].Size = ((tableType.Length + 1) * 2);
+                    data[3].DataPointer = (IntPtr)(&previousTable);
+                    data[3].Size = 4;
+                    data[4].DataPointer = (IntPtr)previousTableContentBytes;
+                    data[4].Size = ((previousTableContent.Length + 1) * 2);
+                    data[5].DataPointer = (IntPtr)(&newTable);
+                    data[5].Size = 4;
+                    data[6].DataPointer = (IntPtr)newTableContentBytes;
+                    data[6].Size = ((newTableContent.Length + 1) * 2);
+                    data[7].DataPointer = (IntPtr)(&input1);
+                    data[7].Size = 4;
+                    data[8].DataPointer = (IntPtr)(&input2);
+                    data[8].Size = 4;
+                    WriteEventCore(6, 9, data);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
[WriteEvent ](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventsource.writeevent?view=net-8.0#system-diagnostics-tracing-eventsource-writeevent(system-int32-system-object())) is quite inefficient in that it takes in a params array of objects, thus allocating both the array and boxing the int/long parameters passed in. Instead, WriteEventCore should be called with an appropriately populated EventSource.EventData.

Found while investigating OOP allocations in a speedometer test.

Old Memory Allocations from speedometer
![image](https://github.com/dotnet/roslyn/assets/6785178/2f0892b0-97e1-4e0f-8379-b794b1a0766d)

New Memory Allocations from speedometer
![image](https://github.com/dotnet/roslyn/assets/6785178/771a0eb5-7d3e-49d9-9c5b-4daab4db2e3a)
