### PR TITLE
Handle unconverted collection expressions in nullable analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3503,10 +3503,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitUnconvertedCollectionExpression(BoundUnconvertedCollectionExpression node)
         {
             // This method is only involved in method inference with unbound lambdas.
-            // The diagnostics on the collection expression elements are reported when
-            // the unbound lambda (and as a result, the collection expression) are converted.
+            var result = base.VisitUnconvertedCollectionExpression(node);
             SetResultType(node, TypeWithState.Create(null, NullableFlowState.NotNull));
-            return null;
+            return result;
         }
 
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3503,9 +3503,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitUnconvertedCollectionExpression(BoundUnconvertedCollectionExpression node)
         {
             // This method is only involved in method inference with unbound lambdas.
-            var result = base.VisitUnconvertedCollectionExpression(node);
+            // The diagnostics on the collection expression elements are reported when
+            // the unbound lambda (and as a result, the collection expression) are converted.
             SetResultType(node, TypeWithState.Create(null, NullableFlowState.NotNull));
-            return result;
+            return null;
         }
 
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3500,6 +3500,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode? VisitUnconvertedCollectionExpression(BoundUnconvertedCollectionExpression node)
+        {
+            // This method is only involved in method inference with unbound lambdas.
+            var result = base.VisitUnconvertedCollectionExpression(node);
+            SetResultType(node, TypeWithState.Create(null, NullableFlowState.NotNull));
+            return result;
+        }
+
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
         {
             // When the collection is target-typed, we can initially only visit the elements and update the state.

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -31126,14 +31126,22 @@ partial class Program
                     static void Main()
                     {
                         object x = new object();
-                        object[] y = new[] { x };
-                        F(y, () => [x]);
+                        object y = null;
+                        object[] z = new[] { x };
+                        F(z, () => [x]);
+                        F(z, () => [y]);
                     }
                     static void F<T>(T t, Func<T> f) { }
                 }
                 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics();
+            comp.VerifyEmitDiagnostics(
+                // (8,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         object y = null;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(8, 20),
+                // (11,21): warning CS8601: Possible null reference assignment.
+                //         F(z, () => [y]);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(11, 21));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -31116,6 +31116,27 @@ partial class Program
         }
 
         [Fact]
+        public void TypeInference_LambdaReturn()
+        {
+            var source = """
+                #nullable enable
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        object x = new object();
+                        object[] y = new[] { x };
+                        F(y, () => [x]);
+                    }
+                    static void F<T>(T t, Func<T> f) { }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
         public void TargetTypedElement_PublicAPI_List()
         {
             var source = """


### PR DESCRIPTION
Fixes assert failure hit in CI in https://github.com/dotnet/roslyn/pull/71591.