### PR TITLE
Recreate the get accessor when extracting an interface member

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -1970,5 +1970,36 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 markup,
                 expectedSuccess: false);
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
+        public async Task TestStruct4()
+        {
+            var markup =
+                """
+                namespace Test
+                {
+                    struct $$Whatever
+                    {
+                        public int I { get; set; }
+                    }
+                }
+                """;
+
+            var expectedInterfaceCode =
+                """
+                namespace Test
+                {
+                    interface IWhatever
+                    {
+                        int I { get; set; }
+                    }
+                }
+                """;
+
+            await TestExtractInterfaceCommandCSharpAsync(
+                markup,
+                expectedSuccess: true,
+                expectedInterfaceCode: expectedInterfaceCode);
+        }
     }
 }

--- a/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
+++ b/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
@@ -411,6 +411,15 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
                         break;
                     case SymbolKind.Property:
                         var property = member as IPropertySymbol;
+                        IMethodSymbol getMethod = null;
+                        var hasGetMethod = property.GetMethod != null && property.GetMethod.DeclaredAccessibility == Accessibility.Public;
+                        if (hasGetMethod)
+                        {
+                            // We recreate the get accessor because it is possible it has the readonly modifier due
+                            // to being an auto property on a struct which is invalid for an interface member
+                            getMethod = CodeGenerationSymbolFactory.CreateAccessorSymbol(property.GetMethod, property.GetMethod.GetAttributes());
+                        }
+
                         interfaceMembers.Add(CodeGenerationSymbolFactory.CreatePropertySymbol(
                             attributes: ImmutableArray<AttributeData>.Empty,
                             accessibility: Accessibility.Public,
@@ -420,7 +429,7 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
                             explicitInterfaceImplementations: default,
                             name: property.Name,
                             parameters: property.Parameters,
-                            getMethod: property.GetMethod == null ? null : (property.GetMethod.DeclaredAccessibility == Accessibility.Public ? property.GetMethod : null),
+                            getMethod: getMethod,
                             setMethod: property.SetMethod == null ? null : (property.SetMethod.DeclaredAccessibility == Accessibility.Public ? property.SetMethod : null),
                             isIndexer: property.IsIndexer));
                         break;


### PR DESCRIPTION
Closes #71640 

The issue was that when we have a struct with an auto property, it will semantically get the readonly modifier applied even if no such modifiers existed on the syntax tree (this is an intentional behavior). This created a problem when extracting an interface because the modifier isn't valid for them.

This pr addresses this by recreating the get accessor symbol when creating the property member which will remove its readonly modifier.