### PR TITLE
WIP: Reduce ImmutableArray allocations around AssemblyIdentity

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -1094,8 +1094,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 private static ImmutableArray<AssemblyIdentity> GetReferencedAssemblies(CSharpCompilation compilation)
                 {
                     // Collect information about references
-                    var result = ArrayBuilder<AssemblyIdentity>.GetInstance();
-
                     var modules = compilation.Assembly.Modules;
 
                     // Filter out linked assemblies referenced by the source module.
@@ -1103,6 +1101,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var sourceReferencedAssemblySymbols = modules[0].GetReferencedAssemblySymbols();
 
                     Debug.Assert(sourceReferencedAssemblies.Length == sourceReferencedAssemblySymbols.Length);
+
+                    // Pre-calculate size to ensure this code only requires a single array allocation.
+                    var builderSize = modules.Sum(static (module, index) =>
+                    {
+                        if (index == 0)
+                            return module.GetReferencedAssemblySymbols().Count(static identity => !identity.IsLinked);
+                        else
+                            return module.GetReferencedAssemblies().Length;
+                    });
+
+                    var result = ArrayBuilder<AssemblyIdentity>.GetInstance(builderSize);
 
                     for (int i = 0; i < sourceReferencedAssemblies.Length; i++)
                     {

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -878,6 +878,15 @@ namespace Microsoft.CodeAnalysis
             return sum;
         }
 
+        public static int Sum<T>(this ImmutableArray<T> items, Func<T, int, int> selector)
+        {
+            var sum = 0;
+            for (var i = 0; i < items.Length; i++)
+                sum += selector(items[i], i);
+
+            return sum;
+        }
+
         internal static void AddToMultiValueDictionaryBuilder<K, T>(Dictionary<K, object> accumulator, K key, T item)
             where K : notnull
             where T : notnull

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -9,14 +9,12 @@ using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -26,6 +24,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.DiaSymReader;
 using Roslyn.Utilities;
@@ -3733,8 +3732,7 @@ namespace Microsoft.CodeAnalysis
                 return ImmutableArray<AssemblyIdentity>.Empty;
             }
 
-            var builder = ArrayBuilder<AssemblyIdentity>.GetInstance();
-
+            using var builder = TemporaryArray<AssemblyIdentity>.Empty;
             foreach (var argument in diagnostic.Arguments)
             {
                 if (argument is AssemblyIdentity id)
@@ -3743,7 +3741,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            return builder.ToImmutableAndFree();
+            return builder.ToImmutableAndClear();
         }
 
         internal abstract bool IsUnreferencedAssemblyIdentityDiagnosticCode(int code);

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyDataForAssemblyBeingBuilt.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyDataForAssemblyBeingBuilt.cs
@@ -35,16 +35,19 @@ namespace Microsoft.CodeAnalysis
 
                 _referencedAssemblyData = referencedAssemblyData;
 
-                var refs = ArrayBuilder<AssemblyIdentity>.GetInstance(referencedAssemblyData.Length + modules.Length); //approximate size
+                // Pre-calculate size to ensure this code only requires a single array allocation.
+                var builderSize = referencedAssemblyData.Length + modules.Sum(static module => module.ReferencedAssemblies.Length);
+                var refs = ArrayBuilder<AssemblyIdentity>.GetInstance(builderSize);
+
                 foreach (AssemblyData data in referencedAssemblyData)
                 {
                     refs.Add(data.Identity);
                 }
 
                 // add assembly names from modules:
-                for (int i = 1; i <= modules.Length; i++)
+                for (int i = 0; i < modules.Length; i++)
                 {
-                    refs.AddRange(modules[i - 1].ReferencedAssemblies);
+                    refs.AddRange(modules[i].ReferencedAssemblies);
                 }
 
                 _referencedAssemblies = refs.ToImmutableAndFree();


### PR DESCRIPTION
Speedometer runs show fairly high OOP allocations inside AssemblyDataForCompilation.GetReferencedAssemblies. The use of ArrayBuilder is a bit problematic in this context, as these arrays are commonly larger than the 128 element limit, thus the entries are not getting placed back in the pool. Additionally, as the array size wasn't known up front, extra allocations are happening inside the immutable array to reach it's final size.

This is an potential alternative approach to https://github.com/dotnet/roslyn/pull/71783.