### PR TITLE
Load Roslyn DevKit assemblies into the default ALC

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.Loader;
 using Microsoft.CodeAnalysis.Contracts.Telemetry;
-using Microsoft.Extensions.Logging;
-using Roslyn.Utilities;
 using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
@@ -32,6 +30,15 @@ public sealed class TelemetryReporterTests : AbstractLanguageServerHostTests
     }
 
     private static string GetEventName(string name) => $"test/event/{name}";
+
+    [Fact]
+    public async Task TestVSTelemetryLoadedIntoDefaultAlc()
+    {
+        var service = await CreateReporterAsync();
+        var assembly = Assembly.GetAssembly(service.GetType());
+        Assert.Contains(AssemblyLoadContext.Default.Assemblies, a => a == assembly);
+        Assert.Contains(AssemblyLoadContext.Default.Assemblies, a => a.GetName().Name == "Microsoft.VisualStudio.Telemetry");
+    }
 
     [Fact]
     public async Task TestFault()

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -20,5 +20,5 @@ internal sealed class LanguageServerTestComposition
         => Path.Combine(AppContext.BaseDirectory, DevKitExtensionSubdirectory, DevKitAssemblyFileName);
 
     public static Task<ExportProvider> CreateExportProviderAsync(ILoggerFactory loggerFactory, bool includeDevKitComponents)
-        => ExportProviderBuilder.CreateExportProviderAsync(extensionAssemblyPaths: includeDevKitComponents ? [GetDevKitExtensionPath()] : Array.Empty<string>(), loggerFactory: loggerFactory);
+        => ExportProviderBuilder.CreateExportProviderAsync(extensionAssemblyPaths: [], devKitDependencyPath: includeDevKitComponents ? GetDevKitExtensionPath() : null, loggerFactory: loggerFactory);
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
@@ -7,14 +7,17 @@ using System.Reflection;
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis.LanguageServer.Logging;
 using Microsoft.CodeAnalysis.LanguageServer.Services;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Composition;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer;
 
 internal sealed class ExportProviderBuilder
 {
-    public static async Task<ExportProvider> CreateExportProviderAsync(IEnumerable<string> extensionAssemblyPaths, ILoggerFactory loggerFactory)
+    public static async Task<ExportProvider> CreateExportProviderAsync(IEnumerable<string> extensionAssemblyPaths, string? devKitDependencyPath, ILoggerFactory loggerFactory)
     {
         var logger = loggerFactory.CreateLogger<ExportProviderBuilder>();
 
@@ -45,6 +48,13 @@ internal sealed class ExportProviderBuilder
         {
             typeof(ExportProviderBuilder).Assembly
         };
+
+        if (devKitDependencyPath != null)
+        {
+            // Load devkit dependencies before other extensions to ensure dependencies
+            // like VS Telemetry are available from the host.
+            assemblies.AddRange(LoadDevKitAssemblies(devKitDependencyPath, logger));
+        }
 
         foreach (var extensionAssemblyPath in extensionAssemblyPaths)
         {
@@ -77,6 +87,25 @@ internal sealed class ExportProviderBuilder
         exportProvider.GetExportedValue<ServerLoggerFactory>().SetFactory(loggerFactory);
 
         return exportProvider;
+    }
+
+    private static ImmutableArray<Assembly> LoadDevKitAssemblies(string devKitDependencyPath, ILogger logger)
+    {
+        var directoryName = Path.GetDirectoryName(devKitDependencyPath);
+        Contract.ThrowIfNull(directoryName);
+        logger.LogTrace("Loading DevKit assemblies from {directory}", directoryName);
+
+        var directory = new DirectoryInfo(directoryName);
+        using var _ = ArrayBuilder<Assembly>.GetInstance(out var builder);
+        foreach (var file in directory.GetFiles("*.dll"))
+        {
+            logger.LogTrace("Loading {assemblyName}", file.Name);
+            // DevKit assemblies are loaded into the default load context. This allows extensions
+            // to share the host's instance of these assemblies as long as they do not ship their own copy.
+            builder.Add(AssemblyLoadContext.Default.LoadFromAssemblyPath(file.FullName));
+        }
+
+        return builder.ToImmutable();
     }
 
     private static void ThrowOnUnexpectedErrors(CompositionConfiguration configuration, ILogger logger)

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -76,7 +76,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
 
     logger.LogTrace($".NET Runtime Version: {RuntimeInformation.FrameworkDescription}");
 
-    using var exportProvider = await ExportProviderBuilder.CreateExportProviderAsync(serverConfiguration.ExtensionAssemblyPaths, loggerFactory);
+    using var exportProvider = await ExportProviderBuilder.CreateExportProviderAsync(serverConfiguration.ExtensionAssemblyPaths, serverConfiguration.DevKitDependencyPath, loggerFactory);
 
     // The log file directory passed to us by VSCode might not exist yet, though its parent directory is guaranteed to exist.
     Directory.CreateDirectory(serverConfiguration.ExtensionLogDirectory);
@@ -179,9 +179,15 @@ static CliRootCommand CreateCommandLineParser()
         Required = false
     };
 
-    var extensionAssemblyPathsOption = new CliOption<string[]?>("--extension", "--extensions") // TODO: remove plural form
+    var extensionAssemblyPathsOption = new CliOption<string[]?>("--extension")
     {
         Description = "Full paths of extension assemblies to load (optional).",
+        Required = false
+    };
+
+    var devKitDependencyPathOption = new CliOption<string?>("--devKitDependencyPath")
+    {
+        Description = "Full path to the Roslyn dependency used with DevKit (optional).",
         Required = false
     };
 
@@ -194,6 +200,7 @@ static CliRootCommand CreateCommandLineParser()
         telemetryLevelOption,
         sessionIdOption,
         extensionAssemblyPathsOption,
+        devKitDependencyPathOption,
         extensionLogDirectoryOption
     };
     rootCommand.SetAction((parseResult, cancellationToken) =>
@@ -204,6 +211,7 @@ static CliRootCommand CreateCommandLineParser()
         var telemetryLevel = parseResult.GetValue(telemetryLevelOption);
         var sessionId = parseResult.GetValue(sessionIdOption);
         var extensionAssemblyPaths = parseResult.GetValue(extensionAssemblyPathsOption) ?? Array.Empty<string>();
+        var devKitDependencyPath = parseResult.GetValue(devKitDependencyPathOption);
         var extensionLogDirectory = parseResult.GetValue(extensionLogDirectoryOption)!;
 
         var serverConfiguration = new ServerConfiguration(
@@ -213,6 +221,7 @@ static CliRootCommand CreateCommandLineParser()
             TelemetryLevel: telemetryLevel,
             SessionId: sessionId,
             ExtensionAssemblyPaths: extensionAssemblyPaths,
+            DevKitDependencyPath: devKitDependencyPath,
             ExtensionLogDirectory: extensionLogDirectory);
 
         return RunAsync(serverConfiguration, cancellationToken);

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
@@ -35,7 +35,7 @@ internal class ServerConfigurationFactory
         // Update any other global options based on the configuration the server was started with.
 
         // Check if the devkit extension is included to see if devkit is enabled.
-        var isDevkitEnabled = serverConfiguration.ExtensionAssemblyPaths.Any(path => Path.GetFileName(path) == "Microsoft.VisualStudio.LanguageServices.DevKit.dll");
+        var isDevkitEnabled = serverConfiguration.DevKitDependencyPath != null;
         // Set the standalone option so other features know whether devkit is running.
         _globalOptionService.SetGlobalOption(LspOptionsStorage.LspUsingDevkitFeatures, isDevkitEnabled);
     }
@@ -48,4 +48,5 @@ internal record class ServerConfiguration(
     string? TelemetryLevel,
     string? SessionId,
     IEnumerable<string> ExtensionAssemblyPaths,
+    string? DevKitDependencyPath,
     string ExtensionLogDirectory);


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/71101

This allows extensions to use the host instance of an assembly if they do not ship their own copy.  This did not work previously because the Roslyn DevKit assemblies were loaded into a separate ALC.  Now that we ship devkit assemblies in the extension alongside the server, it is safe to load them in the default ALC.

For example, an extension can now access the same instance of VS telemetry that the host has created (and use its telemetry session).
<img width="521" alt="Untitled" src="https://github.com/dotnet/roslyn/assets/5749229/12ffeeb7-0a0d-4763-9073-62876d19bdd4">

Requires client side PR https://github.com/dotnet/vscode-csharp/pull/6831
