### PR TITLE
Make dynamic nullable if its type was annotated to be nullable when generating its type syntax

### DIFF
--- a/src/Features/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/Features/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -148,6 +148,41 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementAbstractClass
                 """);
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70623")]
+        public async Task TestMethodWithNullableDynamic()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                abstract class Base
+                {
+                    public abstract dynamic? M(dynamic? arg);
+                }
+
+                class [|Program|] : Base
+                {
+                }
+                """,
+                """
+                abstract class Base
+                {
+                    public abstract dynamic? M(dynamic? arg);
+                }
+
+                class Program : Base
+                {
+                    public override dynamic? M(dynamic? arg)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """,
+                compilationOptions: new CSharpCompilationOptions
+                (
+                    OutputKind.DynamicallyLinkedLibrary,
+                    nullableContextOptions: NullableContextOptions.Enable
+                ));
+        }
+
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543234")]
         public async Task TestNotAvailableForStruct()
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
@@ -108,7 +108,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             public override TypeSyntax VisitDynamicType(IDynamicTypeSymbol symbol)
-                => AddInformationTo(SyntaxFactory.IdentifierName("dynamic"), symbol);
+            {
+                var typeSyntax = SyntaxFactory.IdentifierName("dynamic");
+                return symbol.NullableAnnotation is NullableAnnotation.Annotated
+                    ? AddInformationTo(SyntaxFactory.NullableType(typeSyntax), symbol)
+                    : AddInformationTo(typeSyntax, symbol);
+            }
 
             public static bool TryCreateNativeIntegerType(INamedTypeSymbol symbol, [NotNullWhen(true)] out TypeSyntax? syntax)
             {


### PR DESCRIPTION
Closes #70623

The issue turned out to be surprisingly deep, but there simply wasn't support for the TypeSyntaxGenerator to have a dynamic? generated when the annotation indicates nullability.

This pr makes it nullable using the same conditions than the NamedType one.
