### PR TITLE
Add strong contract assertion about project syncing

### DIFF
--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -31,7 +31,7 @@ internal abstract class AbstractAssetProvider
 
         using var _ = ArrayBuilder<ProjectInfo>.GetInstance(solutionChecksums.Projects.Length, out var projects);
         foreach (var (projectChecksum, projectId) in solutionChecksums.Projects)
-            projects.AddIfNotNull(await CreateProjectInfoAsync(projectId, projectChecksum, cancellationToken).ConfigureAwait(false));
+            projects.Add(await CreateProjectInfoAsync(projectId, projectChecksum, cancellationToken).ConfigureAwait(false));
 
         var analyzerReferences = await CreateCollectionAsync<AnalyzerReference>(AssetHint.None, solutionChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false);
 
@@ -39,18 +39,13 @@ internal abstract class AbstractAssetProvider
             solutionAttributes.Id, solutionAttributes.Version, solutionAttributes.FilePath, projects.ToImmutableAndClear(), analyzerReferences).WithTelemetryId(solutionAttributes.TelemetryId);
     }
 
-    public async Task<ProjectInfo?> CreateProjectInfoAsync(ProjectId projectId, Checksum projectChecksum, CancellationToken cancellationToken)
+    public async Task<ProjectInfo> CreateProjectInfoAsync(ProjectId projectId, Checksum projectChecksum, CancellationToken cancellationToken)
     {
         var projectChecksums = await GetAssetAsync<ProjectStateChecksums>(assetHint: projectId, projectChecksum, cancellationToken).ConfigureAwait(false);
         Contract.ThrowIfFalse(projectId == projectChecksums.ProjectId);
 
         var attributes = await GetAssetAsync<ProjectInfo.ProjectAttributes>(assetHint: projectId, projectChecksums.Info, cancellationToken).ConfigureAwait(false);
-        if (!RemoteSupportedLanguages.IsSupported(attributes.Language))
-        {
-            // only add project our workspace supports. 
-            // workspace doesn't allow creating project with unknown languages
-            return null;
-        }
+        Contract.ThrowIfFalse(RemoteSupportedLanguages.IsSupported(attributes.Language));
 
         var compilationOptions = attributes.FixUpCompilationOptions(
             await GetAssetAsync<CompilationOptions>(assetHint: projectId, projectChecksums.CompilationOptions, cancellationToken).ConfigureAwait(false));

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -140,13 +140,6 @@ namespace Microsoft.CodeAnalysis.Remote
                     if (!oldMap.ContainsKey(projectId))
                     {
                         var projectInfo = await _assetProvider.CreateProjectInfoAsync(projectId, newProjectChecksums.Checksum, cancellationToken).ConfigureAwait(false);
-                        if (projectInfo == null)
-                        {
-                            // this project is not supported in OOP
-                            continue;
-                        }
-
-                        // we have new project added
                         solution = solution.AddProject(projectInfo);
                     }
                 }


### PR DESCRIPTION
We only ever sync C#/VB over to OOP.  So it should not be possible to get a null project.