### PR TITLE
Change an ApplyChangeToWorkspace overload to remove some async

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspace.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspace.cs
@@ -67,7 +67,6 @@ internal class LanguageServerWorkspace : Workspace, ILspWorkspace
             _ =>
             {
                 this.OnDocumentTextChanged(documentId, sourceText, PreservationMode.PreserveIdentity, requireDocumentPresent: false);
-                return ValueTask.CompletedTask;
             },
             cancellationToken);
     }
@@ -78,7 +77,6 @@ internal class LanguageServerWorkspace : Workspace, ILspWorkspace
             _ =>
             {
                 this.OnDocumentOpened(documentId, textContainer, isCurrentContext, requireDocumentPresentAndClosed: false);
-                return ValueTask.CompletedTask;
             },
             cancellationToken);
     }
@@ -86,7 +84,7 @@ internal class LanguageServerWorkspace : Workspace, ILspWorkspace
     internal override ValueTask TryOnDocumentClosedAsync(DocumentId documentId, CancellationToken cancellationToken)
     {
         return this.ProjectSystemProjectFactory.ApplyChangeToWorkspaceAsync(
-            async w =>
+            w =>
             {
                 // TODO(cyrusn): This only works for normal documents currently.  We'll have to rethink how things work
                 // in the world if we ever support additionalfiles/editorconfig in our language server.
@@ -100,7 +98,9 @@ internal class LanguageServerWorkspace : Workspace, ILspWorkspace
                         // Dynamic files don't exist on disk so if we were to use the FileTextLoader we'd effectively be emptying out the document.
                         // We also assume they're not user editable, and hence can't have "unsaved" changes that are expected to go away on close.
                         // Instead we just maintain their current state as per the LSP view of the world.
-                        var documentText = await document.GetTextAsync(cancellationToken);
+
+                        // Since we know this is a dynamic file, the text is held in memory so GetTextSynchronously is safe to call.
+                        var documentText = document.GetTextSynchronously(cancellationToken);
                         loader = new SourceTextLoader(documentText, filePath);
                     }
                     else

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
@@ -75,7 +75,6 @@ internal sealed class LanguageServerWorkspaceFactory
         await ProjectSystemProjectFactory.ApplyChangeToWorkspaceAsync(w =>
         {
             w.SetCurrentSolution(s => s.WithAnalyzerReferences(references), WorkspaceChangeKind.SolutionChanged);
-            return ValueTask.CompletedTask;
         });
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -113,10 +113,12 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
                 compilationOptions: creationInfo.CompilationOptions,
                 parseOptions: creationInfo.ParseOptions);
 
-            await ApplyChangeToWorkspaceAsync(async w =>
+            await ApplyChangeToWorkspaceAsync(w =>
             {
-                await w.SetCurrentSolutionAsync(
-                    useAsync: true,
+                // We call the synchronous SetCurrentSolution which is fine here since we've already acquired our outer lock so this will
+                // never block. But once we remove the ProjectSystemProjectFactory lock in favor of everybody calling the newer overloads of
+                // SetCurrentSolution, this should become async again.
+                w.SetCurrentSolution(
                     oldSolution =>
                     {
                         // If we don't have any projects and this is our first project being added, then we'll create a
@@ -148,8 +150,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
                             : (WorkspaceChangeKind.ProjectAdded, projectId, documentId: null);
                     },
                     onBeforeUpdate: null,
-                    onAfterUpdate: null,
-                    CancellationToken.None).ConfigureAwait(false);
+                    onAfterUpdate: null);
             }).ConfigureAwait(false);
 
             return project;
@@ -195,11 +196,11 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
         /// <summary>
         /// Applies a single operation to the workspace. <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
         /// </summary>
-        public async ValueTask ApplyChangeToWorkspaceAsync(Func<Workspace, ValueTask> action, CancellationToken cancellationToken = default)
+        public async ValueTask ApplyChangeToWorkspaceAsync(Action<Workspace> action, CancellationToken cancellationToken = default)
         {
             using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                await action(Workspace).ConfigureAwait(false);
+                action(Workspace);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis
         /// updated by <paramref name="transformation"/> to be passed to the workspace change event.</param>
         /// <returns>True if <see cref="CurrentSolution"/> was set to the transformed solution, false if the
         /// transformation did not change the solution.</returns>
-        private protected (bool updated, Solution newSolution) SetCurrentSolution(
+        internal (bool updated, Solution newSolution) SetCurrentSolution(
             Func<Solution, Solution> transformation,
             Func<Solution, Solution, (WorkspaceChangeKind changeKind, ProjectId? projectId, DocumentId? documentId)> changeKind,
             Action<Solution, Solution>? onBeforeUpdate = null,


### PR DESCRIPTION
We had an ApplyChangeToWorkspace overload that besides being async for acquiring the lock, also allowed async work underneath it. This can lead to a temptation to do JTF things (like thread switches) while holding the lock which is not a good idea; the lock is not JTF friendly and also taking thread switchs while you hold the global lock could easily stall solution load.

It turns out that nothing actually needed the inner thing being async: the only two places it was async was to acquire another lock (which would have always succeeded) or to fetch some text in an edge case, also which would have always completed synchronously. So we can easily change this signature.

Hat tip to @davkean for the suggestion here.