### PR TITLE
Allow the Invert If refactor if the parent statement is a global one

### DIFF
--- a/src/Features/CSharp/Portable/InvertIf/CSharpInvertIfCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InvertIf/CSharpInvertIfCodeRefactoringProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InvertIf
             => ifNode.Else == null;
 
         protected override bool CanInvert(IfStatementSyntax ifNode)
-            => ifNode?.Parent is (kind: SyntaxKind.Block or SyntaxKind.SwitchSection);
+            => ifNode?.Parent is (kind: SyntaxKind.Block or SyntaxKind.SwitchSection or SyntaxKind.GlobalStatement);
 
         protected override SyntaxNode GetCondition(IfStatementSyntax ifNode)
             => ifNode.Condition;


### PR DESCRIPTION
Closes #71424 

This is pretty straight forward: the parent statement wasn't allows to be a global one for the refactor to be available so this pr amends this.