### PR TITLE
Rename Tools/Options inline hint settings

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsFormatDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsFormatDefinition.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
             public InlineHintsFormatDefinition()
             {
-                this.DisplayName = EditorFeaturesResources.Inline_Hints;
+                this.DisplayName = EditorFeaturesResources.Inlay_Hints;
                 this.ForegroundBrush = new SolidColorBrush(Color.FromRgb(104, 104, 104));
                 this.BackgroundBrush = new SolidColorBrush(Color.FromRgb(230, 230, 230));
             }

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -771,8 +771,8 @@ Do you want to proceed?</value>
   <data name="external" xml:space="preserve">
     <value>(external)</value>
   </data>
-  <data name="Inline_Hints" xml:space="preserve">
-    <value>Inline Hints</value>
+  <data name="Inlay_Hints" xml:space="preserve">
+    <value>Inlay Hints</value>
   </data>
   <data name="User_Types_Records" xml:space="preserve">
     <value>User Types - Records</value>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Velikost odsazení</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Vložená diagnostika – Chyba</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Vložená diagnostika – Upozornění</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Vložené nápovědy</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Einzugsgröße</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Inline-Diagnose – Fehler</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Inline-Diagnose – Warnung</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Inlinehinweise</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Tamaño de sangría</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Diagnósticos integrados: error</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Diagnóstico integrado: advertencia</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Sugerencias insertadas</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Taille de la mise en retrait</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Diagnostics en ligne – Erreur</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Diagnostics en ligne – Avertissement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Indicateurs inline</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Dimensione rientro</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Diagnostica inline - Errore</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Diagnostica inline - Avviso</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Suggerimenti inline</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -112,6 +112,11 @@
         <target state="translated">インデントのサイズ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">インライン診断 - エラー</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">インライン診断 - 警告</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">インラインのヒント</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -112,6 +112,11 @@
         <target state="translated">들여쓰기 크기</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">인라인 진단 - 오류</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">인라인 진단 - 경고</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">인라인 힌트</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Rozmiar wcięcia</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Diagnostyka w tekście — błąd</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Diagnostyka w tekście — ostrzeżenie</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Wskazówki w tekście</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Tamanho do Recuo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Diagnóstico em linha - Erro</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Diagnóstico em linha - Aviso</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Dicas Embutidas</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Размер отступа</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Встроенная диагностика — ошибка</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Встроенная диагностика — предупреждение</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Встроенные подсказки</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -112,6 +112,11 @@
         <target state="translated">Girintileme Boyutu</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">Satır İçi Tanılama - Hata</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">Satır İçi Tanılama - Uyarı</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Satır İçi İpuçları</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -112,6 +112,11 @@
         <target state="translated">缩进大小</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">内联诊断 - 错误</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">内联诊断 - 警告</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">内联提示</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -112,6 +112,11 @@
         <target state="translated">縮排大小</target>
         <note />
       </trans-unit>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Diagnostics_Error">
         <source>Inline Diagnostics - Error</source>
         <target state="translated">內嵌診斷 - 錯誤</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Inline_Diagnostics_Warning">
         <source>Inline Diagnostics - Warning</source>
         <target state="translated">內嵌診斷 - 警告</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">內嵌提示</target>
         <note />
       </trans-unit>
       <trans-unit id="Insert_Final_Newline">

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -318,7 +318,7 @@
             </GroupBox>
 
             <GroupBox x:Uid="InlineHintsGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Inline_Hints}">
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Inlay_Hints}">
                 <StackPanel>
                     <CheckBox x:Name="DisplayAllHintsWhilePressingAltF1"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_all_hints_while_pressing_Alt_F1}" />
@@ -327,7 +327,7 @@
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Color_hints}" />
 
                     <CheckBox x:Name="DisplayInlineParameterNameHints"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inline_parameter_name_hints}"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inlay_parameter_name_hints}"
                               Checked="DisplayInlineParameterNameHints_Checked"
                               Unchecked="DisplayInlineParameterNameHints_Unchecked"/>
 
@@ -362,7 +362,7 @@
                     </StackPanel>
                     
                     <CheckBox x:Name="DisplayInlineTypeHints"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inline_type_hints}"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Display_inlay_type_hints}"
                               Checked="DisplayInlineTypeHints_Checked"
                               Unchecked="DisplayInlineTypeHints_Unchecked"/>
                     <StackPanel Margin="15, 0, 0, 0">

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -81,8 +81,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_analyze_source_generated_files
             => ServicesVSResources.Analyze_source_generated_files;
 
-        public static string Option_Inline_Hints
-            => ServicesVSResources.Inline_Hints;
+        public static string Option_Inlay_Hints
+            => ServicesVSResources.Inlay_Hints;
 
         public static string Option_Display_all_hints_while_pressing_Alt_F1
             => ServicesVSResources.Display_all_hints_while_pressing_Alt_F1;
@@ -90,8 +90,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_Color_hints
             => ServicesVSResources.Color_hints;
 
-        public static string Option_Display_inline_parameter_name_hints
-            => ServicesVSResources.Display_inline_parameter_name_hints;
+        public static string Option_Display_inlay_parameter_name_hints
+            => ServicesVSResources.Display_inlay_parameter_name_hints;
 
         public static string Option_Show_hints_for_literals
             => ServicesVSResources.Show_hints_for_literals;
@@ -114,8 +114,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_Suppress_hints_when_argument_matches_parameter_name
             => ServicesVSResources.Suppress_hints_when_argument_matches_parameter_name;
 
-        public static string Option_Display_inline_type_hints
-            => ServicesVSResources.Display_inline_type_hints;
+        public static string Option_Display_inlay_type_hints
+            => ServicesVSResources.Display_inlay_type_hints;
 
         public static string Option_Show_hints_for_variables_with_inferred_types
             => ServicesVSResources.Show_hints_for_variables_with_inferred_types;

--- a/src/VisualStudio/CSharp/Impl/VSPackage.resx
+++ b/src/VisualStudio/CSharp/Impl/VSPackage.resx
@@ -144,6 +144,7 @@
   <data name="306" xml:space="preserve">
     <value>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.cs.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Podtrhnout znovu přiřazené proměnné;
+        <target state="needs-review-translation">Podtrhnout znovu přiřazené proměnné;
 Zobrazovat vložené nápovědy;
 Zobrazit diagnostiku pro zavřené soubory;
 Vybarvit regulární výraz;

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.de.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Neu zugewiesene Variablen unterstreichen;
+        <target state="needs-review-translation">Neu zugewiesene Variablen unterstreichen;
 Inlinehinweise anzeigen;
 Diagnoseinformationen für geschlossene Dateien anzeigen;
 Reguläre Ausdrücke farbig hervorheben;

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.es.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Subrayar variables reasignadas;
+        <target state="needs-review-translation">Subrayar variables reasignadas;
 Mostrar sugerencias insertadas;
 Mostrar diagnóstico para archivos cerrados;
 Colorear expresión regular; 

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.fr.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Souligner les variables réaffectées ;
+        <target state="needs-review-translation">Souligner les variables réaffectées ;
 Afficher les indications en ligne ;
 Afficher les diagnostics pour les fichiers fermés ;
 Coloriser les expressions régulières ;

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.it.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Sottolinea variabili riassegnate;
+        <target state="needs-review-translation">Sottolinea variabili riassegnate;
 Visualizza suggerimenti inline;
 Mostra diagnostica per i file chiusi;
 Colora espressione regolare; 

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ja.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">再割り当てされた変数に下線を引く; 
+        <target state="needs-review-translation">再割り当てされた変数に下線を引く; 
 インラインのヒントを表示する; 
 閉じているファイルの診断結果を表示する; 
 正規表現をカラー化する; 

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ko.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">다시 할당된 변수에 밑줄 긋기;
+        <target state="needs-review-translation">다시 할당된 변수에 밑줄 긋기;
 인라인 힌트 표시;
 닫힌 파일에 대한 진단 표시;
 정규식 색 지정; 

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pl.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Podkreślaj ponownie przypisane zmienne;
+        <target state="needs-review-translation">Podkreślaj ponownie przypisane zmienne;
 Wyświetlaj wskazówki w tekście;
 Pokaż dane diagnostyczne dla zamkniętych plików;
 Koloruj wyrażenia regularne; 

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pt-BR.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Sublinhar variáveis ​​reatribuídas;
+        <target state="needs-review-translation">Sublinhar variáveis ​​reatribuídas;
 Exibir dicas embutidas;
 Mostrar diagnósticos para arquivos fechados;
 Colorizar expressões regulares; 

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ru.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Подчеркивать переназначенные переменные;
+        <target state="needs-review-translation">Подчеркивать переназначенные переменные;
 Показывать встроенные подсказки;
 Показывать диагностику для закрытых файлов;
 Выделять регулярные выражения цветом;

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.tr.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">Yeniden atanan değişkenlerin altını çiz;
+        <target state="needs-review-translation">Yeniden atanan değişkenlerin altını çiz;
 Satır içi ipuçlarını görüntüleme;
 Kapatılan dosyalara ilişkin tanılamaları göster;
 Normal ifadeyi renklendir; 

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hans.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">为重新分配的变量添加下划线；
+        <target state="needs-review-translation">为重新分配的变量添加下划线；
 显示内联提示；
 显示已关闭文件的诊断；
 对正则表达式着色；

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hant.xlf
@@ -35,6 +35,7 @@
       <trans-unit id="306">
         <source>Underline reassigned variables;
 Display inline hints;
+Display inlay hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 
@@ -94,7 +95,7 @@ Detect and offer editor features for JSON strings;
 Use enhanced colors;
 Editor Color Scheme;
 Inheritance Margin;</source>
-        <target state="translated">為重新指派的變數加上底線;
+        <target state="needs-review-translation">為重新指派的變數加上底線;
 顯示內嵌提示;
 顯示已關閉檔案的診斷;
 為規則運算式上色; 

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1373,8 +1373,8 @@ Additional information: {1}</value>
   <data name="Warning_colon_type_does_not_bind" xml:space="preserve">
     <value>Warning: type does not bind</value>
   </data>
-  <data name="Display_inline_parameter_name_hints" xml:space="preserve">
-    <value>Disp_lay inline parameter name hints</value>
+  <data name="Display_inlay_parameter_name_hints" xml:space="preserve">
+    <value>Disp_lay inlay parameter name hints</value>
   </data>
   <data name="Current_parameter" xml:space="preserve">
     <value>Current parameter</value>
@@ -1407,8 +1407,8 @@ Additional information: {1}</value>
   <data name="Comments" xml:space="preserve">
     <value>Comments</value>
   </data>
-  <data name="Inline_Hints" xml:space="preserve">
-    <value>Inline Hints</value>
+  <data name="Inlay_Hints" xml:space="preserve">
+    <value>Inlay Hints</value>
   </data>
   <data name="Show_hints_for_everything_else" xml:space="preserve">
     <value>Show hints for everything else</value>
@@ -1422,8 +1422,8 @@ Additional information: {1}</value>
   <data name="Suppress_hints_when_parameter_names_differ_only_by_suffix" xml:space="preserve">
     <value>Suppress hints when parameter names differ only by suffix</value>
   </data>
-  <data name="Display_inline_type_hints" xml:space="preserve">
-    <value>Display inline type hints</value>
+  <data name="Display_inlay_type_hints" xml:space="preserve">
+    <value>Display inlay type hints</value>
   </data>
   <data name="Show_hints_for_lambda_parameter_types" xml:space="preserve">
     <value>Show hints for lambda parameter types</value>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Zobrazit vloženou diagnostiku (experimentální)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">Zobrazovat nápovědy k názvům v_ložených parametrů</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Zobrazovat vložené nápovědy k typům</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Zděděná rozhraní</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Vložené nápovědy</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Diagnose inline anzeigen (experimentell)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">Hinweise zu In_lineparameternamen anzeigen</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Inlinetyphinweise anzeigen</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Geerbte Schnittstelle</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Inlinehinweise</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Mostrar diagnósticos incorporados (experimental)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">_Mostrar sugerencias de nombre de parámetro insertadas</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Mostrar sugerencias de tipo insertado</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Interfaces heredadas</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Sugerencias insertadas</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Afficher les diagnostics en ligne (expérimental)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">Affic_her les indicateurs de noms de paramètres inline</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Afficher les indicateurs de type inline</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Interfaces héritées</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Indicateurs inline</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Visualizza diagnostica inline (sperimentale)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">Visua_lizza suggerimenti per i nomi di parametro inline</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Visualizza suggerimenti di tipo inline</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Interfacce ereditate</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Suggerimenti inline</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -357,14 +357,14 @@
         <target state="translated">診断をインラインで表示する (試験的)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">インライン パラメーター名のヒントを表示する(_L)</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">インライン型のヒントを表示する</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">継承されたインターフェイス</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">インラインのヒント</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -357,14 +357,14 @@
         <target state="translated">진단 인라인 표시(실험적)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">인라인 매개 변수 이름 힌트 표시(_L)</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">인라인 유형 힌트 표시</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">상속된 인터페이스</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">인라인 힌트</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Wyświetl diagnostykę w tekście (eksperymentalne)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">Wyś_wietl wskazówki w tekście dla nazw parametrów</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Wyświetl wskazówki w tekście dla typów</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Dziedziczone interfejsy</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Wskazówki w tekście</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Exibir diagnósticos em linha (experimental)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">Exi_bir as dicas embutidas de nome de parâmetro</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Exibir as dicas embutidas de tipo</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Interfaces herdadas</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Dicas Embutidas</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Отображать встроенную диагностику (экспериментальная функция)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">Отображать п_одсказки для имен встроенных параметров</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Отображать подсказки для встроенных типов</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Унаследованные интерфейсы</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Встроенные подсказки</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -357,14 +357,14 @@
         <target state="translated">Tanılamayı satır içi görüntüle (deneysel)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">Satır içi parametre adı ipuç_larını göster</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">Satır içi tür ipuçlarını göster</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">Devralınan arabirimler</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">Satır İçi İpuçları</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -357,14 +357,14 @@
         <target state="translated">内联显示诊断(实验性)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">显示内联参数名称提示(_L)</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">显示内联类型提示</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">继承的接口</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">内联提示</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -357,14 +357,14 @@
         <target state="translated">顯示內嵌診斷 (實驗性)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_parameter_name_hints">
-        <source>Disp_lay inline parameter name hints</source>
-        <target state="translated">顯示內嵌參數名稱提示(_L)</target>
+      <trans-unit id="Display_inlay_parameter_name_hints">
+        <source>Disp_lay inlay parameter name hints</source>
+        <target state="new">Disp_lay inlay parameter name hints</target>
         <note />
       </trans-unit>
-      <trans-unit id="Display_inline_type_hints">
-        <source>Display inline type hints</source>
-        <target state="translated">顯示內嵌類型提示</target>
+      <trans-unit id="Display_inlay_type_hints">
+        <source>Display inlay type hints</source>
+        <target state="new">Display inlay type hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Document_Outline">
@@ -577,9 +577,9 @@
         <target state="translated">繼承介面</target>
         <note />
       </trans-unit>
-      <trans-unit id="Inline_Hints">
-        <source>Inline Hints</source>
-        <target state="translated">內嵌提示</target>
+      <trans-unit id="Inlay_Hints">
+        <source>Inlay Hints</source>
+        <target state="new">Inlay Hints</target>
         <note />
       </trans-unit>
       <trans-unit id="Inserting_call_site_value_0">

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -92,10 +92,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             ServicesVSResources.Color_hints
 
         Public ReadOnly Property Option_Inline_Hints As String =
-            ServicesVSResources.Inline_Hints
+            ServicesVSResources.Inlay_Hints
 
         Public ReadOnly Property Option_Display_inline_parameter_name_hints As String =
-            ServicesVSResources.Display_inline_parameter_name_hints
+            ServicesVSResources.Display_inlay_parameter_name_hints
 
         Public ReadOnly Property Option_Show_hints_for_literals As String =
             ServicesVSResources.Show_hints_for_literals

--- a/src/VisualStudio/VisualBasic/Impl/VSPackage.resx
+++ b/src/VisualStudio/VisualBasic/Impl/VSPackage.resx
@@ -128,7 +128,7 @@
     <value>Visual Basic Editor</value>
   </data>
   <data name="10160" xml:space="preserve">
-    <value>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+    <value>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.cs.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.cs.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Podtrhnout znovu přiřazené proměnné;Zobrazovat vložené nápovědy;Automatické vložení koncových konstruktorů;Změnit nastavení přehledného výpisu;Změnit režim sbalení;Automatické vkládání členů Interface a MustOverride;Zobrazit nebo skrýt oddělovače řádků procedur;Zapnout nebo vypnout návrhy oprav chyb;Zapnout nebo vypnout zvýrazňování odkazů a klíčových slov;
+        <target state="needs-review-translation">Podtrhnout znovu přiřazené proměnné;Zobrazovat vložené nápovědy;Automatické vložení koncových konstruktorů;Změnit nastavení přehledného výpisu;Změnit režim sbalení;Automatické vkládání členů Interface a MustOverride;Zobrazit nebo skrýt oddělovače řádků procedur;Zapnout nebo vypnout návrhy oprav chyb;Zapnout nebo vypnout zvýrazňování odkazů a klíčových slov;
 Regex;
 regulární výrazy;
 související komponenty pod kurzorem;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.de.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.de.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Neu zugewiesene Variablen unterstreichen;Inlinehinweise anzeigen;Automatisches Einfügen von Endkonstrukten;Einstellungen für ziemliche Auflistung ändern;Gliederungsmodus ändern;Automatisches Einfügen von Schnittstellen- und MustOverride-Membern;Prozedurzeilentrennzeichen ein- oder ausblenden;Fehlerkorrekturvorschläge aktivieren oder deaktivieren;Aktivieren oder Deaktivieren der Hervorhebung von Verweisen und Schlüsselwörtern;
+        <target state="needs-review-translation">Neu zugewiesene Variablen unterstreichen;Inlinehinweise anzeigen;Automatisches Einfügen von Endkonstrukten;Einstellungen für ziemliche Auflistung ändern;Gliederungsmodus ändern;Automatisches Einfügen von Schnittstellen- und MustOverride-Membern;Prozedurzeilentrennzeichen ein- oder ausblenden;Fehlerkorrekturvorschläge aktivieren oder deaktivieren;Aktivieren oder Deaktivieren der Hervorhebung von Verweisen und Schlüsselwörtern;
 Regex;
 reguläre Ausdrücke;
 zugehörigen Komponenten unter dem Cursor;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.es.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.es.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Subrayar variables reasignadas;Mostrar sugerencias alineadas;Insertar automáticamente las construcciones finales;Cambiar configuración de la lista descriptiva;Cambiar el modo de esquematización;Inserción automática de miembros Interface y MustOverride; Mostrar u ocultar separadores de línea de procedimiento;Activar o desactivar las sugerencias de corrección de errores; Activar o desactivar el resaltado de referencias y palabras clave;
+        <target state="needs-review-translation">Subrayar variables reasignadas;Mostrar sugerencias alineadas;Insertar automáticamente las construcciones finales;Cambiar configuración de la lista descriptiva;Cambiar el modo de esquematización;Inserción automática de miembros Interface y MustOverride; Mostrar u ocultar separadores de línea de procedimiento;Activar o desactivar las sugerencias de corrección de errores; Activar o desactivar el resaltado de referencias y palabras clave;
 Expresión regular;
 expresiones regulares;
 componentes relacionados bajo el cursor;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.fr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.fr.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Souligner les variables réaffectées;Afficher les indicateurs inline; Insertion automatique des constructions de fin ; Modifier les paramètres de liste de création de listes ; Modifier le mode plan ; Insertion automatique des membres Interface et MustOverride ; Afficher ou masquer les séparateurs de ligne de procédure ; Activer ou désactiver les suggestions de correction d’erreur ; Activer ou désactiver la mise en surbrillance des références et des mots clés ;
+        <target state="needs-review-translation">Souligner les variables réaffectées;Afficher les indicateurs inline; Insertion automatique des constructions de fin ; Modifier les paramètres de liste de création de listes ; Modifier le mode plan ; Insertion automatique des membres Interface et MustOverride ; Afficher ou masquer les séparateurs de ligne de procédure ; Activer ou désactiver les suggestions de correction d’erreur ; Activer ou désactiver la mise en surbrillance des références et des mots clés ;
 Regex;
 expressions régulières ;
 composants associés sous le curseur ;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.it.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.it.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Sottolinea le variabili riassegnate;Visualizza hint inline; Inserimento automatico di costrutti finali; Modifica le impostazioni dell'elenco; Modifica la modalità di struttura; Inserimento automatico dei membri Interface e MustOverride; Mostra o nascondi i separatori di riga della procedura; Attiva o disattiva i suggerimenti per la correzione degli errori; Attiva o disattiva l'evidenziazione di riferimenti e parole chiave; 
+        <target state="needs-review-translation">Sottolinea le variabili riassegnate;Visualizza hint inline; Inserimento automatico di costrutti finali; Modifica le impostazioni dell'elenco; Modifica la modalità di struttura; Inserimento automatico dei membri Interface e MustOverride; Mostra o nascondi i separatori di riga della procedura; Attiva o disattiva i suggerimenti per la correzione degli errori; Attiva o disattiva l'evidenziazione di riferimenti e parole chiave; 
 Regex;
 espressioni regolari;
 componenti correlati sotto il cursore;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ja.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ja.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">再割り当てされる変数に下線を引く; インラインのヒントを表示する; コンストラクトの終端の自動挿入; 再フォーマット設定の変更; アウトライン モードの変更; Interface と MustOverride メンバーの自動挿入; プロシージャ行の区切り記号の表示/非表示; エラー修正候補のオン/オフの切り替え; 参照とキーワードの強調表示のオン/オフの切り替え; 
+        <target state="needs-review-translation">再割り当てされる変数に下線を引く; インラインのヒントを表示する; コンストラクトの終端の自動挿入; 再フォーマット設定の変更; アウトライン モードの変更; Interface と MustOverride メンバーの自動挿入; プロシージャ行の区切り記号の表示/非表示; エラー修正候補のオン/オフの切り替え; 参照とキーワードの強調表示のオン/オフの切り替え; 
 Regex; 
 正規表現; 
 カーソルの下の関連コンポーネント; 

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ko.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ko.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">재할당된 변수에 밑줄 표시, 인라인 힌트 표시, 최종 구문 자동 삽입, 예쁜 목록 설정 변경, 개요 모드 변경, Interface 및 MustOverride 구성원 자동 삽입, 절차 줄 구분 기호 표시 또는 숨기기, 오류 수정 제안 켜기 또는 끄기, 참조 강조 표시 끄기 및 키워드 켜기 또는 끄기, 
+        <target state="needs-review-translation">재할당된 변수에 밑줄 표시, 인라인 힌트 표시, 최종 구문 자동 삽입, 예쁜 목록 설정 변경, 개요 모드 변경, Interface 및 MustOverride 구성원 자동 삽입, 절차 줄 구분 기호 표시 또는 숨기기, 오류 수정 제안 켜기 또는 끄기, 참조 강조 표시 끄기 및 키워드 켜기 또는 끄기, 
 정규식,
 정규식,
 커서 아래에 있는 관련 구성 요소,

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.pl.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.pl.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Podkreślanie ponownie przypisanych zmiennych;Wyświatlnie wskazówek śródwierszowych; Automatyczne wstawianie konstrukcji końcowych; Zmiana ustawień wyświetlania listy;Zmiana trybu konspektu; Automatyczne wstawianie elementów członkowskich Interfejs i Należy Zastąpić; Pokazywanie lub ukrywanie separatorów wierszy procedury; Włączanie lub wyłączanie sugestii poprawek błędów; Włączanie lub wyłączanie wyróżnianie odwołań i słów kluczowych;
+        <target state="needs-review-translation">Podkreślanie ponownie przypisanych zmiennych;Wyświatlnie wskazówek śródwierszowych; Automatyczne wstawianie konstrukcji końcowych; Zmiana ustawień wyświetlania listy;Zmiana trybu konspektu; Automatyczne wstawianie elementów członkowskich Interfejs i Należy Zastąpić; Pokazywanie lub ukrywanie separatorów wierszy procedury; Włączanie lub wyłączanie sugestii poprawek błędów; Włączanie lub wyłączanie wyróżnianie odwołań i słów kluczowych;
 Wyrażenie regularne;
 Wyrażenia regularne;
 Powiązane składniki pod kursorem;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.pt-BR.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.pt-BR.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Sublinhar variáveis reatribuídas;Exibir dicas incorporadas;Inserção automática de construtores finais;Alterar as configurações de reformatação automática;Alterar o modo de estrutura de tópicos;Inserção automática de interface e membros MustOverride;Mostrar ou ocultar separadores de linha de procedimento;Ativar ou desativar as sugestões de correção de erros;Ativar ou desativar o realce de referências e palavras-chave;
+        <target state="needs-review-translation">Sublinhar variáveis reatribuídas;Exibir dicas incorporadas;Inserção automática de construtores finais;Alterar as configurações de reformatação automática;Alterar o modo de estrutura de tópicos;Inserção automática de interface e membros MustOverride;Mostrar ou ocultar separadores de linha de procedimento;Ativar ou desativar as sugestões de correção de erros;Ativar ou desativar o realce de referências e palavras-chave;
 Regex; 
 expressões regulares;
 componentes relacionados sob o cursor;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ru.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ru.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Подчеркивать переназначенные переменные;Показывать встроенные подсказки;Автоматическая вставка конечных конструкций;Изменять параметры автоматического форматирования;Изменять режим структуры;Автоматическая вставка интерфейса и элементов MustOverride;Показывать или скрывать разделители строк для процедуры;Включить или отключить предложения по исправлению ошибок;Включить или отключить выделение ссылок и ключевых слов;
+        <target state="needs-review-translation">Подчеркивать переназначенные переменные;Показывать встроенные подсказки;Автоматическая вставка конечных конструкций;Изменять параметры автоматического форматирования;Изменять режим структуры;Автоматическая вставка интерфейса и элементов MustOverride;Показывать или скрывать разделители строк для процедуры;Включить или отключить предложения по исправлению ошибок;Включить или отключить выделение ссылок и ключевых слов;
 Регулярные выражения;
 регулярные выражения;
 связанные компоненты под курсором;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.tr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.tr.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">Yeniden atanan değişkenlerin altını çiz;Satır içi ipuçlarını görüntüle;Bitiş yapılarının otomatik olarak eklenmesi;Düzgün listeleme ayarlarını değiştir;Ana hat modunu değiştir;Interface ve MustOverride üyelerinin otomatik olarak eklenmesi;Yordam satır ayraçlarını göster veya gizle;Hata düzeltme önerilerini aç veya kapat;Başvuruları ve anahtar sözcükleri vurgulamayı aç veya kapat;
+        <target state="needs-review-translation">Yeniden atanan değişkenlerin altını çiz;Satır içi ipuçlarını görüntüle;Bitiş yapılarının otomatik olarak eklenmesi;Düzgün listeleme ayarlarını değiştir;Ana hat modunu değiştir;Interface ve MustOverride üyelerinin otomatik olarak eklenmesi;Yordam satır ayraçlarını göster veya gizle;Hata düzeltme önerilerini aç veya kapat;Başvuruları ve anahtar sözcükleri vurgulamayı aç veya kapat;
 Normal ifade;
 normal ifadeler;
 imlecin altındaki ilgili bileşenler; 

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.zh-Hans.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.zh-Hans.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">为重新分配变量添加下划线;显示内联提示;自动插入 End 构造;更改整齐排列设置;更改大纲模式;自动插入 Interface 和 MustOverride 成员;显示或隐藏过程行分隔符;打开或关闭错误纠正建议;打开或关闭引用和关键字的突出显示;
+        <target state="needs-review-translation">为重新分配变量添加下划线;显示内联提示;自动插入 End 构造;更改整齐排列设置;更改大纲模式;自动插入 Interface 和 MustOverride 成员;显示或隐藏过程行分隔符;打开或关闭错误纠正建议;打开或关闭引用和关键字的突出显示;
 正则表达式;
 正则表达式;
 游标下的相关组件;

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.zh-Hant.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.zh-Hant.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="10160">
-        <source>Underline reassigned variables;Display inline hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
+        <source>Underline reassigned variables;Display inline hints;Display inlay hints;Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;
 Regex;
 regular expressions;
 related components under cursor;
@@ -33,7 +33,7 @@ Collapse #regions on file open;
 Collapse Imports on file open;
 Collapse metadata implementations on file open;
 Use enhanced colors;Editor Color Scheme;Inheritance Margin;Import Directives;</source>
-        <target state="translated">為重新指派的變數加上底線;顯示內嵌提示;自動插入結束建構;變更美化排列設定;變更大綱模式;自動插入介面和 MustOverride 成員;顯示或隱藏程序行分隔符號;開啟或關閉錯誤校正建議;開啟或關閉參考及關鍵字的醒目提示;
+        <target state="needs-review-translation">為重新指派的變數加上底線;顯示內嵌提示;自動插入結束建構;變更美化排列設定;變更大綱模式;自動插入介面和 MustOverride 成員;顯示或隱藏程序行分隔符號;開啟或關閉錯誤校正建議;開啟或關閉參考及關鍵字的醒目提示;
 Regex;
 規則運算式;
 游標下的相關元件;


### PR DESCRIPTION
For consistency with LSP and VS Code, renaming user visible strings to use "inlay hints" instead of "inline hints".

I'm willing to also rename the code, but it will be a chunky PR...