### PR TITLE
Prevent setting the vs icon information if it doesn't differ from the kind.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/DefaultLspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/DefaultLspCompletionResultCreationService.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             TextSpan defaultSpan,
             string typedText,
             CompletionItem item,
+            LSP.CompletionItemKind kind,
             CompletionService completionService,
             CancellationToken cancellationToken)
         {


### PR DESCRIPTION
VS uses either the kind value or the _vs_icon value in LSP completion to determine the icon to display. Roslyn previously always set information for both, when most of the time the kind information is sufficient. We can utilize this to significantly reduce our lsp completion payload size.

This locally reduced the payload of the serialized json for a single completion response from 205 KB -> 61 KB.