### PR TITLE
Switch the BuildHost to build with net6.0 again

### DIFF
--- a/docs/contributing/Target Framework Strategy.md
+++ b/docs/contributing/Target Framework Strategy.md
@@ -22,7 +22,7 @@ Projects in our repository should include the following values in `<TargetFramew
 4. `$(NetVSShared)`: code that needs to execute in both Visual Studio and VS Code but does not need to be source built.
 5. `$(NetRoslynToolset)`: packages that ship the Roslyn toolset. The compiler often builds against multiple target frameworks. This property controls which of those frameworks are shipped in the toolset packages. This value will potentially change in source builds.
 6. `$(NetRoslynAll)`: code, generally test utilities, that need to build for all .NET runtimes that we support.
-7. `$(NetRoslyn)`:code that needs to execute on .NET but does not have any specific product deployment requirements. For example utilities that are used by our infra, compiler unit tests, etc ...
+7. `$(NetRoslyn)`: code that needs to execute on .NET but does not have any specific product deployment requirements. For example utilities that are used by our infra, compiler unit tests, etc ...
 
 This properties `$(NetCurrent)`, `$(NetPrevious)` and `$(NetMinimum)` are not used in our project files because they change in ways that make it hard for us to maintain corect product deployments. Our product ships on VS and VS Code which are not captured by arcade `$(Net...)` macros. Further as the arcade properties change it's very easy for us to end up with duplicate entries in a `<TargetFarmeworks>` setting. Instead our repo uses the above values and when inside source build or VMR our properties are initialized with arcade properties.
 

--- a/docs/contributing/Target Framework Strategy.md
+++ b/docs/contributing/Target Framework Strategy.md
@@ -9,6 +9,7 @@ The roslyn repository produces components for a number of different products tha
 - Source build: requires us to ship `$(NetCurrent)` and `$(NetPrevious)` in workspaces and below (presently `net9.0` and `net8.0` respectively)
 - Visual Studio: requires us to ship `net472` for base IDE components and `$(NetVisualStudio)` (presently `net8.0`) for private runtime components.
 - Visual Studio Code: expects us to ship against the same runtime as DevKit (presently `net7.0`) to avoid two runtime downloads.
+- MSBuildWorkspace: requires to ship a process that must be usable on the lowest supported SDK (presently `net6.0`)
 
 It is not reasonable for us to take the union of all TFM and multi-target every single project to them. That would add several hundred compilations to any build operation which would in turn negatively impact our developer throughput. Instead we attempt to use the TFM where needed. That keeps our builds smaller but increases complexity a bit as we end up shipping a mix of TFM for binaries across our layers.
 
@@ -23,6 +24,7 @@ Projects in our repository should include the following values in `<TargetFramew
 5. `$(NetRoslynToolset)`: packages that ship the Roslyn toolset. The compiler often builds against multiple target frameworks. This property controls which of those frameworks are shipped in the toolset packages. This value will potentially change in source builds.
 6. `$(NetRoslynAll)`: code, generally test utilities, that need to build for all .NET runtimes that we support.
 7. `$(NetRoslyn)`: code that needs to execute on .NET but does not have any specific product deployment requirements. For example utilities that are used by our infra, compiler unit tests, etc ...
+8. `$(NetRoslynBuildHostNetCoreVersion)`: the target used for the .NET Core BuildHost process used by MSBuildWorkspace.
 
 This properties `$(NetCurrent)`, `$(NetPrevious)` and `$(NetMinimum)` are not used in our project files because they change in ways that make it hard for us to maintain corect product deployments. Our product ships on VS and VS Code which are not captured by arcade `$(Net...)` macros. Further as the arcade properties change it's very easy for us to end up with duplicate entries in a `<TargetFarmeworks>` setting. Instead our repo uses the above values and when inside source build or VMR our properties are initialized with arcade properties.
 

--- a/eng/targets/TargetFrameworks.props
+++ b/eng/targets/TargetFrameworks.props
@@ -17,6 +17,7 @@
     <NetVS>net8.0</NetVS>
     <NetVSCode>net7.0</NetVSCode>
     <NetVSShared>net7.0;net8.0</NetVSShared>
+    <NetRoslynBuildHostNetCoreVersion>net6.0</NetRoslynBuildHostNetCoreVersion>
   </PropertyGroup>
 
   <!-- 
@@ -38,6 +39,7 @@
         <NetRoslynToolset>$(NetPrevious)</NetRoslynToolset>
         <NetRoslynSourceBuild>$(NetCurrent);$(NetPrevious)</NetRoslynSourceBuild>
         <NetRoslynAll>$(NetCurrent);$(NetPrevious)</NetRoslynAll>
+        <NetRoslynBuildHostNetCoreVersion>$(NetPrevious)</NetRoslynBuildHostNetCoreVersion>
       </PropertyGroup>
     </When>
 
@@ -49,6 +51,7 @@
         <NetRoslynToolset>$(NetCurrent)</NetRoslynToolset>
         <NetRoslynSourceBuild>$(NetCurrent);$(NetPrevious)</NetRoslynSourceBuild>
         <NetRoslynAll>$(NetCurrent);$(NetPrevious)</NetRoslynAll>
+        <NetRoslynBuildHostNetCoreVersion>$(NetCurrent)</NetRoslynBuildHostNetCoreVersion>
       </PropertyGroup>
     </When>
 

--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -255,6 +255,15 @@ namespace BuildBoss
                     case "$(NetVSCode)":
                     case "$(NetVSShared)":
                         continue;
+
+                    case "$(NetRoslynBuildHostNetCoreVersion)":
+                        {
+                            // This property should only be used in one specific project
+                            if (_data.FileName == "Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj")
+                                continue;
+                            else
+                                break;
+                        }
                 }
 
                 textWriter.WriteLine($"TargetFramework {targetFramework} is not supported in this build");

--- a/src/Workspaces/Core/MSBuild.BuildHost/BuildHost.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/BuildHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+extern alias workspaces;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -105,7 +106,11 @@ internal sealed class BuildHost
         }
     }
 
+#if NET472 || NET6_0 // If we're compiling against net472 or net6.0, we get our MemberNotNull from the workspaces assembly. It has it in the net6.0 case since we're consuming the netstandard2.0 version of Workspaces.
+    [workspaces::System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_buildManager))]
+#else // If we're compiling against net7.0 or higher, then we're getting it staright from the framework.
     [MemberNotNull(nameof(_buildManager))]
+#endif
     [MethodImpl(MethodImplOptions.NoInlining)] // Do not inline this, since this creates MSBuild types which are being loaded by the caller
     private void CreateBuildManager()
     {

--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis</RootNamespace>
-    <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
+    <TargetFrameworks>$(NetRoslynBuildHostNetCoreVersion);net472</TargetFrameworks>
     <!-- We'll always be running our build host with the same host that is used to launch the language server process directly, so we don't need to create another one -->
     <UseAppHost>false</UseAppHost>
     <!-- Set to false since it's also set in Microsoft.CodeAnalysis.LanguageServer -->
@@ -22,9 +22,11 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
+    <!-- We specifically reference Microsoft.Build 17.3.2, since it's the oldest version still compatible net6.0. The version targeted is only used for build time, since
+         we use MSBuildLocator to discover the proper version at runtime. -->
+    <PackageReference Include="Microsoft.Build" VersionOverride="17.3.2" ExcludeAssets="Runtime" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Framework" VersionOverride="17.3.2" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="17.3.2" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.CommandLine" />
@@ -33,7 +35,14 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
-    <ProjectReference Include="..\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
+    <ProjectReference Include="..\Portable\Microsoft.CodeAnalysis.Workspaces.csproj">
+      <Aliases>global,workspaces</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\CompilerFeatureRequiredAttribute.cs" Link="Utilities\CompilerFeatureRequiredAttribute.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="Utilities\IsExternalInit.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\RequiredMemberAttribute.cs" Link="Utilities\RequiredMemberAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />

--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -91,22 +91,18 @@
     property that we could hook but we can't in this case.
   -->
   <Target Name="DeployNetFrameworkBuildHost" BeforeTargets="_GetPackageFiles;AssignTargetPaths" Condition="'$(DesignTimeBuild)' != 'true'">
-    <!-- When we're not doing source build we package two variants: $(NetVS) and net472 for the broadest compability. -->
+    <!-- If we're not doing source build, we will include a net472 version for the broadest compatibility -->
     <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
       <_NetFrameworkBuildHostProjectReference Include="..\..\..\Workspaces\Core\MSBuild.BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj">
         <TargetFramework>net472</TargetFramework>
         <ContentFolderName>BuildHost-net472</ContentFolderName>
       </_NetFrameworkBuildHostProjectReference>
-      <_NetFrameworkBuildHostProjectReference Include="..\..\..\Workspaces\Core\MSBuild.BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj">
-        <TargetFramework>$(NetVSCode)</TargetFramework>
-        <ContentFolderName>BuildHost-netcore</ContentFolderName>
-      </_NetFrameworkBuildHostProjectReference>
     </ItemGroup>
 
-    <!-- For source build, we just build the SourceBuild targeted version -->
-    <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <!-- We'll include a .NET Core version no matter what -->
+    <ItemGroup>
       <_NetFrameworkBuildHostProjectReference Include="..\..\..\Workspaces\Core\MSBuild.BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj">
-        <TargetFramework>$(NetRoslynToolset)</TargetFramework>
+        <TargetFramework>$(NetRoslynBuildHostNetCoreVersion)</TargetFramework>
         <ContentFolderName>BuildHost-netcore</ContentFolderName>
       </_NetFrameworkBuildHostProjectReference>
     </ItemGroup>


### PR DESCRIPTION
When we launch the BuildHost we generally use the dotnet.exe on the path, which the assumption that's the one the user is using for their development and that has the right SDKs installed. This means we can run into some fun version issues with VS Code though, where we target the language server on net7.0 (of this writing); in the case that the user has only a 6.0 SDK + runtime installed globally, we'll download a 7.0 runtime, but that's only used for the language server process. The BuildHost will still run with the regular dotnet.exe which needs to support 6.0 runtimes + SDKs.

This PR downgrades us to use net6.0 for just the build host. The core change there is trivial but it did result in a few other changes:

1. The Microsoft.Build packages only support net7.0 or higher, so we switch back to the version that we're using for source build which are old enough. Since we only use them as reference assemblies, it doesn't really matter what we pick.
2. 6.0 builds are then missing some attributes we have on higher versions, so we need to start declaring them again.