### PR TITLE
Remove support for base extensions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1339,10 +1339,6 @@ outerDefault:
                 {
                     return true;
                 }
-                else if (currentType.IsExtension && type.IsExtension && currentType.AllBaseExtensionsWithDefinitionUseSiteDiagnostics(ref useSiteInfo).Contains((NamedTypeSymbol)type))
-                {
-                    return true;
-                }
                 else if (currentType.IsClassType() && type.IsClassType() && currentType.IsDerivedFrom(type, TypeCompareKind.ConsiderEverything, useSiteInfo: ref useSiteInfo))
                 {
                     return true;

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3968,6 +3968,9 @@ You should consider suppressing the warning only if you're sure that you don't w
   <data name="ERR_NotYetImplementedInRoslyn" xml:space="preserve">
     <value>This language feature ('{0}') is not yet implemented.</value>
   </data>
+  <data name="IDS_FeatureBaseExtensions" xml:space="preserve">
+    <value>base extensions</value>
+  </data>
   <data name="ERR_DefaultValueNotAllowed" xml:space="preserve">
     <value>Default values are not valid in this context.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -655,7 +655,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!_globalHasErrors)
             {
                 var extensionMarker = new SynthesizedExtensionMarker(sourceExtension,
-                    sourceExtension.ExtendedTypeNoUseSiteDiagnostics, sourceExtension.BaseExtensionsNoUseSiteDiagnostics,
+                    sourceExtension.ExtendedTypeNoUseSiteDiagnostics,
                     _diagnostics);
 
 #if DEBUG

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1250,6 +1250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // unused 7104-8000
 
         #region more diagnostics introduced in Roslyn (C# 6)
+        ERR_NotYetImplementedInRoslyn = 8000,
         WRN_UnimplementedCommandLineSwitch = 8001,
         WRN_ReferencedAssemblyDoesNotHaveStrongName = 8002,
         ERR_InvalidSignaturePublicKey = 8003,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2287,11 +2287,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         // PROTOTYPE compact error codes
         ERR_BadExtensionUnderlyingType = 9305,
         ERR_StaticBaseTypeOnInstanceExtension = 9306,
-        ERR_OnlyBaseExtensionAllowed = 9307,
+        ERR_OnlyBaseExtensionAllowed = 9307, // PROTOTYPE restore base extension support
         ERR_PartialMultipleUnderlyingTypes = 9308,
         ERR_BadVisUnderlyingType = 9309,
-        ERR_BadVisBaseExtension = 9310,
-        ERR_CycleInBaseExtensions = 9311,
+        ERR_BadVisBaseExtension = 9310, // PROTOTYPE restore base extension support
+        ERR_CycleInBaseExtensions = 9311, // PROTOTYPE restore base extension support
         ERR_FileTypeUnderlying = 9312,
         ERR_StateInExtension = 9313,
         ERR_ExtensionMissingUnderlyingType = 9314,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -1634,6 +1634,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_EncReferenceToAddedMember:
                 case ErrorCode.ERR_MutuallyExclusiveOptions:
                 case ErrorCode.ERR_InvalidDebugInfo:
+                case ErrorCode.ERR_NotYetImplementedInRoslyn:
                 case ErrorCode.WRN_UnimplementedCommandLineSwitch:
                 case ErrorCode.WRN_ReferencedAssemblyDoesNotHaveStrongName:
                 case ErrorCode.ERR_InvalidSignaturePublicKey:

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -281,6 +281,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_ImplicitIndexerInitializer = MessageBase + 12840,
 
         IDS_FeatureExtensions = MessageBase + 12850, // PROTOTYPE consolidate feature identifier
+        IDS_FeatureBaseExtensions = MessageBase + 12851, // PROTOTYPE remove this temporary feature flag
     }
 
     // Message IDs may refer to strings that need to be localized.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1572,6 +1572,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // PROTOTYPE decide whether to keep parsing base extensions or not
             var baseList = this.ParseBaseList();
+            if (mainKeyword.Kind == SyntaxKind.ExtensionKeyword
+                && baseList is not null)
+            {
+                baseList = this.AddError(baseList, ErrorCode.ERR_NotYetImplementedInRoslyn, MessageID.IDS_FeatureBaseExtensions.Localize());
+            }
+
             _termState = saveTerm;
 
             // Parse class body

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1570,6 +1570,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 forType = ParseType();
             }
 
+            // PROTOTYPE decide whether to keep parsing base extensions or not
             var baseList = this.ParseBaseList();
             _termState = saveTerm;
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1738,7 +1738,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             static TypeDeclarationSyntax constructTypeDeclaration(ContextAwareSyntax syntaxFactory, SyntaxList<AttributeListSyntax> attributes, SyntaxListBuilder modifiers,
                 SyntaxToken? firstKeyword, SyntaxToken? secondKeyword, SyntaxToken mainKeyword,
                 SyntaxToken name, TypeParameterListSyntax typeParameters, ParameterListSyntax? paramList, SyntaxToken? forKeyword, TypeSyntax? forType,
-                BaseListSyntax baseList, SyntaxListBuilder<TypeParameterConstraintClauseSyntax> constraints,
+                BaseListSyntax? baseList, SyntaxListBuilder<TypeParameterConstraintClauseSyntax> constraints,
                 SyntaxToken? openBrace, SyntaxListBuilder<MemberDeclarationSyntax> members, SyntaxToken? closeBrace, SyntaxToken semicolon)
             {
                 var modifiersList = (SyntaxList<SyntaxToken>)modifiers.ToList();

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
@@ -273,16 +273,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override bool IsExplicitExtension => false;
 
             internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-            internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-                => ImmutableArray<NamedTypeSymbol>.Empty;
-
-            internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-                => ImmutableArray<NamedTypeSymbol>.Empty;
 
             internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
-                => throw ExceptionUtilities.Unreachable();
-
-            internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
                 => throw ExceptionUtilities.Unreachable();
 
             internal abstract override bool Equals(TypeSymbol t2, TypeCompareKind comparison);

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
@@ -324,15 +324,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override bool IsExplicitExtension => false;
 
             internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-            internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-                => ImmutableArray<NamedTypeSymbol>.Empty;
-            internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-                => ImmutableArray<NamedTypeSymbol>.Empty;
 
             internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
-                => throw ExceptionUtilities.Unreachable();
-
-            internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
                 => throw ExceptionUtilities.Unreachable();
 
             internal sealed override bool HasPossibleWellKnownCloneMethod() => false;

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -488,10 +488,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal sealed override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
@@ -50,11 +50,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     else if (namedType.IsExtension)
                     {
                         TypeDependsClosure(namedType.GetDeclaredExtensionUnderlyingType(), currentCompilation, partialClosure);
-
-                        foreach (var bt in namedType.GetDeclaredBaseExtensions(basesBeingResolved: null))
-                        {
-                            TypeDependsClosure(bt, currentCompilation, partialClosure);
-                        }
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -253,10 +253,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -560,15 +560,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
-            => throw ExceptionUtilities.Unreachable();
-
-        internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
             => throw ExceptionUtilities.Unreachable();
 
         internal sealed override bool HasPossibleWellKnownCloneMethod() => false;

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -221,10 +221,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionTypeSymbol.cs
@@ -131,10 +131,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal override ObsoleteAttributeData ObsoleteAttributeData => throw ExceptionUtilities.Unreachable();
 

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -187,15 +187,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
-            => throw ExceptionUtilities.Unreachable();
-
-        internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
             => throw ExceptionUtilities.Unreachable();
 
         internal sealed override bool HasPossibleWellKnownCloneMethod() => false;

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -315,10 +315,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal sealed override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -181,21 +181,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
         internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
-        internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
-            => throw ExceptionUtilities.Unreachable();
-
         protected override void CheckUnderlyingType(BindingDiagnosticBag diagnostics)
-            => throw ExceptionUtilities.Unreachable();
-
-        protected override void CheckBaseExtensions(BindingDiagnosticBag diagnostics)
             => throw ExceptionUtilities.Unreachable();
 
         internal sealed override bool HasInlineArrayAttribute(out int length)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -536,7 +536,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected abstract void CheckBase(BindingDiagnosticBag diagnostics);
         protected abstract void CheckInterfaces(BindingDiagnosticBag diagnostics);
         protected abstract void CheckUnderlyingType(BindingDiagnosticBag diagnostics);
-        protected abstract void CheckBaseExtensions(BindingDiagnosticBag diagnostics);
 
         internal override void ForceComplete(SourceLocation? locationOpt, CancellationToken cancellationToken)
         {
@@ -559,7 +558,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if (IsExtension)
                             {
                                 CheckUnderlyingType(diagnostics);
-                                CheckBaseExtensions(diagnostics);
                             }
                             else
                             {
@@ -1829,7 +1827,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var baseType = BaseTypeNoUseSiteDiagnostics;
             var interfaces = GetInterfacesToEmit();
             var extendedType = ExtendedTypeNoUseSiteDiagnostics;
-            var baseExtensions = BaseExtensionsNoUseSiteDiagnostics;
 
             if (compilation.ShouldEmitNativeIntegerAttributes())
             {
@@ -1906,8 +1903,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return (baseType is not null && predicate(baseType)) ||
                     interfaces.As<TypeSymbol>().Any(predicate) ||
-                    (extendedType is not null && predicate(extendedType)) ||
-                    baseExtensions.As<TypeSymbol>().Any(predicate);
+                    (extendedType is not null && predicate(extendedType));
             }
 
             static bool needsTupleElementNamesAttribute(TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             // InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics populates the set with interfaces that match by CLR signature.
                             Debug.Assert(!other.Equals(@interface, TypeCompareKind.ConsiderEverything));
                             Debug.Assert(other.Equals(@interface, TypeCompareKind.CLRSignatureCompareOptions));
-                            ReportDuplicate(other, @interface, location, diagnostics, forBaseExtension: false);
+                            ReportDuplicate(other, @interface, location, diagnostics);
                         }
                     }
                 }
@@ -188,56 +188,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         protected void ReportDuplicate(NamedTypeSymbol other, NamedTypeSymbol @interface,
-            SourceLocation location, BindingDiagnosticBag diagnostics, bool forBaseExtension)
+            SourceLocation location, BindingDiagnosticBag diagnostics)
         {
             if (other.Equals(@interface, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
             {
                 if (!other.Equals(@interface, TypeCompareKind.ObliviousNullableModifierMatchesAny))
                 {
-                    var code = forBaseExtension
-                        ? ErrorCode.WRN_DuplicateExtensionWithNullabilityMismatchInBaseList
-                        : ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList;
-
-                    diagnostics.Add(code, location, @interface, this);
+                    diagnostics.Add(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, location, @interface, this);
                 }
             }
             else if (other.Equals(@interface, TypeCompareKind.IgnoreTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
             {
-                var code = forBaseExtension
-                    ? ErrorCode.ERR_DuplicateExtensionWithTupleNamesInBaseList
-                    : ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList;
-
-                diagnostics.Add(code, location, @interface, other, this);
+                diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, location, @interface, other, this);
             }
             else
             {
-                var code = forBaseExtension
-                    ? ErrorCode.ERR_DuplicateExtensionWithDifferencesInBaseList
-                    : ErrorCode.ERR_DuplicateInterfaceWithDifferencesInBaseList;
-
-                diagnostics.Add(code, location, @interface, other, this);
+                diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceWithDifferencesInBaseList, location, @interface, other, this);
             }
         }
 
         protected void ReportDuplicateLocally(NamedTypeSymbol type, TypeSymbol referenceType,
-            SourceLocation location, BindingDiagnosticBag diagnostics, bool forBaseExtension)
+            SourceLocation location, BindingDiagnosticBag diagnostics)
         {
             if (type.Equals(referenceType, TypeCompareKind.ConsiderEverything))
             {
-                var code = forBaseExtension
-                    ? ErrorCode.ERR_DuplicateExtensionInBaseList
-                    : ErrorCode.ERR_DuplicateInterfaceInBaseList;
-
-                diagnostics.Add(code, location, referenceType);
+                diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceInBaseList, location, referenceType);
             }
             else if (type.Equals(referenceType, TypeCompareKind.ObliviousNullableModifierMatchesAny))
             {
                 // duplicates with ?/! differences are reported later, we report local differences between oblivious and ?/! here
-                var code = forBaseExtension
-                    ? ErrorCode.WRN_DuplicateExtensionWithNullabilityMismatchInBaseList
-                    : ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList;
-
-                diagnostics.Add(code, location, referenceType, this);
+                diagnostics.Add(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, location, referenceType, this);
             }
         }
 
@@ -589,7 +569,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case TypeKind.Interface:
                         foreach (var t in localInterfaces)
                         {
-                            ReportDuplicateLocally(t, baseType, location, diagnostics, forBaseExtension: false);
+                            ReportDuplicateLocally(t, baseType, location, diagnostics);
                         }
 
                         if (this.IsStatic)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
@@ -18,21 +18,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
-        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
-            => throw ExceptionUtilities.Unreachable();
-
         protected override void CheckUnderlyingType(BindingDiagnosticBag diagnostics)
-            => throw ExceptionUtilities.Unreachable();
-
-        protected override void CheckBaseExtensions(BindingDiagnosticBag diagnostics)
             => throw ExceptionUtilities.Unreachable();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -487,15 +487,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
             => _unbound ? null : Map.SubstituteType(OriginalDefinition.ExtendedTypeNoUseSiteDiagnostics).Type;
 
-        internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => _unbound ? ImmutableArray<NamedTypeSymbol>.Empty : Map.SubstituteNamedTypes(OriginalDefinition.BaseExtensionsNoUseSiteDiagnostics);
-        internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => _unbound ? ImmutableArray<NamedTypeSymbol>.Empty : Map.SubstituteNamedTypes(OriginalDefinition.AllBaseExtensionsNoUseSiteDiagnostics);
-
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
-            => throw new InvalidOperationException("PROTOTYPE"); // PROTOTYPE
-
-        internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
             => throw new InvalidOperationException("PROTOTYPE"); // PROTOTYPE
 
         internal sealed override bool HasInlineArrayAttribute(out int length)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Extensions/SynthesizedExtensionMarker.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Extensions/SynthesizedExtensionMarker.cs
@@ -19,10 +19,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// It encodes:
     /// - whether the extension type is implicit or explicit (PROTOTYPE)
     /// - the underlying type (first parameter type)
-    /// - the base extensions (subsequent parameter types)
     ///
-    /// For example: 'implicit extension R for UnderlyingType : BaseExtension1, BaseExtension2' yield
-    /// 'private static void &lt;Extension>$(UnderlyingType, BaseExtension1, BaseExtension2, ...)'. // PROTOTYPE
+    /// For example: 'implicit extension R for UnderlyingType' yield
+    /// 'private static void &lt;Extension>$(UnderlyingType)'. // PROTOTYPE
     /// </summary>
     internal sealed class SynthesizedExtensionMarker : SynthesizedMethodSymbol
     {
@@ -30,20 +29,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly TypeSymbol _returnType;
         private readonly ImmutableArray<ParameterSymbol> _parameters;
 
-        internal SynthesizedExtensionMarker(SourceExtensionTypeSymbol extensionType,
-            TypeSymbol underlyingType, ImmutableArray<NamedTypeSymbol> baseExtensionTypes, BindingDiagnosticBag diagnostics)
+        internal SynthesizedExtensionMarker(SourceExtensionTypeSymbol extensionType, TypeSymbol underlyingType, BindingDiagnosticBag diagnostics)
         {
             _extensionType = extensionType;
             _returnType = Binder.GetSpecialType(DeclaringCompilation, SpecialType.System_Void, extensionType.GetFirstLocation(), diagnostics);
-
-            var parameters = ArrayBuilder<ParameterSymbol>.GetInstance(baseExtensionTypes.Length);
-            parameters.Add(makeParameter(0, underlyingType));
-            for (int i = 0; i < baseExtensionTypes.Length; i++)
-            {
-                parameters.Add(makeParameter(i + 1, baseExtensionTypes[i]));
-            }
-
-            _parameters = parameters.ToImmutableAndFree();
+            _parameters = [makeParameter(0, underlyingType)];
 
             return;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
@@ -804,14 +804,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
-
-        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
-            => throw ExceptionUtilities.Unreachable();
-
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -61,15 +61,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
-            => throw ExceptionUtilities.Unreachable();
-
-        internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
             => throw ExceptionUtilities.Unreachable();
 
         internal sealed override bool HasPossibleWellKnownCloneMethod() => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -176,15 +176,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
-            => throw ExceptionUtilities.Unreachable();
-
-        internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
             => throw ExceptionUtilities.Unreachable();
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
@@ -210,15 +210,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
-        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
-            => throw ExceptionUtilities.Unreachable();
-
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-
         private sealed class InlineArrayTypeParameterSymbol : TypeParameterSymbol
         {
             private readonly SynthesizedInlineArrayTypeSymbol _container;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
@@ -194,14 +194,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
-
-        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved)
-            => throw ExceptionUtilities.Unreachable();
-
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -722,10 +722,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal sealed override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics
-            => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal sealed override bool HasInlineArrayAttribute(out int length)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -229,18 +229,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        internal ImmutableArray<NamedTypeSymbol> AllBaseExtensionsWithDefinitionUseSiteDiagnostics(ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
-        {
-            var baseExtensions = AllBaseExtensionsNoUseSiteDiagnostics;
-
-            foreach (var baseExtension in baseExtensions)
-            {
-                baseExtension.OriginalDefinition.AddUseSiteInfo(ref useSiteInfo);
-            }
-
-            return baseExtensions;
-        }
-
         /// <summary>
         /// If this is a type parameter returns its effective base class, otherwise returns this type.
         /// </summary>
@@ -2503,8 +2491,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract TypeSymbol? ExtendedTypeNoUseSiteDiagnostics { get; }
 
-        internal abstract ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics { get; }
+        // PROTOTYPE restore base extension logic
+        internal ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics => [];
 
+        // PROTOTYPE restore base extension logic
         /// <summary>
         /// For extension types, returns the list of all base extensions 
         /// (this excludes this type itself).
@@ -2512,7 +2502,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// relationship: if extension type A inherits extension type B, then A precedes B in the
         /// list.
         /// </summary>
-        internal abstract ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics { get; }
+        internal ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics => [];
 
         internal abstract bool HasInlineArrayAttribute(out int length);
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">pole s automatickou výchozí strukturou</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">zaškrtnuté uživatelem definované operátory</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">Strukturfelder automatisch als Standard verwenden</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">Überprüfte benutzerdefinierte Operatoren</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">campos de estructura predeterminados automáticos</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">operadores definidos por el usuario comprobados</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">champs de struct par défaut automatique</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">opérateurs définis par l’utilisateur vérifiés</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">campi struct predefiniti in automatico</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">operatori definiti dall'utente controllati</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">自動既定の構造体フィールド</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">チェックされたユーザー定義演算子</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">자동 기본 구조체 필드</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">확인된 사용자 정의 연산자</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">pola automatycznej struktury domyślnej</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">zaznaczone operatory zdefiniowane przez użytkownika</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">campos de struct para auto-padrão</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">operadores verificados, definidos pelo usuário</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">автоматически применять значения по умолчанию к полям структуры</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">проверенные операторы, определяемые пользователем</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">otomatik varsayılan yapı alanları</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">kullanıcı tanımlı işleçler işaretlendi</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">自动默认结构字段</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">选中的用户定义运算符</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2212,6 +2212,11 @@
         <target state="translated">自動預設結構欄位</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureBaseExtensions">
+        <source>base extensions</source>
+        <target state="new">base extensions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCheckedUserDefinedOperators">
         <source>checked user-defined operators</source>
         <target state="translated">已檢查使用者定義的運算子</target>

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/ExtensionTypeTests.cs
@@ -821,9 +821,6 @@ explicit extension R2 for UnderlyingClass : I
             // (11,12): error CS0541: 'R1.M()': explicit interface declaration can only be declared in a class, record, struct or interface
             //     void I.M() { }
             Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "M").WithArguments("R1.M()").WithLocation(11, 12),
-            // (13,45): error CS9307: A base extension must be an extension type.
-            // explicit extension R2 for UnderlyingClass : I
-            Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "I").WithLocation(13, 45),
             // (15,12): error CS0541: 'R2.M()': explicit interface declaration can only be declared in a class, record, struct or interface
             //     void I.M() { }
             Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "M").WithArguments("R2.M()").WithLocation(15, 12)
@@ -834,6 +831,20 @@ explicit extension R2 for UnderlyingClass : I
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         AssertEx.Equal(new[] { "void R2.M()" }, r2.GetMembers().ToTestDisplayStrings());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
+        comp.VerifyDiagnostics(
+           // (11,12): error CS0541: 'R1.M()': explicit interface declaration can only be declared in a class, record, struct or interface
+           //     void I.M() { }
+           Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "M").WithArguments("R1.M()").WithLocation(11, 12),
+           // (13,45): error CS9307: A base extension must be an extension type.
+           // explicit extension R2 for UnderlyingClass : I
+           Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "I").WithLocation(13, 45),
+           // (15,12): error CS0541: 'R2.M()': explicit interface declaration can only be declared in a class, record, struct or interface
+           //     void I.M() { }
+           Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "M").WithArguments("R2.M()").WithLocation(15, 12)
+           );
     }
 
     [Fact]
@@ -2079,7 +2090,7 @@ explicit extension R for int[]
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void Scopes()
     {
         var src = """
@@ -2285,7 +2296,7 @@ explicit extension R for UnderlyingClass
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void UnderlyingType_StaticType_InstanceExtension_PE()
     {
         // static class C { }
@@ -2332,7 +2343,7 @@ public static explicit extension R4 for C : R1 { }
         Assert.True(r1ExtendedType.IsErrorType());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void UnderlyingType_StaticType_InstanceExtension_Retargeting()
     {
         var src1 = """
@@ -2371,6 +2382,8 @@ public explicit extension E2 for C : E1 { }
             Diagnostic(ErrorCode.ERR_StaticBaseTypeOnInstanceExtension, "C").WithArguments("E2", "C").WithLocation(1, 34)
             );
 
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         var e2 = comp.GlobalNamespace.GetTypeMember("E2");
         var e1 = (RetargetingNamedTypeSymbol)e2.BaseExtensionsNoUseSiteDiagnostics.Single();
         Assert.Equal("E1", e1.Name);
@@ -2398,7 +2411,7 @@ public {{keyword}} extension E1 for E0
             );
     }
 
-    [Theory, CombinatorialData]
+    [ConditionalTheory(typeof(NoBaseExtensions)), CombinatorialData]
     public void UnderlyingType_Extension_Retargeting(bool isExplicit)
     {
         var src1 = $$"""
@@ -2938,6 +2951,8 @@ public explicit extension R for nint { }
 
         CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate);
 
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         var src2 = """
 explicit extension R2 for nint : R { }
 """;
@@ -2980,6 +2995,8 @@ public explicit extension R for C<nint> { }
 
         CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate);
 
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         var src2 = """
 explicit extension R2 for C<nint> : R { }
 """;
@@ -3019,6 +3036,8 @@ public explicit extension R for C<dynamic> { }
         comp.VerifyDiagnostics();
 
         CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.FailsPEVerify);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
 
         var src2 = """
 explicit extension R2 for C<dynamic> : R { }
@@ -3060,6 +3079,8 @@ public explicit extension R for C<object?> { }
         comp.VerifyDiagnostics();
 
         CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.FailsPEVerify);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
 
         var src2 = """
 #nullable enable
@@ -3115,6 +3136,8 @@ public explicit extension R for C<object> { }
         comp.VerifyDiagnostics();
 
         CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.FailsPEVerify);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
 
         var src2 = """
 #nullable enable
@@ -3176,6 +3199,8 @@ public explicit extension R for (int a, int b) { }
             // public explicit extension R for (int a, int b) { }
             Diagnostic(ErrorCode.ERR_TupleElementNamesAttributeMissing, "(int a, int b)").WithArguments("System.Runtime.CompilerServices.TupleElementNamesAttribute").WithLocation(1, 33)
             );
+
+        if (new NoBaseExtensions().ShouldSkip) return;
 
         var src2 = """
 explicit extension R2 for (int a, int b)  : R { }
@@ -3769,7 +3794,7 @@ partial {{keyword}} extension R { }
         Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void Partial_DifferentBaseExtensions()
     {
         var src = """
@@ -3885,7 +3910,7 @@ partial explicit extension R for C
         AssertEx.Equal(new[] { "void R.M1()", "void R.M2()" }, r.GetMembers().ToTestDisplayStrings());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void Partial_MergeConstraintsNullability()
     {
         var src = """
@@ -4015,7 +4040,7 @@ explicit extension R for R { }
         Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_SelfReference_AsContainingType()
     {
         var src = """
@@ -4107,7 +4132,7 @@ explicit extension R for C<R> { }
         Assert.Equal("C<R>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_CircularityViaBaseExtensions()
     {
         var src = """
@@ -4148,7 +4173,7 @@ explicit extension Z for S : X { }
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_CircularityViaBaseExtensions_Metadata()
     {
         var src1 = """
@@ -4212,7 +4237,7 @@ public explicit extension X for S : Y { }
         Assert.True(yBaseExtension.IsErrorType());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_CircularityViaUnderlyingType()
     {
         var src = """
@@ -4285,6 +4310,8 @@ public explicit extension R1 for R2 { }
         Assert.Equal("R2", r2FromR1.ToTestDisplayString());
         AssertEx.Equal("error CS9322: Extension marker method on type 'R1' is malformed.", r2FromR1.ErrorInfo.ToString());
 
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         var src6 = """
 public explicit extension R6 for object : R1 { }
 public explicit extension R7 for object : R2 { }
@@ -4317,7 +4344,7 @@ public explicit extension R9 for R2 { }
             r2FromR1.ErrorInfo.ToString());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_CircularityViaUnderlyingType_WithArray()
     {
         var src = """
@@ -4342,7 +4369,7 @@ explicit extension R2 for R2.Nested[] : R
         Assert.Equal(new[] { "R" }, r2.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_CircularityViaUnderlyingType_WithTuple()
     {
         var src = """
@@ -4365,7 +4392,7 @@ explicit extension R2 for (R2.Nested, int) : R
         Assert.Equal(new[] { "R" }, r2.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_CircularityViaUnderlyingTypeAndBaseExtensions()
     {
         var src = """
@@ -4457,7 +4484,7 @@ public explicit extension R1 for R2.Nested2<R2>
         comp1.VerifyDiagnostics();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_CircularityAttemptWithUnderylingType3()
     {
         var ilSource = """
@@ -4506,7 +4533,7 @@ public explicit extension R3 for object : R1 { }
         Assert.True(r2ExtendedType.IsErrorType());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void TypeDepends_CircularityWithBaseExtension()
     {
         var ilSource = """
@@ -4765,7 +4792,7 @@ record struct R2(int j) : Extension { } // 1
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension()
     {
         var src = """
@@ -4797,7 +4824,7 @@ partial explicit extension R4 for C : R2 { }
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Generic()
     {
         var src = """
@@ -4842,7 +4869,7 @@ class D<U>
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtensions_ErrorType()
     {
         var src = """
@@ -4866,7 +4893,7 @@ explicit extension R for C : error
         Assert.True(baseExtensions.Single().IsErrorType());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtensions_ErrorType_Nested()
     {
         var src = """
@@ -4887,7 +4914,7 @@ explicit extension R2 for C : R1<error>
         Assert.Equal(new[] { "R1<error>" }, baseExtensions.ToTestDisplayStrings());
     }
 
-    [Theory]
+    [ConditionalTheory(typeof(NoBaseExtensions))]
     [InlineData("internal", "public")]
     [InlineData("protected", "public")]
     [InlineData("private protected", "public")]
@@ -4944,7 +4971,7 @@ public class C
         comp.VerifyDiagnostics();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_FileType_NonFileExtension()
     {
         var src = """
@@ -4965,7 +4992,7 @@ explicit extension R for UnderlyingClass : R1 { }
         Assert.Equal(new[] { "R1@<tree 0>" }, r.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_FileType_NonFileExtension_SecondPosition()
     {
         var src = """
@@ -4986,7 +5013,7 @@ explicit extension R for UnderlyingClass : R1, R2 { }
         Assert.Equal(new[] { "R1", "R2@<tree 0>" }, r.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_FileType_NonFileExtension_Both()
     {
         var src = """
@@ -5021,7 +5048,7 @@ class C { }
         comp.VerifyDiagnostics();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_MiscTypes()
     {
         var src = """
@@ -5091,7 +5118,7 @@ unsafe explicit extension R9 for C : C* { } // 6
         Assert.Equal("R7", r8.BaseExtensionsNoUseSiteDiagnostics.Single().ToTestDisplayString());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Pointer()
     {
         var src = """
@@ -5114,7 +5141,7 @@ explicit extension R2 for C : D<int*> { } // 2, 3
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Constraints()
     {
         var src = """
@@ -5145,7 +5172,7 @@ explicit extension R6 for C : D<R1> { } // 4
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_DeriveWithWeakerConstraints()
     {
         var src = """
@@ -5173,7 +5200,7 @@ explicit extension R3<T> for C : R2<T>, R1<T> { } // 2, 3, 4
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_DuplicatesAndVariations()
     {
         var src = """
@@ -5243,7 +5270,7 @@ explicit extension R8 for C : R3<(int i, int j)>, R3<(int, int)> { } // 6
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_DuplicatesAndVariations_FromBase()
     {
         var src = """
@@ -5306,7 +5333,7 @@ interface I2<T1, T2> : I1<T1>, I1<T2> { } // 1
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_UnderlyingTypeMismatch()
     {
         var src = """
@@ -5354,7 +5381,7 @@ explicit extension R11 for C<string> { }
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_UnderlyingTypeMismatch_Generic()
     {
         var src = """
@@ -5377,7 +5404,7 @@ explicit extension R4<U> for C<U> : R3<U> { }
         Assert.Equal("C<U>", r4.BaseExtensionsNoUseSiteDiagnostics.Single().ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_UnderlyingTypeMismatch_PE()
     {
         // class C { }
@@ -5437,7 +5464,7 @@ public explicit extension R4 for C : R2 { }
         Assert.False(r2BaseExtension.IsErrorType());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_UnderlyingTypeMismatch_Retargeting()
     {
         var src1 = """
@@ -5489,7 +5516,7 @@ explicit extension E4 for object : E2 { }
             ((ErrorTypeSymbol)e2BaseExtension).ErrorInfo.ToString());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_StaticType_InstanceExtension()
     {
         var src = """
@@ -6481,7 +6508,7 @@ unsafe class C
         VerifyNotExtension<FunctionPointerTypeSymbol>(m.ReturnType);
     }
 
-    [Theory, CombinatorialData]
+    [ConditionalTheory(typeof(NoBaseExtensions)), CombinatorialData]
     public void IsExtension_SubstitutedNamedTypeSymbol(bool isExplicit)
     {
         var src = $$"""
@@ -6541,7 +6568,7 @@ explicit extension E2 for int : E1<object> { }
         }
     }
 
-    [Theory, CombinatorialData]
+    [ConditionalTheory(typeof(NoBaseExtensions)), CombinatorialData]
     public void IsExtension_Retargeting(bool isExplicit)
     {
         var src = $$"""
@@ -6837,7 +6864,7 @@ partial public explicit extension R for C { }
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void SuppressConstraintChecksInitially()
     {
         var text = @"
@@ -6854,7 +6881,7 @@ public explicit extension R2<T> for C : R1<R2<T>> { }
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void SuppressConstraintChecksInitially_PointerAsTypeArgument()
     {
         var text = @"
@@ -6969,18 +6996,22 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead
-        comp.VerifyDiagnostics(
-            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'Object'.
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "System.Object").WithLocation(1, 27)
-            );
+        comp.VerifyDiagnostics();
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
         var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
+        // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead
+        comp.VerifyDiagnostics(
+            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'Object'.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "System.Object").WithLocation(1, 27)
+            );
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7007,15 +7038,19 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead (if we keep an error)
         comp.VerifyDiagnostics(
             // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends '?'.
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "?").WithLocation(1, 27)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7041,15 +7076,19 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead
         comp.VerifyDiagnostics(
             // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends '?'.
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "?").WithLocation(1, 27)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
     }
 
     [Theory, CombinatorialData]
@@ -7073,18 +7112,22 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead (if we keep an error)
-        comp.VerifyDiagnostics(
-            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'Object'.
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "System.Object").WithLocation(1, 27)
-            );
+        comp.VerifyDiagnostics();
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
         var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
+        // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead (if we keep an error)
+        comp.VerifyDiagnostics(
+            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'Object'.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "System.Object").WithLocation(1, 27)
+            );
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7111,12 +7154,7 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead
-        comp.VerifyDiagnostics(
-            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'Object'.
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "System.Object").WithLocation(1, 27)
-            );
+        comp.VerifyDiagnostics();
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7124,6 +7162,15 @@ public explicit extension R2 for object : R1 { }
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
         AssertEx.Equal("error CS9322: Extension marker method on type 'R1' is malformed.", r1ExtendedType.ErrorInfo.ToString());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
+        // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead
+        comp.VerifyDiagnostics(
+            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'Object'.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "System.Object").WithLocation(1, 27)
+            );
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7160,14 +7207,18 @@ public explicit extension R3 for object : R2 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         comp.VerifyDiagnostics(
             // (1,27): error CS9322: Extension marker method on type 'R2' is malformed.
             // public explicit extension R3 for object : R2 { }
             Diagnostic(ErrorCode.ERR_MalformedExtensionInMetadata, "R3").WithArguments("R2").WithLocation(1, 27)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<PENamedTypeSymbol>(r2, isExplicit: isExplicit);
@@ -7195,14 +7246,18 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyNotExtension<PENamedTypeSymbol>(r1);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         comp.VerifyDiagnostics(
             // (1,43): error CS9307: A base extension must be an extension type.
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "R1").WithLocation(1, 43)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyNotExtension<PENamedTypeSymbol>(r1);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7241,20 +7296,25 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics(
-            // (1,43): error CS0619: 'R1' is obsolete: 'Extension type are not supported in this version of your compiler.'
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "R1").WithArguments("R1", PEModule.ExtensionMarker).WithLocation(1, 43),
-            // (1,43): error CS9307: A base extension must be an extension type.
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "R1").WithLocation(1, 43)
-            );
+        comp.VerifyDiagnostics();
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyNotExtension<PENamedTypeSymbol>(r1);
 
-        var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
+        if (!new NoBaseExtensions().ShouldSkip)
+        {
+            comp.VerifyDiagnostics(
+                // (1,43): error CS0619: 'R1' is obsolete: 'Extension type are not supported in this version of your compiler.'
+                // public explicit extension R2 for object : R1 { }
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "R1").WithArguments("R1", PEModule.ExtensionMarker).WithLocation(1, 43),
+                // (1,43): error CS9307: A base extension must be an extension type.
+                // public explicit extension R2 for object : R1 { }
+                Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "R1").WithLocation(1, 43)
+                );
+
+            var r2 = comp.GlobalNamespace.GetTypeMember("R2");
+            VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
+        }
 
         comp = CreateCompilationWithIL(src, ilSource,
             options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
@@ -7300,20 +7360,25 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics(
-            // (1,43): error CS0619: 'R1' is obsolete: 'Extension type are not supported in this version of your compiler.'
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "R1").WithArguments("R1", PEModule.ExtensionMarker).WithLocation(1, 43),
-            // (1,43): error CS9307: A base extension must be an extension type.
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "R1").WithLocation(1, 43)
-            );
+        comp.VerifyDiagnostics();
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyNotExtension<PENamedTypeSymbol>(r1);
 
-        var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
+        if (!new NoBaseExtensions().ShouldSkip)
+        {
+            comp.VerifyDiagnostics(
+                // (1,43): error CS0619: 'R1' is obsolete: 'Extension type are not supported in this version of your compiler.'
+                // public explicit extension R2 for object : R1 { }
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "R1").WithArguments("R1", PEModule.ExtensionMarker).WithLocation(1, 43),
+                // (1,43): error CS9307: A base extension must be an extension type.
+                // public explicit extension R2 for object : R1 { }
+                Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "R1").WithLocation(1, 43)
+                );
+
+            var r2 = comp.GlobalNamespace.GetTypeMember("R2");
+            VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
+        }
 
         comp = CreateCompilationWithIL(src, ilSource,
             options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
@@ -7409,13 +7474,8 @@ public explicit extension R2 for object : R1 { }
 public explicit extension R2 for object : R1 { }
 """;
 
-        // PROTOTYPE should have a use-site error too
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics(
-            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'dynamic'.
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "dynamic").WithLocation(1, 27)
-            );
+        comp.VerifyDiagnostics();
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7423,6 +7483,15 @@ public explicit extension R2 for object : R1 { }
         Assert.Equal("dynamic", r1Underyling.ToTestDisplayString());
         Assert.True(r1Underyling.IsErrorType());
         Assert.Empty(r1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
+        // PROTOTYPE should have a use-site error too
+        comp.VerifyDiagnostics(
+            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'dynamic'.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "dynamic").WithLocation(1, 27)
+            );
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7458,13 +7527,8 @@ public explicit extension R2 for object : R1 { }
 """;
 
         // PROTOTYPE this test should be updated once we emit erase references to extensions (different metadata format)
-        // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics(
-            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'R0'.
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "R0").WithLocation(1, 27)
-            );
+        comp.VerifyDiagnostics();
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7473,6 +7537,15 @@ public explicit extension R2 for object : R1 { }
         Assert.True(r1Underyling.IsErrorType());
         AssertEx.Equal("error CS9322: Extension marker method on type 'R1' is malformed.", r1Underyling.ErrorInfo.ToString());
         Assert.Empty(r1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
+        // PROTOTYPE should have an error like "Extension marker method on type '...' is malformed" instead
+        comp.VerifyDiagnostics(
+            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'R0'.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "R0").WithLocation(1, 27)
+            );
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7500,11 +7573,7 @@ public explicit extension R2 for object : R1 { }
         // PROTOTYPE this test should be updated once we emit erase references to extensions (different metadata format)
         // PROTOTYPE should have a use-site error too
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics(
-            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'R1'.
-            // public explicit extension R2 for object : R1 { }
-            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "R1").WithLocation(1, 27)
-            );
+        comp.VerifyDiagnostics();
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
@@ -7513,11 +7582,19 @@ public explicit extension R2 for object : R1 { }
         Assert.True(r1Underyling.IsErrorType());
         Assert.Empty(r1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
 
+        if (new NoBaseExtensions().ShouldSkip) return;
+
+        comp.VerifyDiagnostics(
+            // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends 'R1'.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "R1").WithLocation(1, 27)
+            );
+
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void ExtensionMarkerMethod_WithNonExtensionSecondParameter()
     {
         var ilSource = $$"""
@@ -7556,7 +7633,7 @@ public explicit extension R2 for object : R1 { }
         Assert.False(r2BaseExtension.IsErrorType());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void ExtensionMarkerMethod_WithSelfReferentialSecondParameter()
     {
         var ilSource = $$"""
@@ -7637,6 +7714,9 @@ public explicit extension R3 for object : R2 { }
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<PENamedTypeSymbol>(r2, isExplicit: true);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         Assert.Equal(new[] { "R1", "R1" }, r2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
         Assert.True(r2.BaseExtensionsNoUseSiteDiagnostics.All(b => !b.IsErrorType()));
 
@@ -7674,6 +7754,13 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyNotExtension<PENamedTypeSymbol>(r1);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         comp.VerifyDiagnostics(
             // (1,43): error CS0619: 'R1' is obsolete: 'Extension types are not supported in this version of your compiler.'
             // public explicit extension R2 for object : R1 { }
@@ -7682,9 +7769,6 @@ public explicit extension R2 for object : R1 { }
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "R1").WithLocation(1, 43)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyNotExtension<PENamedTypeSymbol>(r1);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7913,7 +7997,7 @@ class C2 : C
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void ObsoleteExtensionMarker_WrongString()
     {
         var ilSource = $$"""
@@ -7967,16 +8051,20 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
+        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         // PROTOTYPE should have a use-site error too
         comp.VerifyDiagnostics(
             // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends '?'.
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "?").WithLocation(1, 27)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -8002,16 +8090,20 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
+        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         // PROTOTYPE should have a use-site error too
         comp.VerifyDiagnostics(
             // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends '?'.
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "?").WithLocation(1, 27)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -8067,16 +8159,20 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
+        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         // PROTOTYPE should have a use-site error too
         comp.VerifyDiagnostics(
             // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends '?'.
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "?").WithLocation(1, 27)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -8103,15 +8199,19 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
+        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         comp.VerifyDiagnostics(
             // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends '?'.
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "?").WithLocation(1, 27)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -8137,6 +8237,13 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         // PROTOTYPE should have a use-site error too
         comp.VerifyDiagnostics(
             // (1,27): error CS9316: Extension 'R2' extends 'object' but base extension 'R1' extends '?'.
@@ -8144,14 +8251,11 @@ public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "?").WithLocation(1, 27)
             );
 
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
-
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Dynamic_Nested()
     {
         // PROTOTYPE type references to extensions should be emitted with erasure
@@ -8173,7 +8277,7 @@ public explicit extension R2 for object : R1<dynamic> { }
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Dynamic_Nested_MissingDynamicAttribute()
     {
         var src = """
@@ -8189,7 +8293,7 @@ explicit extension R2 for object : R1<dynamic> { }
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Tuple_Nested()
     {
         // PROTOTYPE type references to extensions should be emitted with erasure
@@ -8211,7 +8315,7 @@ public explicit extension R2 for object : R1<(int a, int b)> { }
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Nullability_Nested()
     {
         // PROTOTYPE type references to extensions should be emitted with erasure
@@ -8233,7 +8337,7 @@ public explicit extension R2 for object : R1<object?> { }
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Nullability_Nested_MissingNullableAttribute()
     {
         var lib_cs = """
@@ -8265,7 +8369,7 @@ public explicit extension R2 for object : R1<object?> { }
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_Nullability_Nested_MissingNullableContextAttribute()
     {
         var src1 = """
@@ -8318,7 +8422,7 @@ public explicit extension R1 for object
         });
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_NativeInteger_Nested()
     {
         // PROTOTYPE type references to extensions should be emitted with erasure
@@ -8410,6 +8514,13 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics();
+
+        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
+        VerifyNotExtension<PENamedTypeSymbol>(r1);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
+
         comp.VerifyDiagnostics(
             // (1,43): error CS0619: 'R1' is obsolete: 'Extension type are not supported in this version of your compiler.'
             // public explicit extension R2 for object : R1 { }
@@ -8418,9 +8529,6 @@ public explicit extension R2 for object : R1 { }
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_OnlyBaseExtensionAllowed, "R1").WithLocation(1, 43)
             );
-
-        var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        VerifyNotExtension<PENamedTypeSymbol>(r1);
     }
 
     [Fact]
@@ -8553,7 +8661,7 @@ public explicit extension E for object
         Assert.Equal("System.Int32 E.Property { get; }", model.GetSymbolInfo(property).Symbol.ToTestDisplayString());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_BaseExtension()
     {
         var src = """
@@ -8650,7 +8758,7 @@ public explicit extension E for object : Base { }
         Assert.Equal("System.Int32 Base.Property { get; }", model.GetSymbolInfo(property).Symbol.ToTestDisplayString());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_BaseExtension_DifferentArities()
     {
         var src = """
@@ -8682,7 +8790,7 @@ public explicit extension E for object : Base
         Assert.Equal("void Base.M<System.Int32>()", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_BaseExtension_Ambiguous()
     {
         var src = """
@@ -8728,7 +8836,7 @@ public explicit extension E for object : Base1, Base2 { }
             model.GetSymbolInfo(property).CandidateSymbols.ToTestDisplayStrings());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_NestedType()
     {
         var src = """
@@ -8755,7 +8863,7 @@ public explicit extension E for object : Base
             e2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_NestedType_DifferentArities()
     {
         var src = """
@@ -8781,7 +8889,7 @@ public explicit extension E for object : Base
             e2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_NestedType_Ambiguous()
     {
         var src = """
@@ -8813,7 +8921,7 @@ public explicit extension E for object : Base1, Base2
         AssertEx.Equal(new[] { "Base1.Ambiguous" }, e2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_BaseExtension_Hiding()
     {
         var src = """
@@ -8868,7 +8976,7 @@ public explicit extension E for object : Base
         }
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_BaseExtension_MethodHidesProperty()
     {
         var src = """
@@ -8915,7 +9023,7 @@ public explicit extension E for object : Base
         }
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_MultipleCandidates()
     {
         var src = """
@@ -8949,7 +9057,7 @@ public explicit extension E for object : Base
         CompileAndVerify(comp, expectedOutput: "Method(long) Method(string) Method(long)", verify: Verification.FailsPEVerify);
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void MemberLookup_BaseExtension_Diamond()
     {
         var src = """
@@ -8994,7 +9102,7 @@ public explicit extension E4 for object : E2, E3 { }
         Assert.Equal("System.Int64 E2.Prop { get; }", model.GetSymbolInfo(property2).Symbol.ToTestDisplayString());
     }
 
-    [ConditionalFact(typeof(ClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(ClrOnly))]
     public void MemberLookup_BaseExtension_Inaccessible()
     {
         var src = """
@@ -9023,7 +9131,7 @@ public explicit extension E for object : Base
             );
     }
 
-    [ConditionalFact(typeof(ClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(ClrOnly))]
     public void MemberLookup_BaseExtension_Circular()
     {
         var src = """
@@ -9066,7 +9174,7 @@ public explicit extension E2 for object : E1 { }
         Assert.Null(model.GetSymbolInfo(property).Symbol);
     }
 
-    [ConditionalTheory(typeof(CoreClrOnly))]
+    [ConditionalTheory(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(2)]
@@ -9139,7 +9247,7 @@ public explicit extension E for object : Base1, Base2 { }
         }
     }
 
-    [ConditionalFact(typeof(ClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(ClrOnly))]
     public void MemberLookup_BaseExtension_CircularityAcrossNestedExtensions()
     {
         var src = """
@@ -9202,7 +9310,7 @@ public explicit extension D for object : C.Base
         Assert.Null(model.GetSymbolInfo(property).Symbol);
     }
 
-    [ConditionalFact(typeof(ClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(ClrOnly))]
     public void MemberLookup_BaseExtension_CircularityAcrossNestedExtensions_MissingBase()
     {
         var src1 = """
@@ -9327,7 +9435,7 @@ public explicit extension E1 for object : E2<B.C>
         CompileAndVerify(comp3, expectedOutput: "Method");
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void RecursiveExtensionLookup()
     {
         var src = """
@@ -9342,7 +9450,7 @@ explicit extension B for object : A<B.Garbage> { }
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void UseSiteErrorReporting_MissingGrandBase()
     {
         var source1 = """
@@ -9408,7 +9516,7 @@ public explicit extension A for object { }
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void MemberLookup_InUsing()
     {
         var src = """
@@ -9448,7 +9556,7 @@ namespace N
         Assert.Equal("Alias3=E.HidingMember", model.GetDeclaredSymbol(alias3).ToTestDisplayString());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void MemberLookup_InGlobalAlias()
     {
         var src = """
@@ -9486,7 +9594,7 @@ explicit extension E for object : Base
         Assert.Equal("E.HidingMember", model.GetSymbolInfo(hidingMember).Symbol.ToTestDisplayString());
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void MemberLookup_InAlias()
     {
         var src = """
@@ -9525,7 +9633,7 @@ explicit extension E for object : Base
         Assert.Equal("E.HidingMember", model.GetSymbolInfo(hidingMember).Symbol.ToTestDisplayString());
     }
 
-    [ConditionalTheory(typeof(ClrOnly))]
+    [ConditionalTheory(typeof(NoBaseExtensions), typeof(ClrOnly))]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(2)]
@@ -9933,7 +10041,7 @@ implicit extension Base for object
         Assert.Empty(model.GetMemberGroup(staticType));
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void ExtensionMemberLookup_Simple_Static_FromBaseExtension_OnlyDerivedInScope()
     {
         var src = """
@@ -10093,7 +10201,7 @@ implicit extension Base for object
         Assert.Empty(model.GetMemberGroup(method)); // PROTOTYPE need to fix the semantic model
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void ExtensionMemberLookup_Simple_Static_FromBaseExtension_Method_OnlyDerivedInScope()
     {
         var src = """
@@ -10212,7 +10320,7 @@ implicit extension E for C
         Assert.Equal(new[] { "void C.M(System.Int32 i)", "void C.M(System.String s)" }, model.GetMemberGroup(method).ToTestDisplayStrings());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void ExtensionMemberLookup_Simple_Static_Shadowing()
     {
         var src = """
@@ -14083,7 +14191,7 @@ implicit extension E for Fixable
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void ExtensionMemberLookup_PatternBasedAwait_NoMethod()
     {
         var text = @"
@@ -14123,7 +14231,7 @@ implicit extension E2 for D : INotifyCompletion
         //CompileAndVerify(comp, expectedOutput: "42");
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void ExtensionMemberLookup_PatternBasedAwait_NoApplicableGetAwaiterMethod()
     {
         var text = @"

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/ExtensionTypeTests.cs
@@ -164,7 +164,11 @@ public {{(isExplicit ? "explicit" : "implicit")}} extension R for UnderlyingClas
 explicit extension R2 for UnderlyingClass : R { }
 """;
         var comp2 = CreateCompilation(src2, references: new[] { AsReference(comp, useImageReference) }, targetFramework: TargetFramework.Net70);
-        comp2.VerifyDiagnostics();
+        comp2.VerifyDiagnostics(
+            // (1,43): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // explicit extension R2 for UnderlyingClass : R { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R").WithArguments("base extensions").WithLocation(1, 43)
+            );
         return;
 
         void validate(ModuleSymbol module)
@@ -821,6 +825,9 @@ explicit extension R2 for UnderlyingClass : I
             // (11,12): error CS0541: 'R1.M()': explicit interface declaration can only be declared in a class, record, struct or interface
             //     void I.M() { }
             Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "M").WithArguments("R1.M()").WithLocation(11, 12),
+            // (13,43): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // explicit extension R2 for UnderlyingClass : I
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": I").WithArguments("base extensions").WithLocation(13, 43),
             // (15,12): error CS0541: 'R2.M()': explicit interface declaration can only be declared in a class, record, struct or interface
             //     void I.M() { }
             Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "M").WithArguments("R2.M()").WithLocation(15, 12)
@@ -925,7 +932,7 @@ partial explicit extension R for UnderlyingClass
         Assert.True(r.GetProperty("MethodRefReadonly").ReturnsByRefReadonly);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void Members_Methods_AllowedModifiers_New()
     {
         var src = """
@@ -944,7 +951,7 @@ partial explicit extension R2 for UnderlyingClass : R1
         comp.VerifyDiagnostics();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void Members_Methods_AllowedModifiers_New_Missing()
     {
         var src = """
@@ -2914,6 +2921,8 @@ public explicit extension R for nint { }
         comp.VerifyDiagnostics();
 
         CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate, verify: Verification.FailsPEVerify);
+
+        if (new NoBaseExtensions().ShouldSkip) return;
 
         var src2 = """
 explicit extension R2 for nint : R { }
@@ -4944,7 +4953,7 @@ public class C
             );
     }
 
-    [Theory]
+    [ConditionalTheory(typeof(NoBaseExtensions))]
     [InlineData("public", "public")]
     [InlineData("public", "internal")]
     [InlineData("public", "protected")]
@@ -5036,7 +5045,7 @@ explicit extension R for UnderlyingClass : R1, R2 { }
         Assert.Equal(new[] { "R1@<tree 0>", "R2@<tree 0>" }, r.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
-    [Theory, CombinatorialData]
+    [ConditionalTheory(typeof(NoBaseExtensions)), CombinatorialData]
     public void BaseExtension_ImplicitVsExplicit(bool baseIsExplicit, bool thisIsExplicit)
     {
         var src = $$"""
@@ -5314,7 +5323,7 @@ explicit extension R8b for C : R8a, R3<(int, int)> { } // 3
             );
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void BaseExtension_CouldUnify()
     {
         var src = """
@@ -5616,7 +5625,7 @@ unsafe explicit extension R for UnderlyingClass
         comp.VerifyDiagnostics();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void Modifiers_New()
     {
         var src = """
@@ -6642,7 +6651,7 @@ class C<T> where T : R
         VerifyNotExtension<TypeParameterSymbol>(m.ReturnType);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoBaseExtensions))]
     public void NotExtension_TypeParameterSymbol_ViaSubstitution()
     {
         var src = $$"""
@@ -6967,7 +6976,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -6996,7 +7009,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7038,7 +7055,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7076,7 +7097,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7112,7 +7137,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7154,7 +7183,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7207,7 +7240,11 @@ public explicit extension R3 for object : R2 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R3 for object : R2 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R2").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7246,7 +7283,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyNotExtension<PENamedTypeSymbol>(r1);
@@ -7296,7 +7337,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyNotExtension<PENamedTypeSymbol>(r1);
@@ -7360,7 +7405,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyNotExtension<PENamedTypeSymbol>(r1);
@@ -7418,7 +7467,11 @@ static class OtherExtension
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7448,7 +7501,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
     }
@@ -7475,7 +7532,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7528,7 +7589,11 @@ public explicit extension R2 for object : R1 { }
 
         // PROTOTYPE this test should be updated once we emit erase references to extensions (different metadata format)
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -7573,7 +7638,11 @@ public explicit extension R2 for object : R1 { }
         // PROTOTYPE this test should be updated once we emit erase references to extensions (different metadata format)
         // PROTOTYPE should have a use-site error too
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
@@ -7706,7 +7775,11 @@ public explicit extension R3 for object : R2 { }
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
         // PROTOTYPE should we consider duplicate base extensions to be bad metadata?
         // PROTOTYPE this test should be updated once we emit erase references to extensions (different metadata format)
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R3 for object : R2 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R2").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
@@ -7754,7 +7827,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyNotExtension<PENamedTypeSymbol>(r1);
@@ -8051,7 +8128,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -8090,7 +8171,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -8129,7 +8214,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
@@ -8159,11 +8248,18 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
         Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+
+        var r2 = comp.GlobalNamespace.GetTypeMember("R2");
+        VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
 
         if (new NoBaseExtensions().ShouldSkip) return;
 
@@ -8173,9 +8269,6 @@ public explicit extension R2 for object : R1 { }
             // public explicit extension R2 for object : R1 { }
             Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R2").WithArguments("R2", "object", "R1", "?").WithLocation(1, 27)
             );
-
-        var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
     }
 
     [Theory, CombinatorialData]
@@ -8199,7 +8292,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
@@ -8237,7 +8334,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
@@ -8478,7 +8579,11 @@ static class OtherExtension
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var m = comp.GlobalNamespace.GetTypeMember("R1").GetMethod("M");
         Assert.False(m.IsExtensionMethod);
@@ -8514,7 +8619,11 @@ public explicit extension R2 for object : R1 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension R2 for object : R1 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": R1").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyNotExtension<PENamedTypeSymbol>(r1);
@@ -9431,7 +9540,13 @@ public explicit extension E1 for object : E2<B.C>
             references: new[] { comp2.ToMetadataReference() });
 
         // PROTOTYPE should we have a diagnostic for using B (whose base extension is missing)?
-        comp3.VerifyDiagnostics();
+        comp3.VerifyDiagnostics(
+            // (6,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // public explicit extension E1 for object : E2<B.C>
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": E2<B.C>").WithArguments("base extensions").WithLocation(6, 41)
+            );
+
+        if (new NoBaseExtensions().ShouldSkip) return;
         CompileAndVerify(comp3, expectedOutput: "Method");
     }
 
@@ -9977,7 +10092,7 @@ implicit extension E for object
         Assert.Equal("void E.Method()", model.GetSymbolInfo(method).Symbol.ToTestDisplayString());
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void ExtensionMemberLookup_Simple_Static_FromBaseExtension()
     {
         var src = """
@@ -10108,7 +10223,7 @@ namespace N
         Assert.Empty(model.GetMemberGroup(staticType));
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void ExtensionMemberLookup_Simple_Static_FromBaseExtension_OnlyDerivedInScope_Inaccessible()
     {
         var src = """
@@ -10175,7 +10290,7 @@ namespace N
         Assert.Empty(model.GetMemberGroup(type));
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [ConditionalFact(typeof(NoBaseExtensions), typeof(CoreClrOnly))]
     public void ExtensionMemberLookup_Simple_Static_FromBaseExtension_Method()
     {
         var src = """
@@ -10447,9 +10562,16 @@ namespace N
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         // PROTOTYPE should warn about hiding
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (5,39): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // implicit extension Derived for object : N.Base
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": N.Base").WithArguments("base extensions").WithLocation(5, 39)
+            );
 
-        CompileAndVerify(comp, expectedOutput: "Property Field(42) Type");
+        if (!new NoBaseExtensions().ShouldSkip)
+        {
+            CompileAndVerify(comp, expectedOutput: "Property Field(42) Type");
+        }
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -7089,6 +7089,9 @@ class C
 
             // Not expected to bind, since we don't consider inherited members.
             comp.VerifyDiagnostics(
+                // (6,39): error CS8000: This language feature ('base extensions') is not yet implemented.
+                // explicit extension Derived for object : Base
+                Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": Base").WithArguments("base extensions").WithLocation(6, 39),
                 // (10,16): warning CS1574: XML comment has cref attribute 'P' that could not be resolved
                 // /// <see cref='Derived.P'/>
                 Diagnostic(ErrorCode.WRN_BadXMLRef, "Derived.P").WithArguments("P").WithLocation(10, 16));
@@ -7130,7 +7133,11 @@ class Member
             var compilation = (Compilation)CreateCompilation(source, targetFramework: TargetFramework.Net70,
                 parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose));
 
-            compilation.VerifyDiagnostics();
+            compilation.VerifyDiagnostics(
+                // (11,43): error CS8000: This language feature ('base extensions') is not yet implemented.
+                //     explicit extension Derived for object : Base { }
+                Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": Base").WithArguments("base extensions").WithLocation(11, 43)
+                );
 
             var expectedSymbol = compilation.GlobalNamespace.GetMember<INamedTypeSymbol>("Member");
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -336,10 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
         internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics => ImmutableArray<NamedTypeSymbol>.Empty;
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics => ImmutableArray<NamedTypeSymbol>.Empty;
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();
-        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol>? basesBeingResolved) => throw ExceptionUtilities.Unreachable();
 #nullable disable
         internal override bool IsInterpolatedStringHandlerType => false;
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExtensionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExtensionParsingTests.cs
@@ -25,7 +25,11 @@ public sealed class ExtensionParsingTests : ParsingTests
 
         var keyword = isExplicit ? "explicit" : "implicit";
         var text = $$"""{{keyword}} extension C for UnderlyingType : BaseExtension1, BaseExtension2 { }""";
-        UsingTreeWithCSharpNext(text);
+        UsingTreeWithCSharpNext(text,
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // explicit extension C for UnderlyingType : BaseExtension1, BaseExtension2 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": BaseExtension1, BaseExtension2").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1094,7 +1098,11 @@ public sealed class ExtensionParsingTests : ParsingTests
         var keyword = isExplicit ? "explicit" : "implicit";
         var text = $$"""{{keyword}} extension C for UnderlyingType : BaseExtension() { }""";
 
-        UsingTreeWithCSharpNext(text);
+        UsingTreeWithCSharpNext(text,
+            // (1,41): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // explicit extension C for UnderlyingType : BaseExtension() { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": BaseExtension()").WithArguments("base extensions").WithLocation(1, 41)
+            );
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -2783,7 +2791,11 @@ explicit extension X
     {
         var keyword = isExplicit ? "explicit" : "implicit";
         var text = $$"""{{keyword}} extension X for delegate*<void> : Base1, Base2 { }""";
-        UsingTreeWithCSharpNext(text);
+        UsingTreeWithCSharpNext(text,
+            // (1,42): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // explicit extension X for delegate*<void> : Base1, Base2 { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": Base1, Base2").WithArguments("base extensions").WithLocation(1, 42)
+            );
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -3090,8 +3102,11 @@ explicit extension X
     {
         var text = """explicit extension X : X1 for int { }""";
         UsingTreeWithCSharpNext(text,
+            // (1,22): error CS8000: This language feature ('base extensions') is not yet implemented.
+            // explicit extension X : X1 for int { }
+            Diagnostic(ErrorCode.ERR_NotYetImplementedInRoslyn, ": X1").WithArguments("base extensions").WithLocation(1, 22),
             // (1,27): error CS1003: Syntax error, ',' expected
-            // explicit extension X : X1 for int
+            // explicit extension X : X1 for int { }
             Diagnostic(ErrorCode.ERR_SyntaxError, "for").WithArguments(",").WithLocation(1, 27)
             );
 

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -420,4 +420,12 @@ namespace Roslyn.Test.Utilities
 
         public override string SkipReason => "Test currently not supported on Framework 4.5";
     }
+
+    // PROTOTYPE support for base extensions was temporarily removed from the compiler
+    // but related tests were merely skipped.
+    public class NoBaseExtensions : ExecutionCondition
+    {
+        public override bool ShouldSkip => true;
+        public override string SkipReason => "Base extensions not supported yet";
+    }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -360,10 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
         internal override TypeSymbol GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();
-        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions(ConsList<TypeSymbol> basesBeingResolved) => throw ExceptionUtilities.Unreachable();
         internal override TypeSymbol ExtendedTypeNoUseSiteDiagnostics => throw ExceptionUtilities.Unreachable();
-        internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics => throw ExceptionUtilities.Unreachable();
-        internal override ImmutableArray<NamedTypeSymbol> AllBaseExtensionsNoUseSiteDiagnostics => throw ExceptionUtilities.Unreachable();
 
         [Conditional("DEBUG")]
         internal static void VerifyTypeParameters(Symbol container, ImmutableArray<TypeParameterSymbol> typeParameters)


### PR DESCRIPTION
Inheritance scenarios have been interfering and causing delays on more core scenarios (static and instance extension support).
By temporarily taking them out of the equation, we're reducing the risk to higher priority scenarios.
The tests involving base extensions are left in the codebase (skipped) so that they can be re-enabled later with minimal loss of context and no merge conflicts.

Relates to test plan https://github.com/dotnet/roslyn/issues/66722