### PR TITLE
Improve error location of missing `object.ToString()` for concatenation

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringConcat.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringConcat.cs
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Evaluate toString at the last possible moment, to avoid spurious diagnostics if it's missing.
             // All code paths below here use it.
-            var objectToStringMethod = UnsafeGetSpecialTypeMethod(syntax, SpecialMember.System_Object__ToString);
+            var objectToStringMethod = UnsafeGetSpecialTypeMethod(expr.Syntax, SpecialMember.System_Object__ToString);
 
             // If it's a struct which has overridden ToString, find that method. Note that we might fail to
             // find it, e.g. if object.ToString is missing

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringConcat.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringConcat.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Convert both sides to a string (calling ToString if necessary)
-            loweredLeft = ConvertConcatExprToString(syntax, loweredLeft);
-            loweredRight = ConvertConcatExprToString(syntax, loweredRight);
+            loweredLeft = ConvertConcatExprToString(loweredLeft);
+            loweredRight = ConvertConcatExprToString(loweredRight);
 
             Debug.Assert(loweredLeft.Type is { } && (loweredLeft.Type.IsStringType() || loweredLeft.Type.IsErrorType()) || loweredLeft.ConstantValueOpt?.IsNull == true);
             Debug.Assert(loweredRight.Type is { } && (loweredRight.Type.IsStringType() || loweredRight.Type.IsErrorType()) || loweredRight.ConstantValueOpt?.IsNull == true);
@@ -366,8 +366,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Returns an expression which converts the given expression into a string (or null).
         /// If necessary, this invokes .ToString() on the expression, to avoid boxing value types.
         /// </summary>
-        private BoundExpression ConvertConcatExprToString(SyntaxNode syntax, BoundExpression expr)
+        private BoundExpression ConvertConcatExprToString(BoundExpression expr)
         {
+            var syntax = expr.Syntax;
+
             // If it's a value type, it'll have been boxed by the +(string, object) or +(object, string)
             // operator. Undo that.
             if (expr.Kind == BoundKind.Conversion)
@@ -405,7 +407,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Evaluate toString at the last possible moment, to avoid spurious diagnostics if it's missing.
             // All code paths below here use it.
-            var objectToStringMethod = UnsafeGetSpecialTypeMethod(expr.Syntax, SpecialMember.System_Object__ToString);
+            var objectToStringMethod = UnsafeGetSpecialTypeMethod(syntax, SpecialMember.System_Object__ToString);
 
             // If it's a struct which has overridden ToString, find that method. Note that we might fail to
             // find it, e.g. if object.ToString is missing
@@ -431,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // types to all special value types.
             if (structToStringMethod != null && (expr.Type.SpecialType != SpecialType.None && !isFieldOfMarshalByRef(expr, _compilation)))
             {
-                return BoundCall.Synthesized(expr.Syntax, expr, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, structToStringMethod);
+                return BoundCall.Synthesized(syntax, expr, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, structToStringMethod);
             }
 
             // - It's a reference type (excluding unconstrained generics): no copy
@@ -454,9 +456,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (!callWithoutCopy)
                 {
-                    expr = new BoundPassByCopy(expr.Syntax, expr, expr.Type);
+                    expr = new BoundPassByCopy(syntax, expr, expr.Type);
                 }
-                return BoundCall.Synthesized(expr.Syntax, expr, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, objectToStringMethod);
+                return BoundCall.Synthesized(syntax, expr, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, objectToStringMethod);
             }
 
             if (callWithoutCopy)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -2403,7 +2403,69 @@ public class Test
             compilation.VerifyEmitDiagnostics(
                 // (9,27): error CS0656: Missing compiler required member 'System.Object.ToString'
                 //         Console.WriteLine(c + "3");
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"c + ""3""").WithArguments("System.Object", "ToString").WithLocation(9, 27)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "c").WithArguments("System.Object", "ToString").WithLocation(9, 27)
+                );
+        }
+
+        [Fact]
+        public void System_Object__ToString_3Args()
+        {
+            var source = """
+                using System;
+
+                public class Test
+                {
+                    static void Main()
+                    {
+                        char c = 'c';
+                        int i = 2;
+                        Console.WriteLine(c + "3" + i);
+                    }
+                }
+                """;
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Object__ToString);
+            compilation.VerifyEmitDiagnostics(
+                // (9,27): error CS0656: Missing compiler required member 'System.Object.ToString'
+                //         Console.WriteLine(c + "3" + i);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "c").WithArguments("System.Object", "ToString").WithLocation(9, 27),
+                // (9,37): error CS0656: Missing compiler required member 'System.Object.ToString'
+                //         Console.WriteLine(c + "3" + i);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "i").WithArguments("System.Object", "ToString").WithLocation(9, 37)
+                );
+        }
+
+        [Fact]
+        public void System_Object__ToString_4Args()
+        {
+            var source = """
+                using System;
+
+                public class Test
+                {
+                    static void Main()
+                    {
+                        char c = 'c';
+                        int i = 2;
+                        double d = 0.7;
+                        Console.WriteLine(c + "3" + i + d);
+                    }
+                }
+                """;
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Object__ToString);
+            compilation.VerifyEmitDiagnostics(
+                // (10,27): error CS0656: Missing compiler required member 'System.Object.ToString'
+                //         Console.WriteLine(c + "3" + i + d);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "c").WithArguments("System.Object", "ToString").WithLocation(10, 27),
+                // (10,37): error CS0656: Missing compiler required member 'System.Object.ToString'
+                //         Console.WriteLine(c + "3" + i + d);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "i").WithArguments("System.Object", "ToString").WithLocation(10, 37),
+                // (10,41): error CS0656: Missing compiler required member 'System.Object.ToString'
+                //         Console.WriteLine(c + "3" + i + d);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "d").WithArguments("System.Object", "ToString").WithLocation(10, 41)
                 );
         }
 


### PR DESCRIPTION
Extracted from https://github.com/dotnet/roslyn/pull/71793 (suggested in https://github.com/dotnet/roslyn/pull/71793#discussion_r1471633235)

Currently if `object.ToString()` member is missing error is reported on the whole concatenation. It makes more sense to report in on the argument, which actually requested that member.

E.g. consider concatenation `a + b + c` where `a` is a string and `b` and `c` are not. If `object.ToString()` is missing without a chage of this PR error locations will be for `b` - `a + b` and for `c` - the whole `a + b + c`. This PR chages it so that errors are reported directly on `b` and `c`. Added 2 tests to show this behavior for 3 and 4 concatenation arguments

I know that this is a very minor change and I would not normally make it, but since such separation of changes was requested by a compiler team meber, here is it. The "fix" is just several charachters long. And regardless of whether this is accepted or not, a lot more tests of missing `object.ToString()` for concatenation are about to come in https://github.com/dotnet/roslyn/pull/71793