### PR TITLE
Disable autoBraceSurround on 17.9 P2 tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpAddMissingReference.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpAddMissingReference.cs
@@ -164,7 +164,7 @@ class Program
             await TestServices.Editor.PlaceCaretAsync("y.goo", charsOffset: 1, HangMitigatingCancellationToken);
             await TestServices.Editor.InvokeCodeActionListAsync(HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CodeActionAsync("Add reference to 'System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.", applyFix: true, cancellationToken: HangMitigatingCancellationToken);
-            await TestServices.SolutionExplorerVerifier.AssemblyReferencePresentAsync(
+            await TestServices.SolutionVerifier.AssemblyReferencePresentAsync(
                 projectName: consoleProject,
                 assemblyName: "System.Windows.Forms",
                 assemblyVersion: "4.0.0.0",
@@ -173,7 +173,7 @@ class Program
             await TestServices.Editor.PlaceCaretAsync("a.bar", charsOffset: 1, HangMitigatingCancellationToken);
             await TestServices.Editor.InvokeCodeActionListAsync(HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CodeActionAsync("Add project reference to 'ClassLibrary3'.", applyFix: true, cancellationToken: HangMitigatingCancellationToken);
-            await TestServices.SolutionExplorerVerifier.ProjectReferencePresentAsync(
+            await TestServices.SolutionVerifier.ProjectReferencePresentAsync(
                 projectName: consoleProject,
                 referencedProjectName: ClassLibrary3Name,
                 HangMitigatingCancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
@@ -192,14 +192,14 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
             ErrorHandler.ThrowOnFailure(solution.SaveSolutionElement((uint)__VSSLNSAVEOPTIONS.SLNSAVEOPT_ForceSave, null, 0));
         }
 
-        public async Task<string[]> GetAssemblyReferencesAsync(string projectName, CancellationToken cancellationToken)
+        public async Task<ImmutableArray<(string name, string version, string publicKeyToken)>> GetAssemblyReferencesAsync(string projectName, CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             var project = await GetProjectAsync(projectName, cancellationToken);
             var references = ((VSProject)project.Object).References.Cast<Reference>()
                 .Where(x => x.SourceProject == null)
-                .Select(x => x.Name + "," + x.Version + "," + x.PublicKeyToken).ToArray();
+                .Select(x => (x.Name, x.Version, x.PublicKeyToken)).ToImmutableArray();
             return references;
         }
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerVerifierInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerVerifierInProcess.cs
@@ -12,7 +12,6 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Test.Utilities;
-using Xunit;
 
 namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 {
@@ -67,19 +66,6 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             }
 
             AssertEx.EqualOrDiff("", string.Join(Environment.NewLine, unsavedFiles), "Unexpected dirty documents after failed Save All");
-        }
-
-        public async Task AssemblyReferencePresentAsync(string projectName, string assemblyName, string assemblyVersion, string assemblyPublicKeyToken, CancellationToken cancellationToken)
-        {
-            var assemblyReferences = await TestServices.SolutionExplorer.GetAssemblyReferencesAsync(projectName, cancellationToken);
-            var expectedAssemblyReference = assemblyName + "," + assemblyVersion + "," + assemblyPublicKeyToken.ToUpper();
-            Assert.Contains(expectedAssemblyReference, assemblyReferences);
-        }
-
-        public async Task ProjectReferencePresentAsync(string projectName, string referencedProjectName, CancellationToken cancellationToken)
-        {
-            var projectReferences = await TestServices.SolutionExplorer.GetProjectReferencesAsync(projectName, cancellationToken);
-            Assert.Contains(referencedProjectName, projectReferences);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionVerifierInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionVerifierInProcess.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Extensibility.Testing;
 using Xunit;
 
@@ -15,11 +17,18 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
         public async Task AssemblyReferencePresentAsync(string projectName, string assemblyName, string assemblyVersion, string assemblyPublicKeyToken, CancellationToken cancellationToken)
         {
             var assemblyReferences = await TestServices.SolutionExplorer.GetAssemblyReferencesAsync(projectName, cancellationToken);
-            var expectedAssemblyReference = assemblyName + "," + assemblyVersion + "," + assemblyPublicKeyToken.ToUpper();
+            var expectedAssemblyReference = (assemblyName, assemblyVersion, assemblyPublicKeyToken.ToUpper());
+            if (assemblyReferences.Contains(expectedAssemblyReference))
+                return;
+
+            var assemblyReferencesMatchingName = assemblyReferences.WhereAsArray(reference => string.Equals(reference.name, expectedAssemblyReference.assemblyName, StringComparison.OrdinalIgnoreCase));
+            if (!assemblyReferencesMatchingName.IsEmpty)
+                assemblyReferences = assemblyReferencesMatchingName;
+
             Assert.Contains(expectedAssemblyReference, assemblyReferences);
         }
 
-        public async Task ProjectReferencePresent(string projectName, string referencedProjectName, CancellationToken cancellationToken)
+        public async Task ProjectReferencePresentAsync(string projectName, string referencedProjectName, CancellationToken cancellationToken)
         {
             var projectReferences = await TestServices.SolutionExplorer.GetProjectReferencesAsync(projectName, cancellationToken);
             Assert.Contains(referencedProjectName, projectReferences);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkaroundsInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkaroundsInProcess.cs
@@ -116,6 +116,17 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
                 var result = writer.RequestCommit("Integration test workaround");
                 Assert.True(result.Outcome is SettingCommitOutcome.Success or SettingCommitOutcome.NoChangesQueued);
             }
+
+            // 17.9 P2 used a different name for the same setting
+            settingName = "textEditor.general.autoBraceSurround";
+            settingRetrieval = reader.GetValue<bool>(settingName);
+            if (settingRetrieval.Value)
+            {
+                var writer = settingManager.GetWriter("Roslyn Integration test");
+                writer.EnqueueChange(settingName, false);
+                var result = writer.RequestCommit("Integration test workaround");
+                Assert.True(result.Outcome is SettingCommitOutcome.Success or SettingCommitOutcome.NoChangesQueued);
+            }
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicAddMissingReference.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicAddMissingReference.cs
@@ -180,7 +180,7 @@ End Module
             await TestServices.Editor.PlaceCaretAsync("a.bar", charsOffset: 1, HangMitigatingCancellationToken);
             await TestServices.Editor.InvokeCodeActionListAsync(HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CodeActionAsync("Add project reference to 'ClassLibrary3'.", applyFix: true, cancellationToken: HangMitigatingCancellationToken);
-            await TestServices.SolutionVerifier.ProjectReferencePresent(
+            await TestServices.SolutionVerifier.ProjectReferencePresentAsync(
                projectName: ConsoleProjectName,
                referencedProjectName: ClassLibrary3Name,
                HangMitigatingCancellationToken);


### PR DESCRIPTION
This feature was renamed in later previews, but our integration tests do not use those versions in CI at this time. Update our workaround to handle both names that appeared for the feature.