### PR TITLE
Move to Preview 4 image

### DIFF
--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -59,7 +59,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.amd64.open
+  default: windows.vs2022preview.scout.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -56,7 +56,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.amd64.open
+  default: windows.vs2022preview.scout.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open


### PR DESCRIPTION
Scouting queue is targeting 17.9 Preview 4 now.
I believe this would make our 17.9 release integration tests green.
I know it's not a good convention to use scouting queue, but It would be useful when people make 17.9 QB fix.