### PR TITLE
Enable implicit primary constructor parameter capture analyzer

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,6 +10,7 @@
     <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json" />

--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->
-    <RoslynDiagnosticsNugetPackageVersion>3.11.0-beta1.23364.2</RoslynDiagnosticsNugetPackageVersion>
+    <RoslynDiagnosticsNugetPackageVersion>3.11.0-beta1.24081.1</RoslynDiagnosticsNugetPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview.23468.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23411.1</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.187-beta</MicrosoftVisualStudioExtensibilityTestingVersion>

--- a/src/Compilers/.editorconfig
+++ b/src/Compilers/.editorconfig
@@ -25,6 +25,10 @@ csharp_style_var_when_type_is_apparent = true:none
 csharp_style_var_elsewhere = false:none
 csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
 
+# RS0062: Do not capture primary constructor parameters
+# Warning so that it doesn't block local F5, but will fail in CI with WarnAsError
+dotnet_diagnostic.RS0062.severity = warning
+
 # XML files
 [*.xml]
 indent_size = 2

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
@@ -30,11 +30,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         CSharpSymbolMatcher? previousSourceToCurrentSource,
         EmitBaseline baseline) : DefinitionMap(edits, baseline)
     {
+        private readonly MetadataDecoder _metadataDecoder = metadataDecoder;
         private readonly CSharpSymbolMatcher _sourceToPrevious = previousSourceToCurrentSource ?? sourceToMetadata;
 
-        public override SymbolMatcher SourceToMetadataSymbolMatcher => sourceToMetadata;
+        public override SymbolMatcher SourceToMetadataSymbolMatcher { get; } = sourceToMetadata;
         public override SymbolMatcher SourceToPreviousSymbolMatcher => _sourceToPrevious;
-        public override SymbolMatcher PreviousSourceToMetadataSymbolMatcher => previousSourceToMetadata;
+        public override SymbolMatcher PreviousSourceToMetadataSymbolMatcher { get; } = previousSourceToMetadata;
 
         protected override ISymbolInternal? GetISymbolInternalOrNull(ISymbol symbol)
         {
@@ -121,17 +122,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             Debug.Assert(!handle.IsNil);
 
-            var localInfos = metadataDecoder.GetLocalsOrThrow(handle);
+            var localInfos = _metadataDecoder.GetLocalsOrThrow(handle);
             var result = CreateLocalSlotMap(debugInfo, localInfos);
             Debug.Assert(result.Length == localInfos.Length);
             return result;
         }
 
         protected override ITypeSymbolInternal? TryGetStateMachineType(MethodDefinitionHandle methodHandle)
-            => metadataDecoder.Module.HasStateMachineAttribute(methodHandle, out var typeName) ? metadataDecoder.GetTypeSymbolForSerializedType(typeName) : null;
+            => _metadataDecoder.Module.HasStateMachineAttribute(methodHandle, out var typeName) ? _metadataDecoder.GetTypeSymbolForSerializedType(typeName) : null;
 
         protected override IMethodSymbolInternal GetMethodSymbol(MethodDefinitionHandle methodHandle)
-            => (IMethodSymbolInternal)metadataDecoder.GetSymbolForILToken(methodHandle);
+            => (IMethodSymbolInternal)_metadataDecoder.GetSymbolForILToken(methodHandle);
 
         /// <summary>
         /// Match local declarations to names to generate a map from

--- a/src/Compilers/CSharp/Test/Emit2/Emit/EditAndContinue/EditAndContinueTest.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/EditAndContinue/EditAndContinueTest.cs
@@ -23,9 +23,11 @@ internal sealed class EditAndContinueTest(
 {
     private readonly CSharpCompilationOptions _compilationOptions = (options ?? TestOptions.DebugDll).WithConcurrentBuild(false);
     private readonly CSharpParseOptions _parseOptions = parseOptions ?? TestOptions.Regular.WithNoRefSafetyRulesAttribute();
+    private readonly TargetFramework _targetFramework = targetFramework;
+    private readonly IEnumerable<MetadataReference>? _references = references;
 
     protected override Compilation CreateCompilation(SyntaxTree tree)
-        => CSharpTestBase.CreateCompilation(tree, references, options: _compilationOptions, targetFramework: targetFramework);
+        => CSharpTestBase.CreateCompilation(tree, _references, options: _compilationOptions, targetFramework: _targetFramework);
 
     protected override SourceWithMarkedNodes CreateSourceWithMarkedNodes(string source)
         => EditAndContinueTestBase.MarkedSource(source, options: _parseOptions);

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverFuzzTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverFuzzTests.cs
@@ -23,6 +23,8 @@ using Roslyn.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
+#pragma warning disable RS0062 // Do not implicitly capture primary constructor parameters
+
 namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 {
     public class GeneratorDriverFuzzTests

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedMethodBody.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedMethodBody.cs
@@ -12,6 +12,8 @@ namespace Microsoft.CodeAnalysis.Emit.EditAndContinue
 {
     internal sealed class DeletedMethodBody(IDeletedMethodDefinition methodDef, ImmutableArray<byte> il) : Cci.IMethodBody
     {
+        private readonly IDeletedMethodDefinition _methodDef = methodDef;
+
         public ImmutableArray<byte> IL { get; } = il;
 
 #nullable disable
@@ -24,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Emit.EditAndContinue
 
         public ImmutableArray<Cci.ILocalDefinition> LocalVariables => ImmutableArray<Cci.ILocalDefinition>.Empty;
 
-        public Cci.IMethodDefinition MethodDefinition => methodDef;
+        public Cci.IMethodDefinition MethodDefinition => _methodDef;
 
         public StateMachineMoveNextBodyDebugInfo MoveNextBodyInfo => null;
 

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -237,8 +237,10 @@ namespace Roslyn.Utilities
 
         private sealed class DebuggerProxy(OneOrMany<T> instance)
         {
+            private readonly OneOrMany<T> _instance = instance;
+
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public T[] Items => instance.ToArray();
+            public T[] Items => _instance.ToArray();
         }
 
         private string GetDebuggerDisplay()

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.NodeEnumerable.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.NodeEnumerable.cs
@@ -13,8 +13,10 @@ internal abstract partial class GreenNode
     [NonCopyable]
     public ref struct NodeEnumerable(GreenNode node)
     {
+        private readonly GreenNode _node = node;
+
         public readonly Enumerator GetEnumerator()
-            => new Enumerator(node);
+            => new Enumerator(_node);
 
         [NonCopyable]
         public ref struct Enumerator

--- a/src/Compilers/Test/Core/Mocks/TestEqualityComparer.cs
+++ b/src/Compilers/Test/Core/Mocks/TestEqualityComparer.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable RS0062 // Do not implicitly capture primary constructor parameters
+
 namespace Roslyn.Test.Utilities
 {
     public class TestEqualityComparer<T>(Func<T?, T?, bool>? equals = null, Func<T, int>? getHashCode = null) : IEqualityComparer<T>

--- a/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
+++ b/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
@@ -77,6 +77,7 @@ namespace Roslyn.Test.Utilities.TestGenerators
         }
     }
 
+#pragma warning disable RS0062 // Do not implicitly capture primary constructor paramters
     internal class CallbackGenerator(
         Action<GeneratorInitializationContext> onInit,
         Action<GeneratorExecutionContext> onExecute,
@@ -113,6 +114,7 @@ namespace Roslyn.Test.Utilities.TestGenerators
             }
         }
     }
+#pragma warning restore RS0062 // Do not implicitly capture primary constructor paramters
 
     internal class CallbackGenerator2 : CallbackGenerator
     {


### PR DESCRIPTION
The compiler codebase is enabling RS0062, which prevents implicit capture of primary constructor parameters. I've also fixed shipping code violations, and suppressed existing violations in test code.
