### PR TITLE
Report better warnings and errors if build hosts exit abnormally

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/DiagnosticReporterLoggerProvider.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/DiagnosticReporterLoggerProvider.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.MSBuild;
+
+internal class DiagnosticReporterLoggerProvider : ILoggerProvider
+{
+    private readonly DiagnosticReporter _reporter;
+
+    private DiagnosticReporterLoggerProvider(DiagnosticReporter reporter)
+    {
+        _reporter = reporter;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new Logger(_reporter, categoryName);
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public static ILoggerFactory CreateLoggerFactoryForDiagnosticReporter(DiagnosticReporter reporter)
+    {
+        // Note: it's important we set MinLevel here, or otherwise we'll still get called in Log() for things below LogLevel.Warning.
+        return new LoggerFactory(
+            [new DiagnosticReporterLoggerProvider(reporter)],
+            new LoggerFilterOptions() { MinLevel = LogLevel.Warning });
+    }
+
+    private sealed class Logger(DiagnosticReporter reporter, string categoryName) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return logLevel >= LogLevel.Warning;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var kind = logLevel == LogLevel.Warning ? WorkspaceDiagnosticKind.Warning : WorkspaceDiagnosticKind.Failure;
+            var message = formatter(state, exception);
+            if (!string.IsNullOrEmpty(categoryName))
+                message = $"[{categoryName}] {message}";
+
+            reporter.Report(new WorkspaceDiagnostic(kind, message));
+        }
+    }
+}

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.MSBuild.Build;
 using Roslyn.Utilities;
 using MSB = Microsoft.Build;
 
@@ -24,6 +23,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         private readonly SolutionServices _solutionServices;
 
         private readonly DiagnosticReporter _diagnosticReporter;
+        private readonly Microsoft.Extensions.Logging.ILoggerFactory _loggerFactory;
         private readonly PathResolver _pathResolver;
         private readonly ProjectFileExtensionRegistry _projectFileExtensionRegistry;
 
@@ -33,13 +33,15 @@ namespace Microsoft.CodeAnalysis.MSBuild
         internal MSBuildProjectLoader(
             SolutionServices solutionServices,
             DiagnosticReporter diagnosticReporter,
-            ProjectFileExtensionRegistry? projectFileExtensionRegistry,
+            Microsoft.Extensions.Logging.ILoggerFactory loggerFactory,
+            ProjectFileExtensionRegistry projectFileExtensionRegistry,
             ImmutableDictionary<string, string>? properties)
         {
             _solutionServices = solutionServices;
             _diagnosticReporter = diagnosticReporter;
+            _loggerFactory = loggerFactory;
             _pathResolver = new PathResolver(_diagnosticReporter);
-            _projectFileExtensionRegistry = projectFileExtensionRegistry ?? new ProjectFileExtensionRegistry(solutionServices, _diagnosticReporter);
+            _projectFileExtensionRegistry = projectFileExtensionRegistry;
 
             Properties = ImmutableDictionary.Create<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -56,8 +58,19 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// <param name="properties">An optional dictionary of additional MSBuild properties and values to use when loading projects.
         /// These are the same properties that are passed to MSBuild via the /property:&lt;n&gt;=&lt;v&gt; command line argument.</param>
         public MSBuildProjectLoader(Workspace workspace, ImmutableDictionary<string, string>? properties = null)
-            : this(workspace.Services.SolutionServices, new DiagnosticReporter(workspace), projectFileExtensionRegistry: null, properties)
         {
+            _solutionServices = workspace.Services.SolutionServices;
+            _diagnosticReporter = new DiagnosticReporter(workspace);
+            _loggerFactory = DiagnosticReporterLoggerProvider.CreateLoggerFactoryForDiagnosticReporter(_diagnosticReporter);
+            _pathResolver = new PathResolver(_diagnosticReporter);
+            _projectFileExtensionRegistry = new ProjectFileExtensionRegistry(_solutionServices, _diagnosticReporter);
+
+            Properties = ImmutableDictionary.Create<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (properties != null)
+            {
+                Properties = Properties.AddRange(properties);
+            }
         }
 
         /// <summary>
@@ -199,7 +212,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 }
             }
 
-            var buildHostProcessManager = new BuildHostProcessManager(Properties);
+            var buildHostProcessManager = new BuildHostProcessManager(Properties, loggerFactory: _loggerFactory);
             await using var _ = buildHostProcessManager.ConfigureAwait(false);
 
             var worker = new Worker(
@@ -261,7 +274,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 onPathFailure: reportingMode,
                 onLoaderFailure: reportingMode);
 
-            var buildHostProcessManager = new BuildHostProcessManager(Properties);
+            var buildHostProcessManager = new BuildHostProcessManager(Properties, loggerFactory: _loggerFactory);
             await using var _ = buildHostProcessManager.ConfigureAwait(false);
 
             var worker = new Worker(

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         private readonly NonReentrantLock _serializationLock = new();
 
         private readonly MSBuildProjectLoader _loader;
+        private readonly Microsoft.Extensions.Logging.ILoggerFactory _loggerFactory;
         private readonly ProjectFileExtensionRegistry _projectFileExtensionRegistry;
         private readonly DiagnosticReporter _reporter;
 
@@ -41,7 +42,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
         {
             _reporter = new DiagnosticReporter(this);
             _projectFileExtensionRegistry = new ProjectFileExtensionRegistry(Services.SolutionServices, _reporter);
-            _loader = new MSBuildProjectLoader(Services.SolutionServices, _reporter, _projectFileExtensionRegistry, properties);
+            _loggerFactory = DiagnosticReporterLoggerProvider.CreateLoggerFactoryForDiagnosticReporter(_reporter);
+            _loader = new MSBuildProjectLoader(Services.SolutionServices, _reporter, _loggerFactory, _projectFileExtensionRegistry, properties);
         }
 
         /// <summary>
@@ -312,7 +314,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 try
                 {
                     Debug.Assert(_applyChangesBuildHostProcessManager == null);
-                    _applyChangesBuildHostProcessManager = new BuildHostProcessManager(Properties);
+                    _applyChangesBuildHostProcessManager = new BuildHostProcessManager(Properties, loggerFactory: _loggerFactory);
 
                     return base.TryApplyChanges(newSolution, progressTracker);
                 }

--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
@@ -2349,18 +2349,18 @@ class C1
 
             CreateFiles(files);
 
-            using var workspace = new AdhocWorkspace(MSBuildMefHostServices.DefaultServices, WorkspaceKind.MSBuild);
+            using var workspace = CreateMSBuildWorkspace();
             var projectFullPath = GetSolutionFileName(@"AnalyzerSolution\CSharpProject_AnalyzerReference.csproj");
 
-            var loader = new MSBuildProjectLoader(workspace);
-            var infos = await loader.LoadProjectInfoAsync(projectFullPath);
+            var project = await workspace.OpenProjectAsync(projectFullPath);
 
-            var doc = infos[0].Documents[0];
-            var tav = doc.TextLoader.LoadTextAndVersionSynchronously(new LoadTextOptions(SourceHashAlgorithms.Default), CancellationToken.None);
+            var document = project.Documents.Single(d => d.Name == "CSharpClass.cs");
+            var documentText = document.GetTextSynchronously(CancellationToken.None);
+            Assert.Contains("public class CSharpClass", documentText.ToString(), StringComparison.Ordinal);
 
-            var adoc = infos[0].AdditionalDocuments.First(a => a.Name == "XamlFile.xaml");
-            var atav = adoc.TextLoader.LoadTextAndVersionSynchronously(new LoadTextOptions(SourceHashAlgorithms.Default), CancellationToken.None);
-            Assert.Contains("Window", atav.Text.ToString(), StringComparison.Ordinal);
+            var additionalDocument = project.AdditionalDocuments.Single(a => a.Name == "XamlFile.xaml");
+            var additionalDocumentText = additionalDocument.GetTextSynchronously(CancellationToken.None);
+            Assert.Contains("Window", additionalDocumentText.ToString(), StringComparison.Ordinal);
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]

--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
@@ -91,6 +91,20 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]
+        public async Task TestDirectUseOfMSBuildProjectLoader()
+        {
+            CreateFiles(GetSimpleCSharpSolutionFiles());
+            var solutionFilePath = GetSolutionFileName("TestSolution.sln");
+
+            using var workspace = CreateMSBuildWorkspace();
+            var msbuildProjectLoader = new MSBuildProjectLoader(workspace);
+            var solutionInfo = await msbuildProjectLoader.LoadSolutionInfoAsync(solutionFilePath);
+            var projectInfo = Assert.Single(solutionInfo.Projects);
+
+            Assert.Single(projectInfo.Documents.Where(d => d.Name == "CSharpClass.cs"));
+        }
+
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]
         public async Task Test_SharedMetadataReferences()
         {
             CreateFiles(GetMultiProjectSolutionFiles());


### PR DESCRIPTION
This reports warnings or errors through the ILogger passed to the BuildHostProcessManager if a process exits abnormally, and includes the stderr of the process. Without this you'd be able to manually turn on tracing in VS Code, but that required extra steps to diagnose. This also allows us to pass warnings and errors through to MSBuildWorkspace, which otherwise didn't pass along this information.

Commit-at-a-time might be helpful, since an unrelated test got cleaned up during this change since it was written differently than the rest of all the tests.