### PR TITLE
Disallow UseConditionalExpression with unsafe or checked/unchecked blocks

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
@@ -478,6 +478,78 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseConditionalExpressio
                 """);
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70750")]
+        public async Task TestMissingWithChecked()
+        {
+            await TestMissingInRegularAndScriptAsync(
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        [||]if (x < 0)
+                        {
+                            throw new System.Exception();
+                        }
+                        checked
+                        {
+                            return x - y;
+                        }
+                    }
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70750")]
+        public async Task TestMissingWithUnchecked()
+        {
+            await TestMissingInRegularAndScriptAsync(
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        [||]if (x < 0)
+                        {
+                            throw new System.Exception();
+                        }
+                        unchecked
+                        {
+                            return x - y;
+                        }
+                    }
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70750")]
+        public async Task TestMissingWithUnsafe()
+        {
+            await TestMissingInRegularAndScriptAsync(
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        [||]if (x < 0)
+                        {
+                            throw new System.Exception();
+                        }
+                        unsafe
+                        {
+                            return x - y;
+                        }
+                    }
+                }
+                """);
+        }
+
         [Fact]
         public async Task TestConversion1_CSharp8()
         {

--- a/src/Analyzers/Core/Analyzers/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
@@ -25,10 +25,16 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
         protected sealed override CodeStyleOption2<bool> GetStylePreference(OperationAnalysisContext context)
             => context.GetAnalyzerOptions().PreferConditionalExpressionOverReturn;
 
-        protected override (bool matched, bool canSimplify) TryMatchPattern(IConditionalOperation ifOperation, ISymbol containingSymbol)
+        protected sealed override (bool matched, bool canSimplify) TryMatchPattern(IConditionalOperation ifOperation, ISymbol containingSymbol)
         {
             if (!UseConditionalExpressionForReturnHelpers.TryMatchPattern(
                     GetSyntaxFacts(), ifOperation, containingSymbol, out var isRef, out var trueStatement, out var falseStatement, out var trueReturn, out var falseReturn))
+            {
+                return default;
+            }
+
+            if (!IsStatementSupported(trueStatement) ||
+                !IsStatementSupported(falseStatement))
             {
                 return default;
             }
@@ -41,5 +47,8 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
 
             return (matched: true, canSimplify);
         }
+
+        protected virtual bool IsStatementSupported(IOperation statement)
+            => true;
     }
 }


### PR DESCRIPTION
Closes #70750 

As it says on the thin. To note, I did checked to see how hard it would be to wrap the statement to an expression in the case of checked/unchecked and I found it would require some refactor I am not sure on how to do so I opted to disallow them for now.