### PR TITLE
Reduce allocations during NamespaceSymbol.LookupNestedNamespace

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -96,7 +96,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             EnsureAllMembersLoaded();
 
             if (lazyNamespaces.TryGetValue(name, out var ns))
+            {
                 return ns;
+            }
 
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -91,6 +91,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return StaticCast<NamedTypeSymbol>.From(_lazyFlattenedTypes);
         }
 
+        internal override NamespaceSymbol GetNestedNamespace(ReadOnlyMemory<char> name)
+        {
+            EnsureAllMembersLoaded();
+
+            if (lazyNamespaces.TryGetValue(name, out var ns))
+                return ns;
+
+            return null;
+        }
+
         public sealed override ImmutableArray<Symbol> GetMembers(ReadOnlyMemory<char> name)
         {
             EnsureAllMembersLoaded();

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal NamespaceSymbol GetNestedNamespace(string name)
             => GetNestedNamespace(name.AsMemory());
 
-        internal NamespaceSymbol GetNestedNamespace(ReadOnlyMemory<char> name)
+        internal virtual NamespaceSymbol GetNestedNamespace(ReadOnlyMemory<char> name)
         {
             foreach (var sym in this.GetMembers(name))
             {


### PR DESCRIPTION
This method showed up in a profile I took of the codeanalysis process while typing 5 lines of text in a console app. When NamespaceSymbol.GetNestedNamespace was previously being called, it would call GetMembers and return the first namespace found. The PENamespaceSymbol GetMembers call was allocating a single entry immutable array on nearly all these calls. By making GetNestedNamespace virtual, PENamespaceSymbol can now override that method and just return a value without allocating.

*** Old memory allocations ***
 
![image](https://github.com/dotnet/roslyn/assets/6785178/feb55c97-0517-4d40-8d0d-fc39ace8136b)

*** New memory allocations ***

![image](https://github.com/dotnet/roslyn/assets/6785178/f403ce31-5a96-4d61-96b3-697ca228af55)

