### PR TITLE
Handle Lock type in VB

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -1732,7 +1732,7 @@ DoneWithDiagnostics:
             End If
         End Sub
 
-        Private Sub WarnOnLockConversion(sourceType As TypeSymbol, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag)
+        Private Shared Sub WarnOnLockConversion(sourceType As TypeSymbol, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag)
             If sourceType IsNot Nothing AndAlso sourceType.IsWellKnownTypeLock() Then
                 ReportDiagnostic(diagnostics, syntax, ERRID.WRN_ConvertingLock)
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -158,7 +158,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 constantResult = Conversions.TryFoldNothingReferenceConversion(argument, conv, targetType)
             End If
 
-            WarnOnLockConversion(sourceType, targetType, argument.Syntax, diagnostics)
+            If Not Conversions.IsIdentityConversion(conv) Then
+                WarnOnLockConversion(sourceType, argument.Syntax, diagnostics)
+            End If
 
             Return New BoundDirectCast(node, argument, conv, constantResult, targetType)
         End Function
@@ -259,7 +261,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim constantResult = Conversions.TryFoldNothingReferenceConversion(argument, conv, targetType)
 
-            WarnOnLockConversion(sourceType, targetType, argument.Syntax, diagnostics)
+            If Not Conversions.IsIdentityConversion(conv) Then
+                WarnOnLockConversion(sourceType, argument.Syntax, diagnostics)
+            End If
 
             Return New BoundTryCast(node, argument, conv, constantResult, targetType)
         End Function
@@ -1732,9 +1736,8 @@ DoneWithDiagnostics:
             End If
         End Sub
 
-        Private Shared Sub WarnOnLockConversion(sourceType As TypeSymbol, targetType As TypeSymbol, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag)
-            If sourceType IsNot Nothing AndAlso sourceType.IsWellKnownTypeLock() AndAlso
-               targetType IsNot Nothing AndAlso Not targetType.IsWellKnownTypeLock() Then
+        Private Shared Sub WarnOnLockConversion(sourceType As TypeSymbol, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag)
+            If sourceType IsNot Nothing AndAlso sourceType.IsWellKnownTypeLock() Then
                 ReportDiagnostic(diagnostics, syntax, ERRID.WRN_ConvertingLock)
             End If
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -158,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 constantResult = Conversions.TryFoldNothingReferenceConversion(argument, conv, targetType)
             End If
 
-            WarnOnLockConversion(sourceType, argument.Syntax, diagnostics)
+            WarnOnLockConversion(sourceType, targetType, argument.Syntax, diagnostics)
 
             Return New BoundDirectCast(node, argument, conv, constantResult, targetType)
         End Function
@@ -259,7 +259,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim constantResult = Conversions.TryFoldNothingReferenceConversion(argument, conv, targetType)
 
-            WarnOnLockConversion(sourceType, argument.Syntax, diagnostics)
+            WarnOnLockConversion(sourceType, targetType, argument.Syntax, diagnostics)
 
             Return New BoundTryCast(node, argument, conv, constantResult, targetType)
         End Function
@@ -1732,8 +1732,9 @@ DoneWithDiagnostics:
             End If
         End Sub
 
-        Private Shared Sub WarnOnLockConversion(sourceType As TypeSymbol, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag)
-            If sourceType IsNot Nothing AndAlso sourceType.IsWellKnownTypeLock() Then
+        Private Shared Sub WarnOnLockConversion(sourceType As TypeSymbol, targetType As TypeSymbol, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag)
+            If sourceType IsNot Nothing AndAlso sourceType.IsWellKnownTypeLock() AndAlso
+               targetType IsNot Nothing AndAlso Not targetType.IsWellKnownTypeLock() Then
                 ReportDiagnostic(diagnostics, syntax, ERRID.WRN_ConvertingLock)
             End If
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
@@ -4731,6 +4731,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ReportDiagnostic(diagnostics,
                                      lockExpression.Syntax,
                                      ErrorFactory.ErrorInfo(ERRID.ERR_SyncLockRequiresReferenceType1, lockExpressionType))
+                ElseIf lockExpressionType.IsWellKnownTypeLock() Then
+                    ReportDiagnostic(diagnostics, lockExpression.Syntax, ERRID.WRN_LockTypeUnsupported)
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Errors/ErrorFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/ErrorFacts.vb
@@ -1537,7 +1537,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      ERRID.WRN_CallerArgumentExpressionAttributeHasInvalidParameterName,
                      ERRID.WRN_AnalyzerReferencesNewerCompiler,
                      ERRID.WRN_DuplicateAnalyzerReference,
-                     ERRID.ERR_InvalidExperimentalDiagID
+                     ERRID.ERR_InvalidExperimentalDiagID,
+                     ERRID.WRN_LockTypeUnsupported
                     Return False
                 Case Else
                     ' NOTE: All error codes must be explicitly handled in the below select case statement

--- a/src/Compilers/VisualBasic/Portable/Errors/ErrorFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/ErrorFacts.vb
@@ -1538,7 +1538,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      ERRID.WRN_AnalyzerReferencesNewerCompiler,
                      ERRID.WRN_DuplicateAnalyzerReference,
                      ERRID.ERR_InvalidExperimentalDiagID,
-                     ERRID.WRN_LockTypeUnsupported
+                     ERRID.WRN_LockTypeUnsupported,
+                     ERRID.WRN_ConvertingLock
                     Return False
                 Case Else
                     ' NOTE: All error codes must be explicitly handled in the below select case statement

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -2011,6 +2011,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         WRN_AnalyzerReferencesNewerCompiler = 42506
         WRN_DuplicateAnalyzerReference = 42507
 
+        WRN_LockTypeUnsupported = 42508
+
         ' // AVAILABLE                             42600 - 49998
         WRN_NextAvailable = 42600
 

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -2012,6 +2012,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         WRN_DuplicateAnalyzerReference = 42507
 
         WRN_LockTypeUnsupported = 42508
+        WRN_ConvertingLock = 42509
 
         ' // AVAILABLE                             42600 - 49998
         WRN_NextAvailable = 42600

--- a/src/Compilers/VisualBasic/Portable/Generated/ErrorFacts.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/ErrorFacts.Generated.vb
@@ -178,7 +178,8 @@
                      ERRID.WRN_CallerArgumentExpressionAttributeHasInvalidParameterName,
                      ERRID.WRN_AnalyzerReferencesNewerCompiler,
                      ERRID.WRN_DuplicateAnalyzerReference,
-                     ERRID.WRN_LockTypeUnsupported
+                     ERRID.WRN_LockTypeUnsupported,
+                     ERRID.WRN_ConvertingLock
                     Return True
                 Case Else
                     Return False

--- a/src/Compilers/VisualBasic/Portable/Generated/ErrorFacts.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/ErrorFacts.Generated.vb
@@ -177,7 +177,8 @@
                      ERRID.WRN_CallerArgumentExpressionAttributeSelfReferential,
                      ERRID.WRN_CallerArgumentExpressionAttributeHasInvalidParameterName,
                      ERRID.WRN_AnalyzerReferencesNewerCompiler,
-                     ERRID.WRN_DuplicateAnalyzerReference
+                     ERRID.WRN_DuplicateAnalyzerReference,
+                     ERRID.WRN_LockTypeUnsupported
                     Return True
                 Case Else
                     Return False

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -1298,6 +1298,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension>
+        Friend Function IsWellKnownTypeLock(typeSymbol As TypeSymbol) As Boolean
+            Return typeSymbol.Name = "Lock" AndAlso typeSymbol.ContainingType Is Nothing AndAlso
+                typeSymbol.IsContainedInNamespace("System", "Threading")
+        End Function
+
+        <Extension>
         Private Function IsWellKnownCompilerServicesTopLevelType(typeSymbol As TypeSymbol, name As String) As Boolean
             If Not String.Equals(typeSymbol.Name, name) Then
                 Return False
@@ -1312,13 +1318,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension>
-        Private Function IsContainedInNamespace(typeSymbol As TypeSymbol, outerNS As String, midNS As String, innerNS As String) As Boolean
-            Dim innerNamespace = typeSymbol.ContainingNamespace
-            If Not String.Equals(innerNamespace?.Name, innerNS) Then
-                Return False
+        Private Function IsContainedInNamespace(typeSymbol As TypeSymbol, outerNS As String, midNS As String, Optional innerNS As String = Nothing) As Boolean
+            Dim midNamespace As NamespaceSymbol
+
+            If innerNS IsNot Nothing Then
+                Dim innerNamespace = typeSymbol.ContainingNamespace
+                If Not String.Equals(innerNamespace?.Name, innerNS) Then
+                    Return False
+                End If
+                midNamespace = innerNamespace.ContainingNamespace
+            Else
+                midNamespace = typeSymbol.ContainingNamespace
             End If
 
-            Dim midNamespace = innerNamespace.ContainingNamespace
             If Not String.Equals(midNamespace?.Name, midNS) Then
                 Return False
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -1299,8 +1299,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         <Extension>
         Friend Function IsWellKnownTypeLock(typeSymbol As TypeSymbol) As Boolean
-            Return typeSymbol.Name = "Lock" AndAlso typeSymbol.ContainingType Is Nothing AndAlso
-                typeSymbol.IsContainedInNamespace("System", "Threading")
+            Dim namedTypeSymbol = TryCast(typeSymbol, NamedTypeSymbol)
+            Return namedTypeSymbol IsNot Nothing AndAlso
+                namedTypeSymbol.Name = "Lock" AndAlso
+                namedTypeSymbol.Arity = 0 AndAlso
+                namedTypeSymbol.ContainingType Is Nothing AndAlso
+                namedTypeSymbol.IsContainedInNamespace("System", "Threading")
         End Function
 
         <Extension>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5695,4 +5695,10 @@
   <data name="ERR_InvalidExperimentalDiagID" xml:space="preserve">
     <value>The diagnosticId argument to the 'Experimental' attribute must be a valid identifier</value>
   </data>
+  <data name="WRN_LockTypeUnsupported" xml:space="preserve">
+    <value>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</value>
+  </data>
+  <data name="WRN_LockTypeUnsupported_Title" xml:space="preserve">
+    <value>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5701,4 +5701,10 @@
   <data name="WRN_LockTypeUnsupported_Title" xml:space="preserve">
     <value>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</value>
   </data>
+  <data name="WRN_ConvertingLock" xml:space="preserve">
+    <value>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</value>
+  </data>
+  <data name="WRN_ConvertingLock_Title" xml:space="preserve">
+    <value>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -608,6 +608,16 @@
         <target state="translated">CallerArgumentExpressionAttribute použitý u parametru nebude mít žádný vliv, protože odkazuje sám na sebe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Odkaz analyzátoru {0} byl zadán vícekrát</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -648,6 +648,16 @@
         <target state="translated">Generátor se nepovedlo inicializovat</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Chybný počet argumentů typu</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -608,6 +608,16 @@
         <target state="translated">Das auf den Parameter angewendete CallerArgumentExpressionAttribute hat keine Auswirkungen, da es selbstreferenziell ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Mehrfacher Verweis auf Analysetool "{0}"</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -648,6 +648,16 @@
         <target state="translated">Fehler beim Initialisieren des Generators.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Falsche Anzahl von Typargumenten.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -608,6 +608,16 @@
         <target state="translated">El atributo CallerArgumentExpressionAttribute aplicado al parámetro no tendrá ningún efecto porque es autorreferencial.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Referencia del analizador "{0}" especificada varias veces</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -648,6 +648,16 @@
         <target state="translated">Error de inicialización del generador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Número de argumentos de tipo incorrecto</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -608,6 +608,16 @@
         <target state="translated">Le CallerArgumentExpressionAttribute appliqué au paramètre n’aura aucun effet, car il est auto-référentiel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Référence de l’analyseur '{0}' spécifiée plusieurs fois</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -648,6 +648,16 @@
         <target state="translated">Échec de l'initialisation du générateur.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Nombre incorrect d'arguments de type</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -649,6 +649,16 @@
         <target state="translated">Non è stato possibile inizializzare il generatore.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Il numero di argomenti di tipo è errato</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -609,6 +609,16 @@
         <target state="translated">CallerArgumentExpressionAttribute applicato al parametro non avrà alcun effetto perché è autoreferenziale.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Il riferimento '{0}' dell'analizzatore è stato specificato più volte</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -650,6 +650,16 @@
         <target state="translated">ジェネレーターを初期化できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">型引数の数が正しくありません</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -610,6 +610,16 @@
         <target state="translated">パラメーターに適用された CallerArgumentExpressionAttribute は自己参照であるため、無効となります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">複数回指定されたアナライザー参照 '{0}'</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -608,6 +608,16 @@
         <target state="translated">매개 변수에 적용된 CallerArgumentExpressionAttribute는 자체 참조이기 때문에 효과가 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">분석기 참조 '{0}'이(가) 여러 번 지정되었습니다.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -648,6 +648,16 @@
         <target state="translated">생성기가 초기화하지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">형식 인수 수가 잘못되었습니다.</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -648,6 +648,16 @@
         <target state="translated">Generator nie mógł przeprowadzić inicjalizacji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Nieprawidłowa liczba argumentów typu</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -608,6 +608,16 @@
         <target state="translated">Atrybut CallerArgumentExpressionAttribute zastosowany do parametru nie będzie działać, ponieważ jest to odwołanie samodzielne.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Odwołanie analizatora „{0}” określono wiele razy</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -648,6 +648,16 @@
         <target state="translated">Falha na inicialização do gerador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Número errado de argumentos de tipo</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -608,6 +608,16 @@
         <target state="translated">O CallerArgumentExpressionAttribute aplicado ao parâmetro não terá efeito porque é de autorreferência.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Referência do analisador '{0}' especificada várias vezes</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -608,6 +608,16 @@ optionstrict[+|-]                Принудительное применени
         <target state="translated">Применение класса CallerArgumentExpressionAttribute к параметру не подействует, так как он ссылается сам на себя.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Ссылка анализатора "{0}" указана несколько раз</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -648,6 +648,16 @@ optionstrict[+|-]                Принудительное применени
         <target state="translated">Не удалось инициализировать генератор.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Неверное число аргументов типа</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -649,6 +649,16 @@
         <target state="translated">Oluşturucu başlatılamadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">Tür bağımsız değişkenlerinin yanlış sayısı</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -609,6 +609,16 @@
         <target state="translated">Parametre kendini işaret ettiğinden, parametreye uygulanan CallerArgumentExpressionAttribute hiçbir etkiye sahip olmaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">Çözümleyici referansı '{0}' birden çok kez belirtildi</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -648,6 +648,16 @@
         <target state="translated">生成器初始化失败。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">类型参数的数目不正确</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -608,6 +608,16 @@
         <target state="translated">应用于参数的 CallerArgumentExpressionAttribute 将不起任何作用，因为它是自引用的。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">已多次指定分析器引用“{0}”</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -649,6 +649,16 @@
         <target state="translated">產生器無法初始化。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_LockTypeUnsupported_Title">
+        <source>A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</source>
+        <target state="new">A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WrongNumberOfTypeArguments">
         <source>Wrong number of type arguments</source>
         <target state="translated">類型引數的數目錯誤</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -609,6 +609,16 @@
         <target state="translated">套用到參數的 CallerArgumentExpressionAttribute 將沒有效果，因為它是自我參考。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_ConvertingLock">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingLock_Title">
+        <source>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</source>
+        <target state="new">A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_DuplicateAnalyzerReference">
         <source>Analyzer reference '{0}' specified multiple times</source>
         <target state="translated">已指定多次分析器參考 '{0}'</target>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/SyncLockTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/SyncLockTests.vb
@@ -497,5 +497,171 @@ End Namespace
                  ~
 ")
         End Sub
+
+        <Fact>
+        Public Sub LockType_CastToObject()
+            Dim source = "
+Imports System.Threading
+
+Module Program
+    Sub Main()
+        Dim l = New Lock()
+        Dim o As Object = l
+
+        o = DirectCast(l, Object)
+        SyncLock DirectCast(l, Object)
+        End SyncLock
+
+        o = CType(l, Object)
+        SyncLock CType(l, Object)
+        End SyncLock
+
+        o = TryCast(l, Object)
+        SyncLock TryCast(l, Object)
+        End SyncLock
+
+        o = M1(l)
+        SyncLock M1(l)
+        End SyncLock
+
+        o = M2(l)
+        SyncLock M2(l)
+        End SyncLock
+
+        o = M3(l)
+        SyncLock M3(l)
+        End SyncLock
+    End Sub
+
+    Function M1(Of T)(o as T) As Object
+        Return o
+    End Function
+
+    Function M2(Of T As Class)(o as T) As Object
+        Return o
+    End Function
+
+    Function M3(Of T As Lock)(o as T) As Object
+        Return o
+    End Function
+End Module
+
+Namespace System.Threading
+    Public Class Lock
+    End Class
+End Namespace
+"
+            CreateCompilation(source).AssertTheseDiagnostics(
+"BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        Dim o As Object = l
+                          ~
+BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        o = DirectCast(l, Object)
+                       ~
+BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        SyncLock DirectCast(l, Object)
+                            ~
+BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        o = CType(l, Object)
+                  ~
+BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        SyncLock CType(l, Object)
+                       ~
+BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        o = TryCast(l, Object)
+                    ~
+BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        SyncLock TryCast(l, Object)
+                         ~
+")
+        End Sub
+
+        <Fact>
+        Public Sub LockType_CastToBase()
+            Dim source = "
+Imports System.Threading
+
+Module Program
+    Sub Main()
+        Dim l = New Lock()
+        Dim o As LockBase = l
+        SyncLock o
+        End SyncLock
+    End Sub
+End Module
+
+Namespace System.Threading
+    Public Class LockBase
+    End Class
+
+    Public Class Lock
+        Inherits LockBase
+    End Class
+End Namespace
+"
+            CreateCompilation(source).AssertTheseDiagnostics(
+"BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        Dim o As LockBase = l
+                            ~
+")
+        End Sub
+
+        <Fact>
+        Public Sub LockType_CastToInterface()
+            Dim source = "
+Imports System.Threading
+
+Module Program
+    Sub Main()
+        Dim l = New Lock()
+        Dim o As ILockBase = l
+        SyncLock o
+        End SyncLock
+    End Sub
+End Module
+
+Namespace System.Threading
+    Public Interface ILockBase
+    End Interface
+
+    Public Class Lock
+        Implements ILockBase
+    End Class
+End Namespace
+"
+            CreateCompilation(source).AssertTheseDiagnostics(
+"BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        Dim o As ILockBase = l
+                             ~
+")
+        End Sub
+
+        <Fact>
+        Public Sub LockType_Downcast()
+            Dim source = "
+Imports System.Threading
+Module Program
+    Sub Main()
+        Dim l = New Lock()
+        Dim o As Object = l
+        SyncLock CType(o, Lock)
+        End SyncLock
+    End Sub
+End Module
+
+Namespace System.Threading
+    Public Class Lock
+    End Class
+End Namespace
+"
+            CreateCompilation(source).AssertTheseDiagnostics(
+"BC42509: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        Dim o As Object = l
+                          ~
+BC42508: A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.
+        SyncLock CType(o, Lock)
+                 ~~~~~~~~~~~~~~
+")
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/SyncLockTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/SyncLockTests.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -472,6 +473,29 @@ End Module
     </file>
 </compilation>).VerifyDiagnostics(
             Diagnostic(ERRID.ERR_CaseElseNoSelect, "Case Else"))
+        End Sub
+
+        <Fact>
+        Public Sub LockType_InSyncLock()
+            Dim source = "
+Module Program
+    Sub Main()
+        Dim l = New System.Threading.Lock()
+        SyncLock l
+        End SyncLock
+    End Sub
+End Module
+
+Namespace System.Threading
+    Public Class Lock
+    End Class
+End Namespace
+"
+            CreateCompilation(source).AssertTheseDiagnostics(
+"BC42508: A value of type 'System.Threading.Lock' in SyncLock will use likely unintended monitor-based locking. Consider manually calling 'Enter' and 'Exit' methods in a Try/Finally block instead.
+        SyncLock l
+                 ~
+")
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/71888

- Warns when a value of type `Lock` is used in `SyncLock` statement (users could expect it to behave like in C# but it currently does not).
- Warns on conversions of values of type `Lock` to a different type (users could expect the new locking to take effect on the target value which isn't supported in VB anyway but we cannot warn on the `SyncLock` statement without the type known to be `Lock` at compile time there).