### PR TITLE
Implement code folding for collection expression

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/CollectionExpressionStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/CollectionExpressionStructureTests.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Structure;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Structure;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure;
+
+[Trait(Traits.Feature, Traits.Features.Outlining)]
+public class CollectionExpressionStructureTests : AbstractCSharpSyntaxNodeStructureTests<CollectionExpressionSyntax>
+{
+    internal override AbstractSyntaxStructureProvider CreateProvider()
+        => new CollectionExpressionStructureProvider();
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/71932")]
+    public async Task TestOuterCollectionExpression()
+    {
+        await VerifyBlockSpansAsync(
+             """
+                class C
+                {
+                    void M()
+                    {
+                        int[] a ={|hint:{|textspan: $$[
+                            1,
+                            2,
+                            3
+                        ]|}|};
+                    }
+                }
+                """,
+             Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/71932")]
+    public async Task TestInnerCollectionExpressionWithoutComma()
+    {
+        await VerifyBlockSpansAsync(
+             """
+                class C
+                {
+                    void M()
+                    {
+                        List<List<int>> b = 
+                        [
+                            [1],
+                            [2, 3],
+                            {|hint:{|textspan:$$[
+                                3, 5, 6
+                            ]|}|}
+                        ];
+                    }
+                }
+                """,
+             Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/71932")]
+    public async Task TestInnerCollectionExpressionWithComma()
+    {
+        await VerifyBlockSpansAsync(
+             """
+                class C
+                {
+                    void M()
+                    {
+                        List<List<int>> c = 
+                        [
+                            [1],
+                            [2, 3],
+                            {|hint:{|textspan:$$[
+                                3, 5, 6
+                            ],|}|}
+                        ];
+                    }
+                }
+                """,
+             Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+    }
+}

--- a/src/Features/CSharp/Portable/Structure/CSharpBlockStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpBlockStructureProvider.cs
@@ -51,6 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             builder.Add<LiteralExpressionSyntax, StringLiteralExpressionStructureProvider>();
             builder.Add<InterpolatedStringExpressionSyntax, InterpolatedStringExpressionStructureProvider>();
             builder.Add<IfDirectiveTriviaSyntax, IfDirectiveTriviaStructureProvider>();
+            builder.Add<CollectionExpressionSyntax, CollectionExpressionStructureProvider>();
 
             return builder.ToImmutable();
         }

--- a/src/Features/CSharp/Portable/Structure/Providers/CollectionExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/CollectionExpressionStructureProvider.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.Structure;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Structure
+{
+    internal class CollectionExpressionStructureProvider : AbstractSyntaxNodeStructureProvider<CollectionExpressionSyntax>
+    {
+        protected override void CollectBlockSpans(
+            SyntaxToken previousToken,
+            CollectionExpressionSyntax node,
+            ref TemporaryArray<BlockSpan> spans,
+            BlockStructureOptions options,
+            CancellationToken cancellationToken)
+        {
+            if (node.Parent?.Parent is CollectionExpressionSyntax)
+            {
+                // We have something like:
+                //
+                //      List<List<int>> v = 
+                //      [
+                //          ...
+                //          [
+                //              ...
+                //          ],
+                //          ...
+                //      ];
+                //
+                //  In this case, we want to collapse the "[ ... ]," (including the comma).
+
+                var nextToken = node.CloseBracketToken.GetNextToken();
+                var end = nextToken.Kind() == SyntaxKind.CommaToken
+                    ? nextToken.Span.End
+                    : node.Span.End;
+
+                var textSpan = TextSpan.FromBounds(node.SpanStart, end);
+
+                spans.Add(new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: textSpan,
+                    hintSpan: textSpan,
+                    type: BlockTypes.Expression));
+            }
+            else
+            {
+                // Parent is something like:
+                //
+                //      List<int> v = 
+                //      [
+                //          ...
+                //      ];
+                //
+                // The collapsed textspan should be from the   =   to the   ]
+
+                var textSpan = TextSpan.FromBounds(previousToken.Span.End, node.Span.End);
+
+                spans.Add(new BlockSpan(
+                    isCollapsible: true,
+                    textSpan: textSpan,
+                    hintSpan: textSpan,
+                    type: BlockTypes.Expression));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #71932

| Before | After |
|--------|--------|
| ![Before](https://github.com/dotnet/roslyn/assets/24962085/884b0c7e-f517-4844-8d28-7c81475161ae) | ![After](https://github.com/dotnet/roslyn/assets/24962085/2313e68b-f6b6-4c73-88ff-ae392377d182) |