### PR TITLE
Add publishing configuration for vscode net8 branch

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -214,7 +214,7 @@
       "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[d17.10 P2]"
     },
-    "dev/jorobich/fix-pr-val": {
+    "features/vscode_net8": {
       "nugetKind": [
         "Shipping",
         "NonShipping"


### PR DESCRIPTION
This is required in order to have nuget packages available.