### PR TITLE
Simplify compilation tracking (part 2)

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -485,7 +485,7 @@ namespace Microsoft.CodeAnalysis
         /// Determines if the compilation returned by <see cref="GetCompilationAsync"/> and all its referenced compilation are from fully loaded projects.
         /// </summary>
         // TODO: make this public
-        internal Task<bool> HasSuccessfullyLoadedAsync(CancellationToken cancellationToken = default)
+        internal Task<bool> HasSuccessfullyLoadedAsync(CancellationToken cancellationToken)
             => _solution.CompilationState.HasSuccessfullyLoadedAsync(_projectState, cancellationToken);
 
         /// <summary>


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/71963

Introduce common base class for all tracker states taht will have a compilation.  