### PR TITLE
Simplify compilation tracking (part4)

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -485,7 +485,7 @@ namespace Microsoft.CodeAnalysis
         /// Determines if the compilation returned by <see cref="GetCompilationAsync"/> and all its referenced compilation are from fully loaded projects.
         /// </summary>
         // TODO: make this public
-        internal Task<bool> HasSuccessfullyLoadedAsync(CancellationToken cancellationToken = default)
+        internal Task<bool> HasSuccessfullyLoadedAsync(CancellationToken cancellationToken)
             => _solution.CompilationState.HasSuccessfullyLoadedAsync(_projectState, cancellationToken);
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis
                 /// Returns a <see cref="AllSyntaxTreesParsedState"/> if <paramref name="intermediateProjects"/> is
                 /// empty, otherwise a <see cref="InProgressState"/>.
                 /// </summary>
-                public static CompilationTrackerState Create(
+                public static WithCompilationTrackerState Create(
                     Compilation compilationWithoutGeneratedDocuments,
                     CompilationTrackerGeneratorInfo generatorInfo,
                     Compilation? compilationWithGeneratedDocuments,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
@@ -269,8 +269,7 @@ namespace Microsoft.CodeAnalysis
                     bool hasSuccessfullyLoaded,
                     CompilationTrackerGeneratorInfo generatorInfo,
                     UnrootedSymbolSet unrootedSymbolSet)
-                    : base(compilationWithoutGeneratedDocuments,
-                           generatorInfo.WithDocumentsAreFinal(true)) // when we're in a final state, we've ran generators and should not run again
+                    : base(compilationWithoutGeneratedDocuments, generatorInfo)
                 {
                     Contract.ThrowIfNull(finalCompilationWithGeneratedDocuments);
                     HasSuccessfullyLoaded = hasSuccessfullyLoaded;
@@ -298,6 +297,8 @@ namespace Microsoft.CodeAnalysis
                     ProjectId projectId,
                     Dictionary<MetadataReference, ProjectId>? metadataReferenceToProjectId)
                 {
+                    Contract.ThrowIfFalse(generatorInfo.DocumentsAreFinal);
+
                     // Keep track of information about symbols from this Compilation.  This will help support other APIs
                     // the solution exposes that allows the user to map back from symbols to project information.
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
@@ -271,6 +271,7 @@ namespace Microsoft.CodeAnalysis
                     UnrootedSymbolSet unrootedSymbolSet)
                     : base(compilationWithoutGeneratedDocuments, generatorInfo)
                 {
+                    Contract.ThrowIfFalse(generatorInfo.DocumentsAreFinal);
                     Contract.ThrowIfNull(finalCompilationWithGeneratedDocuments);
                     HasSuccessfullyLoaded = hasSuccessfullyLoaded;
                     FinalCompilationWithGeneratedDocuments = finalCompilationWithGeneratedDocuments;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
@@ -148,9 +148,14 @@ namespace Microsoft.CodeAnalysis
             /// State used when we potentially have some information (like prior generated documents)
             /// but no compilation.
             /// </summary>
-            private sealed class NoCompilationState(CompilationTrackerGeneratorInfo generatorInfo)
-                : CompilationTrackerState(generatorInfo)
+            private sealed class NoCompilationState : CompilationTrackerState
             {
+                public NoCompilationState(CompilationTrackerGeneratorInfo generatorInfo)
+                    : base(generatorInfo)
+                {
+                    // The no compilation state can never be in the 'DocumentsAreFinal' state.
+                    Contract.ThrowIfTrue(generatorInfo.DocumentsAreFinal);
+                }
             }
 
             private abstract class WithCompilationState : CompilationTrackerState

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis
                     // DeclarationState now. We'll pass false for generatedDocumentsAreFinal because this is being called
                     // if our referenced projects are changing, so we'll have to rerun to consume changes.
                     return intermediateProjects.IsEmpty
-                        ? new AllSyntaxTreesParsedState(compilationWithoutGeneratedDocuments, generatorInfo.WithDocumentsAreFinal(false))
+                        ? new AllSyntaxTreesParsedState(compilationWithoutGeneratedDocuments, generatorInfo.WithDocumentsAreFinal(false), compilationWithGeneratedDocuments)
                         : new InProgressState(compilationWithoutGeneratedDocuments, generatorInfo, compilationWithGeneratedDocuments, intermediateProjects);
                 }
             }
@@ -222,9 +222,16 @@ namespace Microsoft.CodeAnalysis
             /// </summary>
             private sealed class AllSyntaxTreesParsedState(
                 Compilation compilationWithoutGeneratedDocuments,
-                CompilationTrackerGeneratorInfo generatorInfo)
-                : WithCompilationTrackerState(compilationWithoutGeneratedDocuments, generatorInfo)
+                CompilationTrackerGeneratorInfo generatorInfo,
+                Compilation? compilationWithGeneratedDocuments) : WithCompilationTrackerState(compilationWithoutGeneratedDocuments, generatorInfo)
             {
+                /// <summary>
+                /// The result of taking the original completed compilation that had generated documents and updating them by
+                /// apply the <see cref="CompilationAndGeneratorDriverTranslationAction" />; this is not a correct snapshot in that
+                /// the generators have not been rerun, but may be reusable if the generators are later found to give the
+                /// same output.
+                /// </summary>
+                public Compilation? CompilationWithGeneratedDocuments { get; } = compilationWithGeneratedDocuments;
             }
 
             /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private abstract class WithCompilationState : CompilationTrackerState
+            private abstract class WithCompilationTrackerState : CompilationTrackerState
             {
                 /// <summary>
                 /// The best compilation that is available that source generators have not ran on. May be an
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis
                 /// </summary>
                 public Compilation CompilationWithoutGeneratedDocuments { get; }
 
-                public WithCompilationState(Compilation compilationWithoutGeneratedDocuments, CompilationTrackerGeneratorInfo generatorInfo)
+                public WithCompilationTrackerState(Compilation compilationWithoutGeneratedDocuments, CompilationTrackerGeneratorInfo generatorInfo)
                     : base(generatorInfo)
                 {
                     CompilationWithoutGeneratedDocuments = compilationWithoutGeneratedDocuments;
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis
             /// A state where we are holding onto a previously built compilation, and have a known set of transformations
             /// that could get us to a more final state.
             /// </summary>
-            private sealed class InProgressState : WithCompilationState
+            private sealed class InProgressState : WithCompilationTrackerState
             {
                 /// <summary>
                 /// The list of changes that have happened since we last computed a compilation. The oldState corresponds to
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis
                            generatorInfo.WithDocumentsAreFinal(false)) // since we have a set of transformations to make, we'll always have to run generators again
                 {
                     Contract.ThrowIfTrue(intermediateProjects is null);
-                    Contract.ThrowIfFalse(intermediateProjects.Count > 0);
+                    Contract.ThrowIfTrue(intermediateProjects.Count == 0);
 
                     this.IntermediateProjects = intermediateProjects;
                     this.CompilationWithGeneratedDocuments = compilationWithGeneratedDocuments;
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis
             private sealed class AllSyntaxTreesParsedState(
                 Compilation compilationWithoutGeneratedDocuments,
                 CompilationTrackerGeneratorInfo generatorInfo)
-                : WithCompilationState(compilationWithoutGeneratedDocuments, generatorInfo)
+                : WithCompilationTrackerState(compilationWithoutGeneratedDocuments, generatorInfo)
             {
             }
 
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis
             /// cref="Solution.GetOriginatingProject(ISymbol)"/>.  If <see cref="Compilation"/>s from other <see
             /// cref="CompilationTrackerState"/>s are passed out, then these other APIs will not function correctly.
             /// </summary>
-            private sealed class FinalState : WithCompilationState
+            private sealed class FinalState : WithCompilationTrackerState
             {
                 /// <summary>
                 /// Specifies whether <see cref="FinalCompilationWithGeneratedDocuments"/> and all compilations it

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.cs
@@ -174,11 +174,15 @@ namespace Microsoft.CodeAnalysis
                     {
                         // We may still have a cached generator; we'll have to remember to run generators again since we are making some
                         // change here. We'll also need to update the other state of the driver if appropriate.
-                        var generatorInfo = state.GeneratorInfo.WithDocumentsAreFinal(false);
+
+                        // The no compilation state can never be in the 'DocumentsAreFinal' state.  The only place where
+                        // we start with the NoCompilationState is the 'Empty' instance (where DocumentsAreFinal=false).
+                        // And then this is the only place where we get a NoCompilationState and create a new instance.
+                        // So there is no way to ever transition this to the DocumentsAreFinal=true state.
+                        Contract.ThrowIfTrue(state.GeneratorInfo.DocumentsAreFinal);
+                        var generatorInfo = state.GeneratorInfo;
                         if (generatorInfo.Driver != null && translate != null)
-                        {
                             generatorInfo = generatorInfo.WithDriver(translate.TransformGeneratorDriver(generatorInfo.Driver));
-                        }
 
                         return new NoCompilationState(generatorInfo);
                     }


### PR DESCRIPTION
Add more contract calls and move to more stringent types transitions with compilation-tracker-states.