### PR TITLE
CompilationOutputInfo.AssemblyPath should be a normalized path

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -90,11 +90,18 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
             Assert.Equal(newObjPath, project.CompilationOutputAssemblyFilePath);
             Assert.Equal(newBinPath, project.BinOutputPath);
 
-            // Change bin output folder to non-normalized path - verify that binOutputPath changes to normalized path, but objOutputPath is the same.
+            // Change bin output folder to non-absolute path - verify that binOutputPath changes to normalized path, but objOutputPath is the same.
             newBinPath = @"test.dll";
             var expectedNewBinPath = Path.Combine(Path.GetTempPath(), newBinPath);
             project.BinOutputPath = newBinPath;
             Assert.Equal(newObjPath, project.CompilationOutputAssemblyFilePath);
+            Assert.Equal(expectedNewBinPath, project.BinOutputPath);
+
+            // Change obj  folder to non-canonical path - verify that objOutputPath changes to normalized path, but binOutputPath is unchanged.
+            var relativeObjPath = @"..\folder\\test.dll";
+            var absoluteObjPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), relativeObjPath));
+            project.SetOptions(ImmutableArray.Create($"/out:{relativeObjPath}"));
+            Assert.Equal(absoluteObjPath, project.CompilationOutputAssemblyFilePath);
             Assert.Equal(expectedNewBinPath, project.BinOutputPath);
         }
 

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
             if (!PathUtilities.IsAbsolute(path))
             {
-                path = Path.Combine(PathUtilities.GetDirectoryName(projectFilePath), path); 
+                path = Path.Combine(PathUtilities.GetDirectoryName(projectFilePath), path);
             }
 
             if (!PathUtilities.IsAbsolute(path))

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
             if (!PathUtilities.IsAbsolute(path))
             {
-                path = Path.Combine(PathUtilities.GetDirectoryName(projectFilePath), path);
+                path = Path.Combine(PathUtilities.GetDirectoryName(projectFilePath), path); 
             }
 
             if (!PathUtilities.IsAbsolute(path))
@@ -227,7 +227,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 throw new InvalidProjectDataException(itemName, values[0], $"Item group '{itemName}' is required to specify an absolute path or a path relative to the directory containing the project: '{values[0]}'.");
             }
 
-            return path;
+            // normalize "." and ".." on the way out
+            return FileUtilities.TryNormalizeAbsolutePath(path) ?? path;
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/pull/9907

ISSUE:
If BaseIntermediateOutputPath or similar properties contain "..", then the path in CompilationOutputInfo.AssemblyPath is not canonical (contains "..").  Code that is keying off this path may end up with multiple ways to reference the same project.

FIX:
Call FileUtilities.TryNormalizeAbsolutePath on the string before returning.  This is called when the project is created/has properties changed, which is infrequent, and then the value is cached.