### PR TITLE
Only request the necessary document and project in GraphBuilder.PopulateMapsForFileInputNode

### DIFF
--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -76,6 +76,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                     return;
                 }
 
+                // Don't walk _solution.Projects as that will possibly create projects that don't match
+                // our criteria. Instead, walk the project states to find the appropriate project id.
                 var projectState = _solution.SolutionState.ProjectStates.FirstOrDefault(
                     p => string.Equals(p.Value.FilePath, projectPath.OriginalString, StringComparison.OrdinalIgnoreCase));
                 if (projectState.Key == null)
@@ -87,6 +89,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
                 _nodeToContextProjectMap.Add(inputNode, project);
 
+                // Don't walk project.Documents as that will possibly create documents that don't match
+                // our criteria. Instead, walk the document states to find the appropriate document id.
                 var documentState = project.State.DocumentStates.States.FirstOrDefault(
                     d => string.Equals(d.Value.FilePath, filePath.OriginalString, StringComparison.OrdinalIgnoreCase));
                 if (documentState.Key == null)

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -78,6 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
                 var docIdsWithPath = _solution.GetDocumentIdsWithFilePath(filePath.OriginalString);
                 Document? document = null;
+                Project? project = null;
 
                 foreach (var docIdWithPath in docIdsWithPath)
                 {
@@ -85,16 +86,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                     if (projectState != null &&
                         string.Equals(projectState.FilePath, projectPath.OriginalString))
                     {
-                        document = _solution.GetDocument(docIdWithPath);
+                        project = _solution.GetRequiredProject(projectState.Id);
+                        document = project.GetRequiredDocument(docIdWithPath);
                         break;
                     }
                 }
 
-                if (document == null)
+                if (document == null || project == null)
                 {
                     return;
                 }
 
+                _nodeToContextProjectMap.Add(inputNode, project);
                 _nodeToContextDocumentMap.Add(inputNode, document);
             }
         }

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -83,11 +84,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 foreach (var docIdWithPath in docIdsWithPath)
                 {
                     var projectState = _solution.GetProjectState(docIdWithPath.ProjectId);
-                    if (projectState != null &&
-                        string.Equals(projectState.FilePath, projectPath.OriginalString))
+                    if (projectState == null)
+                    {
+                        FatalError.ReportAndCatch(new Exception("GetDocumentIdsWithFilePath returned a document in a project that does not exist."));
+                        continue;
+                    }
+
+                    if (string.Equals(projectState.FilePath, projectPath.OriginalString))
                     {
                         project = _solution.GetRequiredProject(projectState.Id);
-                        document = project.GetRequiredDocument(docIdWithPath);
+                        document = project.GetDocument(docIdWithPath);
                         break;
                     }
                 }

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -76,21 +76,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                     return;
                 }
 
-                var project = _solution.Projects.FirstOrDefault(
-                    p => string.Equals(p.FilePath, projectPath.OriginalString, StringComparison.OrdinalIgnoreCase));
-                if (project == null)
+                var projectState = _solution.SolutionState.ProjectStates.FirstOrDefault(
+                    p => string.Equals(p.Value.FilePath, projectPath.OriginalString, StringComparison.OrdinalIgnoreCase));
+                if (projectState.Key == null)
                 {
                     return;
                 }
+
+                var project = _solution.GetRequiredProject(projectState.Key);
 
                 _nodeToContextProjectMap.Add(inputNode, project);
 
-                var document = project.Documents.FirstOrDefault(
-                    d => string.Equals(d.FilePath, filePath.OriginalString, StringComparison.OrdinalIgnoreCase));
-                if (document == null)
+                var documentState = project.State.DocumentStates.States.FirstOrDefault(
+                    d => string.Equals(d.Value.FilePath, filePath.OriginalString, StringComparison.OrdinalIgnoreCase));
+                if (documentState.Key == null)
                 {
                     return;
                 }
+
+                var document = project.GetRequiredDocument(documentState.Key);
 
                 _nodeToContextDocumentMap.Add(inputNode, document);
             }


### PR DESCRIPTION
This method previously enumerated documents and projects until it found ones with the appropriate path, creating many unused documents and projects along the way.

Instead, as the file path informtion is stored in both the projectstate and documentstate, we can walk those state objects and find the appropriate ProjectId and DocumentId. Once we have those, it's a direct shot to get the Project and Document.

Profiles were gathered against typing one 50 character line of text slowly (1 sec per char) in a large .cs file (LanguageParser.cs in Roslyn sln) with C# LSP turned on.

Old allocation:

![image](https://github.com/dotnet/roslyn/assets/6785178/250b0db0-1cb5-4836-8a78-f495eabb8e2a)

New allocation:

![image](https://github.com/dotnet/roslyn/assets/6785178/43303ab8-0286-4a41-8145-2415e385782b)