### PR TITLE
Fix some comments in the Workspaces.MSBuild project file

### DIFF
--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
 
-    <!-- These PackageReferences aren't needed to make our build work, but ensure correct NuGet packaging. We get references to these packages because
-         we have a ProjectReference to BuildHost.csproj, but since it's PrivateAssets="true" they don't flow into this package's package references when packaging. -->
+    <!-- These PackageReferences aren't needed for the compiler for this project, but ensure correct NuGet packaging. Since we're bundling the BuildHost in lib/, we need to
+         ensure we include the references it needs, but since it's PrivateAssets="true" they don't flow into this package's package references when packaging. -->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
@@ -34,15 +34,9 @@
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
     <ProjectReference Include="..\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
 
-    <!-- For the following packages we directly include the binary into this NuGet package because we don't want/need separate NuGet packages
-         for these. PrivateAssets="all" is needed to prevent this reference from becoming a package reference in the package, as a workaround for
+    <!-- For the following package we directly include the binary into this NuGet package because we don't want/need a separate NuGet package
+         for it. PrivateAssets="all" is needed to prevent this reference from becoming a package reference in the package, as a workaround for
          https://github.com/NuGet/Home/issues/3891.
-         
-         For the BuildHost, we use RPC interfaces from it so we want to load it too.
-
-         Design time builds force the Razor compiler to use external access APIs, and so the RazorCompiler external access DLL should be present.
-         Technically this could impact any user of the compiler as an API, but since the far most common case is going to be consumers of MSBuildWorkspace,
-         we'll just do this here rather than impacting all consumers of that package unless we find other needs in the wild.
          -->
     <ProjectReference Include="..\MSBuild.BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj" PrivateAssets="all">
       <IncludeOutputInThisPackage>true</IncludeOutputInThisPackage>
@@ -82,7 +76,7 @@
   </Target>
 
   <!--
-    Deploy a net472 and $(NetVS) version of the BuildHost process which will be used depending on the type of project. We will use the deployed version even if
+    Deploy a net472 and $(NetRoslynBuildHostNetCoreVersion) version of the BuildHost process which will be used depending on the type of project. We will use the deployed version even if
     it matches the runtime type of the caller of MSBuildWorkspace since we still need the separate process for dependency isolation and in the case of the .NET Core
     side, ensuring we potential rollforward to a runtime that supports the SDK version.
 


### PR DESCRIPTION
We had some stale comments that didn't get deleted when we removed ExternalAccessor.RazorCompiler.