### PR TITLE
Revert dotnet installation

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -739,7 +739,8 @@ try {
       Setup-IntegrationTestRun
     }
 
-    $dotnet = (InitializeDotNetCli -install:$true)
+    $global:_DotNetInstallDir = Join-Path $RepoRoot ".dotnet"
+    InstallDotNetSdk $global:_DotNetInstallDir $GlobalJson.tools.dotnet
   }
 
   if ($restore) {


### PR DESCRIPTION
Reverts parts of https://github.com/dotnet/roslyn/pull/71666 which broke Test_Windows_CoreClr_Debug_Single_Machine in rolling CI ([last working run](https://dev.azure.com/dnceng-public/public/_build/results?buildId=540677&view=results), [first broken run](https://dev.azure.com/dnceng-public/public/_build/results?buildId=540729&view=results)).

Full build of this PR including the Single_Machine leg: https://dev.azure.com/dnceng-public/public/_build/results?buildId=556939&view=results