### PR TITLE
Modify CpsDiagnosticItemSourceProvider.CreateCollectionSource to be resilient to being passed a disposed hierarchy item.

### DIFF
--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/CpsDiagnosticItemSourceProvider.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/CpsDiagnosticItemSourceProvider.cs
@@ -43,12 +43,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             _workspace = workspace;
         }
 
-        protected override IAttachedCollectionSource? CreateCollectionSource(IVsHierarchyItem item, string relationshipName)
+        protected override IAttachedCollectionSource? CreateCollectionSource(IVsHierarchyItem? item, string relationshipName)
         {
-            if (item != null &&
+            if (item?.HierarchyIdentity?.NestedHierarchy != null &&
                 !item.IsDisposed &&
-                item.HierarchyIdentity != null &&
-                item.HierarchyIdentity.NestedHierarchy != null &&
                 relationshipName == KnownRelationships.Contains)
             {
                 if (NestedHierarchyHasProjectTreeCapability(item, "AnalyzerDependency"))

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/CpsDiagnosticItemSourceProvider.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/CpsDiagnosticItemSourceProvider.cs
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         protected override IAttachedCollectionSource? CreateCollectionSource(IVsHierarchyItem item, string relationshipName)
         {
             if (item != null &&
+                !item.IsDisposed &&
                 item.HierarchyIdentity != null &&
                 item.HierarchyIdentity.NestedHierarchy != null &&
                 relationshipName == KnownRelationships.Contains)


### PR DESCRIPTION
Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1950695

This behavior regressed recently due to the fix I introduced in https://github.com/dotnet/roslyn/pull/71664. The code winds it's way down to IVsBrowseObjectContext.UnconfiguredProject via NestedHierarchyHasProjectTreeCapability => TryGetFlags. The UnconfiguredProject property throws if the hierarchy is disposed, whereas we previously would go through interop, get back a failed hresult and return false, and silently fail out of the callstack.

I've pinged several folks and haven't gotten back a response about whether sending in a disposed hierarchy item is a bug in the caller. I assume this isn't a recent change though as we were resilient to this before and probably should continue to be.