### PR TITLE
Params parameters are implicitly scoped when their type is a ref struct.

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -821,15 +821,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (Format.ParameterOptions.IncludesOption(SymbolDisplayParameterOptions.IncludeModifiers))
                 {
-                    if (symbol.ScopedKind == ScopedKind.ScopedValue && symbol.RefKind == RefKind.None)
-                    {
-                        AddKeyword(SyntaxKind.ScopedKeyword);
-                        AddSpace();
-                    }
-
                     if (symbol.IsParams)
                     {
                         AddKeyword(SyntaxKind.ParamsKeyword);
+                        AddSpace();
+                    }
+
+                    if (symbol.ScopedKind == ScopedKind.ScopedValue &&
+                        symbol.RefKind == RefKind.None &&
+                        !(symbol.IsParams && symbol.Type.IsRefLikeType))
+                    {
+                        AddKeyword(SyntaxKind.ScopedKeyword);
                         AddSpace();
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -866,7 +866,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private bool IsValidUnscopedRefAttributeTarget()
         {
-            return UseUpdatedEscapeRules && RefKind != RefKind.None;
+            return UseUpdatedEscapeRules && (RefKind != RefKind.None || (IsParams && Type.IsRefLikeType));
         }
 
         private static bool? DecodeMaybeNullWhenOrNotNullWhenOrDoesNotReturnIfAttribute(CSharpAttributeData attribute)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -225,9 +225,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected ScopedKind CalculateEffectiveScopeIgnoringAttributes()
         {
             var declaredScope = this.DeclaredScope;
-            return declaredScope == ScopedKind.None && ParameterHelpers.IsRefScopedByDefault(this) ?
-                ScopedKind.ScopedRef :
-                declaredScope;
+
+            if (declaredScope == ScopedKind.None)
+            {
+                if (ParameterHelpers.IsRefScopedByDefault(this))
+                {
+                    return ScopedKind.ScopedRef;
+                }
+                else if (IsParams && Type.IsRefLikeType)
+                {
+                    return ScopedKind.ScopedValue;
+                }
+            }
+
+            return declaredScope;
         }
 
         internal sealed override bool UseUpdatedEscapeRules => ContainingModule.UseUpdatedEscapeRules;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -11186,7 +11186,7 @@ static class Extensions
                 //     static void F2(params scoped object[] args) { }
                 Diagnostic(ErrorCode.ERR_ScopedRefAndRefStructOnly, "params scoped object[] args").WithLocation(4, 20));
 
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "scoped params System.Object[] args", RefKind.None, ScopedKind.ScopedValue);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "params scoped System.Object[] args", RefKind.None, ScopedKind.ScopedValue);
         }
 
         [Theory]


### PR DESCRIPTION
UnscopedRefAttribute can be used to override that.

https://github.com/dotnet/csharplang/blob/main/proposals/params-collections.md#ref-safety