### PR TITLE
Reduce allocations in AbstractFormatEngine.Format

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ListExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ListExtensions.cs
@@ -107,14 +107,5 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             return -1;
         }
-
-        public static void AddRangeWhere<T>(this List<T> list, List<T> collection, Func<T, bool> predicate)
-        {
-            foreach (var element in collection)
-            {
-                if (predicate(element))
-                    list.Add(element);
-            }
-        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             using (Logger.LogBlock(FunctionId.Formatting_Format, FormatSummary, cancellationToken))
             {
                 // setup environment
-                var nodeOperations = CreateNodeOperations(cancellationToken);
+                using var nodeOperations = CreateNodeOperations(cancellationToken);
 
                 var tokenStream = new TokenStream(this.TreeData, Options, this.SpanToFormat, CreateTriviaFactory());
                 using var tokenOperations = s_tokenPairListPool.GetPooledObject();
@@ -162,13 +162,17 @@ namespace Microsoft.CodeAnalysis.Formatting
             return nodeOperations;
         }
 
-        private static void AddOperations<T>(List<T> operations, List<T> scratch, SyntaxNode node, Action<List<T>, SyntaxNode> addOperations)
+        private static void AddOperations<T>(SegmentedList<T> operations, List<T> scratch, SyntaxNode node, Action<List<T>, SyntaxNode> addOperations)
         {
             Debug.Assert(scratch.Count == 0);
 
             addOperations(scratch, node);
+            foreach (var operation in scratch)
+            {
+                if (operation is not null)
+                    operations.Add(operation);
+            }
 
-            operations.AddRangeWhere(scratch, static item => item is not null);
             scratch.Clear();
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/NodeOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/NodeOperations.cs
@@ -2,21 +2,44 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
     /// <summary>
     /// this collector gathers formatting operations that are based on a node
     /// </summary>
-    internal class NodeOperations
+    internal record NodeOperations : IDisposable
     {
+        private static readonly ObjectPool<SegmentedList<IndentBlockOperation>> s_indentBlockOperationPool = new(() => new());
+        private static readonly ObjectPool<SegmentedList<SuppressOperation>> s_suppressOperationPool = new(() => new());
+        private static readonly ObjectPool<SegmentedList<AlignTokensOperation>> s_alignTokensOperationPool = new(() => new());
+        private static readonly ObjectPool<SegmentedList<AnchorIndentationOperation>> s_anchorIndentationOperationPool = new(() => new());
+
         public static NodeOperations Empty = new();
 
-        public List<IndentBlockOperation> IndentBlockOperation { get; } = new();
-        public List<SuppressOperation> SuppressOperation { get; } = new();
-        public List<AlignTokensOperation> AlignmentOperation { get; } = new();
-        public List<AnchorIndentationOperation> AnchorIndentationOperations { get; } = new();
+        public SegmentedList<IndentBlockOperation> IndentBlockOperation { get; } = s_indentBlockOperationPool.Allocate();
+        public SegmentedList<SuppressOperation> SuppressOperation { get; } = s_suppressOperationPool.Allocate();
+        public SegmentedList<AlignTokensOperation> AlignmentOperation { get; } = s_alignTokensOperationPool.Allocate();
+        public SegmentedList<AnchorIndentationOperation> AnchorIndentationOperations { get; } = s_anchorIndentationOperationPool.Allocate();
+
+        public void Dispose()
+        {
+            // Intentionally don't call ClearAndFree as these pooled lists can easily exceed the threshold
+            IndentBlockOperation.Clear();
+            s_indentBlockOperationPool.Free(IndentBlockOperation);
+
+            SuppressOperation.Clear();
+            s_suppressOperationPool.Free(SuppressOperation);
+
+            AlignmentOperation.Clear();
+            s_alignTokensOperationPool.Free(AlignmentOperation);
+
+            AnchorIndentationOperations.Clear();
+            s_anchorIndentationOperationPool.Free(AnchorIndentationOperations);
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/NodeOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/NodeOperations.cs
@@ -28,6 +28,9 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public void Dispose()
         {
+            if (this == Empty)
+                return;
+
             // Intentionally don't call ClearAndFree as these pooled lists can easily exceed the threshold
             IndentBlockOperation.Clear();
             s_indentBlockOperationPool.Free(IndentBlockOperation);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/NodeOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/NodeOperations.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Formatting
     /// <summary>
     /// this collector gathers formatting operations that are based on a node
     /// </summary>
-    internal record NodeOperations : IDisposable
+    internal sealed class NodeOperations : IDisposable
     {
         private static readonly ObjectPool<SegmentedList<IndentBlockOperation>> s_indentBlockOperationPool = new(() => new());
         private static readonly ObjectPool<SegmentedList<SuppressOperation>> s_suppressOperationPool = new(() => new());


### PR DESCRIPTION
This is called by analyzers and showing up heavily in local profiles. This PR makes two basic changes to the code:

1) Change the lists inside NodeOperations to pooled SegmentedLists. These arrays can get quite large (the file I'm testing makes several of these exceed 1000 elements). The lifetime of NodeOperations is fairly contained, so making it follow the disposable pattern to free the lists back to the pool was straight forward.

2)  Change FormattingContext.AddSuppressOperations to not allocate an apparently unnecessary segmented array. It looks like the code enumerating the values that were added to the array only cared about one case, and it was trivial to inline that code directly into the first loop.

Scenario profiled: Open LanguageParser.cs in Roslyn.sln, wait for things to calm down. Start profiler, type 50 chars. Interesting sections highlighted in both profiles:

Old allocations:
![image](https://github.com/dotnet/roslyn/assets/6785178/097821df-fb1b-40e8-ac81-0a669e6b93e9)

New allocations:
![image](https://github.com/dotnet/roslyn/assets/6785178/649eddb9-79c8-4efe-9733-eed462091827)