### PR TITLE
Reduce allocations in ImmutableArrayExtensions.GetTypesFromMemberMap

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -995,7 +995,13 @@ namespace Microsoft.CodeAnalysis
             where TNamespaceOrTypeSymbol : class
             where TNamedTypeSymbol : class, TNamespaceOrTypeSymbol
         {
-            var dictionary = new Dictionary<TKey, ImmutableArray<TNamedTypeSymbol>>(comparer);
+            // Initialize dictionary capacity to avoid resize allocations during Add calls.
+            // Most iterations through the loop add an entry. If map is smaller than the
+            // smallest capacity dictionary will use, we'll let it grow organically as
+            // it's possible we might not add anything to the dictionary.
+            var capacity = map.Count > 3 ? map.Count : 0;
+
+            var dictionary = new Dictionary<TKey, ImmutableArray<TNamedTypeSymbol>>(capacity, comparer);
 
             foreach (var (name, members) in map)
             {


### PR DESCRIPTION
By specifying an initial capacity we can prevent a bunch of resizing of the dictionary populated in this method. From my testing, I see the majority of loop iterations add an entry into the dictionary. However, I also did see very small maps that didn't have any entries added to the dictionary, so I wanted to make sure this code didn't end up allocating the backing data structures in the dictionary in those cases.

Scenario: Open LanguageParser.cs in Roslyn.sln and wait for things to stabilize. Start profiling. Type 50 chars.

Old allocations:
![image](https://github.com/dotnet/roslyn/assets/6785178/dd0e7355-d984-443f-a1c2-c21f24f9e06c)

New allocations:
![image](https://github.com/dotnet/roslyn/assets/6785178/b61d4203-e391-43d2-a4dc-03f317acccdc)