### PR TITLE
Fix crash in 'replace method with property' when references are in generated parts.

### DIFF
--- a/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -3020,14 +3020,12 @@ index: 1);
                 """
                 <Workspace>
                     <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
-                        <Document>
-                partial class C
+                        <Document>partial class C
                 {
                     int [||]GetGoo()
                     {
                     }
-                }
-                        </Document>
+                }</Document>
                         <DocumentFromSourceGenerator>
                 partial class C
                 {
@@ -3041,7 +3039,7 @@ index: 1);
                 </Workspace>
                 """,
                 """
-                class C
+                partial class C
                 {
                     int Goo
                     {

--- a/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -108,8 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/6034")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/6034")]
         public async Task TestMethodWithArrowBody()
         {
             await TestWithAllCodeStyleOff(
@@ -330,8 +329,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod1()
         {
             await TestWithAllCodeStyleOff(
@@ -360,8 +358,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod2()
         {
             await TestWithAllCodeStyleOff(
@@ -398,8 +395,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod3()
         {
             await TestWithAllCodeStyleOff(
@@ -436,8 +432,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """, index: 1);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod4()
         {
             await TestWithAllCodeStyleOff(
@@ -474,8 +469,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod5()
         {
             await TestWithAllCodeStyleOff(
@@ -1880,8 +1874,7 @@ index: 1);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/14327")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/14327")]
         public async Task TestUpdateChainedGet1()
         {
             await TestWithAllCodeStyleOff(
@@ -1918,8 +1911,7 @@ index: 1);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle1()
         {
             await TestInRegularAndScriptAsync(
@@ -1940,8 +1932,7 @@ index: 1);
                 """, options: PreferExpressionBodiedAccessors);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle2()
         {
             await TestInRegularAndScriptAsync(
@@ -1962,8 +1953,7 @@ index: 1);
                 """, options: PreferExpressionBodiedProperties);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle3()
         {
             await TestInRegularAndScriptAsync(
@@ -1984,8 +1974,7 @@ index: 1);
                 """, options: PreferExpressionBodiedAccessorsAndProperties);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle4()
         {
             await TestInRegularAndScriptAsync(
@@ -2013,8 +2002,7 @@ index: 1,
 options: PreferExpressionBodiedAccessors);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle5()
         {
             await TestInRegularAndScriptAsync(
@@ -2053,8 +2041,7 @@ index: 1,
 options: PreferExpressionBodiedProperties);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle6()
         {
             await TestInRegularAndScriptAsync(
@@ -2082,8 +2069,7 @@ index: 1,
 options: PreferExpressionBodiedAccessorsAndProperties);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle7()
         {
             await TestInRegularAndScriptAsync(
@@ -2101,8 +2087,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, options: PreferExpressionBodiedProperties);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle8()
         {
             await TestInRegularAndScriptAsync(
@@ -2120,8 +2105,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, options: PreferExpressionBodiedAccessors);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle9()
         {
             await TestInRegularAndScriptAsync(
@@ -2139,8 +2123,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, options: PreferExpressionBodiedAccessors);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle10()
         {
             await TestInRegularAndScriptAsync(
@@ -2243,8 +2226,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems?id=443523")]
+        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems?id=443523")]
         public async Task TestSystemObjectMetadataOverride()
         {
             await TestMissingAsync(
@@ -2258,8 +2240,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems?id=443523")]
+        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems?id=443523")]
         public async Task TestMetadataOverride()
         {
             await TestWithAllCodeStyleOff(
@@ -2473,8 +2454,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/38379")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38379")]
         public async Task TestUnsafeGetter()
         {
             await TestInRegularAndScriptAsync(
@@ -2503,8 +2483,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, index: 1);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/38379")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38379")]
         public async Task TestUnsafeSetter()
         {
             await TestInRegularAndScriptAsync(
@@ -2683,8 +2662,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/42699")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42699")]
         public async Task TestSameNameMemberAsProperty()
         {
             await TestInRegularAndScript1Async(
@@ -2711,8 +2689,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/42698")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42698")]
         public async Task TestMethodWithTrivia_3()
         {
             await TestInRegularAndScript1Async(
@@ -2734,8 +2711,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/42698")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42698")]
         public async Task TestMethodWithTrivia_4()
         {
             await TestWithAllCodeStyleOff(
@@ -2816,8 +2792,7 @@ index: 1);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/37991")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37991")]
         public async Task AllowIfNestedNullableIsSame()
         {
             await TestInRegularAndScriptAsync(
@@ -2855,8 +2830,7 @@ index: 1);
                 """, index: 1);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/37991")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37991")]
         public async Task TestGetSetWithGeneric()
         {
             await TestInRegularAndScriptAsync(
@@ -2890,8 +2864,7 @@ index: 1);
                 """, index: 1);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
         public async Task TestReferenceTrivia1()
         {
             await TestInRegularAndScriptAsync(
@@ -2923,8 +2896,7 @@ index: 1);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
         public async Task TestReferenceTrivia2()
         {
             await TestInRegularAndScriptAsync(
@@ -2956,8 +2928,7 @@ index: 1);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
         public async Task TestReferenceTrivia3()
         {
             await TestInRegularAndScriptAsync(
@@ -2985,8 +2956,7 @@ index: 1);
                 """);
         }
 
-        [Fact]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
         public async Task TestReferenceTrivia4()
         {
             await TestInRegularAndScriptAsync(
@@ -3014,7 +2984,7 @@ index: 1);
                 """);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72035")]
         public async Task TestUpdateGetReferenceGeneratedPart()
         {
             await TestInRegularAndScript1Async(

--- a/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -3012,5 +3012,45 @@ index: 1);
                 }
                 """);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestUpdateGetReferenceGeneratedPart()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                partial class C
+                {
+                    int [||]GetGoo()
+                    {
+                    }
+                }
+                        </Document>
+                        <DocumentFromSourceGenerator>
+                partial class C
+                {
+                    void Bar()
+                    {
+                        var x = GetGoo();
+                    }
+                }
+                        </DocumentFromSourceGenerator>
+                    </Project>
+                </Workspace>
+                """,
+                """
+                class C
+                {
+                    int Goo
+                    {
+                        get
+                        {
+                        }
+                    }
+                }
+                """);
+        }
     }
 }

--- a/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMethodWithProperty
 {
+    [Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
     public class ReplaceMethodWithPropertyTests : AbstractCSharpCodeActionTest_NoEditor
     {
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(TestWorkspace workspace, TestParameters parameters)
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 { CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CSharpCodeStyleOptions.WhenPossibleWithSuggestionEnforcement },
             };
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithGetName()
         {
             await TestWithAllCodeStyleOff(
@@ -82,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithoutGetName()
         {
             await TestWithAllCodeStyleOff(
@@ -107,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/6034")]
         public async Task TestMethodWithArrowBody()
         {
@@ -132,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithoutBody()
         {
             await TestWithAllCodeStyleOff(
@@ -150,7 +151,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithModifiers()
         {
             await TestWithAllCodeStyleOff(
@@ -175,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithAttributes()
         {
             await TestWithAllCodeStyleOff(
@@ -202,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithTrivia_1()
         {
             await TestWithAllCodeStyleOff(
@@ -229,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithTrailingTrivia()
         {
             await TestWithAllCodeStyleOff(
@@ -256,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestDelegateWithTrailingTrivia()
         {
             await TestWithAllCodeStyleOff(
@@ -292,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestIndentation()
         {
             await TestWithAllCodeStyleOff(
@@ -329,7 +330,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod1()
         {
@@ -359,7 +360,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod2()
         {
@@ -397,7 +398,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod3()
         {
@@ -435,7 +436,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """, index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod4()
         {
@@ -473,7 +474,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/21460")]
         public async Task TestIfDefMethod5()
         {
@@ -513,7 +514,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
                 """, index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithTrivia_2()
         {
             await TestWithAllCodeStyleOff(
@@ -550,7 +551,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestExplicitInterfaceMethod_1()
         {
             await TestWithAllCodeStyleOff(
@@ -575,7 +576,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestExplicitInterfaceMethod_2()
         {
             await TestWithAllCodeStyleOff(
@@ -610,7 +611,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestExplicitInterfaceMethod_3()
         {
             await TestWithAllCodeStyleOff(
@@ -645,7 +646,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestInAttribute()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -660,7 +661,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestInMethod()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -675,7 +676,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestVoidMethod()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -689,7 +690,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestAsyncMethod()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -703,7 +704,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestGenericMethod()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -717,7 +718,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestExtensionMethod()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -731,7 +732,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithParameters_1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -745,7 +746,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestMethodWithParameters_2()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -759,7 +760,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestNotInSignature_1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -774,7 +775,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestNotInSignature_2()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -789,7 +790,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetReferenceNotInMethod()
         {
             await TestWithAllCodeStyleOff(
@@ -824,7 +825,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetReferenceSimpleInvocation()
         {
             await TestWithAllCodeStyleOff(
@@ -859,7 +860,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetReferenceMemberAccessInvocation()
         {
             await TestWithAllCodeStyleOff(
@@ -894,7 +895,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetReferenceBindingMemberInvocation()
         {
             await TestWithAllCodeStyleOff(
@@ -931,7 +932,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetReferenceInMethod()
         {
             await TestWithAllCodeStyleOff(
@@ -958,7 +959,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestOverride()
         {
             await TestWithAllCodeStyleOff(
@@ -1000,7 +1001,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetReference_NonInvoked()
         {
             await TestWithAllCodeStyleOff(
@@ -1039,7 +1040,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetReference_ImplicitReference()
         {
             await TestWithAllCodeStyleOff(
@@ -1082,7 +1083,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSet()
         {
             await TestWithAllCodeStyleOff(
@@ -1120,7 +1121,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSetReference_NonInvoked()
         {
             await TestWithAllCodeStyleOff(
@@ -1168,7 +1169,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSet_SetterAccessibility()
         {
             await TestWithAllCodeStyleOff(
@@ -1206,7 +1207,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSet_ExpressionBodies()
         {
             await TestWithAllCodeStyleOff(
@@ -1241,7 +1242,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSet_GetInSetReference()
         {
             await TestWithAllCodeStyleOff(
@@ -1289,7 +1290,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSet_UpdateSetParameterName_1()
         {
             await TestWithAllCodeStyleOff(
@@ -1329,7 +1330,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSet_UpdateSetParameterName_2()
         {
             await TestWithAllCodeStyleOff(
@@ -1369,7 +1370,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSet_SetReferenceInSetter()
         {
             await TestWithAllCodeStyleOff(
@@ -1409,7 +1410,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestVirtualGetWithOverride_1()
         {
             await TestWithAllCodeStyleOff(
@@ -1452,7 +1453,7 @@ index: 1);
 index: 0);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestVirtualGetWithOverride_2()
         {
             await TestWithAllCodeStyleOff(
@@ -1497,7 +1498,7 @@ index: 0);
 index: 0);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestGetWithInterface()
         {
             await TestWithAllCodeStyleOff(
@@ -1533,7 +1534,7 @@ index: 0);
 index: 0);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestWithPartialClasses()
         {
             await TestWithAllCodeStyleOff(
@@ -1574,7 +1575,7 @@ index: 0);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetSetCaseInsensitive()
         {
             await TestWithAllCodeStyleOff(
@@ -1612,7 +1613,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task Tuple()
         {
             await TestWithAllCodeStyleOff(
@@ -1637,7 +1638,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task Tuple_GetAndSet()
         {
             await TestWithAllCodeStyleOff(
@@ -1675,7 +1676,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TupleWithNames_GetAndSet()
         {
             await TestWithAllCodeStyleOff(
@@ -1713,7 +1714,7 @@ index: 1);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TupleWithDifferentNames_GetAndSet()
         {
             // Cannot refactor tuples with different names together
@@ -1735,7 +1736,7 @@ index: 1);
 count: 1, new TestParameters(options: AllCodeStyleOff));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestOutVarDeclaration_1()
         {
             await TestWithAllCodeStyleOff(
@@ -1782,7 +1783,7 @@ count: 1, new TestParameters(options: AllCodeStyleOff));
 index: 0);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestOutVarDeclaration_2()
         {
             await TestWithAllCodeStyleOff(
@@ -1829,7 +1830,7 @@ index: 0);
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestOutVarDeclaration_3()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -1854,7 +1855,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestOutVarDeclaration_4()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -1879,7 +1880,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/14327")]
         public async Task TestUpdateChainedGet1()
         {
@@ -1917,7 +1918,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle1()
         {
@@ -1939,7 +1940,7 @@ index: 1);
                 """, options: PreferExpressionBodiedAccessors);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle2()
         {
@@ -1961,7 +1962,7 @@ index: 1);
                 """, options: PreferExpressionBodiedProperties);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle3()
         {
@@ -1983,7 +1984,7 @@ index: 1);
                 """, options: PreferExpressionBodiedAccessorsAndProperties);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle4()
         {
@@ -2012,7 +2013,7 @@ index: 1,
 options: PreferExpressionBodiedAccessors);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle5()
         {
@@ -2052,7 +2053,7 @@ index: 1,
 options: PreferExpressionBodiedProperties);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle6()
         {
@@ -2081,7 +2082,7 @@ index: 1,
 options: PreferExpressionBodiedAccessorsAndProperties);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle7()
         {
@@ -2100,7 +2101,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, options: PreferExpressionBodiedProperties);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle8()
         {
@@ -2119,7 +2120,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, options: PreferExpressionBodiedAccessors);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle9()
         {
@@ -2138,7 +2139,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, options: PreferExpressionBodiedAccessors);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/16980")]
         public async Task TestCodeStyle10()
         {
@@ -2157,7 +2158,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, options: PreferExpressionBodiedProperties);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUseExpressionBodyWhenOnSingleLine_AndIsSingleLine()
         {
             await TestInRegularAndScriptAsync(
@@ -2175,7 +2176,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CSharpCodeStyleOptions.WhenOnSingleLineWithSilentEnforcement));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUseExpressionBodyWhenOnSingleLine_AndIsNotSingleLine()
         {
             await TestInRegularAndScriptAsync(
@@ -2205,7 +2206,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
     });
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestExplicitInterfaceImplementation()
         {
             await TestWithAllCodeStyleOff(
@@ -2242,7 +2243,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems?id=443523")]
         public async Task TestSystemObjectMetadataOverride()
         {
@@ -2257,7 +2258,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems?id=443523")]
         public async Task TestMetadataOverride()
         {
@@ -2283,7 +2284,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task IgnoreIfTopLevelNullableIsDifferent_GetterNullable()
         {
             await TestInRegularAndScriptAsync(
@@ -2322,7 +2323,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task IgnoreIfTopLevelNullableIsDifferent_SetterNullable()
         {
             await TestInRegularAndScriptAsync(
@@ -2361,7 +2362,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task IgnoreIfNestedNullableIsDifferent_GetterNullable()
         {
             await TestInRegularAndScriptAsync(
@@ -2400,7 +2401,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task IgnoreIfNestedNullableIsDifferent_SetterNullable()
         {
             await TestInRegularAndScriptAsync(
@@ -2443,7 +2444,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task NullabilityOfFieldDifferentThanProperty()
         {
             await TestInRegularAndScriptAsync(
@@ -2472,7 +2473,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/38379")]
         public async Task TestUnsafeGetter()
         {
@@ -2502,7 +2503,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/38379")]
         public async Task TestUnsafeSetter()
         {
@@ -2532,7 +2533,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """, index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestAtStartOfMethod()
         {
             await TestWithAllCodeStyleOff(
@@ -2557,7 +2558,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestBeforeStartOfMethod_OnSameLine()
         {
             await TestWithAllCodeStyleOff(
@@ -2582,7 +2583,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestBeforeStartOfMethod_OnPreviousLine()
         {
             await TestWithAllCodeStyleOff(
@@ -2609,7 +2610,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestBeforeStartOfMethod_NotMultipleLinesPrior()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -2625,7 +2626,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestBeforeStartOfMethod_NotBeforeAttributes()
         {
             await TestInRegularAndScript1Async(
@@ -2652,7 +2653,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestBeforeStartOfMethod_NotBeforeComments()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -2667,7 +2668,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestBeforeStartOfMethod_NotInComment()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -2682,7 +2683,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/42699")]
         public async Task TestSameNameMemberAsProperty()
         {
@@ -2710,7 +2711,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/42698")]
         public async Task TestMethodWithTrivia_3()
         {
@@ -2733,7 +2734,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/42698")]
         public async Task TestMethodWithTrivia_4()
         {
@@ -2815,7 +2816,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/37991")]
         public async Task AllowIfNestedNullableIsSame()
         {
@@ -2854,7 +2855,7 @@ index: 1);
                 """, index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/37991")]
         public async Task TestGetSetWithGeneric()
         {
@@ -2889,7 +2890,7 @@ index: 1);
                 """, index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
         public async Task TestReferenceTrivia1()
         {
@@ -2922,7 +2923,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
         public async Task TestReferenceTrivia2()
         {
@@ -2955,7 +2956,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
         public async Task TestReferenceTrivia3()
         {
@@ -2984,7 +2985,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/40758")]
         public async Task TestReferenceTrivia4()
         {
@@ -3013,7 +3014,7 @@ index: 1);
                 """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [Fact]
         public async Task TestUpdateGetReferenceGeneratedPart()
         {
             await TestInRegularAndScript1Async(

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
@@ -212,6 +212,10 @@ internal sealed class ReplaceMethodWithPropertyCodeRefactoringProvider() : CodeR
         IEnumerable<ReferenceLocation> setReferences,
         CancellationToken cancellationToken)
     {
+        // No point updating references in generated code, it will just get regenerated based on the changes to actual code.
+        if (originalDocument.Id.IsSourceGenerated)
+            return originalDocument.Project.Solution;
+
         var root = await originalDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
         var editor = new SyntaxEditor(root, originalDocument.Project.Solution.Services);

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
@@ -21,468 +21,462 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
+namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty;
+
+[ExportCodeRefactoringProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = PredefinedCodeRefactoringProviderNames.ReplaceMethodWithProperty), Shared]
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed class ReplaceMethodWithPropertyCodeRefactoringProvider() : CodeRefactoringProvider
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, LanguageNames.VisualBasic,
-        Name = PredefinedCodeRefactoringProviderNames.ReplaceMethodWithProperty), Shared]
-    internal class ReplaceMethodWithPropertyCodeRefactoringProvider :
-        CodeRefactoringProvider
+    private const string GetPrefix = "Get";
+
+    public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
     {
-        private const string GetPrefix = "Get";
-
-        [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-        public ReplaceMethodWithPropertyCodeRefactoringProvider()
+        var (document, _, cancellationToken) = context;
+        var service = document.GetLanguageService<IReplaceMethodWithPropertyService>();
+        if (service == null)
         {
+            return;
         }
 
-        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        var methodDeclaration = await service.GetMethodDeclarationAsync(context).ConfigureAwait(false);
+        if (methodDeclaration == null)
         {
-            var (document, _, cancellationToken) = context;
-            var service = document.GetLanguageService<IReplaceMethodWithPropertyService>();
-            if (service == null)
+            return;
+        }
+
+        // Ok, we're in the signature of the method.  Now see if the method is viable to be 
+        // replaced with a property.
+        var generator = SyntaxGenerator.GetGenerator(document);
+        var methodName = generator.GetName(methodDeclaration);
+
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol methodSymbol ||
+            !IsValidGetMethod(methodSymbol))
+        {
+            return;
+        }
+
+        var hasGetPrefix = HasGetPrefix(methodName);
+        var propertyName = hasGetPrefix
+            ? NameGenerator.GenerateUniqueName(
+                methodName[GetPrefix.Length..],
+                n => !methodSymbol.ContainingType.GetMembers(n).Any())
+            : methodName;
+        var nameChanged = hasGetPrefix;
+
+        // Looks good!
+        context.RegisterRefactoring(CodeAction.Create(
+            string.Format(FeaturesResources.Replace_0_with_property, methodName),
+            c => ReplaceMethodsWithPropertyAsync(document, propertyName, nameChanged, methodSymbol, setMethod: null, context.Options, cancellationToken: c),
+            methodName),
+            methodDeclaration.Span);
+
+        // If this method starts with 'Get' see if there's an associated 'Set' method we could 
+        // replace as well.
+        if (hasGetPrefix)
+        {
+            var setMethod = FindSetMethod(methodSymbol);
+            if (setMethod != null)
             {
-                return;
-            }
-
-            var methodDeclaration = await service.GetMethodDeclarationAsync(context).ConfigureAwait(false);
-            if (methodDeclaration == null)
-            {
-                return;
-            }
-
-            // Ok, we're in the signature of the method.  Now see if the method is viable to be 
-            // replaced with a property.
-            var generator = SyntaxGenerator.GetGenerator(document);
-            var methodName = generator.GetName(methodDeclaration);
-
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            if (semanticModel.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol methodSymbol ||
-                !IsValidGetMethod(methodSymbol))
-            {
-                return;
-            }
-
-            var hasGetPrefix = HasGetPrefix(methodName);
-            var propertyName = hasGetPrefix
-                ? NameGenerator.GenerateUniqueName(
-                    methodName[GetPrefix.Length..],
-                    n => !methodSymbol.ContainingType.GetMembers(n).Any())
-                : methodName;
-            var nameChanged = hasGetPrefix;
-
-            // Looks good!
-            context.RegisterRefactoring(CodeAction.Create(
-                string.Format(FeaturesResources.Replace_0_with_property, methodName),
-                c => ReplaceMethodsWithPropertyAsync(document, propertyName, nameChanged, methodSymbol, setMethod: null, context.Options, cancellationToken: c),
-                methodName),
-                methodDeclaration.Span);
-
-            // If this method starts with 'Get' see if there's an associated 'Set' method we could 
-            // replace as well.
-            if (hasGetPrefix)
-            {
-                var setMethod = FindSetMethod(methodSymbol);
-                if (setMethod != null)
-                {
-                    context.RegisterRefactoring(CodeAction.Create(
-                        string.Format(FeaturesResources.Replace_0_and_1_with_property, methodName, setMethod.Name),
-                        c => ReplaceMethodsWithPropertyAsync(document, propertyName, nameChanged, methodSymbol, setMethod, context.Options, cancellationToken: c),
-                        methodName + "-get/set"),
-                        methodDeclaration.Span);
-                }
+                context.RegisterRefactoring(CodeAction.Create(
+                    string.Format(FeaturesResources.Replace_0_and_1_with_property, methodName, setMethod.Name),
+                    c => ReplaceMethodsWithPropertyAsync(document, propertyName, nameChanged, methodSymbol, setMethod, context.Options, cancellationToken: c),
+                    methodName + "-get/set"),
+                    methodDeclaration.Span);
             }
         }
+    }
 
-        private static bool HasGetPrefix(string text)
-            => HasPrefix(text, GetPrefix);
-        private static bool HasPrefix(string text, string prefix)
-            => text.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && text.Length > prefix.Length && !char.IsLower(text[prefix.Length]);
+    private static bool HasGetPrefix(string text)
+        => HasPrefix(text, GetPrefix);
+    private static bool HasPrefix(string text, string prefix)
+        => text.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && text.Length > prefix.Length && !char.IsLower(text[prefix.Length]);
 
-        private static IMethodSymbol? FindSetMethod(IMethodSymbol getMethod)
+    private static IMethodSymbol? FindSetMethod(IMethodSymbol getMethod)
+    {
+        var containingType = getMethod.ContainingType;
+        var setMethodName = "Set" + getMethod.Name[GetPrefix.Length..];
+        var setMethod = containingType.GetMembers()
+                                      .OfType<IMethodSymbol>()
+                                      .Where(m => setMethodName.Equals(m.Name, StringComparison.OrdinalIgnoreCase))
+                                      .Where(m => IsValidSetMethod(m, getMethod))
+                                      .FirstOrDefault();
+
+        return setMethod;
+    }
+
+    private static bool IsValidGetMethod(IMethodSymbol getMethod)
+    {
+        return getMethod != null &&
+            getMethod.ContainingType != null &&
+            !getMethod.IsGenericMethod &&
+            !getMethod.IsAsync &&
+            getMethod.Parameters.Length == 0 &&
+            !getMethod.ReturnsVoid &&
+            getMethod.DeclaringSyntaxReferences.Length == 1 &&
+            !OverridesMethodFromSystemObject(getMethod);
+    }
+
+    private static bool OverridesMethodFromSystemObject(IMethodSymbol method)
+    {
+        for (var current = method; current != null; current = current.OverriddenMethod)
         {
-            var containingType = getMethod.ContainingType;
-            var setMethodName = "Set" + getMethod.Name[GetPrefix.Length..];
-            var setMethod = containingType.GetMembers()
-                                          .OfType<IMethodSymbol>()
-                                          .Where(m => setMethodName.Equals(m.Name, StringComparison.OrdinalIgnoreCase))
-                                          .Where(m => IsValidSetMethod(m, getMethod))
-                                          .FirstOrDefault();
-
-            return setMethod;
-        }
-
-        private static bool IsValidGetMethod(IMethodSymbol getMethod)
-        {
-            return getMethod != null &&
-                getMethod.ContainingType != null &&
-                !getMethod.IsGenericMethod &&
-                !getMethod.IsAsync &&
-                getMethod.Parameters.Length == 0 &&
-                !getMethod.ReturnsVoid &&
-                getMethod.DeclaringSyntaxReferences.Length == 1 &&
-                !OverridesMethodFromSystemObject(getMethod);
-        }
-
-        private static bool OverridesMethodFromSystemObject(IMethodSymbol method)
-        {
-            for (var current = method; current != null; current = current.OverriddenMethod)
+            if (current.ContainingType.SpecialType == SpecialType.System_Object)
             {
-                if (current.ContainingType.SpecialType == SpecialType.System_Object)
-                {
-                    return true;
-                }
+                return true;
             }
-
-            return false;
         }
 
-        private static bool IsValidSetMethod(IMethodSymbol setMethod, IMethodSymbol getMethod)
+        return false;
+    }
+
+    private static bool IsValidSetMethod(IMethodSymbol setMethod, IMethodSymbol getMethod)
+    {
+        return IsValidSetMethod(setMethod) &&
+            setMethod.Parameters is [{ RefKind: RefKind.None } parameter] &&
+            SymbolEqualityComparer.IncludeNullability.Equals(parameter.Type, getMethod.ReturnType) &&
+            setMethod.IsAbstract == getMethod.IsAbstract;
+    }
+
+    private static bool IsValidSetMethod(IMethodSymbol setMethod)
+    {
+        return setMethod != null &&
+            !setMethod.IsGenericMethod &&
+            !setMethod.IsAsync &&
+            setMethod.ReturnsVoid &&
+            setMethod.DeclaringSyntaxReferences.Length == 1;
+    }
+
+    private static async Task<Solution> ReplaceMethodsWithPropertyAsync(
+        Document document,
+        string propertyName,
+        bool nameChanged,
+        IMethodSymbol getMethod,
+        IMethodSymbol? setMethod,
+        CodeGenerationOptionsProvider fallbackOptions,
+        CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+        var project = document.Project;
+        var originalSolution = project.Solution;
+        var getMethodReferences = await SymbolFinder.FindReferencesAsync(
+            getMethod, originalSolution, cancellationToken).ConfigureAwait(false);
+        var setMethodReferences = setMethod == null
+            ? SpecializedCollections.EmptyEnumerable<ReferencedSymbol>()
+            : await SymbolFinder.FindReferencesAsync(
+                setMethod, originalSolution, cancellationToken).ConfigureAwait(false);
+
+        // Get the warnings we'd like to put at the definition site.
+        var definitionWarning = GetDefinitionIssues(getMethodReferences);
+
+        var getReferencesByDocument = getMethodReferences.SelectMany(r => r.Locations).ToLookup(loc => loc.Document);
+        var setReferencesByDocument = setMethodReferences.SelectMany(r => r.Locations).ToLookup(loc => loc.Document);
+
+        // References and definitions can overlap (for example, references to one method
+        // inside the definition of another).  So we do a multi phase rewrite.  We first
+        // rewrite all references to point at the property instead.  Then we remove all
+        // the actual method definitions and replace them with the new properties.
+        var updatedSolution = originalSolution;
+
+        updatedSolution = await UpdateReferencesAsync(updatedSolution, propertyName, nameChanged, getReferencesByDocument, setReferencesByDocument, cancellationToken).ConfigureAwait(false);
+        updatedSolution = await ReplaceGetMethodsAndRemoveSetMethodsAsync(originalSolution, updatedSolution, propertyName, nameChanged, getMethodReferences, setMethodReferences, updateSetMethod: setMethod != null, fallbackOptions, cancellationToken).ConfigureAwait(false);
+
+        return updatedSolution;
+    }
+
+    private static async Task<Solution> UpdateReferencesAsync(Solution updatedSolution, string propertyName, bool nameChanged, ILookup<Document, ReferenceLocation> getReferencesByDocument, ILookup<Document, ReferenceLocation> setReferencesByDocument, CancellationToken cancellationToken)
+    {
+        var allReferenceDocuments = getReferencesByDocument.Concat(setReferencesByDocument).Select(g => g.Key).Distinct();
+        foreach (var referenceDocument in allReferenceDocuments)
         {
-            return IsValidSetMethod(setMethod) &&
-                setMethod.Parameters is [{ RefKind: RefKind.None } parameter] &&
-                SymbolEqualityComparer.IncludeNullability.Equals(parameter.Type, getMethod.ReturnType) &&
-                setMethod.IsAbstract == getMethod.IsAbstract;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            updatedSolution = await UpdateReferencesInDocumentAsync(
+                propertyName, nameChanged, updatedSolution, referenceDocument,
+                getReferencesByDocument[referenceDocument],
+                setReferencesByDocument[referenceDocument],
+                cancellationToken).ConfigureAwait(false);
         }
 
-        private static bool IsValidSetMethod(IMethodSymbol setMethod)
+        return updatedSolution;
+    }
+
+    private static async Task<Solution> UpdateReferencesInDocumentAsync(
+        string propertyName,
+        bool nameChanged,
+        Solution updatedSolution,
+        Document originalDocument,
+        IEnumerable<ReferenceLocation> getReferences,
+        IEnumerable<ReferenceLocation> setReferences,
+        CancellationToken cancellationToken)
+    {
+        var root = await originalDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        var editor = new SyntaxEditor(root, originalDocument.Project.Solution.Services);
+        var service = originalDocument.GetRequiredLanguageService<IReplaceMethodWithPropertyService>();
+
+        ReplaceGetReferences(propertyName, nameChanged, getReferences, root, editor, service, cancellationToken);
+        ReplaceSetReferences(propertyName, nameChanged, setReferences, root, editor, service, cancellationToken);
+
+        updatedSolution = updatedSolution.WithDocumentSyntaxRoot(originalDocument.Id, editor.GetChangedRoot());
+
+        return updatedSolution;
+    }
+
+    private static void ReplaceGetReferences(
+        string propertyName, bool nameChanged,
+        IEnumerable<ReferenceLocation> getReferences,
+        SyntaxNode root, SyntaxEditor editor,
+        IReplaceMethodWithPropertyService service,
+        CancellationToken cancellationToken)
+    {
+        if (getReferences != null)
         {
-            return setMethod != null &&
-                !setMethod.IsGenericMethod &&
-                !setMethod.IsAsync &&
-                setMethod.ReturnsVoid &&
-                setMethod.DeclaringSyntaxReferences.Length == 1;
-        }
-
-        private static async Task<Solution> ReplaceMethodsWithPropertyAsync(
-            Document document,
-            string propertyName,
-            bool nameChanged,
-            IMethodSymbol getMethod,
-            IMethodSymbol? setMethod,
-            CodeGenerationOptionsProvider fallbackOptions,
-            CancellationToken cancellationToken)
-        {
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-            var project = document.Project;
-            var originalSolution = project.Solution;
-            var getMethodReferences = await SymbolFinder.FindReferencesAsync(
-                getMethod, originalSolution, cancellationToken).ConfigureAwait(false);
-            var setMethodReferences = setMethod == null
-                ? SpecializedCollections.EmptyEnumerable<ReferencedSymbol>()
-                : await SymbolFinder.FindReferencesAsync(
-                    setMethod, originalSolution, cancellationToken).ConfigureAwait(false);
-
-            // Get the warnings we'd like to put at the definition site.
-            var definitionWarning = GetDefinitionIssues(getMethodReferences);
-
-            var getReferencesByDocument = getMethodReferences.SelectMany(r => r.Locations).ToLookup(loc => loc.Document);
-            var setReferencesByDocument = setMethodReferences.SelectMany(r => r.Locations).ToLookup(loc => loc.Document);
-
-            // References and definitions can overlap (for example, references to one method
-            // inside the definition of another).  So we do a multi phase rewrite.  We first
-            // rewrite all references to point at the property instead.  Then we remove all
-            // the actual method definitions and replace them with the new properties.
-            var updatedSolution = originalSolution;
-
-            updatedSolution = await UpdateReferencesAsync(updatedSolution, propertyName, nameChanged, getReferencesByDocument, setReferencesByDocument, cancellationToken).ConfigureAwait(false);
-            updatedSolution = await ReplaceGetMethodsAndRemoveSetMethodsAsync(originalSolution, updatedSolution, propertyName, nameChanged, getMethodReferences, setMethodReferences, updateSetMethod: setMethod != null, fallbackOptions, cancellationToken).ConfigureAwait(false);
-
-            return updatedSolution;
-        }
-
-        private static async Task<Solution> UpdateReferencesAsync(Solution updatedSolution, string propertyName, bool nameChanged, ILookup<Document, ReferenceLocation> getReferencesByDocument, ILookup<Document, ReferenceLocation> setReferencesByDocument, CancellationToken cancellationToken)
-        {
-            var allReferenceDocuments = getReferencesByDocument.Concat(setReferencesByDocument).Select(g => g.Key).Distinct();
-            foreach (var referenceDocument in allReferenceDocuments)
+            // We may hit a location multiple times due to how we do FAR for linked symbols, but each linked symbol
+            // is allowed to report the entire set of references it think it is compatible with.  So ensure we're 
+            // hitting each location only once.
+            // 
+            // Note Use DistinctBy (.Net6) once available.
+            foreach (var referenceLocation in getReferences.Distinct(LinkedFileReferenceLocationEqualityComparer.Instance))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                updatedSolution = await UpdateReferencesInDocumentAsync(
-                    propertyName, nameChanged, updatedSolution, referenceDocument,
-                    getReferencesByDocument[referenceDocument],
-                    setReferencesByDocument[referenceDocument],
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            return updatedSolution;
-        }
-
-        private static async Task<Solution> UpdateReferencesInDocumentAsync(
-            string propertyName,
-            bool nameChanged,
-            Solution updatedSolution,
-            Document originalDocument,
-            IEnumerable<ReferenceLocation> getReferences,
-            IEnumerable<ReferenceLocation> setReferences,
-            CancellationToken cancellationToken)
-        {
-            var root = await originalDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            var editor = new SyntaxEditor(root, originalDocument.Project.Solution.Services);
-            var service = originalDocument.GetRequiredLanguageService<IReplaceMethodWithPropertyService>();
-
-            ReplaceGetReferences(propertyName, nameChanged, getReferences, root, editor, service, cancellationToken);
-            ReplaceSetReferences(propertyName, nameChanged, setReferences, root, editor, service, cancellationToken);
-
-            updatedSolution = updatedSolution.WithDocumentSyntaxRoot(originalDocument.Id, editor.GetChangedRoot());
-
-            return updatedSolution;
-        }
-
-        private static void ReplaceGetReferences(
-            string propertyName, bool nameChanged,
-            IEnumerable<ReferenceLocation> getReferences,
-            SyntaxNode root, SyntaxEditor editor,
-            IReplaceMethodWithPropertyService service,
-            CancellationToken cancellationToken)
-        {
-            if (getReferences != null)
-            {
-                // We may hit a location multiple times due to how we do FAR for linked symbols, but each linked symbol
-                // is allowed to report the entire set of references it think it is compatible with.  So ensure we're 
-                // hitting each location only once.
-                // 
-                // Note Use DistinctBy (.Net6) once available.
-                foreach (var referenceLocation in getReferences.Distinct(LinkedFileReferenceLocationEqualityComparer.Instance))
+                var location = referenceLocation.Location;
+                var nameToken = root.FindToken(location.SourceSpan.Start);
+                if (nameToken.Parent == null)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
+                    Debug.Fail($"Parent node of {nameToken} is null.");
+                    continue;
+                }
 
-                    var location = referenceLocation.Location;
-                    var nameToken = root.FindToken(location.SourceSpan.Start);
-                    if (nameToken.Parent == null)
-                    {
-                        Debug.Fail($"Parent node of {nameToken} is null.");
-                        continue;
-                    }
-
-                    if (referenceLocation.IsImplicit)
-                    {
-                        // Warn the user that we can't properly replace this method with a property.
-                        editor.ReplaceNode(nameToken.Parent, nameToken.Parent.WithAdditionalAnnotations(
-                            ConflictAnnotation.Create(FeaturesResources.Method_referenced_implicitly)));
-                    }
-                    else
-                    {
-                        service.ReplaceGetReference(editor, nameToken, propertyName, nameChanged);
-                    }
+                if (referenceLocation.IsImplicit)
+                {
+                    // Warn the user that we can't properly replace this method with a property.
+                    editor.ReplaceNode(nameToken.Parent, nameToken.Parent.WithAdditionalAnnotations(
+                        ConflictAnnotation.Create(FeaturesResources.Method_referenced_implicitly)));
+                }
+                else
+                {
+                    service.ReplaceGetReference(editor, nameToken, propertyName, nameChanged);
                 }
             }
         }
+    }
 
-        private static void ReplaceSetReferences(
-            string propertyName, bool nameChanged,
-            IEnumerable<ReferenceLocation> setReferences,
-            SyntaxNode root, SyntaxEditor editor,
-            IReplaceMethodWithPropertyService service,
-            CancellationToken cancellationToken)
+    private static void ReplaceSetReferences(
+        string propertyName, bool nameChanged,
+        IEnumerable<ReferenceLocation> setReferences,
+        SyntaxNode root, SyntaxEditor editor,
+        IReplaceMethodWithPropertyService service,
+        CancellationToken cancellationToken)
+    {
+        if (setReferences != null)
         {
-            if (setReferences != null)
+            // We may hit a location multiple times due to how we do FAR for linked symbols, but each linked symbol
+            // is allowed to report the entire set of references it think it is compatible with.  So ensure we're 
+            // hitting each location only once.
+            // 
+            // Note Use DistinctBy (.Net6) once available.
+            foreach (var referenceLocation in setReferences.Distinct(LinkedFileReferenceLocationEqualityComparer.Instance))
             {
-                // We may hit a location multiple times due to how we do FAR for linked symbols, but each linked symbol
-                // is allowed to report the entire set of references it think it is compatible with.  So ensure we're 
-                // hitting each location only once.
-                // 
-                // Note Use DistinctBy (.Net6) once available.
-                foreach (var referenceLocation in setReferences.Distinct(LinkedFileReferenceLocationEqualityComparer.Instance))
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var location = referenceLocation.Location;
+                var nameToken = root.FindToken(location.SourceSpan.Start);
+                if (nameToken.Parent == null)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
+                    Debug.Fail($"Parent node of {nameToken} is null.");
+                    continue;
+                }
 
-                    var location = referenceLocation.Location;
-                    var nameToken = root.FindToken(location.SourceSpan.Start);
-                    if (nameToken.Parent == null)
-                    {
-                        Debug.Fail($"Parent node of {nameToken} is null.");
-                        continue;
-                    }
-
-                    if (referenceLocation.IsImplicit)
-                    {
-                        // Warn the user that we can't properly replace this method with a property.
-                        editor.ReplaceNode(nameToken.Parent, nameToken.Parent.WithAdditionalAnnotations(
-                            ConflictAnnotation.Create(FeaturesResources.Method_referenced_implicitly)));
-                    }
-                    else
-                    {
-                        service.ReplaceSetReference(editor, nameToken, propertyName, nameChanged);
-                    }
+                if (referenceLocation.IsImplicit)
+                {
+                    // Warn the user that we can't properly replace this method with a property.
+                    editor.ReplaceNode(nameToken.Parent, nameToken.Parent.WithAdditionalAnnotations(
+                        ConflictAnnotation.Create(FeaturesResources.Method_referenced_implicitly)));
+                }
+                else
+                {
+                    service.ReplaceSetReference(editor, nameToken, propertyName, nameChanged);
                 }
             }
         }
+    }
 
-        private static async Task<Solution> ReplaceGetMethodsAndRemoveSetMethodsAsync(
-            Solution originalSolution,
-            Solution updatedSolution,
-            string propertyName,
-            bool nameChanged,
-            IEnumerable<ReferencedSymbol> getMethodReferences,
-            IEnumerable<ReferencedSymbol> setMethodReferences,
-            bool updateSetMethod,
-            CodeGenerationOptionsProvider fallbackOptions,
-            CancellationToken cancellationToken)
+    private static async Task<Solution> ReplaceGetMethodsAndRemoveSetMethodsAsync(
+        Solution originalSolution,
+        Solution updatedSolution,
+        string propertyName,
+        bool nameChanged,
+        IEnumerable<ReferencedSymbol> getMethodReferences,
+        IEnumerable<ReferencedSymbol> setMethodReferences,
+        bool updateSetMethod,
+        CodeGenerationOptionsProvider fallbackOptions,
+        CancellationToken cancellationToken)
+    {
+        var getDefinitionsByDocumentId = await GetDefinitionsByDocumentIdAsync(originalSolution, getMethodReferences, cancellationToken).ConfigureAwait(false);
+        var setDefinitionsByDocumentId = await GetDefinitionsByDocumentIdAsync(originalSolution, setMethodReferences, cancellationToken).ConfigureAwait(false);
+
+        var documentIds = getDefinitionsByDocumentId.Keys.Concat(setDefinitionsByDocumentId.Keys).Distinct();
+        foreach (var documentId in documentIds)
         {
-            var getDefinitionsByDocumentId = await GetDefinitionsByDocumentIdAsync(originalSolution, getMethodReferences, cancellationToken).ConfigureAwait(false);
-            var setDefinitionsByDocumentId = await GetDefinitionsByDocumentIdAsync(originalSolution, setMethodReferences, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            var documentIds = getDefinitionsByDocumentId.Keys.Concat(setDefinitionsByDocumentId.Keys).Distinct();
-            foreach (var documentId in documentIds)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
+            var getDefinitions = getDefinitionsByDocumentId[documentId];
+            var setDefinitions = setDefinitionsByDocumentId[documentId];
 
-                var getDefinitions = getDefinitionsByDocumentId[documentId];
-                var setDefinitions = setDefinitionsByDocumentId[documentId];
-
-                updatedSolution = await ReplaceGetMethodsAndRemoveSetMethodsAsync(
-                    propertyName, nameChanged, updatedSolution, documentId, getDefinitions, setDefinitions, updateSetMethod, fallbackOptions, cancellationToken).ConfigureAwait(false);
-            }
-
-            return updatedSolution;
+            updatedSolution = await ReplaceGetMethodsAndRemoveSetMethodsAsync(
+                propertyName, nameChanged, updatedSolution, documentId, getDefinitions, setDefinitions, updateSetMethod, fallbackOptions, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task<Solution> ReplaceGetMethodsAndRemoveSetMethodsAsync(
-            string propertyName,
-            bool nameChanged,
-            Solution updatedSolution,
-            DocumentId documentId,
-            MultiDictionary<DocumentId, IMethodSymbol>.ValueSet originalGetDefinitions,
-            MultiDictionary<DocumentId, IMethodSymbol>.ValueSet originalSetDefinitions,
-            bool updateSetMethod,
-            CodeGenerationOptionsProvider fallbackOptions,
-            CancellationToken cancellationToken)
+        return updatedSolution;
+    }
+
+    private static async Task<Solution> ReplaceGetMethodsAndRemoveSetMethodsAsync(
+        string propertyName,
+        bool nameChanged,
+        Solution updatedSolution,
+        DocumentId documentId,
+        MultiDictionary<DocumentId, IMethodSymbol>.ValueSet originalGetDefinitions,
+        MultiDictionary<DocumentId, IMethodSymbol>.ValueSet originalSetDefinitions,
+        bool updateSetMethod,
+        CodeGenerationOptionsProvider fallbackOptions,
+        CancellationToken cancellationToken)
+    {
+        var updatedDocument = await updatedSolution.GetRequiredDocumentAsync(
+            documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+        var compilation = await updatedDocument.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+        // We've already gone and updated all references.  So now re-resolve all the definitions
+        // in the current compilation to find their updated location.
+        var getSetPairs = await GetGetSetPairsAsync(
+            updatedSolution, compilation, documentId, originalGetDefinitions, updateSetMethod, cancellationToken).ConfigureAwait(false);
+
+        var service = updatedDocument.GetRequiredLanguageService<IReplaceMethodWithPropertyService>();
+
+        var semanticModel = await updatedDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var syntaxTree = await updatedDocument.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+        var root = await updatedDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        var editor = new SyntaxEditor(root, updatedSolution.Services);
+
+        var codeGenerationOptions = await updatedDocument.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
+        var parseOptions = syntaxTree.Options;
+
+        // First replace all the get methods with properties.
+        foreach (var getSetPair in getSetPairs)
         {
-            var updatedDocument = updatedSolution.GetRequiredDocument(documentId);
-            var compilation = await updatedDocument.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            // We've already gone and updated all references.  So now re-resolve all the definitions
-            // in the current compilation to find their updated location.
-            var getSetPairs = await GetGetSetPairsAsync(
-                updatedSolution, compilation, documentId, originalGetDefinitions, updateSetMethod, cancellationToken).ConfigureAwait(false);
+            service.ReplaceGetMethodWithProperty(
+                codeGenerationOptions, parseOptions, editor, semanticModel,
+                getSetPair, propertyName, nameChanged, cancellationToken);
+        }
 
-            var service = updatedDocument.GetRequiredLanguageService<IReplaceMethodWithPropertyService>();
+        // Then remove all the set methods.
+        foreach (var originalSetMethod in originalSetDefinitions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
 
-            var semanticModel = await updatedDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var syntaxTree = await updatedDocument.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var root = await updatedDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var setMethod = GetSymbolInCurrentCompilation(compilation, originalSetMethod, cancellationToken);
+            var setMethodDeclaration = await GetMethodDeclarationAsync(setMethod, cancellationToken).ConfigureAwait(false);
 
-            var editor = new SyntaxEditor(root, updatedSolution.Services);
-
-            var codeGenerationOptions = await updatedDocument.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
-            var parseOptions = syntaxTree.Options;
-
-            // First replace all the get methods with properties.
-            foreach (var getSetPair in getSetPairs)
+            var setMethodDocument = updatedSolution.GetDocument(setMethodDeclaration?.SyntaxTree);
+            if (setMethodDocument?.Id == documentId)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                service.ReplaceGetMethodWithProperty(
-                    codeGenerationOptions, parseOptions, editor, semanticModel,
-                    getSetPair, propertyName, nameChanged, cancellationToken);
+                service.RemoveSetMethod(editor, setMethodDeclaration);
             }
+        }
 
-            // Then remove all the set methods.
-            foreach (var originalSetMethod in originalSetDefinitions)
+        return updatedSolution.WithDocumentSyntaxRoot(documentId, editor.GetChangedRoot());
+    }
+
+    private static async Task<ImmutableArray<GetAndSetMethods>> GetGetSetPairsAsync(
+        Solution updatedSolution,
+        Compilation compilation,
+        DocumentId documentId,
+        MultiDictionary<DocumentId, IMethodSymbol>.ValueSet originalDefinitions,
+        bool updateSetMethod,
+        CancellationToken cancellationToken)
+    {
+        using var _ = ArrayBuilder<GetAndSetMethods>.GetInstance(out var result);
+        foreach (var originalDefinition in originalDefinitions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var getMethod = GetSymbolInCurrentCompilation(compilation, originalDefinition, cancellationToken);
+            if (getMethod != null && IsValidGetMethod(getMethod))
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var setMethod = GetSymbolInCurrentCompilation(compilation, originalSetMethod, cancellationToken);
+                var setMethod = updateSetMethod ? FindSetMethod(getMethod) : null;
+                var getMethodDeclaration = await GetMethodDeclarationAsync(getMethod, cancellationToken).ConfigureAwait(false);
                 var setMethodDeclaration = await GetMethodDeclarationAsync(setMethod, cancellationToken).ConfigureAwait(false);
 
-                var setMethodDocument = updatedSolution.GetDocument(setMethodDeclaration?.SyntaxTree);
-                if (setMethodDocument?.Id == documentId)
+                if (getMethodDeclaration != null && updatedSolution.GetDocument(getMethodDeclaration.SyntaxTree)?.Id == documentId)
                 {
-                    service.RemoveSetMethod(editor, setMethodDeclaration);
+                    result.Add(new GetAndSetMethods(getMethod, setMethod, getMethodDeclaration, setMethodDeclaration));
                 }
             }
-
-            return updatedSolution.WithDocumentSyntaxRoot(documentId, editor.GetChangedRoot());
         }
 
-        private static async Task<ImmutableArray<GetAndSetMethods>> GetGetSetPairsAsync(
-            Solution updatedSolution,
-            Compilation compilation,
-            DocumentId documentId,
-            MultiDictionary<DocumentId, IMethodSymbol>.ValueSet originalDefinitions,
-            bool updateSetMethod,
-            CancellationToken cancellationToken)
+        return result.ToImmutable();
+    }
+
+    private static TSymbol? GetSymbolInCurrentCompilation<TSymbol>(Compilation compilation, TSymbol originalDefinition, CancellationToken cancellationToken)
+        where TSymbol : class, ISymbol
+    {
+        return originalDefinition.GetSymbolKey(cancellationToken).Resolve(compilation, cancellationToken: cancellationToken).GetAnySymbol() as TSymbol;
+    }
+
+    private static async Task<SyntaxNode?> GetMethodDeclarationAsync(IMethodSymbol? method, CancellationToken cancellationToken)
+    {
+        if (method == null)
         {
-            using var _ = ArrayBuilder<GetAndSetMethods>.GetInstance(out var result);
-            foreach (var originalDefinition in originalDefinitions)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var getMethod = GetSymbolInCurrentCompilation(compilation, originalDefinition, cancellationToken);
-                if (getMethod != null && IsValidGetMethod(getMethod))
-                {
-                    var setMethod = updateSetMethod ? FindSetMethod(getMethod) : null;
-                    var getMethodDeclaration = await GetMethodDeclarationAsync(getMethod, cancellationToken).ConfigureAwait(false);
-                    var setMethodDeclaration = await GetMethodDeclarationAsync(setMethod, cancellationToken).ConfigureAwait(false);
-
-                    if (getMethodDeclaration != null && updatedSolution.GetDocument(getMethodDeclaration.SyntaxTree)?.Id == documentId)
-                    {
-                        result.Add(new GetAndSetMethods(getMethod, setMethod, getMethodDeclaration, setMethodDeclaration));
-                    }
-                }
-            }
-
-            return result.ToImmutable();
-        }
-
-        private static TSymbol? GetSymbolInCurrentCompilation<TSymbol>(Compilation compilation, TSymbol originalDefinition, CancellationToken cancellationToken)
-            where TSymbol : class, ISymbol
-        {
-            return originalDefinition.GetSymbolKey(cancellationToken).Resolve(compilation, cancellationToken: cancellationToken).GetAnySymbol() as TSymbol;
-        }
-
-        private static async Task<SyntaxNode?> GetMethodDeclarationAsync(IMethodSymbol? method, CancellationToken cancellationToken)
-        {
-            if (method == null)
-            {
-                return null;
-            }
-
-            Debug.Assert(method.DeclaringSyntaxReferences.Length == 1);
-            var reference = method.DeclaringSyntaxReferences[0];
-            return await reference.GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        private static async Task<MultiDictionary<DocumentId, IMethodSymbol>> GetDefinitionsByDocumentIdAsync(
-            Solution originalSolution,
-            IEnumerable<ReferencedSymbol> referencedSymbols,
-            CancellationToken cancellationToken)
-        {
-            var result = new MultiDictionary<DocumentId, IMethodSymbol>();
-            foreach (var referencedSymbol in referencedSymbols)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var definition = referencedSymbol.Definition as IMethodSymbol;
-                if (definition?.DeclaringSyntaxReferences.Length > 0)
-                {
-                    var syntax = await definition.DeclaringSyntaxReferences[0].GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
-                    if (syntax != null)
-                    {
-                        var document = originalSolution.GetDocument(syntax.SyntaxTree);
-                        if (document != null)
-                        {
-                            result.Add(document.Id, definition);
-                        }
-                    }
-                }
-            }
-
-            return result;
-        }
-
-#pragma warning disable IDE0060 // Remove unused parameter - Method not completely implemented.
-        private static string? GetDefinitionIssues(IEnumerable<ReferencedSymbol> getMethodReferences)
-#pragma warning restore IDE0060 // Remove unused parameter
-        {
-            // TODO: add things to be concerned about here.  For example:
-            // 1. If any of the referenced symbols are from metadata.
-            // 2. If a symbol is referenced implicitly.
-            // 3. if the methods have attributes on them.
             return null;
         }
+
+        Debug.Assert(method.DeclaringSyntaxReferences.Length == 1);
+        var reference = method.DeclaringSyntaxReferences[0];
+        return await reference.GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<MultiDictionary<DocumentId, IMethodSymbol>> GetDefinitionsByDocumentIdAsync(
+        Solution originalSolution,
+        IEnumerable<ReferencedSymbol> referencedSymbols,
+        CancellationToken cancellationToken)
+    {
+        var result = new MultiDictionary<DocumentId, IMethodSymbol>();
+        foreach (var referencedSymbol in referencedSymbols)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var definition = referencedSymbol.Definition as IMethodSymbol;
+            if (definition?.DeclaringSyntaxReferences.Length > 0)
+            {
+                var syntax = await definition.DeclaringSyntaxReferences[0].GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
+                if (syntax != null)
+                {
+                    var document = originalSolution.GetDocument(syntax.SyntaxTree);
+                    if (document != null)
+                    {
+                        result.Add(document.Id, definition);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+#pragma warning disable IDE0060 // Remove unused parameter - Method not completely implemented.
+    private static string? GetDefinitionIssues(IEnumerable<ReferencedSymbol> getMethodReferences)
+#pragma warning restore IDE0060 // Remove unused parameter
+    {
+        // TODO: add things to be concerned about here.  For example:
+        // 1. If any of the referenced symbols are from metadata.
+        // 2. If a symbol is referenced implicitly.
+        // 3. if the methods have attributes on them.
+        return null;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/72035