### PR TITLE
Remove -windows TFM being used in MSBuild tests

### DIFF
--- a/eng/pipelines/test-integration-helix.yml
+++ b/eng/pipelines/test-integration-helix.yml
@@ -70,9 +70,9 @@ stages:
 
       # This is a temporary step until the actual test run moves to helix (then we would need to rehydrate the tests there instead)
       - task: BatchScript@1
-        displayName: Rehydrate Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests (net8.0-windows)
+        displayName: Rehydrate Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests (net8.0)
         inputs:
-          filename: ./artifacts\bin\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests/${{ parameters.configuration }}/net8.0-windows/rehydrate.cmd
+          filename: ./artifacts\bin\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests/${{ parameters.configuration }}/net8.0/rehydrate.cmd
         env:
           HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)\.duplicate'
 

--- a/src/Workspaces/MSBuildTest/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj
+++ b/src/Workspaces/MSBuildTest/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.MSBuild.UnitTests</RootNamespace>
-    <TargetFrameworks>$(NetVS)-windows;net472</TargetFrameworks>
+    <TargetFrameworks>$(NetRoslyn);net472</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />


### PR DESCRIPTION
This should be fully cross-platform now.