### PR TITLE
Fix quick info for anonymous types not escaping identifiers named as keywords

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -8831,5 +8831,26 @@ class Program
 "var x = $$[1, 2]";
             await TestAsync(source);
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71638")]
+        public async Task TestAnonymousType()
+        {
+            var markup = """
+                _ = new
+                {
+                    @string = ""
+                }.$$@string;
+                """;
+            var description = $"string 'a.@string {{ get; }}";
+
+            await VerifyWithMscorlib45Async(markup, new[]
+            {
+                MainDescription(description),
+                AnonymousTypes(
+$@"
+{FeaturesResources.Types_colon}
+    'a {FeaturesResources.is_} new {{ string @string }}")
+            });
+        }
     }
 }

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpStructuralTypeDisplayService.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpStructuralTypeDisplayService.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
                 first = false;
                 members.AddRange(property.Type.ToMinimalDisplayParts(semanticModel, position, s_minimalWithoutExpandedTuples).Select(p => p.MassageErrorTypeNames("?")));
                 members.AddRange(Space());
-                members.Add(new SymbolDisplayPart(SymbolDisplayPartKind.PropertyName, property, property.Name));
+                members.Add(new SymbolDisplayPart(SymbolDisplayPartKind.PropertyName, property, CSharpSyntaxFacts.Instance.EscapeIdentifier(property.Name)));
             }
 
             members.AddRange(Space());


### PR DESCRIPTION
Fixes #71638