### PR TITLE
Prevent 'InvalidOperationException' when array is null

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypedConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypedConstantTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -99,6 +100,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             EqualityTesting.AssertNotEqual(
                 new TypedConstant(_stringType, TypedConstantKind.Primitive, null),
                 new TypedConstant(_systemType, TypedConstantKind.Primitive, null));
+        }
+        
+        [Fact]
+        public void Null_Array()
+        {
+            TypedConstant nullTypedConstant = new TypedConstant(_arrayType, TypedConstantKind.Array, null);
+
+            Assert.Equal(TypedConstantKind.Array, nullTypedConstant.Kind);
+            Assert.Empty(nullTypedConstant.Values);
+            Assert.True(nullTypedConstant.IsNull);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypedConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypedConstantTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
                 new TypedConstant(_stringType, TypedConstantKind.Primitive, null),
                 new TypedConstant(_systemType, TypedConstantKind.Primitive, null));
         }
-        
+
         [Fact]
         public void Null_Array()
         {

--- a/src/Compilers/Core/Portable/Symbols/TypedConstant.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypedConstant.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis
 
                 if (this.IsNull)
                 {
-                    return default;
+                    return ImmutableArray<TypedConstant>.Empty;
                 }
 
                 return (ImmutableArray<TypedConstant>)_value!;


### PR DESCRIPTION
When a `TypedConstant` is an array type with a null value, calling trying to iterate through any of its values will throw an InvalidOperationException. This change stops that exception from being thrown and will simply return an empty array with no inner values.

Fixes #72046 