### PR TITLE
Change NullableWalker.VisitConversion to not unsplit

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8004,7 +8004,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             (BoundExpression operand, Conversion conversion) = RemoveConversion(node, includeExplicitConversions: true);
             SnapshotWalkerThroughConversionGroup(node, operand);
-            if (targetType.NullableUnderlyingTypeOrSelf.SpecialType == SpecialType.System_Boolean &&
+            if (targetType.SpecialType == SpecialType.System_Boolean &&
                 (operand.Type?.SpecialType == SpecialType.System_Boolean || operand.Type?.IsErrorType() == true))
             {
                 Visit(operand);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8004,7 +8004,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             (BoundExpression operand, Conversion conversion) = RemoveConversion(node, includeExplicitConversions: true);
             SnapshotWalkerThroughConversionGroup(node, operand);
-            Visit(operand);
+            if (targetType.NullableUnderlyingTypeOrSelf.SpecialType == SpecialType.System_Boolean &&
+                (operand.Type?.SpecialType == SpecialType.System_Boolean || operand.Type?.IsErrorType() == true))
+            {
+                Visit(operand);
+            }
+            else
+            {
+                VisitRvalue(operand);
+            }
+
             SetResultType(node,
                 VisitConversion(
                     node,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8004,21 +8004,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             (BoundExpression operand, Conversion conversion) = RemoveConversion(node, includeExplicitConversions: true);
             SnapshotWalkerThroughConversionGroup(node, operand);
-            TypeWithState operandType = VisitRvalueWithState(operand);
+            Visit(operand);
             SetResultType(node,
                 VisitConversion(
                     node,
                     operand,
                     conversion,
                     targetType,
-                    operandType,
+                    ResultType,
                     checkConversion: true,
                     fromExplicitCast: fromExplicitCast,
                     useLegacyWarnings: fromExplicitCast,
                     AssignmentKind.Assignment,
                     reportTopLevelWarnings: fromExplicitCast,
                     reportRemainingWarnings: true,
-                    trackMembers: true));
+                    trackMembers: !IsConditionalState));
 
             return null;
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -176,10 +176,7 @@ class C
             c.VerifyDiagnostics(
                 // (7,18): error CS0150: A constant value is expected
                 //         if (x is nonConstant)
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "nonConstant").WithLocation(7, 18),
-                // (9,13): warning CS8602: Dereference of a possibly null reference.
-                //             x.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(9, 13)
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "nonConstant").WithLocation(7, 18)
                 );
         }
 


### PR DESCRIPTION
Closes #67880 

The unsplit was causing problems when the operand of the conversion was a conditional state since it would break its dual state.

I would like to mention the tests changes because they didn't seemed right to me at first glance, but upon closer inspection, it seems these changes are correct and the tests weren't accurate in the first place. The most damning one is `NotNullWhenFalse_ReturningObject_FromMetadata` because the attribute should have made the false case NotNull, but it never did because of the unsplit.

For `IsCondAccess_NotNullWhenTrue_02` and `IsCondAccess_NotNullWhenTrue_02`, these can be explained by the compiler putting a "bad" node in the dag which implicitly tests for not being null. It means that for all intents and purposes, this pattern does test for not being null which would change the nullability were it not for the unsplit breaking this. This specific change, I noticed in multiple tests with the simplest case being `IsInvalidConstant` because F becomes a bad pattern which implicitly tests for not null, but the fake conversion makes it so this information is lost with the unsplit.

It seems like what happened was these tests accidentally masked the bug. I added 2 tests that more explicitly tests for this on top of these changes.

