### PR TITLE
Add an assertion that the .NET Core BuildHost is deployed

### DIFF
--- a/src/Workspaces/Core/MSBuild/WorkspaceMSBuildResources.resx
+++ b/src/Workspaces/Core/MSBuild/WorkspaceMSBuildResources.resx
@@ -168,4 +168,7 @@
   <data name="Path_for_additional_document_0_was_null" xml:space="preserve">
     <value>Path for additional document '{0}' was null}</value>
   </data>
+  <data name="The_build_host_could_not_be_found_at_0" xml:space="preserve">
+    <value>The build host could not be found at '{0}'</value>
+  </data>
 </root>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.cs.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Cesta projektu pro {0} byla null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">Nedá se přidat odkaz na metadata {0}.</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.de.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Der Projektpfad für "{0}" war NULL</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">Der Metadaten-Verweis "{0}" wurde nicht hinzugefügt</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.es.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">La ruta de acceso del proyecto para '{0}' era null</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">No se puede agregar la referencia de metadatos '{0}'</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.fr.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Le chemin d’accès du projet pour '{0}' était null</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">Impossible d’ajouter une référence de métadonnées '{0}'</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.it.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Il percorso del progetto per '{0}' è null</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">Non è possibile aggiungere il riferimento ai metadati '{0}'</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ja.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">' {0} ' のプロジェクト パスが null でした</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">メタデータ参照 "{0}" を追加できません。</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ko.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">'{0}'에 대한 프로젝트 경로가 null이었음</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">메타데이터 참조 '{0}'을(를) 추가할 수 없음</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pl.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Ścieżka projektu dla pliku "{0}" miała wartość null</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">Nie można dodać odwołania do metadanych "{0}"</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pt-BR.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">O caminho do projeto para '{0}' era nulo</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">Não foi possível adicionar a referência de metadados '{0}'</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ru.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Путь проекта для "{0}" имел значение NULL</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">Не удается добавить ссылку на метаданные "{0}"</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.tr.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">'{0}' için proje yolu null değerindeydi</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">'{0}' meta veri başvurusu eklenemiyor</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">"{0}" 的项目路径为 null</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">无法添加元数据文件 '{0}'</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">'{0}' 的專案路徑為 null</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_build_host_could_not_be_found_at_0">
+        <source>The build host could not be found at '{0}'</source>
+        <target state="new">The build host could not be found at '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_add_metadata_reference_0">
         <source>Unable to add metadata reference '{0}'</source>
         <target state="translated">無法新增中繼資料參照 '{0}'</target>


### PR DESCRIPTION
This adds an assertion that the .NET Core BuildHost is deployed too. This always should be the case, but in some NuGet cases this might not happen.

Inspired by https://github.com/dotnet/roslyn/issues/71914, where having this would have made this much easier to diagnose.