### PR TITLE
UseConditionExpression: Add support for checked expression in if and return statement

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/CSharpUseConditionalExpressionForReturnCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/CSharpUseConditionalExpressionForReturnCodeFixProvider.cs
@@ -45,6 +45,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
             return statement;
         }
 
+        protected override SyntaxNode WrapIfStatementIfNecessary(IConditionalOperation operation)
+        {
+            if (operation.Syntax is IfStatementSyntax { Condition: CheckedExpressionSyntax exp })
+                return exp;
+
+            return base.WrapIfStatementIfNecessary(operation);
+        }
+
+        protected override ExpressionSyntax WrapReturnExpressionIfNecessary(ExpressionSyntax returnExpression, IOperation returnOperation)
+        {
+            if (returnOperation.Syntax is ReturnStatementSyntax { Expression: CheckedExpressionSyntax exp })
+                return exp;
+
+            return base.WrapReturnExpressionIfNecessary(returnExpression, returnOperation);
+        }
+
         protected override ExpressionSyntax ConvertToExpression(IThrowOperation throwOperation)
             => CSharpUseConditionalExpressionHelpers.ConvertToExpression(throwOperation);
 

--- a/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
@@ -502,6 +502,146 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseConditionalExpressio
                 """);
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70748")]
+        public async Task TestMissingWithCheckedInIf()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        [||]if (checked(x == y))
+                        {
+                            return 0;
+                        }
+                        else
+                        {
+                            return 1;
+                        }
+                    }
+                }
+                """,
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        return checked(x == y) ? 0 : 1;
+                    }
+                }
+                """, parseOptions: CSharp8);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70748")]
+        public async Task TestMissingWithUncheckedInIf()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        [||]if (unchecked(x == y))
+                        {
+                            return 0;
+                        }
+                        else
+                        {
+                            return 1;
+                        }
+                    }
+                }
+                """,
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        return unchecked(x == y) ? 0 : 1;
+                    }
+                }
+                """, parseOptions: CSharp8);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70748")]
+        public async Task TestMissingWithCheckedInTrueStatement()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        [||]if (x == y)
+                        {
+                            return checked(x - y);
+                        }
+                        else
+                        {
+                            return 1;
+                        }
+                    }
+                }
+                """,
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        return x == y ? checked(x - y) : 1;
+                    }
+                }
+                """, parseOptions: CSharp8);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70748")]
+        public async Task TestMissingWithUncheckedInTrueStatement()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        [||]if (x == y)
+                        {
+                            return unchecked(x - y);
+                        }
+                        else
+                        {
+                            return 1;
+                        }
+                    }
+                }
+                """,
+                """
+                class C
+                {
+                    int M()
+                    {
+                        int x = 0;
+                        int y = 0;
+                        return x == y ? unchecked(x - y) : 1;
+                    }
+                }
+                """, parseOptions: CSharp8);
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70750")]
         public async Task TestMissingWithUnchecked()
         {


### PR DESCRIPTION
Closes #70748 

This was relatively straight forward as it simply involved to wrap the expression in its checked statement if it existed. I added some tests to validate this.