### PR TITLE
Remove .NET 7 install step

### DIFF
--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -28,15 +28,6 @@ jobs:
   steps:
     - checkout: none
 
-    # A .NET 7 runtime is needed since our unit tests target net7.0
-    - task: UseDotNet@2
-      displayName: 'Install .NET 7 Runtime'
-      inputs:
-        packageType: runtime
-        version: 7.0.0-rc.1.22426.10
-        includePreviewVersions: true
-        installationPath: '$(Build.SourcesDirectory)/.dotnet'
-
     - task: DownloadPipelineArtifact@2
       displayName: Download Test Payload
       inputs:


### PR DESCRIPTION
Fixes Test_Windows_CoreClr_Debug_Single_Machine leg in [rolling CI](https://dev.azure.com/dnceng-public/public/_build?definitionId=95&_a=summary).

Full build of this PR (including the Single_Machine leg which doesn't normally run for PRs): https://dev.azure.com/dnceng-public/public/_build/results?buildId=566224&view=results