### PR TITLE
Include SourceLink file in CoreCompile dependency checks

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -50,7 +50,8 @@
                   @(AdditionalFiles);
                   @(EmbeddedFiles);
                   @(Analyzer);
-                  @(EditorConfigFiles)"
+                  @(EditorConfigFiles);
+                  $(SourceLink)"
           Outputs="@(DocFileItem);
                    @(IntermediateAssembly);
                    @(IntermediateRefAssembly);

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -20,7 +20,8 @@
                   @(AdditionalFiles);
                   @(EmbeddedFiles);
                   @(Analyzer);
-                  @(EditorConfigFiles)"
+                  @(EditorConfigFiles);
+                  $(SourceLink)"
           Outputs="@(DocFileItem);
                    @(IntermediateAssembly);
                    @(IntermediateRefAssembly);


### PR DESCRIPTION
A companion to https://github.com/dotnet/msbuild/pull/9743 to ensure that more sourcelink/determinism-related flags correctly cause the compiler to be invoked when they change