### PR TITLE
Support more than one frozen source generated document at once

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -249,8 +249,13 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
         internal void SolutionCompilationStateEqual(SolutionCompilationStateChecksums solutionObject1, SolutionCompilationStateChecksums solutionObject2)
         {
             Assert.Equal(solutionObject1.Checksum, solutionObject2.Checksum);
-            Assert.Equal(solutionObject1.FrozenSourceGeneratedDocumentIdentity, solutionObject2.FrozenSourceGeneratedDocumentIdentity);
-            Assert.Equal(solutionObject1.FrozenSourceGeneratedDocumentText, solutionObject2.FrozenSourceGeneratedDocumentText);
+            Assert.Equal(solutionObject1.FrozenSourceGeneratedDocumentIdentities.HasValue, solutionObject2.FrozenSourceGeneratedDocumentIdentities.HasValue);
+            if (solutionObject1.FrozenSourceGeneratedDocumentIdentities.HasValue)
+                AssertChecksumCollectionEqual(solutionObject1.FrozenSourceGeneratedDocumentIdentities.Value, solutionObject2.FrozenSourceGeneratedDocumentIdentities!.Value);
+
+            Assert.Equal(solutionObject1.FrozenSourceGeneratedDocuments.HasValue, solutionObject2.FrozenSourceGeneratedDocuments.HasValue);
+            if (solutionObject1.FrozenSourceGeneratedDocuments.HasValue)
+                AssertChecksumCollectionEqual(solutionObject1.FrozenSourceGeneratedDocuments.Value, solutionObject2.FrozenSourceGeneratedDocuments!.Value);
         }
 
         internal void SolutionStateEqual(SolutionStateChecksums solutionObject1, SolutionStateChecksums solutionObject2)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1549,7 +1549,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal Document WithFrozenSourceGeneratedDocument(SourceGeneratedDocumentIdentity documentIdentity, SourceText text)
         {
-            var newCompilationState = _compilationState.WithFrozenSourceGeneratedDocument(documentIdentity, text);
+            var newCompilationState = _compilationState.WithFrozenSourceGeneratedDocuments([(documentIdentity, text)]);
             var newSolution = newCompilationState != _compilationState
                 ? new Solution(newCompilationState)
                 : this;
@@ -1559,6 +1559,14 @@ namespace Microsoft.CodeAnalysis
 
             var newProject = newSolution.GetRequiredProject(newDocumentState.Id.ProjectId);
             return newProject.GetOrCreateSourceGeneratedDocument(newDocumentState);
+        }
+
+        internal Solution WithFrozenSourceGeneratedDocuments(ImmutableArray<(SourceGeneratedDocumentIdentity documentIdentity, SourceText text)> documents)
+        {
+            var newCompilationState = _compilationState.WithFrozenSourceGeneratedDocuments(documents);
+            return newCompilationState != _compilationState
+                ? new Solution(newCompilationState)
+                : this;
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.GeneratedFileReplacingCompilationTracker.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis
         /// to return a generated document with a specific content, regardless of what the generator actually produces. In other words, it says
         /// "take the compilation this other thing produced, and pretend the generator gave this content, even if it wouldn't."
         /// </summary>
-        private class GeneratedFileReplacingCompilationTracker(ICompilationTracker underlyingTracker, SourceGeneratedDocumentState replacementDocumentState) : ICompilationTracker
+        private class GeneratedFileReplacingCompilationTracker(ICompilationTracker underlyingTracker, TextDocumentStates<SourceGeneratedDocumentState> replacementDocumentStates) : ICompilationTracker
         {
             private AsyncLazy<Checksum>? _lazyDependentChecksum;
 
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
             /// <see cref="GetCompilationAsync"/>.
             /// </summary>
             [DisallowNull]
-            private Compilation? _compilationWithReplacement;
+            private Compilation? _compilationWithReplacements;
 
             public ICompilationTracker UnderlyingTracker { get; } = underlyingTracker;
             public SkeletonReferenceCache SkeletonReferenceCache { get; } = underlyingTracker.SkeletonReferenceCache.Clone();
@@ -38,14 +38,14 @@ namespace Microsoft.CodeAnalysis
 
             public bool ContainsAssemblyOrModuleOrDynamic(ISymbol symbol, bool primary)
             {
-                if (_compilationWithReplacement == null)
+                if (_compilationWithReplacements == null)
                 {
                     // We don't have a compilation yet, so this couldn't have came from us
                     return false;
                 }
                 else
                 {
-                    return UnrootedSymbolSet.Create(_compilationWithReplacement).ContainsAssemblyOrModuleOrDynamic(symbol, primary);
+                    return UnrootedSymbolSet.Create(_compilationWithReplacements).ContainsAssemblyOrModuleOrDynamic(symbol, primary);
                 }
             }
 
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis
             public ICompilationTracker FreezePartialState(CancellationToken cancellationToken)
             {
                 // Ensure the underlying tracker is totally frozen, and then ensure our replaced generated doc is present.
-                return new GeneratedFileReplacingCompilationTracker(UnderlyingTracker.FreezePartialState(cancellationToken), replacementDocumentState);
+                return new GeneratedFileReplacingCompilationTracker(UnderlyingTracker.FreezePartialState(cancellationToken), replacementDocumentStates);
             }
 
             public ICompilationTracker FreezePartialStateWithDocument(DocumentState docState, CancellationToken cancellationToken)
@@ -72,39 +72,40 @@ namespace Microsoft.CodeAnalysis
             public async Task<Compilation> GetCompilationAsync(SolutionCompilationState compilationState, CancellationToken cancellationToken)
             {
                 // Fast path if we've definitely already done this before
-                if (_compilationWithReplacement != null)
+                if (_compilationWithReplacements != null)
                 {
-                    return _compilationWithReplacement;
+                    return _compilationWithReplacements;
                 }
 
-                var underlyingCompilation = await UnderlyingTracker.GetCompilationAsync(compilationState, cancellationToken).ConfigureAwait(false);
                 var underlyingSourceGeneratedDocuments = await UnderlyingTracker.GetSourceGeneratedDocumentStatesAsync(compilationState, cancellationToken).ConfigureAwait(false);
+                var newCompilation = await UnderlyingTracker.GetCompilationAsync(compilationState, cancellationToken).ConfigureAwait(false);
 
-                underlyingSourceGeneratedDocuments.TryGetState(replacementDocumentState.Id, out var existingState);
-
-                Compilation newCompilation;
-
-                var newSyntaxTree = await replacementDocumentState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-
-                if (existingState != null)
+                foreach (var (id, replacementState) in replacementDocumentStates.States)
                 {
-                    // The generated file still exists in the underlying compilation, but the contents may not match the open file if the open file
-                    // is stale. Replace the syntax tree so we have a tree that matches the text.
-                    var existingSyntaxTree = await existingState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                    newCompilation = underlyingCompilation.ReplaceSyntaxTree(existingSyntaxTree, newSyntaxTree);
-                }
-                else
-                {
-                    // The existing output no longer exists in the underlying compilation. This could happen if the user made
-                    // an edit which would cause this file to no longer exist, but they're still operating on an open representation
-                    // of that file. To ensure that this snapshot is still usable, we'll just add this document back in. This is not a
-                    // semantically correct operation, but working on stale snapshots never has that guarantee.
-                    newCompilation = underlyingCompilation.AddSyntaxTrees(newSyntaxTree);
+                    underlyingSourceGeneratedDocuments.TryGetState(id, out var existingState);
+
+                    var replacementSyntaxTree = await replacementState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (existingState != null)
+                    {
+                        // The generated file still exists in the underlying compilation, but the contents may not match the open file if the open file
+                        // is stale. Replace the syntax tree so we have a tree that matches the text.
+                        var existingSyntaxTree = await existingState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                        newCompilation = newCompilation.ReplaceSyntaxTree(existingSyntaxTree, replacementSyntaxTree);
+                    }
+                    else
+                    {
+                        // The existing output no longer exists in the underlying compilation. This could happen if the user made
+                        // an edit which would cause this file to no longer exist, but they're still operating on an open representation
+                        // of that file. To ensure that this snapshot is still usable, we'll just add this document back in. This is not a
+                        // semantically correct operation, but working on stale snapshots never has that guarantee.
+                        newCompilation = newCompilation.AddSyntaxTrees(replacementSyntaxTree);
+                    }
                 }
 
-                Interlocked.CompareExchange(ref _compilationWithReplacement, newCompilation, null);
+                Interlocked.CompareExchange(ref _compilationWithReplacements, newCompilation, null);
 
-                return _compilationWithReplacement;
+                return _compilationWithReplacements;
             }
 
             public Task<VersionStamp> GetDependentVersionAsync(SolutionCompilationState compilationState, CancellationToken cancellationToken)
@@ -128,7 +129,7 @@ namespace Microsoft.CodeAnalysis
             private async Task<Checksum> ComputeDependentChecksumAsync(SolutionCompilationState compilationState, CancellationToken cancellationToken)
                 => Checksum.Create(
                     await UnderlyingTracker.GetDependentChecksumAsync(compilationState, cancellationToken).ConfigureAwait(false),
-                    await replacementDocumentState.GetChecksumAsync(cancellationToken).ConfigureAwait(false));
+                    (await replacementDocumentStates.GetChecksumsAndIdsAsync(cancellationToken).ConfigureAwait(false)).Checksum);
 
             public MetadataReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference)
             {
@@ -145,23 +146,28 @@ namespace Microsoft.CodeAnalysis
             public async ValueTask<TextDocumentStates<SourceGeneratedDocumentState>> GetSourceGeneratedDocumentStatesAsync(
                 SolutionCompilationState compilationState, CancellationToken cancellationToken)
             {
-                var underlyingGeneratedDocumentStates = await UnderlyingTracker.GetSourceGeneratedDocumentStatesAsync(
+                var newStates = await UnderlyingTracker.GetSourceGeneratedDocumentStatesAsync(
                     compilationState, cancellationToken).ConfigureAwait(false);
 
-                if (underlyingGeneratedDocumentStates.Contains(replacementDocumentState.Id))
+                foreach (var (id, replacementState) in replacementDocumentStates.States)
                 {
-                    // The generated file still exists in the underlying compilation, but the contents may not match the open file if the open file
-                    // is stale. Replace the syntax tree so we have a tree that matches the text.
-                    return underlyingGeneratedDocumentStates.SetState(replacementDocumentState.Id, replacementDocumentState);
+                    if (newStates.Contains(id))
+                    {
+                        // The generated file still exists in the underlying compilation, but the contents may not match the open file if the open file
+                        // is stale. Replace the syntax tree so we have a tree that matches the text.
+                        newStates = newStates.SetState(id, replacementState);
+                    }
+                    else
+                    {
+                        // The generated output no longer exists in the underlying compilation. This could happen if the user made
+                        // an edit which would cause this file to no longer exist, but they're still operating on an open representation
+                        // of that file. To ensure that this snapshot is still usable, we'll just add this document back in. This is not a
+                        // semantically correct operation, but working on stale snapshots never has that guarantee.
+                        newStates = newStates.AddRange([replacementState]);
+                    }
                 }
-                else
-                {
-                    // The generated output no longer exists in the underlying compilation. This could happen if the user made
-                    // an edit which would cause this file to no longer exist, but they're still operating on an open representation
-                    // of that file. To ensure that this snapshot is still usable, we'll just add this document back in. This is not a
-                    // semantically correct operation, but working on stale snapshots never has that guarantee.
-                    return underlyingGeneratedDocumentStates.AddRange([replacementDocumentState]);
-                }
+
+                return newStates;
             }
 
             public Task<bool> HasSuccessfullyLoadedAsync(
@@ -172,15 +178,15 @@ namespace Microsoft.CodeAnalysis
 
             public bool TryGetCompilation([NotNullWhen(true)] out Compilation? compilation)
             {
-                compilation = _compilationWithReplacement;
+                compilation = _compilationWithReplacements;
                 return compilation != null;
             }
 
             public SourceGeneratedDocumentState? TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(DocumentId documentId)
             {
-                if (documentId == replacementDocumentState.Id)
+                if (replacementDocumentStates.TryGetState(documentId, out var replacementState))
                 {
-                    return replacementDocumentState;
+                    return replacementState;
                 }
                 else
                 {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -13,26 +13,39 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Serialization;
 
-internal sealed class SolutionCompilationStateChecksums(
-    Checksum solutionState,
-    Checksum frozenSourceGeneratedDocumentIdentity,
-    Checksum frozenSourceGeneratedDocumentText)
+internal sealed class SolutionCompilationStateChecksums
 {
-    public Checksum Checksum { get; } = Checksum.Create(
-        solutionState,
-        frozenSourceGeneratedDocumentIdentity,
-        frozenSourceGeneratedDocumentText);
+    public SolutionCompilationStateChecksums(
+        Checksum solutionState,
+        ChecksumCollection? frozenSourceGeneratedDocumentIdentities,
+        ChecksumsAndIds<DocumentId>? frozenSourceGeneratedDocuments)
+    {
+        // For the frozen source generated document info, we expect two either have both checksum collections or neither, and they
+        // should both be the same length as there is a 1:1 correspondence between them.
+        Contract.ThrowIfFalse(frozenSourceGeneratedDocumentIdentities.HasValue == frozenSourceGeneratedDocuments.HasValue);
+        Contract.ThrowIfFalse(frozenSourceGeneratedDocumentIdentities?.Count == frozenSourceGeneratedDocuments?.Length);
 
-    public Checksum SolutionState { get; } = solutionState;
-    public Checksum FrozenSourceGeneratedDocumentIdentity { get; } = frozenSourceGeneratedDocumentIdentity;
-    public Checksum FrozenSourceGeneratedDocumentText { get; } = frozenSourceGeneratedDocumentText;
+        SolutionState = solutionState;
+        FrozenSourceGeneratedDocumentIdentities = frozenSourceGeneratedDocumentIdentities;
+        FrozenSourceGeneratedDocuments = frozenSourceGeneratedDocuments;
+
+        Checksum = Checksum.Create(
+            SolutionState,
+            FrozenSourceGeneratedDocumentIdentities?.Checksum ?? Checksum.Null,
+            FrozenSourceGeneratedDocuments?.Checksum ?? Checksum.Null);
+    }
+
+    public Checksum Checksum { get; }
+    public Checksum SolutionState { get; }
+    public ChecksumCollection? FrozenSourceGeneratedDocumentIdentities { get; }
+    public ChecksumsAndIds<DocumentId>? FrozenSourceGeneratedDocuments { get; }
 
     public void AddAllTo(HashSet<Checksum> checksums)
     {
         checksums.AddIfNotNullChecksum(this.Checksum);
         checksums.AddIfNotNullChecksum(this.SolutionState);
-        checksums.AddIfNotNullChecksum(this.FrozenSourceGeneratedDocumentIdentity);
-        checksums.AddIfNotNullChecksum(this.FrozenSourceGeneratedDocumentText);
+        this.FrozenSourceGeneratedDocumentIdentities?.AddAllTo(checksums);
+        this.FrozenSourceGeneratedDocuments?.Checksums.AddAllTo(checksums);
     }
 
     public void Serialize(ObjectWriter writer)
@@ -40,17 +53,35 @@ internal sealed class SolutionCompilationStateChecksums(
         // Writing this is optional, but helps ensure checksums are being computed properly on both the host and oop side.
         this.Checksum.WriteTo(writer);
         this.SolutionState.WriteTo(writer);
-        this.FrozenSourceGeneratedDocumentIdentity.WriteTo(writer);
-        this.FrozenSourceGeneratedDocumentText.WriteTo(writer);
+
+        // Write out a boolean to know whether we'll have this extra information
+        writer.WriteBoolean(this.FrozenSourceGeneratedDocumentIdentities.HasValue);
+        if (FrozenSourceGeneratedDocumentIdentities.HasValue)
+        {
+            this.FrozenSourceGeneratedDocumentIdentities.Value.WriteTo(writer);
+            this.FrozenSourceGeneratedDocuments!.Value.WriteTo(writer);
+        }
     }
 
     public static SolutionCompilationStateChecksums Deserialize(ObjectReader reader)
     {
         var checksum = Checksum.ReadFrom(reader);
+        var solutionState = Checksum.ReadFrom(reader);
+
+        var hasFrozenSourceGeneratedDocuments = reader.ReadBoolean();
+        ChecksumCollection? frozenSourceGeneratedDocumentIdentities = null;
+        ChecksumsAndIds<DocumentId>? frozenSourceGeneratedDocuments = null;
+
+        if (hasFrozenSourceGeneratedDocuments)
+        {
+            frozenSourceGeneratedDocumentIdentities = ChecksumCollection.ReadFrom(reader);
+            frozenSourceGeneratedDocuments = ChecksumsAndIds<DocumentId>.ReadFrom(reader);
+        }
+
         var result = new SolutionCompilationStateChecksums(
-            solutionState: Checksum.ReadFrom(reader),
-            frozenSourceGeneratedDocumentIdentity: Checksum.ReadFrom(reader),
-            frozenSourceGeneratedDocumentText: Checksum.ReadFrom(reader));
+            solutionState: solutionState,
+            frozenSourceGeneratedDocumentIdentities: frozenSourceGeneratedDocumentIdentities,
+            frozenSourceGeneratedDocuments: frozenSourceGeneratedDocuments);
         Contract.ThrowIfFalse(result.Checksum == checksum);
         return result;
     }
@@ -70,16 +101,25 @@ internal sealed class SolutionCompilationStateChecksums(
         if (searchingChecksumsLeft.Remove(Checksum))
             result[Checksum] = this;
 
-        if (searchingChecksumsLeft.Remove(FrozenSourceGeneratedDocumentIdentity))
+        if (compilationState.FrozenSourceGeneratedDocumentStates.HasValue)
         {
-            Contract.ThrowIfNull(compilationState.FrozenSourceGeneratedDocumentState, "We should not have had a FrozenSourceGeneratedDocumentIdentity checksum if we didn't have a text in the first place.");
-            result[FrozenSourceGeneratedDocumentIdentity] = compilationState.FrozenSourceGeneratedDocumentState.Identity;
-        }
+            Contract.ThrowIfFalse(FrozenSourceGeneratedDocumentIdentities.HasValue);
 
-        if (searchingChecksumsLeft.Remove(FrozenSourceGeneratedDocumentText))
-        {
-            Contract.ThrowIfNull(compilationState.FrozenSourceGeneratedDocumentState, "We should not have had a FrozenSourceGeneratedDocumentState checksum if we didn't have a text in the first place.");
-            result[FrozenSourceGeneratedDocumentText] = await SerializableSourceText.FromTextDocumentStateAsync(compilationState.FrozenSourceGeneratedDocumentState, cancellationToken).ConfigureAwait(false);
+            // This could either be the checksum for the text (which we'll use our regular helper for first)...
+            await ChecksumCollection.FindAsync(compilationState.FrozenSourceGeneratedDocumentStates.Value, assetHint.DocumentId, searchingChecksumsLeft, result, cancellationToken).ConfigureAwait(false);
+
+            // ... or one of the identities. In this case, we'll use the fact that there's a 1:1 correspondence between the
+            // two collections we hold onto.
+            for (var i = 0; i < FrozenSourceGeneratedDocumentIdentities.Value.Count; i++)
+            {
+                var identityChecksum = FrozenSourceGeneratedDocumentIdentities.Value[0];
+                if (searchingChecksumsLeft.Remove(identityChecksum))
+                {
+                    var id = FrozenSourceGeneratedDocuments!.Value.Ids[i];
+                    Contract.ThrowIfFalse(compilationState.FrozenSourceGeneratedDocumentStates.Value.TryGetState(id, out var state));
+                    result[identityChecksum] = state.Identity;
+                }
+            }
         }
 
         var solutionState = compilationState.SolutionState;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -236,6 +237,13 @@ namespace Microsoft.CodeAnalysis
 
                 return x.Id.CompareTo(y.Id);
             }
+        }
+
+        public async ValueTask<ChecksumsAndIds<DocumentId>> GetChecksumsAndIdsAsync(CancellationToken cancellationToken)
+        {
+            var documentChecksumTasks = SelectAsArray(static (state, token) => state.GetChecksumAsync(token), cancellationToken);
+            var documentChecksums = new ChecksumCollection(await documentChecksumTasks.WhenAll().ConfigureAwait(false));
+            return new(documentChecksums, SelectAsArray(static s => s.Id));
         }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Drawing.Text;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -805,6 +806,79 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // We should have ran the generator, and it should not have had any trees
             Assert.True(noTreesPassed.HasValue);
             Assert.False(noTreesPassed!.Value);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task FreezingSourceGeneratedDocumentsWorks(TestHost testHost)
+        {
+            using var workspace = CreateWorkspace(testHost: testHost);
+
+            var analyzerReference = new TestGeneratorReference(
+                new SingleFileTestGenerator("// Hello, World"));
+
+            var project = AddEmptyProject(workspace.CurrentSolution).AddAnalyzerReference(analyzerReference);
+
+            var sourceGeneratedDocument = Assert.Single(await project.GetSourceGeneratedDocumentsAsync());
+            var sourceGeneratedDocumentIdentity = sourceGeneratedDocument.Identity;
+
+            // Do some assertions with freezing that document
+            await AssertFrozen(project, sourceGeneratedDocumentIdentity);
+
+            // Now remove the generator, and ensure we can freeze it even if it's not there. This scenario exists for IDEs where 
+            // a text buffer might still be wired up to the workspace and we're invoking a feature on it. The generated document might have gone
+            // away, but we don't know that synchronously.
+            project = project.RemoveAnalyzerReference(analyzerReference);
+            await AssertFrozen(project, sourceGeneratedDocumentIdentity);
+
+            static async Task AssertFrozen(Project project, SourceGeneratedDocumentIdentity identity)
+            {
+                var frozenWithSingleDocument = project.Solution.WithFrozenSourceGeneratedDocument(identity, SourceText.From("// Frozen Document"));
+                Assert.Equal("// Frozen Document", (await frozenWithSingleDocument.GetTextAsync()).ToString());
+                var frozenTree = Assert.Single((await frozenWithSingleDocument.Project.GetRequiredCompilationAsync(CancellationToken.None)).SyntaxTrees);
+                Assert.Equal("// Frozen Document", frozenTree.ToString());
+            }
+        }
+
+        [Theory, CombinatorialData]
+        public async Task FreezingSourceGeneratedDocumentsInTwoProjectsWorks(TestHost testHost)
+        {
+            using var workspace = CreateWorkspace(testHost: testHost);
+
+            var analyzerReference = new TestGeneratorReference(
+                new SingleFileTestGenerator("// Hello, World"));
+
+            var solution = AddEmptyProject(workspace.CurrentSolution).AddAnalyzerReference(analyzerReference).Solution;
+            var projectId1 = solution.ProjectIds.Single();
+            var project2 = AddEmptyProject(solution, name: "TestProject2").AddAnalyzerReference(analyzerReference);
+            solution = project2.Solution;
+            var projectId2 = project2.Id;
+
+            var sourceGeneratedDocument1 = Assert.Single(await solution.GetRequiredProject(projectId1).GetSourceGeneratedDocumentsAsync());
+            var sourceGeneratedDocument2 = Assert.Single(await solution.GetRequiredProject(projectId2).GetSourceGeneratedDocumentsAsync());
+
+            // And now freeze both of them at once
+            var solutionWithFrozenDocuments = solution.WithFrozenSourceGeneratedDocuments(
+                [(sourceGeneratedDocument1.Identity, SourceText.From("// Frozen 1")), (sourceGeneratedDocument2.Identity, SourceText.From("// Frozen 2"))]);
+
+            Assert.Equal("// Frozen 1", (await (await solutionWithFrozenDocuments.GetRequiredProject(projectId1).GetSourceGeneratedDocumentsAsync()).Single().GetTextAsync()).ToString());
+            Assert.Equal("// Frozen 2", (await (await solutionWithFrozenDocuments.GetRequiredProject(projectId2).GetSourceGeneratedDocumentsAsync()).Single().GetTextAsync()).ToString());
+        }
+
+        [Theory, CombinatorialData]
+        public async Task FreezingWithSameContentDoesNotFork(TestHost testHost)
+        {
+            using var workspace = CreateWorkspace(testHost: testHost);
+
+            var analyzerReference = new TestGeneratorReference(
+                new SingleFileTestGenerator("// Hello, World"));
+
+            var project = AddEmptyProject(workspace.CurrentSolution).AddAnalyzerReference(analyzerReference);
+
+            var sourceGeneratedDocument = Assert.Single(await project.GetSourceGeneratedDocumentsAsync());
+            var sourceGeneratedDocumentIdentity = sourceGeneratedDocument.Identity;
+
+            var frozenSolution = project.Solution.WithFrozenSourceGeneratedDocument(sourceGeneratedDocumentIdentity, SourceText.From("// Hello, World"));
+            Assert.Same(project.Solution, frozenSolution.Project.Solution);
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -199,6 +199,12 @@ namespace Microsoft.CodeAnalysis.Remote
                 var compilationChecksums = await solution.CompilationState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                 await compilationChecksums.FindAsync(solution.CompilationState, assetHint: AssetHint.None, Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
 
+                foreach (var frozenSourceGeneratedDocumentState in solution.CompilationState.FrozenSourceGeneratedDocumentStates?.States.Values ?? [])
+                {
+                    var documentChecksums = await frozenSourceGeneratedDocumentState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
+                    await compilationChecksums.FindAsync(solution.CompilationState, assetHint: AssetHint.None, Flatten(documentChecksums), map, cancellationToken).ConfigureAwait(false);
+                }
+
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                 await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, assetHint: AssetHint.None, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
We have special support in a Solution object to freeze a specific source generated document to a specific text, ignoring whatever the underlying generator might be producing at the time. This is needed for if a user is operating from an open source generated document, since we need to pretend the contents are whatever is currently in their text buffer. We supported just one document simply because the only entrypoint was GetOpenDocumentInCurrentContextWithChanges(), which only operated on a single document -- the other source generated documents which might be open were just left as is.

For LSP we have a model where we fork solutions to ensure that all document contents match all open buffers. To keep that pattern working uniformly for open source generated documents, we add here the ability to have multiple source generated documents to be frozen. The PR here is largely mechanical, just replacing the previous single element with a collection, and propagating through the solution sync system. This PR isn't connecting this up to the LSP system, that's a followup.

I debated doing this (since we're going to be revamping this entire concept of frozen documents soonish) but decided this kept the LSP system functioning how it does. Although it would have been easy to use the existing method to fork _just_ the document with the request being targeted, but that meant that it didn't fit in with the rest of how things fork, and could mean a response targets the wrong span in the case of other mismatched things.