### PR TITLE
Fallback to solution options

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/AddImport/AddImportPlacementOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/AddImport/AddImportPlacementOptions.cs
@@ -6,8 +6,6 @@ using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Options;
 
 #if !CODE_STYLE
@@ -54,8 +52,11 @@ internal static partial class AddImportPlacementOptionsProviders
 
     public static async ValueTask<AddImportPlacementOptions> GetAddImportPlacementOptionsAsync(this Document document, AddImportPlacementOptions? fallbackOptions, CancellationToken cancellationToken)
     {
+        var project = document.Project;
+        var services = project.Services;
+        var solutionOptions = project.Solution.Options;
         var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
-        return configOptions.GetAddImportPlacementOptions(document.Project.Services, document.AllowImportsInHiddenRegions(), fallbackOptions);
+        return configOptions.GetAddImportPlacementOptions(services, document.AllowImportsInHiddenRegions(), solutionOptions.GetAddImportPlacementOptions(services, document.AllowImportsInHiddenRegions(), fallbackOptions));
     }
 
     // Normally we don't allow generation into a hidden region in the file.  However, if we have a

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/SyntaxFormattingOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/SyntaxFormattingOptions.cs
@@ -6,7 +6,6 @@ using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Options;
 
@@ -65,8 +64,11 @@ internal static partial class SyntaxFormattingOptionsProviders
 
     public static async ValueTask<SyntaxFormattingOptions> GetSyntaxFormattingOptionsAsync(this Document document, SyntaxFormattingOptions? fallbackOptions, CancellationToken cancellationToken)
     {
+        var project = document.Project;
+        var services = project.Services;
+        var solutionOptions = project.Solution.Options;
         var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
-        return configOptions.GetSyntaxFormattingOptions(document.Project.Services, fallbackOptions);
+        return configOptions.GetSyntaxFormattingOptions(services, solutionOptions.GetSyntaxFormattingOptions(services, fallbackOptions));
     }
 
     public static async ValueTask<SyntaxFormattingOptions> GetSyntaxFormattingOptionsAsync(this Document document, SyntaxFormattingOptionsProvider fallbackOptionsProvider, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Simplification/SimplifierOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Simplification/SimplifierOptions.cs
@@ -80,8 +80,11 @@ namespace Microsoft.CodeAnalysis.Simplification
 
         public static async ValueTask<SimplifierOptions> GetSimplifierOptionsAsync(this Document document, SimplifierOptions? fallbackOptions, CancellationToken cancellationToken)
         {
+            var project = document.Project;
+            var services = project.Services;
+            var solutionOptions = project.Solution.Options;
             var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
-            return configOptions.GetSimplifierOptions(document.Project.Services, fallbackOptions);
+            return configOptions.GetSimplifierOptions(services, solutionOptions.GetSimplifierOptions(services, fallbackOptions));
         }
 
         public static async ValueTask<SimplifierOptions> GetSimplifierOptionsAsync(this Document document, SimplifierOptionsProvider fallbackOptionsProvider, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/71570

The problem is that `GetAnalyzerConfigOptionsAsync` only gets analyzer config options for the given document and don't fallback to solution options on its own. I am not sure whether I did the correct fix for the given problem. If not, I'm happy to reimplement it if requested. I just want to get the process of fixing the issue going