### PR TITLE
Reduce allocations during check for duplicate analyzers

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -864,6 +864,11 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
+        /// <summary>
+        /// Determines whether duplicates exist using default equality comparer.
+        /// </summary>
+        /// <param name="array">Array to search for duplicates</param>
+        /// <returns>Whether duplicates were found</returns>
         internal static bool HasDuplicates<T>(this ImmutableArray<T> array)
         {
             switch (array.Length)
@@ -893,6 +898,13 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <summary>
+        /// Determines whether duplicates exist using <paramref name="comparer"/>. Use other override
+        /// if you don't need a custom comparer.
+        /// </summary>
+        /// <param name="array">Array to search for duplicates</param>
+        /// <param name="comparer">Comparer to use in search</param>
+        /// <returns>Whether duplicates were found</returns>
         internal static bool HasDuplicates<T>(this ImmutableArray<T> array, IEqualityComparer<T> comparer)
         {
             switch (array.Length)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -142,39 +142,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 throw new ArgumentException(CodeAnalysisResources.ArgumentElementCannotBeNull, nameof(analyzers));
             }
 
-            if (HasDuplicateAnalyzers(analyzers))
+            if (analyzers.HasDuplicates())
             {
                 // Has duplicate analyzer instances.
                 throw new ArgumentException(CodeAnalysisResources.DuplicateAnalyzerInstances, nameof(analyzers));
-            }
-        }
-
-        private static bool HasDuplicateAnalyzers(ImmutableArray<DiagnosticAnalyzer> analyzers)
-        {
-            switch (analyzers.Length)
-            {
-                case 0:
-                case 1:
-                    return false;
-
-                case 2:
-                    return analyzers[0] == analyzers[1];
-
-                default:
-                    var seenAnalyzers = PooledHashSet<DiagnosticAnalyzer>.GetInstance();
-                    var foundDuplicate = false;
-
-                    foreach (var i in analyzers)
-                    {
-                        if (!seenAnalyzers.Add(i))
-                        {
-                            foundDuplicate = true;
-                            break;
-                        }
-                    }
-
-                    seenAnalyzers.Free();
-                    return foundDuplicate;
             }
         }
 
@@ -205,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 throw new ArgumentException(CodeAnalysisResources.UnsupportedAnalyzerInstance, nameof(_analyzers));
             }
 
-            if (HasDuplicateAnalyzers(analyzers))
+            if (analyzers.HasDuplicates())
             {
                 // Has duplicate analyzer instances.
                 throw new ArgumentException(CodeAnalysisResources.DuplicateAnalyzerInstances, nameof(analyzers));

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 default:
                     var seenAnalyzers = PooledHashSet<DiagnosticAnalyzer>.GetInstance();
-                    bool foundDuplicate = false;
+                    var foundDuplicate = false;
 
                     foreach (var i in analyzers)
                     {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -142,10 +142,39 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 throw new ArgumentException(CodeAnalysisResources.ArgumentElementCannotBeNull, nameof(analyzers));
             }
 
-            if (analyzers.HasDuplicates())
+            if (HasDuplicateAnalyzers(analyzers))
             {
                 // Has duplicate analyzer instances.
                 throw new ArgumentException(CodeAnalysisResources.DuplicateAnalyzerInstances, nameof(analyzers));
+            }
+        }
+
+        private static bool HasDuplicateAnalyzers(ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            switch (analyzers.Length)
+            {
+                case 0:
+                case 1:
+                    return false;
+
+                case 2:
+                    return analyzers[0] == analyzers[1];
+
+                default:
+                    var seenAnalyzers = PooledHashSet<DiagnosticAnalyzer>.GetInstance();
+                    bool foundDuplicate = false;
+
+                    foreach (var i in analyzers)
+                    {
+                        if (!seenAnalyzers.Add(i))
+                        {
+                            foundDuplicate = true;
+                            break;
+                        }
+                    }
+
+                    seenAnalyzers.Free();
+                    return foundDuplicate;
             }
         }
 
@@ -176,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 throw new ArgumentException(CodeAnalysisResources.UnsupportedAnalyzerInstance, nameof(_analyzers));
             }
 
-            if (analyzers.HasDuplicates())
+            if (HasDuplicateAnalyzers(analyzers))
             {
                 // Has duplicate analyzer instances.
                 throw new ArgumentException(CodeAnalysisResources.DuplicateAnalyzerInstances, nameof(analyzers));


### PR DESCRIPTION
The HasDuplicates extension method always creates a HashSet of unspecified size when the number of entries being checked exceeds 2. As the CompilationWithAnalyzers Verify methods call this on large collections, there would be a significant amount of resizing during the checking for duplicates. I didn't want to change the extension method to use pooling on an unknown type parameter, and didn't want to change it to specify a capacity as I don't know the characteristics of other callers into the method.

Instead, I duplicated the HasDuplicates method directly into CompilationWithAnalyzers and modified it to use a pooled hashset (there are other uses of PooledHashSet<DiagnosticAnalyzer> in the code, so this doesn't introduce a new pool)

Old memory allocations:
![image](https://github.com/dotnet/roslyn/assets/6785178/11b90fe3-438b-45f4-905f-05827a67c507)

New memory allocations:
![image](https://github.com/dotnet/roslyn/assets/6785178/1107090d-225f-4e36-8a1d-59531ba3e15b)