### PR TITLE
Remove at most 1 end of line preceding redundant nullable directives

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirec
 
                     // If we have a blank line both before and after the directive, then remove the one that follows to
                     // keep the code clean.
-                    if (HasPrecedingBlankLine(leadingTrivia, index) &&
+                    if (HasPrecedingBlankLine(leadingTrivia, index - 1) &&
                         HasFollowingBlankLine(leadingTrivia, index))
                     {
                         // Delete optional following whitespace.
@@ -98,10 +98,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirec
 
         private static bool HasPrecedingBlankLine(SyntaxTriviaList leadingTrivia, int index)
         {
-            if (index > 0 && leadingTrivia[index - 1].IsWhitespace())
+            if (index >= 0 && leadingTrivia[index].IsWhitespace())
                 index--;
 
-            return index > 0 && leadingTrivia[index - 1].IsEndOfLine();
+            return index >= 0 && leadingTrivia[index].IsEndOfLine();
         }
 
         private static bool HasFollowingBlankLine(SyntaxTriviaList leadingTrivia, int index)

--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
@@ -77,8 +77,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirec
                     if (HasPrecedingBlankLine(leadingTrivia, index) &&
                         HasFollowingBlankLine(leadingTrivia, index))
                     {
-                        // Delete following whitespace.
-                        while (leadingTrivia[index].IsWhitespace())
+                        // Delete optional following whitespace.
+                        if (leadingTrivia[index].IsWhitespace())
                             leadingTrivia = leadingTrivia.RemoveAt(index);
 
                         // Then the following blank line.
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirec
 
         private static bool HasPrecedingBlankLine(SyntaxTriviaList leadingTrivia, int index)
         {
-            while (index > 0 && leadingTrivia[index - 1].IsWhitespace())
+            if (index > 0 && leadingTrivia[index - 1].IsWhitespace())
                 index--;
 
             return index > 0 && leadingTrivia[index - 1].IsEndOfLine();
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirec
 
         private static bool HasFollowingBlankLine(SyntaxTriviaList leadingTrivia, int index)
         {
-            while (index < leadingTrivia.Count && leadingTrivia[index].IsWhitespace())
+            if (index < leadingTrivia.Count && leadingTrivia[index].IsWhitespace())
                 index++;
 
             return index < leadingTrivia.Count && leadingTrivia[index].IsEndOfLine();

--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
@@ -59,9 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirec
         {
             // We first group the nullable directives by the syntax node they are attached
             // This allows to replace each node separately even if they have multiple nullable directives
-            var nullableDirectivesByNodes = diagnostics.GroupBy(x =>
-                x.Location.FindNode(findInsideTrivia: false, getInnermostNodeForTie: false, cancellationToken), x =>
-                x.Location.FindNode(findInsideTrivia: true, getInnermostNodeForTie: true, cancellationToken))
+            var nullableDirectivesByNodes = diagnostics
+                .GroupBy(
+                    x => x.Location.FindNode(findInsideTrivia: false, getInnermostNodeForTie: false, cancellationToken),
+                    x => x.Location.FindNode(findInsideTrivia: true, getInnermostNodeForTie: true, cancellationToken))
                 .ToDictionary(x => x.Key, x => x.ToList());
 
             foreach (var (node, nullableDirectives) in nullableDirectivesByNodes)

--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
@@ -86,11 +86,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirec
                     }
                 }
 
-                // We replace the leading trivias of the token the nullable directive was attached,
-                // then replace the token on the node and finally, replace the node with its new token.
-                var newToken = token.WithLeadingTrivia(leadingTrivia);
+                // Update the token and replace it within its parent.
                 var node = token.GetRequiredParent();
-                editor.ReplaceNode(node, node.ReplaceToken(token, newToken));
+                editor.ReplaceNode(
+                    node,
+                    node.ReplaceToken(token, token.WithLeadingTrivia(leadingTrivia)));
             }
 
             return Task.CompletedTask;

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveTests.cs
@@ -218,6 +218,62 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.RemoveUnnecessaryNul
         }
 
         [Fact]
+        public async Task TestRedundantDirectiveBetweenUsingAndNamespace2()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                using System;
+                [|#nullable enable|]
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """,
+                """
+                using System;
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestRedundantDirectiveBetweenUsingAndNamespace3()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                using System;
+
+                [|#nullable enable|]
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """,
+                """
+                using System;
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact]
         public async Task TestRedundantDirectiveWithNamespaceAndDerivedType()
         {
             await VerifyCodeFixAsync(

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveTests.cs
@@ -303,6 +303,155 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.RemoveUnnecessaryNul
                 """);
         }
 
+        [Fact]
+        public async Task TestRedundantDirectiveMultiple1()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                using System;
+
+                [|#nullable enable|]
+                [|#nullable enable|]
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """,
+                """
+                using System;
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestRedundantDirectiveMultiple2()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                using System;
+
+                [|#nullable enable|]
+
+                [|#nullable enable|]
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """,
+                """
+                using System;
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestRedundantDirectiveMultiple3()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                using System;
+                [|#nullable enable|]
+                [|#nullable enable|]
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """,
+                """
+                using System;
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestRedundantDirectiveMultiple4()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                using System;
+                [|#nullable enable|]
+
+                [|#nullable enable|]
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """,
+                """
+                using System;
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestRedundantDirectiveMultiple5()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                using System;
+
+                [|#nullable enable|]
+                [|#nullable enable|]
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """,
+                """
+                using System;
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """);
+        }
+
         private static string GetDisableDirectiveContext(NullableContextOptions options)
         {
             return options switch

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveTests.cs
@@ -182,9 +182,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.RemoveUnnecessaryNul
                 """
                 // File Header
 
-
                 class Program
                 {
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestRedundantDirectiveBetweenUsingAndNamespace()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                using System;
+                
+                [|#nullable enable|]
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
+                }
+                """,
+                """
+                using System;
+
+                namespace MyNamespace
+                {
+                    class MyClass
+                    {
+                    }
                 }
                 """);
         }

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveTests.cs
@@ -86,7 +86,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.RemoveUnnecessaryNul
                 """
                 // File Header
 
-
                 enum EnumName
                 {
                     First,


### PR DESCRIPTION
Closes #63163

This pr changes the way the redudant directive is removed by checking the trivias preceding them. All of the whitespaces ones are removed until an end of line trivia is found. This means at most, this will delete a blank like preceding the directive which removes a potential blank line.

I added a test, but I needed to change 2 tests to fit the changes. The new algorithm first groups the nodes by their directive nodes which allows to go through each of their parent's childs and perform their removal. This is done on a per node basis so cases where there's multiple directives in a row are batched together.

I am not too sure about the complexity of this and it might be because there's some node apis I wasn't aware of that would have made this simpler, but I at least wanted to present a working solution in case it could be simplified.