### PR TITLE
Fix crash in designer discovery

### DIFF
--- a/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
@@ -107,9 +107,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             IDesignerAttributeDiscoveryService.ICallback callback,
             CancellationToken cancellationToken)
         {
-            if (!solution.GetRequiredProject(priorityDocumentId.ProjectId).SupportsCompilation)
-                return;
-
             // Create a frozen snapshot guaranteed to have this document in it.  Note: it's important that we do
             // this, and not just depend on the solution.WithFrozenPartialCompilationsAsync below.  Very
             // importantly, that solution may not contain this document yet.  This does mean we'll process two

--- a/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
@@ -107,6 +107,9 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             IDesignerAttributeDiscoveryService.ICallback callback,
             CancellationToken cancellationToken)
         {
+            if (!solution.GetRequiredProject(priorityDocumentId.ProjectId).SupportsCompilation)
+                return;
+
             // Create a frozen snapshot guaranteed to have this document in it.  Note: it's important that we do
             // this, and not just depend on the solution.WithFrozenPartialCompilationsAsync below.  Very
             // importantly, that solution may not contain this document yet.  This does mean we'll process two

--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -121,32 +121,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             if (client == null)
                 return;
 
-            var trackingService = _workspace.Services.GetRequiredService<IDocumentTrackingService>();
-            var priorityDocument = trackingService.GetActiveDocument(solution);
-
-            // If there is an active document, then process changes to it right away, so that the UI updates quickly
-            // when the user adds/removes a form from a particular document.
-            if (RemoteSupportedLanguages.IsSupported(priorityDocument?.Project.Language))
-            {
-                // We only need to do a project sync to compute the up to date data for this particular file.
-                var priorityDocumentId = priorityDocument.Id;
-                await client.TryInvokeAsync<IRemoteDesignerAttributeDiscoveryService>(
-                    priorityDocument.Project,
-                    (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(
-                        callbackId, checksum, priorityDocumentId, cancellationToken),
-                    callbackTarget: this,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            // Wait a little after the priority document and process the rest of the solution at a lower priority.
-            await _listener.Delay(DelayTimeSpan.NonFocus, cancellationToken).ConfigureAwait(false);
-
-            await client.TryInvokeAsync<IRemoteDesignerAttributeDiscoveryService>(
-                solution,
-                (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(
-                    callbackId, checksum, cancellationToken),
-                callbackTarget: this,
-                cancellationToken).ConfigureAwait(false);
+            var trackingService = solution.Services.GetRequiredService<IDocumentTrackingService>();
+            await DesignerAttributeDiscoveryService.DiscoverDesignerAttributesAsync(
+                solution, trackingService.GetActiveDocument(solution), client, _listener, this, cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask NotifyProjectSystemAsync(

--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -122,16 +122,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 return;
 
             var trackingService = _workspace.Services.GetRequiredService<IDocumentTrackingService>();
-            var activeDocument = trackingService.GetActiveDocument(solution);
+            var priorityDocument = trackingService.GetActiveDocument(solution);
 
             // If there is an active document, then process changes to it right away, so that the UI updates quickly
             // when the user adds/removes a form from a particular document.
-            if (RemoteSupportedLanguages.IsSupported(activeDocument?.Project.Language))
+            if (RemoteSupportedLanguages.IsSupported(priorityDocument?.Project.Language))
             {
                 // We only need to do a project sync to compute the up to date data for this particular file.
-                var priorityDocumentId = activeDocument.Id;
+                var priorityDocumentId = priorityDocument.Id;
                 await client.TryInvokeAsync<IRemoteDesignerAttributeDiscoveryService>(
-                    activeDocument.Project,
+                    priorityDocument.Project,
                     (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(
                         callbackId, checksum, priorityDocumentId, cancellationToken),
                     callbackTarget: this,

--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -128,9 +128,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             // when the user adds/removes a form from a particular document.
             if (RemoteSupportedLanguages.IsSupported(activeDocument?.Project.Language))
             {
+                // We only need to do a project sync to compute the up to date data for this particular file.
                 var priorityDocumentId = activeDocument.Id;
                 await client.TryInvokeAsync<IRemoteDesignerAttributeDiscoveryService>(
-                    solution,
+                    activeDocument.Project,
                     (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(
                         callbackId, checksum, priorityDocumentId, cancellationToken),
                     callbackTarget: this,

--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -122,12 +122,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 return;
 
             var trackingService = _workspace.Services.GetRequiredService<IDocumentTrackingService>();
-            var priorityDocumentId = trackingService.GetActiveDocument(solution)?.Id;
+            var activeDocument = trackingService.GetActiveDocument(solution);
 
             // If there is an active document, then process changes to it right away, so that the UI updates quickly
             // when the user adds/removes a form from a particular document.
-            if (priorityDocumentId != null)
+            if (RemoteSupportedLanguages.IsSupported(activeDocument?.Project.Language))
             {
+                var priorityDocumentId = activeDocument.Id;
                 await client.TryInvokeAsync<IRemoteDesignerAttributeDiscoveryService>(
                     solution,
                     (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -175,6 +175,11 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             }
         }
 
+        [Fact]
+        public async Task TestDesignerAttributesUnsupportedLanguage()
+        {
+        }
+
         private class DesignerAttributeComputerCallback : IDesignerAttributeDiscoveryService.ICallback
         {
             private readonly TaskCompletionSource<ImmutableArray<DesignerAttributeData>> _infosSource = new();

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -175,11 +175,6 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             }
         }
 
-        [Fact]
-        public async Task TestDesignerAttributesUnsupportedLanguage()
-        {
-        }
-
         private class DesignerAttributeComputerCallback : IDesignerAttributeDiscoveryService.ICallback
         {
             private readonly TaskCompletionSource<ImmutableArray<DesignerAttributeData>> _infosSource = new();

--- a/src/Workspaces/Core/Portable/Remote/RemoteSupportedLanguages.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteSupportedLanguages.cs
@@ -2,16 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.CodeAnalysis.Remote
+namespace Microsoft.CodeAnalysis.Remote;
+
+internal static class RemoteSupportedLanguages
 {
-    internal static class RemoteSupportedLanguages
-    {
-        public static bool IsSupported(this string language)
-        {
-            return language is LanguageNames.CSharp or
-                   LanguageNames.VisualBasic;
-        }
-    }
+    public static bool IsSupported([NotNullWhen(true)] this string? language)
+        => language is LanguageNames.CSharp or LanguageNames.VisualBasic;
 }


### PR DESCRIPTION
This regressed with https://github.com/dotnet/roslyn/pull/71999 because we changed the logic from: "sync solution (which only syncs C#/VB projects), then process whole solution on remote site" to "first, attempt to analyze the active document, then do the original full-sync and analyze".  However, the code to analyze the active document was invalid for the case of this not being a C#/VB file.  IN that case, we'd sync over the C#/VB subset of projects, then not find the non-C#/VB file on the oop side, immediately crashing.