### PR TITLE
Incorporate underlying type's hierarchy into overload resolution

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -844,7 +844,6 @@ outerDefault:
             bool checkOverriddenOrHidden = true)
             where TMember : Symbol
         {
-            // PROTOTYPE update overload resolution so that extension members can hide members of the underlying type
             Debug.Assert(checkOverriddenOrHidden || containingTypeMapOpt is null);
 
             // SPEC VIOLATION:
@@ -916,6 +915,7 @@ outerDefault:
                                 return;
                             }
 
+                            // PROTOTYPE could we encounter an extension type in metadata with a `hidebyname` method?
                             if (MemberGroupHidesByName(others, member, ref useSiteInfo))
                             {
                                 return;
@@ -1305,7 +1305,7 @@ outerDefault:
             }
         }
 
-        // Is this type a base type of any valid method on the list?
+        // Is this type a base type (or base type of an extended type) of any valid method on the list?
         private static bool IsLessDerivedThanAny<TMember>(int index, TypeSymbol type, ArrayBuilder<MemberResolutionResult<TMember>> results, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             where TMember : Symbol
         {
@@ -1337,6 +1337,10 @@ outerDefault:
                 }
 
                 if (currentType.IsInterfaceType() && type.IsInterfaceType() && currentType.AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteInfo).Contains((NamedTypeSymbol)type))
+                {
+                    return true;
+                }
+                else if (currentType.IsExtension && currentType.ExtendedTypeIsOrDerivedFrom(type, TypeCompareKind.ConsiderEverything, useSiteInfo: ref useSiteInfo))
                 {
                     return true;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -273,6 +273,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// Checks whether the extended type is or is derived from <paramref name="type"/>.
+        /// </summary>
+        internal bool ExtendedTypeIsOrDerivedFrom(TypeSymbol type, TypeCompareKind comparison, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            Debug.Assert(this.IsExtension);
+            return this.ExtendedTypeNoUseSiteDiagnostics is { } extendedType
+                && extendedType.IsEqualToOrDerivedFrom(type, comparison, ref useSiteInfo);
+        }
+
+        /// <summary>
         /// Returns true if this type is equal or derives from a given type.
         /// </summary>
         internal bool IsEqualToOrDerivedFrom(TypeSymbol type, TypeCompareKind comparison, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)


### PR DESCRIPTION
Relates to test plan https://github.com/dotnet/roslyn/issues/66722