### PR TITLE
Reduce allocations in AbstractRecommendationServiceBasedCompletionProvider.GetSymbolsAsync

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -68,10 +68,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                         // Don't preselect intrinsic type symbols so we can preselect their keywords instead. We will also
                         // ignore nullability for purposes of preselection -- if a method is returning a string? but we've
                         // inferred we're assigning to a string or vice versa we'll still count those as the same.
-                        var preselect = args.InferredTypes.Contains(GetSymbolType(symbol), SymbolEqualityComparer.Default) && !args.This.IsInstrinsic(symbol);
+                        var preselect = args.inferredTypes.Contains(GetSymbolType(symbol), SymbolEqualityComparer.Default) && !args.self.IsInstrinsic(symbol);
                         return new SymbolAndSelectionInfo(symbol, preselect);
                     },
-                    (InferredTypes: inferredTypes, This: this));
+                    (inferredTypes, self: this));
             }
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Recommendations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
@@ -63,18 +62,16 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
                 var inferredTypes = context.InferredTypes.Where(t => t.SpecialType != SpecialType.System_Void).ToSet();
 
-                using var _ = ArrayBuilder<SymbolAndSelectionInfo>.GetInstance(out var result);
-
-                foreach (var symbol in recommendedSymbols.NamedSymbols)
-                {
-                    // Don't preselect intrinsic type symbols so we can preselect their keywords instead. We will also
-                    // ignore nullability for purposes of preselection -- if a method is returning a string? but we've
-                    // inferred we're assigning to a string or vice versa we'll still count those as the same.
-                    var preselect = inferredTypes.Contains(GetSymbolType(symbol), SymbolEqualityComparer.Default) && !IsInstrinsic(symbol);
-                    result.Add(new SymbolAndSelectionInfo(symbol, preselect));
-                }
-
-                return result.ToImmutable();
+                return recommendedSymbols.NamedSymbols.SelectAsArray(
+                    static (symbol, args) =>
+                    {
+                        // Don't preselect intrinsic type symbols so we can preselect their keywords instead. We will also
+                        // ignore nullability for purposes of preselection -- if a method is returning a string? but we've
+                        // inferred we're assigning to a string or vice versa we'll still count those as the same.
+                        var preselect = args.InferredTypes.Contains(GetSymbolType(symbol), SymbolEqualityComparer.Default) && !args.This.IsInstrinsic(symbol);
+                        return new SymbolAndSelectionInfo(symbol, preselect);
+                    },
+                    (InferredTypes: inferredTypes, This: this));
             }
         }
 


### PR DESCRIPTION
This method was individually adding items to an ArrayBuilder without it's size configured. Potential issues with the current approach:

1) There could be multiple resizes during the Add calls to get the array to it's final size 
2) Very likely the final capacity will exceed the array size, causing an allocation in generating the immutablearray. 
3) I was seeing a large number of items in these arrays, causing the array that does get created not to get freed back into the pool.

Instead, if we use the SelectAsArray method, we shouldn't have any extra allocations other than the resultant ImmutableArray.

Before allocations of type SymbolAndSelectionInfo[]:
![image](https://github.com/dotnet/roslyn/assets/6785178/2561c1ab-479e-410d-ae49-b50d7d97c589)

After allocations of type SymbolAndSelectionInfo[]:
![image](https://github.com/dotnet/roslyn/assets/6785178/9eab2c15-34ec-47a8-bb5b-ce4599ba2b78)