### PR TITLE
Slight reduction in allocations under CSharpRecommendationServiceRunner.IsUndesirable

### DIFF
--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -375,7 +375,7 @@ internal partial class CSharpRecommendationService
 
                 if (symbol.IsExtensionMethod() &&
                     !Equals(enclosingNamedType, symbol.ContainingType) &&
-                    !outerTypes.Any(outerType => outerType.Equals(symbol.ContainingType)))
+                    !outerTypes.Contains(symbol.ContainingType))
                 {
                     return true;
                 }


### PR DESCRIPTION
Unclear why this code was walking all items in the set to find a match. This method is called enough that the closure generated to call the Any method as showing up in completion profiles.

Old allocations:
![image](https://github.com/dotnet/roslyn/assets/6785178/a4cf4a7d-828f-4e2b-ab80-808a9211b12c)

New allocations:
![image](https://github.com/dotnet/roslyn/assets/6785178/bfc2f1eb-96a3-41f7-b4c3-b5763dee9c83)