### PR TITLE
Reduce allocations in TextDocumentStates.SelectAs* methods

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -100,38 +100,41 @@ namespace Microsoft.CodeAnalysis
 
         public ImmutableArray<TValue> SelectAsArray<TValue>(Func<TState, TValue> selector)
         {
-            using var _ = ArrayBuilder<TValue>.GetInstance(out var builder);
+            // Directly use ImmutableArray.Builder as we know the final size
+            var builder = ImmutableArray.CreateBuilder<TValue>(_map.Count);
 
             foreach (var (_, state) in _map)
             {
                 builder.Add(selector(state));
             }
 
-            return builder.ToImmutable();
+            return builder.MoveToImmutable();
         }
 
         public ImmutableArray<TValue> SelectAsArray<TValue, TArg>(Func<TState, TArg, TValue> selector, TArg arg)
         {
-            using var _ = ArrayBuilder<TValue>.GetInstance(out var builder);
+            // Directly use ImmutableArray.Builder as we know the final size
+            var builder = ImmutableArray.CreateBuilder<TValue>(_map.Count);
 
             foreach (var (_, state) in _map)
             {
                 builder.Add(selector(state, arg));
             }
 
-            return builder.ToImmutable();
+            return builder.MoveToImmutable();
         }
 
         public async ValueTask<ImmutableArray<TValue>> SelectAsArrayAsync<TValue, TArg>(Func<TState, TArg, CancellationToken, ValueTask<TValue>> selector, TArg arg, CancellationToken cancellationToken)
         {
-            using var _ = ArrayBuilder<TValue>.GetInstance(out var builder);
+            // Directly use ImmutableArray.Builder as we know the final size
+            var builder = ImmutableArray.CreateBuilder<TValue>(_map.Count);
 
             foreach (var (_, state) in _map)
             {
                 builder.Add(await selector(state, arg, cancellationToken).ConfigureAwait(true));
             }
 
-            return builder.ToImmutable();
+            return builder.MoveToImmutable();
         }
 
         public TextDocumentStates<TState> AddRange(ImmutableArray<TState> states)


### PR DESCRIPTION
These methods were using an unsized ArrayBuilder to create an ImmutableArray.

Instead, as the size is pre-known in all these methods, we can just use ImmutableArray.CreateBuilder directly.

These two methods were showing up as a combined 0.4% of allocations in the codeanalysis process when inspecting a profile taken while typing a line of text.

```
Name                                                        	                                                                         Inc %	    Inc
Microsoft.CodeAnalysis.Workspaces!Microsoft.CodeAnalysis.TextDocumentStates`1[System.__Canon].SelectAsArray(class System.Func`3,!!1) 	  0.3	   39,169,344
Microsoft.CodeAnalysis.Workspaces!Microsoft.CodeAnalysis.TextDocumentStates`1[System.__Canon].SelectAsArray(class System.Func`2) 	  0.1	   9,204,744
```
