### PR TITLE
Cache frozen solution snapshots at the solution level (not the SolutionCompilationState level).

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -46,9 +46,7 @@ namespace Microsoft.CodeAnalysis
             _projectIdToProjectMap = [];
             _compilationState = compilationState;
 
-            this.CachedFrozenSolution = new AsyncLazy<Solution>(
-                cancellationToken => Task.FromResult(ComputeFrozenSolution(cancellationToken)),
-                cancellationToken => ComputeFrozenSolution(cancellationToken));
+            this.CachedFrozenSolution = AsyncLazy.Create(ComputeFrozenSolution);
         }
 
         internal Solution(
@@ -1506,11 +1504,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             static AsyncLazy<Solution> CreateLazyFrozenSolution(SolutionCompilationState compilationState, DocumentId documentId)
-            {
-                return new AsyncLazy<Solution>(
-                    cancellationToken => Task.FromResult(ComputeFrozenSolution(compilationState, documentId, cancellationToken)),
-                    cancellationToken => ComputeFrozenSolution(compilationState, documentId, cancellationToken));
-            }
+                => AsyncLazy.Create(cancellationToken => ComputeFrozenSolution(compilationState, documentId, cancellationToken));
 
             static Solution ComputeFrozenSolution(SolutionCompilationState compilationState, DocumentId documentId, CancellationToken cancellationToken)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -17,6 +17,9 @@ namespace Roslyn.Utilities
         public static AsyncLazy<T> Create<T>(Func<CancellationToken, Task<T>> asynchronousComputeFunction)
             => new(asynchronousComputeFunction);
 
+        public static AsyncLazy<T> Create<T>(Func<CancellationToken, T> synchronousComputeFunction)
+            => new(cancellationToken => Task.FromResult(synchronousComputeFunction(cancellationToken)), synchronousComputeFunction);
+
         public static AsyncLazy<T> Create<T>(T value)
             => new(value);
     }


### PR DESCRIPTION
With this change, if you ask a Document instance multiple times for its frozen snapshot, you'll always get back the same instance.  Previously, you'd always get a fresh solution instance back.  

This means that you wouldn't ever benefit from things like being able to share data cached on a Document instance (like the SemanticModel for example).  So if you had N features waking up, and freezing a Doc, and then getting sematnic models, they'd all operate on different instance.  Now, they'll operate on the same instance, as long as one of htem is currently keeping it alive. 