### PR TITLE
Remove obsoleted constructor

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -83,18 +83,7 @@ namespace Roslyn.Utilities
         /// Creates an AsyncLazy that always returns the value, analogous to <see cref="Task.FromResult{T}" />.
         /// </summary>
         public AsyncLazy(T value)
-        {
-            _cachedResult = Task.FromResult(value);
-        }
-
-#pragma warning disable IDE0060 // Remove unused parameter
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("'cacheResult' is no longer supported.  Use constructor without it.", error: false)]
-        public AsyncLazy(Func<CancellationToken, Task<T>> asynchronousComputeFunction, bool cacheResult)
-            : this(asynchronousComputeFunction)
-        {
-        }
-#pragma warning restore IDE0060 // Remove unused parameter
+            => _cachedResult = Task.FromResult(value);
 
         public AsyncLazy(Func<CancellationToken, Task<T>> asynchronousComputeFunction)
             : this(asynchronousComputeFunction, synchronousComputeFunction: null)


### PR DESCRIPTION
This constructor was obsoleted last march (with an error).  It can be removed now.