### PR TITLE
Re-enable GetAsyncEnumerator optional parameter asserts

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -1110,11 +1110,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         extensionReceiverOpt: null,
                         expanded: false,
                         collectionExpr.Syntax,
-                        diagnostics,
-                        // C# 8 shipped allowing the CancellationToken of `IAsyncEnumerable.GetAsyncEnumerator` to be non-optional,
-                        // filling in a default value in that case. https://github.com/dotnet/roslyn/issues/50182 tracks making
-                        // this an error and breaking the scenario.
-                        assertMissingParametersAreOptional: false);
+                        diagnostics);
 
                     MethodSymbol currentPropertyGetter;
                     if (isAsync)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -179,10 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // ((C)(x)).GetEnumerator();  OR  (x).GetEnumerator();  OR  async variants (which fill-in arguments for optional parameters)
             BoundExpression enumeratorVarInitValue = SynthesizeCall(getEnumeratorInfo, forEachSyntax, receiver,
-                allowExtensionAndOptionalParameters: isAsync || getEnumeratorInfo.Method.IsExtensionMethod,
-                // C# 8 shipped allowing the CancellationToken of `IAsyncEnumerable.GetAsyncEnumerator` to be non-optional.
-                // https://github.com/dotnet/roslyn/issues/50182 tracks making this an error and breaking the scenario.
-                assertParametersAreOptional: false);
+                allowExtensionAndOptionalParameters: isAsync || getEnumeratorInfo.Method.IsExtensionMethod);
 
             // E e = ((C)(x)).GetEnumerator();
             BoundStatement enumeratorVarDecl = MakeLocalDeclaration(forEachSyntax, enumeratorVar, enumeratorVarInitValue);


### PR DESCRIPTION
Discovered while investigating https://github.com/dotnet/roslyn/issues/72004.

Related to https://github.com/dotnet/roslyn/issues/50182 (cc @333fred).