### PR TITLE
Fix excessive CPU classify large string literals with tons of embedded classifications in them.

### DIFF
--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -190,7 +190,12 @@ internal sealed class TotalClassificationTaggerProvider(
                 // Only need to ask for the spans that overlapped the string literals.
                 using var _1 = SegmentedListPool.GetPooledList<ITagSpan<IClassificationTag>>(out var embeddedClassifications);
 
-                var stringLiteralSpans = new NormalizedSnapshotSpanCollection(stringLiterals.Select(s => s.Span));
+                var stringLiteralSpansFull = new NormalizedSnapshotSpanCollection(stringLiterals.Select(s => s.Span));
+
+                // The spans of the string literal itself may be far off screen.  Intersect the string literal spans
+                // with the view spans to get the actual spans we want to classify.
+                var stringLiteralSpans = NormalizedSnapshotSpanCollection.Intersection(stringLiteralSpansFull, spans);
+
                 embeddedTagger.AddTags(stringLiteralSpans, embeddedClassifications);
 
                 // Nothing complex to do if we got no embedded classifications back.  Just add in all the string


### PR DESCRIPTION
Fixes [AB#1957865](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1957865)

Validated before this that VS was unusable.  After this, it works completely great :) 

There may be followup options to improve things more.  Will be taking traces to see.  But this is a trivial and sensible change that mitigates the problem. 