### PR TITLE
Improvements to classification perf with large string literals.

### DIFF
--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
@@ -106,9 +106,12 @@ namespace Microsoft.CodeAnalysis.Classification
             private void ProcessToken(SyntaxToken token)
             {
                 _cancellationToken.ThrowIfCancellationRequested();
-                ProcessTriviaList(token.LeadingTrivia);
+
+                // Directives need to be processes as they can contain strings, which then have escapes in them.
+                if (token.ContainsDirectives)
+                    ProcessTriviaList(token.LeadingTrivia);
+
                 ClassifyToken(token);
-                ProcessTriviaList(token.TrailingTrivia);
             }
 
             private void ClassifyToken(SyntaxToken token)
@@ -146,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Classification
 
             private void ProcessTrivia(SyntaxTrivia trivia)
             {
-                if (trivia.HasStructure && trivia.FullSpan.IntersectsWith(_textSpan))
+                if (trivia.IsDirective && trivia.FullSpan.IntersectsWith(_textSpan))
                     VisitTokens(trivia.GetStructure()!);
             }
         }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 if (token.Span.IntersectsWith(_textSpan) && _owner.SyntaxTokenKinds.Contains(token.RawKind))
                 {
                     var context = new EmbeddedLanguageClassificationContext(
-                        _solutionServices, _project, _semanticModel, token, _options, _owner.Info.VirtualCharService, _result, _cancellationToken);
+                        _solutionServices, _project, _semanticModel, token, _textSpan, _options, _owner.Info.VirtualCharService, _result, _cancellationToken);
 
                     var classifiers = _owner.GetServices(_semanticModel, token, _cancellationToken);
                     foreach (var classifier in classifiers)

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractFallbackEmbeddedLanguageClassifier.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractFallbackEmbeddedLanguageClassifier.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Classification
 
             foreach (var vc in virtualChars)
             {
-                // utf-16 virtual char might have either one or two in text span.
+                // utf-16 virtual char might have either one or two in text span
                 if (vc.Span.Length > vc.Rune.Utf16SequenceLength)
                     context.AddClassification(ClassificationTypeNames.StringEscapeCharacter, vc.Span);
             }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractFallbackEmbeddedLanguageClassifier.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractFallbackEmbeddedLanguageClassifier.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Classification
 
             foreach (var vc in virtualChars)
             {
-                // utf-16 virtual char might have either one or two in text span
+                // utf-16 virtual char might have either one or two in text span.
                 if (vc.Span.Length > vc.Rune.Utf16SequenceLength)
                     context.AddClassification(ClassificationTypeNames.StringEscapeCharacter, vc.Span);
             }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/EmbeddedLanguageClassifierContext.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/EmbeddedLanguageClassifierContext.cs
@@ -8,52 +8,63 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.Classification
+namespace Microsoft.CodeAnalysis.Classification;
+
+internal readonly struct EmbeddedLanguageClassificationContext
 {
-    internal readonly struct EmbeddedLanguageClassificationContext
+    internal readonly SolutionServices SolutionServices;
+
+    private readonly SegmentedList<ClassifiedSpan> _result;
+
+    /// <summary>
+    /// The portion of the string or character token to classify.
+    /// </summary>
+    private readonly TextSpan _spanToClassify;
+
+    public Project Project { get; }
+
+    /// <summary>
+    /// The string or character token to classify.
+    /// </summary>
+    public SyntaxToken SyntaxToken { get; }
+
+    /// <summary>
+    /// SemanticModel that <see cref="SyntaxToken"/> is contained in.
+    /// </summary>
+    public SemanticModel SemanticModel { get; }
+
+    public CancellationToken CancellationToken { get; }
+
+    internal readonly ClassificationOptions Options;
+    internal readonly IVirtualCharService VirtualCharService;
+
+    internal EmbeddedLanguageClassificationContext(
+        SolutionServices solutionServices,
+        Project project,
+        SemanticModel semanticModel,
+        SyntaxToken syntaxToken,
+        TextSpan spanToClassify,
+        ClassificationOptions options,
+        IVirtualCharService virtualCharService,
+        SegmentedList<ClassifiedSpan> result,
+        CancellationToken cancellationToken)
     {
-        internal readonly SolutionServices SolutionServices;
+        SolutionServices = solutionServices;
+        Project = project;
+        SemanticModel = semanticModel;
+        SyntaxToken = syntaxToken;
+        _spanToClassify = spanToClassify;
+        Options = options;
+        VirtualCharService = virtualCharService;
+        _result = result;
+        CancellationToken = cancellationToken;
+    }
 
-        private readonly SegmentedList<ClassifiedSpan> _result;
-
-        public Project Project { get; }
-
-        /// <summary>
-        /// The string or character token to classify.
-        /// </summary>
-        public SyntaxToken SyntaxToken { get; }
-
-        /// <summary>
-        /// SemanticModel that <see cref="SyntaxToken"/> is contained in.
-        /// </summary>
-        public SemanticModel SemanticModel { get; }
-
-        public CancellationToken CancellationToken { get; }
-
-        internal readonly ClassificationOptions Options;
-        internal readonly IVirtualCharService VirtualCharService;
-
-        internal EmbeddedLanguageClassificationContext(
-            SolutionServices solutionServices,
-            Project project,
-            SemanticModel semanticModel,
-            SyntaxToken syntaxToken,
-            ClassificationOptions options,
-            IVirtualCharService virtualCharService,
-            SegmentedList<ClassifiedSpan> result,
-            CancellationToken cancellationToken)
-        {
-            SolutionServices = solutionServices;
-            Project = project;
-            SemanticModel = semanticModel;
-            SyntaxToken = syntaxToken;
-            Options = options;
-            VirtualCharService = virtualCharService;
-            _result = result;
-            CancellationToken = cancellationToken;
-        }
-
-        public void AddClassification(string classificationType, TextSpan span)
-            => _result.Add(new ClassifiedSpan(classificationType, span));
+    public void AddClassification(string classificationType, TextSpan span)
+    {
+        // Ignore characters that don't intersect with the requested span.  That avoids potentially adding lots of
+        // classifications for portions of a large string that are out of view.
+        if (span.IntersectsWith(_spanToClassify))
+            _result.Add(new ClassifiedSpan(classificationType, span));
     }
 }


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/72216.

Takes classification cost down from:

![image](https://github.com/dotnet/roslyn/assets/4564579/986199ea-6ff2-4f58-96bb-a9211dddc409)

to

![image](https://github.com/dotnet/roslyn/assets/4564579/92c4f74c-9683-4575-8be4-86530dd03af6)

Basically, we were producign *lots* of tags in the case of some very large strings.  This ended up being costly with later processing.  This change fixes us up to produce far fewer tags (gated to just what is in view).  

--

There is still further optimizations we can do.  Specifically, for regex/json classification, we can limit how we walk those language subtrees to avoid even classifying portions of the embedded language tree that is not in view.