### PR TITLE
Enable OSX queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -339,17 +339,17 @@ stages:
 
   # https://github.com/dotnet/runtime/issues/97186
   # Disabled until runtime can track down the crash
-  # - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  #   - template: eng/pipelines/test-unix-job.yml
-  #     parameters:
-  #       testRunName: 'Test macOS Debug'
-  #       jobName: Test_macOS_Debug
-  #       testArtifactName: Transport_Artifacts_Unix_Debug
-  #       configuration: Debug
-  #       testArguments: --testCoreClr 
-  #       helixQueueName: $(HelixMacOsQueueName)
-  #       helixApiAccessToken: $(HelixApiAccessToken)
-  #       poolParameters: ${{ parameters.ubuntuPool }}
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - template: eng/pipelines/test-unix-job.yml
+      parameters:
+        testRunName: 'Test macOS Debug'
+        jobName: Test_macOS_Debug
+        testArtifactName: Transport_Artifacts_Unix_Debug
+        configuration: Debug
+        testArguments: --testCoreClr 
+        helixQueueName: $(HelixMacOsQueueName)
+        helixApiAccessToken: $(HelixApiAccessToken)
+        poolParameters: ${{ parameters.ubuntuPool }}
 
 - stage: Correctness
   dependsOn: []


### PR DESCRIPTION
Re-enable OSX queues so we can get crashes again for runtime to look at.