### PR TITLE
WIP: Reduce allocations under RemoveAssetProvider.SynchronizeAssetsAsync

### DIFF
--- a/src/Workspaces/Core/Portable/Serialization/PooledList.cs
+++ b/src/Workspaces/Core/Portable/Serialization/PooledList.cs
@@ -5,8 +5,7 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Serialization
 {
@@ -15,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Serialization
     /// </summary>
     internal static class Creator
     {
-        public static PooledObject<HashSet<Checksum>> CreateChecksumSet(ImmutableArray<Checksum> checksums)
+        public static PooledObject<HashSet<Checksum>> CreateChecksumSet(SegmentedList<Checksum> checksums)
         {
             var items = SharedPools.Default<HashSet<Checksum>>().GetPooledObject();
 

--- a/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
@@ -18,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing;
 internal sealed class SimpleAssetSource(ISerializerService serializerService, IReadOnlyDictionary<Checksum, object> map) : IAssetSource
 {
     public ValueTask<ImmutableArray<object>> GetAssetsAsync(
-        Checksum solutionChecksum, AssetHint assetHint, ImmutableArray<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
+        Checksum solutionChecksum, AssetHint assetHint, SegmentedList<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
     {
         var results = new List<object>();
 

--- a/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Serialization;
 
 namespace Microsoft.CodeAnalysis.Remote;
@@ -26,5 +26,5 @@ internal interface ISolutionAssetProvider
     /// save substantially on performance by avoiding having to search the full solution tree to find matching items for
     /// a particular checksum.</param>
     ValueTask WriteAssetsAsync(
-        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ImmutableArray<Checksum> checksums, CancellationToken cancellationToken);
+        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, SegmentedList<Checksum> checksums, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
 using Nerdbank.Streams;
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ISerializerService serializer,
             SolutionReplicationContext context,
             Checksum solutionChecksum,
-            ImmutableArray<Checksum> checksums,
+            SegmentedList<Checksum> checksums,
             CancellationToken cancellationToken)
         {
             using var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken);
@@ -35,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Remote
             solutionChecksum.WriteTo(writer);
 
             // special case
-            if (checksums.Length == 0)
+            if (checksums.Count == 0)
                 return;
 
             Debug.Assert(assetMap != null);

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -4,13 +4,12 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Immutable;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
@@ -31,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Remote
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
             AssetHint assetHint,
-            ImmutableArray<Checksum> checksums,
+            SegmentedList<Checksum> checksums,
             CancellationToken cancellationToken)
         {
             // Suppress ExecutionContext flow for asynchronous operations operate on the pipe. In addition to avoiding
@@ -43,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Remote
             using var _ = FlowControlHelper.TrySuppressFlow();
             return WriteAssetsSuppressedFlowAsync(pipeWriter, solutionChecksum, assetHint, checksums, cancellationToken);
 
-            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ImmutableArray<Checksum> checksums, CancellationToken cancellationToken)
+            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, SegmentedList<Checksum> checksums, CancellationToken cancellationToken)
             {
                 // The responsibility is on us (as per the requirements of RemoteCallback.InvokeAsync) to Complete the
                 // pipewriter.  This will signal to streamjsonrpc that the writer passed into it is complete, which will
@@ -68,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Remote
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
             AssetHint assetHint,
-            ImmutableArray<Checksum> checksums,
+            SegmentedList<Checksum> checksums,
             CancellationToken cancellationToken)
         {
             var assetStorage = _services.GetRequiredService<ISolutionAssetStorageProvider>().AssetStorage;

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -4,10 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
@@ -45,7 +45,7 @@ internal partial class SolutionAssetStorage
         /// </summary>
         public async Task AddAssetsAsync(
             AssetHint assetHint,
-            ImmutableArray<Checksum> checksums,
+            SegmentedList<Checksum> checksums,
             Dictionary<Checksum, object> assetMap,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Serialization;
 
 namespace Microsoft.CodeAnalysis.Remote;
@@ -15,5 +16,5 @@ namespace Microsoft.CodeAnalysis.Remote;
 internal interface IAssetSource
 {
     ValueTask<ImmutableArray<object>> GetAssetsAsync(
-        Checksum solutionChecksum, AssetHint assetHint, ImmutableArray<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
+        Checksum solutionChecksum, AssetHint assetHint, SegmentedList<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Threading;
@@ -18,7 +19,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
     public async ValueTask<ImmutableArray<object>> GetAssetsAsync(
         Checksum solutionChecksum,
         AssetHint assetHint,
-        ImmutableArray<Checksum> checksums,
+        SegmentedList<Checksum> checksums,
         ISerializerService serializerService,
         CancellationToken cancellationToken)
     {
@@ -30,7 +31,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
             SolutionAssetProvider.ServiceDescriptor,
             (callback, cancellationToken) => callback.InvokeAsync(
                 (proxy, pipeWriter, cancellationToken) => proxy.WriteAssetsAsync(pipeWriter, solutionChecksum, assetHint, checksums, cancellationToken),
-                (pipeReader, cancellationToken) => RemoteHostAssetSerialization.ReadDataAsync(pipeReader, solutionChecksum, checksums.Length, serializerService, cancellationToken),
+                (pipeReader, cancellationToken) => RemoteHostAssetSerialization.ReadDataAsync(pipeReader, solutionChecksum, checksums.Count, serializerService, cancellationToken),
                 cancellationToken),
             cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
This code realized an ImmutableArray before from an ArrayBuilder. This immutablearray was only used within the scope of SynchronizeAssetsAsync.

*** Prior allocations from speedometer:
![image](https://github.com/dotnet/roslyn/assets/6785178/bdec15d1-ab2c-44af-a483-3c3ab90e1a46)