### PR TITLE
Guard the 'CustomSeverityConfigurable' tag with AnalysisLevel 9.0

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
@@ -76,6 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers
                 Descriptor,
                 name.GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: additionalLocations,
                 modifiersAdded ? ModifiersAddedProperties : null));
         }

--- a/src/Analyzers/CSharp/Analyzers/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
@@ -111,6 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 Descriptor,
                 firstToken.GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: null,
                 properties: null,
                 SyntaxFacts.GetText(firstToken.Kind())));

--- a/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToBlockScopedNamespaceDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToBlockScopedNamespaceDiagnosticAnalyzer.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
                 this.Descriptor,
                 diagnosticLocation,
                 option.Notification,
+                context.Options,
                 ImmutableArray.Create(declaration.GetLocation()),
                 ImmutableDictionary<string, string?>.Empty);
         }

--- a/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToFileScopedNamespaceDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToFileScopedNamespaceDiagnosticAnalyzer.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
                 this.Descriptor,
                 diagnosticLocation,
                 option.Notification,
+                context.Options,
                 ImmutableArray.Create(declaration.GetLocation()),
                 ImmutableDictionary<string, string?>.Empty);
         }

--- a/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertToProgramMainDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertToProgramMainDiagnosticAnalyzer.cs
@@ -57,6 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TopLevelStatements
                 GetUseProgramMainDiagnosticLocation(
                     root, isHidden: severity.WithDefaultSeverity(DiagnosticSeverity.Hidden) == ReportDiagnostic.Hidden),
                 option.Notification,
+                context.Options,
                 [],
                 ImmutableDictionary<string, string?>.Empty));
         }

--- a/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertToTopLevelStatementsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertToTopLevelStatementsDiagnosticAnalyzer.cs
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TopLevelStatements
                             GetUseTopLevelStatementsDiagnosticLocation(
                                 methodDeclaration, isHidden: option.Notification.Severity.WithDefaultSeverity(DiagnosticSeverity.Hidden) == ReportDiagnostic.Hidden),
                             option.Notification,
+                            context.Options,
                             ImmutableArray.Create(methodDeclaration.GetLocation()),
                             ImmutableDictionary<string, string?>.Empty));
                     }

--- a/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                 // Report the diagnostic on the "switch" keyword.
                 location: switchStatement.GetFirstToken().GetLocation(),
                 notificationOption: styleOption.Notification,
+                context.Options,
                 additionalLocations: additionalLocations.ToArrayAndFree(),
                 properties: ImmutableDictionary<string, string?>.Empty
                     .Add(Constants.NodeToGenerateKey, ((int)nodeToGenerate).ToString(CultureInfo.InvariantCulture))

--- a/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -246,6 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                 Descriptor,
                 reportNode.GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: allLocations,
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
@@ -184,6 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
                 Descriptor,
                 fadeLocation,
                 NotificationOption2.ForSeverity(Descriptor.DefaultSeverity),
+                syntaxContext.Options,
                 additionalLocations,
                 additionalUnnecessaryLocations: [fadeLocation],
                 properties));
@@ -193,6 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
                 Descriptor,
                 expressionStatement.GetLocation(),
                 notificationOption,
+                syntaxContext.Options,
                 additionalLocations, properties));
 
             // If the if-statement extends past the expression statement, then fade out the rest.
@@ -203,6 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
                     Descriptor,
                     fadeLocation,
                     NotificationOption2.ForSeverity(Descriptor.DefaultSeverity),
+                    syntaxContext.Options,
                     additionalLocations,
                     additionalUnnecessaryLocations: [fadeLocation],
                     properties));

--- a/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticDiagnosticAnalyzer.cs
@@ -54,6 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
                     Descriptor,
                     localFunction.Identifier.GetLocation(),
                     option.Notification,
+                    context.Options,
                     additionalLocations: ImmutableArray.Create(localFunction.GetLocation()),
                     properties: null));
             }

--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -162,6 +162,7 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer()
                 Descriptor,
                 location,
                 notificationOption,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(additionalLocation),
                 properties: null);
         }

--- a/src/Analyzers/CSharp/Analyzers/MakeStructReadOnly/CSharpMakeStructReadOnlyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructReadOnly/CSharpMakeStructReadOnlyDiagnosticAnalyzer.cs
@@ -61,6 +61,7 @@ internal sealed class CSharpMakeStructReadOnlyDiagnosticAnalyzer : AbstractBuilt
                         Descriptor,
                         location,
                         option.Notification,
+                        context.Options,
                         additionalLocations: ImmutableArray.Create(additionalLocation),
                         properties: null));
                 });

--- a/src/Analyzers/CSharp/Analyzers/MisplacedUsingDirectives/MisplacedUsingDirectivesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MisplacedUsingDirectives/MisplacedUsingDirectivesDiagnosticAnalyzer.cs
@@ -106,6 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
                     descriptor,
                     usingDirective.GetLocation(),
                     option.Notification,
+                    context.Options,
                     additionalLocations: null,
                     properties: null));
             }

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
@@ -78,6 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ArrowExpressionClausePlacement
                 this.Descriptor,
                 arrowExpressionClause.ArrowToken.GetLocation(),
                 notificationOption,
+                context.Options,
                 additionalLocations: null,
                 properties: null));
 

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConditionalExpressionPlacement/ConditionalExpressionPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConditionalExpressionPlacement/ConditionalExpressionPlacementDiagnosticAnalyzer.cs
@@ -60,6 +60,7 @@ internal sealed class ConditionalExpressionPlacementDiagnosticAnalyzer : Abstrac
             this.Descriptor,
             conditionalExpression.QuestionToken.GetLocation(),
             option.Notification,
+            context.Options,
             additionalLocations: null,
             properties: null));
 

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
@@ -84,6 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConsecutiveBracePlacement
                 this.Descriptor,
                 secondBrace.GetLocation(),
                 notificationOption,
+                context.Options,
                 additionalLocations: null,
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConstructorInitializerPlacement
                 this.Descriptor,
                 colonToken.GetLocation(),
                 notificationOption,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(initializer.GetLocation()),
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
@@ -78,6 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.EmbeddedStatementPlacement
                 this.Descriptor,
                 statement.GetFirstToken().GetLocation(),
                 notificationOption,
+                context.Options,
                 additionalLocations,
                 properties: null));
             return true;

--- a/src/Analyzers/CSharp/Analyzers/RemoveConfusingSuppression/CSharpRemoveConfusingSuppressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveConfusingSuppression/CSharpRemoveConfusingSuppressionDiagnosticAnalyzer.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveConfusingSuppression
                 Descriptor,
                 ((PostfixUnaryExpressionSyntax)left).OperatorToken.GetLocation(),
                 NotificationOption2.Warning,
+                context.Options,
                 ImmutableArray.Create(node.GetLocation()),
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
@@ -232,6 +232,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryLambdaExpression
                 Descriptor,
                 syntaxTree.GetLocation(startReportSpan),
                 preference.Notification,
+                context.Options,
                 additionalLocations: [anonymousFunction.GetLocation()],
                 additionalUnnecessaryLocations: [syntaxTree.GetLocation(startReportSpan), syntaxTree.GetLocation(endReportSpan)]));
         }

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
@@ -124,6 +124,7 @@ internal class CSharpRemoveUnreachableCodeDiagnosticAnalyzer : AbstractBuiltInUn
             Descriptor,
             firstStatementLocation,
             NotificationOption2.ForSeverity(Descriptor.DefaultSeverity),
+            context.Options,
             additionalLocations: [],
             additionalUnnecessaryLocations: additionalLocations));
 
@@ -142,6 +143,7 @@ internal class CSharpRemoveUnreachableCodeDiagnosticAnalyzer : AbstractBuiltInUn
                 Descriptor,
                 location,
                 NotificationOption2.ForSeverity(Descriptor.DefaultSeverity),
+                context.Options,
                 additionalLocations,
                 additionalUnnecessaryLocations,
                 s_subsequentSectionProperties));

--- a/src/Analyzers/CSharp/Analyzers/SimplifyPropertyPattern/CSharpSimplifyPropertyPatternDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/SimplifyPropertyPattern/CSharpSimplifyPropertyPatternDiagnosticAnalyzer.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SimplifyPropertyPattern
                 Descriptor,
                 expressionColon.GetLocation(),
                 styleOption.Notification,
+                syntaxContext.Options,
                 ImmutableArray.Create(subpattern.GetLocation()),
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
@@ -191,6 +191,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
                 Descriptor,
                 initializer.OpenBraceToken.GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(initializer.GetLocation()),
                 properties: changesSemantics ? ChangesSemantics : null));
         }
@@ -205,6 +206,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
             Descriptor,
             expression.GetFirstToken().GetLocation(),
             notification,
+            context.Options,
             additionalLocations: locations,
             properties: properties));
 
@@ -219,6 +221,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
             UnnecessaryCodeDescriptor,
             additionalUnnecessaryLocations[0],
             NotificationOption2.ForSeverity(UnnecessaryCodeDescriptor.DefaultSeverity),
+            context.Options,
             additionalLocations: locations,
             additionalUnnecessaryLocations: additionalUnnecessaryLocations,
             properties: properties));

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderDiagnosticAnalyzer.cs
@@ -54,6 +54,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderDiagnosticA
             Descriptor,
             analysisResult.DiagnosticLocation,
             option.Notification,
+            context.Options,
             additionalLocations: locations,
             properties: properties));
 
@@ -70,6 +71,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderDiagnosticA
                 UnnecessaryCodeDescriptor,
                 additionalUnnecessaryLocations[0],
                 NotificationOption2.ForSeverity(UnnecessaryCodeDescriptor.DefaultSeverity),
+                context.Options,
                 additionalLocations: locations,
                 additionalUnnecessaryLocations: additionalUnnecessaryLocations,
                 properties: properties));
@@ -87,6 +89,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderDiagnosticA
                     UnnecessaryCodeDescriptor,
                     additionalUnnecessaryLocations[0],
                     NotificationOption2.ForSeverity(UnnecessaryCodeDescriptor.DefaultSeverity),
+                    context.Options,
                     additionalLocations: locations,
                     additionalUnnecessaryLocations: additionalUnnecessaryLocations,
                     properties: properties));

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
@@ -60,6 +60,7 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
             Descriptor,
             memberAccess.Name.Identifier.GetLocation(),
             option.Notification,
+            context.Options,
             additionalLocations: locations,
             properties));
 
@@ -73,6 +74,7 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
             UnnecessaryCodeDescriptor,
             additionalUnnecessaryLocations[0],
             NotificationOption2.ForSeverity(UnnecessaryCodeDescriptor.DefaultSeverity),
+            context.Options,
             additionalLocations: locations,
             additionalUnnecessaryLocations: additionalUnnecessaryLocations,
             properties));

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer.cs
@@ -56,6 +56,7 @@ internal sealed partial class CSharpUseCollectionExpressionForEmptyDiagnosticAna
             Descriptor,
             memberAccess.Name.Identifier.GetLocation(),
             option.Notification,
+            context.Options,
             additionalLocations: ImmutableArray.Create(nodeToReplace.GetLocation()),
             properties: changesSemantics ? ChangesSemantics : null));
     }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForFluentDiagnosticAnalyzer.cs
@@ -110,6 +110,7 @@ internal sealed partial class CSharpUseCollectionExpressionForFluentDiagnosticAn
             Descriptor,
             memberAccess.Name.Identifier.GetLocation(),
             option.Notification,
+            context.Options,
             additionalLocations: ImmutableArray.Create(invocation.GetLocation()),
             properties: analysisResult.Value.ChangesSemantics ? ChangesSemantics : null));
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs
@@ -59,6 +59,7 @@ internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnost
             Descriptor,
             expression.GetFirstToken().GetLocation(),
             option.Notification,
+            context.Options,
             additionalLocations: locations,
             properties: null));
 
@@ -71,6 +72,7 @@ internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnost
             UnnecessaryCodeDescriptor,
             additionalUnnecessaryLocations[0],
             NotificationOption2.ForSeverity(UnnecessaryCodeDescriptor.DefaultSeverity),
+            context.Options,
             additionalLocations: locations,
             additionalUnnecessaryLocations: additionalUnnecessaryLocations));
     }
@@ -97,6 +99,7 @@ internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnost
             Descriptor,
             expression.GetFirstToken().GetLocation(),
             option.Notification,
+            context.Options,
             additionalLocations: locations,
             properties: null));
 
@@ -109,6 +112,7 @@ internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnost
             UnnecessaryCodeDescriptor,
             additionalUnnecessaryLocations[0],
             NotificationOption2.ForSeverity(UnnecessaryCodeDescriptor.DefaultSeverity),
+            context.Options,
             additionalLocations: locations,
             additionalUnnecessaryLocations: additionalUnnecessaryLocations));
     }

--- a/src/Analyzers/CSharp/Analyzers/UseCompoundAssignment/CSharpUseCompoundCoalesceAssignmentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCompoundAssignment/CSharpUseCompoundCoalesceAssignmentDiagnosticAnalyzer.cs
@@ -96,6 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment
                 Descriptor,
                 coalesceExpression.OperatorToken.GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(coalesceExpression.GetLocation()),
                 properties: null));
         }
@@ -168,6 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment
                 Descriptor,
                 ifStatement.IfKeyword.GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(ifStatement.GetLocation()),
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
                 Descriptor,
                 variableDeclaration.Variables[0].Identifier.GetLocation(),
                 notificationOption,
+                context.Options,
                 additionalLocations: null,
                 properties: null));
         }
@@ -80,6 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
                 Descriptor,
                 forEachStatement.Identifier.GetLocation(),
                 notificationOption,
+                context.Options,
                 additionalLocations: null,
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/UseDefaultLiteral/CSharpUseDefaultLiteralDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseDefaultLiteral/CSharpUseDefaultLiteralDiagnosticAnalyzer.cs
@@ -52,6 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDefaultLiteral
                     Descriptor,
                     defaultExpression.GetLocation(),
                     preference.Notification,
+                    context.Options,
                     additionalLocations: [],
                     additionalUnnecessaryLocations: [defaultExpression.SyntaxTree.GetLocation(fadeSpan)]));
         }

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/UseExpressionBodyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/UseExpressionBodyDiagnosticAnalyzer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 var properties = ImmutableDictionary<string, string?>.Empty.Add(nameof(UseExpressionBody), "");
                 return DiagnosticHelper.Create(
                     CreateDescriptorWithId(helper.DiagnosticId, helper.EnforceOnBuild, hasAnyCodeStyleOption: true, helper.UseExpressionBodyTitle, helper.UseExpressionBodyTitle),
-                    location, preference.Notification, additionalLocations: additionalLocations, properties: properties);
+                    location, preference.Notification, context.Options, additionalLocations: additionalLocations, properties: properties);
             }
 
             if (helper.CanOfferUseBlockBody(preference, declaration, forAnalyzer: true, out var fixesError, out var expressionBody))
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 var additionalLocations = ImmutableArray.Create(declaration.GetLocation());
                 return DiagnosticHelper.Create(
                     CreateDescriptorWithId(helper.DiagnosticId, helper.EnforceOnBuild, hasAnyCodeStyleOption: true, helper.UseBlockBodyTitle, helper.UseBlockBodyTitle),
-                    location, preference.Notification, additionalLocations: additionalLocations, properties: properties);
+                    location, preference.Notification, context.Options, additionalLocations: additionalLocations, properties: properties);
             }
 
             return null;

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBodyForLambda/UseExpressionBodyForLambdaDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBodyForLambda/UseExpressionBodyForLambdaDiagnosticAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
         private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context, CodeStyleOption2<ExpressionBodyPreference> option)
         {
             var declaration = (LambdaExpressionSyntax)context.Node;
-            var diagnostic = AnalyzeSyntax(context.SemanticModel, option, declaration, context.CancellationToken);
+            var diagnostic = AnalyzeSyntax(context.SemanticModel, option, declaration, context.Options, context.CancellationToken);
             if (diagnostic != null)
             {
                 context.ReportDiagnostic(diagnostic);
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
 
         private static Diagnostic? AnalyzeSyntax(
             SemanticModel semanticModel, CodeStyleOption2<ExpressionBodyPreference> option,
-            LambdaExpressionSyntax declaration, CancellationToken cancellationToken)
+            LambdaExpressionSyntax declaration, AnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
         {
             if (UseExpressionBodyForLambdaHelpers.CanOfferUseExpressionBody(option.Value, declaration, declaration.GetLanguageVersion(), cancellationToken))
             {
@@ -79,7 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
                 var properties = ImmutableDictionary<string, string?>.Empty;
                 return DiagnosticHelper.Create(
                     s_useExpressionBodyForLambda,
-                    location, option.Notification, additionalLocations, properties);
+                    location, option.Notification,
+                    analyzerOptions, additionalLocations, properties);
             }
 
             if (UseExpressionBodyForLambdaHelpers.CanOfferUseBlockBody(semanticModel, option.Value, declaration, cancellationToken))
@@ -92,7 +93,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
                 var additionalLocations = ImmutableArray.Create(declaration.GetLocation());
                 return DiagnosticHelper.Create(
                     s_useBlockBodyForLambda,
-                    location, option.Notification, additionalLocations, properties);
+                    location, option.Notification,
+                    analyzerOptions, additionalLocations, properties);
             }
 
             return null;

--- a/src/Analyzers/CSharp/Analyzers/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationDiagnosticAnalyzer.cs
@@ -59,6 +59,7 @@ internal class CSharpUseImplicitObjectCreationDiagnosticAnalyzer : AbstractBuilt
             Descriptor,
             objectCreation.Type.GetLocation(),
             styleOption.Notification,
+            context.Options,
             ImmutableArray.Create(objectCreation.GetLocation()),
             properties: null));
     }

--- a/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -72,10 +72,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
             // The severity preference is not Hidden, as indicated by IsStylePreferred.
             var descriptor = Descriptor;
-            context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, declaredType.StripRefIfNeeded().Span, typeStyle.Notification));
+            context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, declaredType.StripRefIfNeeded().Span, typeStyle.Notification, context.Options));
         }
 
-        private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode declaration, TextSpan diagnosticSpan, NotificationOption2 notificationOption)
-            => DiagnosticHelper.Create(descriptor, declaration.SyntaxTree.GetLocation(diagnosticSpan), notificationOption, additionalLocations: null, properties: null);
+        private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode declaration, TextSpan diagnosticSpan, NotificationOption2 notificationOption, AnalyzerOptions analyzerOptions)
+            => DiagnosticHelper.Create(descriptor, declaration.SyntaxTree.GetLocation(diagnosticSpan), notificationOption, analyzerOptions, additionalLocations: null, properties: null);
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.cs
@@ -207,6 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                     Descriptor,
                     binaryExpression.GetLocation(),
                     option.Notification,
+                    context.Options,
                     [],
                     ImmutableDictionary<string, string?>.Empty));
         }

--- a/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             if (CSharpSemanticFacts.Instance.IsInExpressionTree(semanticModel, operation.Syntax, infoCache.ExpressionOfTType, context.CancellationToken))
                 return;
 
-            context.ReportDiagnostic(CreateDiagnostic(result.Value, option.Notification));
+            context.ReportDiagnostic(CreateDiagnostic(result.Value, option.Notification, context.Options));
         }
 
         public static Result? AnalyzeInvocation(IInvocationOperation invocation, InfoCache infoCache)
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             return !invocation.Syntax.IsLeftSideOfAnyAssignExpression() || indexer == null || !IsWriteableIndexer(invocation, indexer);
         }
 
-        private Diagnostic CreateDiagnostic(Result result, NotificationOption2 notificationOption)
+        private Diagnostic CreateDiagnostic(Result result, NotificationOption2 notificationOption, AnalyzerOptions analyzerOptions)
         {
             // Keep track of the invocation node
             var invocation = result.Invocation;
@@ -262,6 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                 Descriptor,
                 location,
                 notificationOption,
+                analyzerOptions,
                 additionalLocations,
                 ImmutableDictionary<string, string?>.Empty,
                 result.SliceLikeMethod.Name);

--- a/src/Analyzers/CSharp/Analyzers/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
                     Descriptor,
                     nameColon.GetLocation(),
                     preference.Notification,
+                    context.Options,
                     additionalLocations: [],
                     additionalUnnecessaryLocations: [syntaxTree.GetLocation(fadeSpan)]));
         }
@@ -83,6 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
                     Descriptor,
                     nameEquals.GetLocation(),
                     preference.Notification,
+                    context.Options,
                     additionalLocations: [],
                     additionalUnnecessaryLocations: [context.Node.SyntaxTree.GetLocation(fadeSpan)]));
         }

--- a/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseIsNullCheckForCastAndEqualityOperatorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseIsNullCheckForCastAndEqualityOperatorDiagnosticAnalyzer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
                 : s_NegatedProperties;
             context.ReportDiagnostic(
                 DiagnosticHelper.Create(
-                    Descriptor, binaryExpression.GetLocation(), option.Notification, additionalLocations: null, properties));
+                    Descriptor, binaryExpression.GetLocation(), option.Notification, context.Options, additionalLocations: null, properties));
         }
 
         private static bool IsObjectCastAndNullCheck(

--- a/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseNullCheckOverTypeCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseNullCheckOverTypeCheckDiagnosticAnalyzer.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
             {
                 context.ReportDiagnostic(
                     DiagnosticHelper.Create(
-                        Descriptor, context.Operation.Syntax.GetLocation(), notificationOption, additionalLocations: null, properties: null));
+                        Descriptor, context.Operation.Syntax.GetLocation(), notificationOption, context.Options, additionalLocations: null, properties: null));
             }
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
             {
                 context.ReportDiagnostic(
                     DiagnosticHelper.Create(
-                        Descriptor, syntax.GetLocation(), notificationOption, additionalLocations: null, properties: null));
+                        Descriptor, syntax.GetLocation(), notificationOption, context.Options, additionalLocations: null, properties: null));
             }
         }
     }

--- a/src/Analyzers/CSharp/Analyzers/UseLocalFunction/CSharpUseLocalFunctionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseLocalFunction/CSharpUseLocalFunctionDiagnosticAnalyzer.cs
@@ -144,6 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseLocalFunction
                     Descriptor,
                     localDeclaration.Declaration.Variables[0].Identifier.GetLocation(),
                     styleOption.Notification,
+                    syntaxContext.Options,
                     additionalLocations,
                     properties: null));
             }
@@ -154,6 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseLocalFunction
                     Descriptor,
                     localDeclaration.GetLocation(),
                     styleOption.Notification,
+                    syntaxContext.Options,
                     additionalLocations,
                     properties: null));
 
@@ -163,6 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseLocalFunction
                         Descriptor,
                         anonymousFunctionStatement!.GetLocation(),
                         styleOption.Notification,
+                        syntaxContext.Options,
                         additionalLocations,
                         properties: null));
                 }

--- a/src/Analyzers/CSharp/Analyzers/UseNameofInNullableAttribute/CSharpUseNameofInNullableAttributeDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseNameofInNullableAttribute/CSharpUseNameofInNullableAttributeDiagnosticAnalyzer.cs
@@ -107,6 +107,7 @@ internal sealed class CSharpUseNameofInAttributeDiagnosticAnalyzer : AbstractBui
                     this.Descriptor,
                     argument.Expression.GetLocation(),
                     NotificationOption2.Suggestion,
+                    context.Options,
                     additionalLocations: null,
                     ImmutableDictionary<string, string?>.Empty.Add(NameKey, stringValue)));
             }

--- a/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzer.cs
@@ -101,6 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternCombinators
                 descriptor: isSafe ? this.Descriptor : s_unsafeDescriptor,
                 expression.GetLocation(),
                 styleOption.Notification,
+                context.Options,
                 additionalLocations: null,
                 properties: isSafe ? s_safeProperties : null));
         }

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndMemberAccessDiagnosticAnalyzer.cs
@@ -83,6 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 Descriptor,
                 asExpression.GetLocation(),
                 styleOption.Notification,
+                context.Options,
                 additionalLocations: null,
                 properties: null));
 

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -270,6 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 Descriptor,
                 localStatement.GetLocation(),
                 styleOption.Notification,
+                syntaxContext.Options,
                 additionalLocations,
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpIsAndCastCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpIsAndCastCheckDiagnosticAnalyzer.cs
@@ -154,6 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 Descriptor,
                 localDeclarationStatement.GetLocation(),
                 styleOption.Notification,
+                syntaxContext.Options,
                 additionalLocations,
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
@@ -97,6 +97,7 @@ internal sealed class CSharpUseNotPatternDiagnosticAnalyzer()
             Descriptor,
             isKeyword.GetLocation(),
             styleOption.Notification,
+            context.Options,
             ImmutableArray.Create(node.GetLocation()),
             properties: null));
     }

--- a/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
@@ -188,6 +188,7 @@ internal sealed class CSharpUsePrimaryConstructorDiagnosticAnalyzer()
                 _diagnosticAnalyzer.Descriptor,
                 _primaryConstructorDeclaration.Identifier.GetLocation(),
                 _styleOption.Notification,
+                context.Options,
                 ImmutableArray.Create(_primaryConstructorDeclaration.GetLocation()),
                 properties));
 

--- a/src/Analyzers/CSharp/Analyzers/UseSimpleUsingStatement/UseSimpleUsingStatementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseSimpleUsingStatement/UseSimpleUsingStatementDiagnosticAnalyzer.cs
@@ -121,6 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
                 Descriptor,
                 outermostUsing.UsingKeyword.GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(outermostUsing.GetLocation()),
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/UseTupleSwap/CSharpUseTupleSwapDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseTupleSwap/CSharpUseTupleSwapDiagnosticAnalyzer.cs
@@ -121,6 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseTupleSwap
                 Descriptor,
                 localDeclarationStatement.GetFirstToken().GetLocation(),
                 styleOption.Notification,
+                syntaxContext.Options,
                 additionalLocations,
                 properties: null));
         }

--- a/src/Analyzers/CSharp/Analyzers/UseUtf8StringLiteral/UseUtf8StringLiteralDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseUtf8StringLiteral/UseUtf8StringLiteralDiagnosticAnalyzer.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
             var properties = ImmutableDictionary<string, string?>.Empty.Add(nameof(ArrayCreationOperationLocation), operationLocation.ToString());
 
             context.ReportDiagnostic(
-                DiagnosticHelper.Create(Descriptor, location, notificationOption, additionalLocations, properties));
+                DiagnosticHelper.Create(Descriptor, location, notificationOption, context.Options, additionalLocations, properties));
         }
 
         internal static bool TryConvertToUtf8String(StringBuilder? builder, ImmutableArray<IOperation> arrayCreationElements)

--- a/src/Analyzers/CSharp/Tests/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -1041,5 +1041,89 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
                 }
                 """, OutputKind.ConsoleApplication);
         }
+
+        [Theory]
+        [InlineData(8.0)]
+        [InlineData(9.0)]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72094")]
+        public async Task TestWithConflictingSeverityConfigurationEntries(double analysisLevel)
+        {
+            var expectFix = analysisLevel >= 9.0;
+
+            string testCode, fixedCode;
+            if (expectFix)
+            {
+                testCode =
+                    """
+                    class C
+                    {
+                        int i;
+                
+                        void M()
+                        {
+                            var c = [|new|] C();
+                            c.i = 1;
+                        }
+                    }
+                    """;
+
+                fixedCode =
+                    """
+                    class C
+                    {
+                        int i;
+                
+                        void M()
+                        {
+                            var c = new C
+                            {
+                                i = 1
+                            };
+                        }
+                    }
+                    """;
+            }
+            else
+            {
+                testCode =
+                    """
+                    class C
+                    {
+                        int i;
+                
+                        void M()
+                        {
+                            var c = new C();
+                            c.i = 1;
+                        }
+                    }
+                    """;
+                fixedCode = testCode;
+            }
+
+            var globalConfig =
+                $"""
+                is_global = true
+
+                dotnet_style_object_initializer = true:suggestion
+                dotnet_diagnostic.IDE0017.severity = none
+
+                build_property.EffectiveAnalysisLevelStyle = {analysisLevel}
+                """;
+
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { testCode },
+                    AnalyzerConfigFiles =
+                    {
+                        ("/.globalconfig", globalConfig),
+                    }
+                },
+                FixedState = { Sources = { fixedCode } },
+                LanguageVersion = LanguageVersion.CSharp12,
+            }.RunAsync();
+        }
     }
 }

--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer_Core.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer_Core.cs
@@ -88,14 +88,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         protected abstract void InitializeWorker(AnalysisContext context);
 
         protected static bool IsAnalysisLevelGreaterThanOrEquals(int minAnalysisLevel, AnalyzerOptions analyzerOptions)
-        {
-            // See https://github.com/dotnet/roslyn/pull/70794 for details.
-            const string AnalysisLevelKey = "build_property.EffectiveAnalysisLevelStyle";
-
-            return analyzerOptions.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue(AnalysisLevelKey, out var value)
-                && double.TryParse(value, out var version)
-                && version >= minAnalysisLevel;
-        }
+            => analyzerOptions.AnalyzerConfigOptionsProvider.GlobalOptions.IsAnalysisLevelGreaterThanOrEquals(minAnalysisLevel);
 
         protected bool ShouldSkipAnalysis(SemanticModelAnalysisContext context, NotificationOption2? notification)
             => ShouldSkipAnalysis(context.FilterTree, context.Options, context.SemanticModel.Compilation.Options, notification, context.CancellationToken);

--- a/src/Analyzers/Core/Analyzers/AddRequiredParentheses/AbstractAddRequiredParenthesesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AddRequiredParentheses/AbstractAddRequiredParenthesesDiagnosticAnalyzer.cs
@@ -147,6 +147,7 @@ namespace Microsoft.CodeAnalysis.AddRequiredParentheses
                     Descriptor,
                     operatorToken.GetLocation(),
                     notificationOption,
+                    context.Options,
                     additionalLocations,
                     properties));
 

--- a/src/Analyzers/Core/Analyzers/ForEachCast/AbstractForEachCastDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/ForEachCast/AbstractForEachCastDiagnosticAnalyzer.cs
@@ -146,6 +146,7 @@ namespace Microsoft.CodeAnalysis.ForEachCast
                 Descriptor,
                 node.GetFirstToken().GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: null,
                 properties: isFixable ? s_isFixableProperties : null,
                 node.GetFirstToken().ToString(),

--- a/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
         /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
         /// <param name="notificationOption">Notification option for the diagnostic.</param>
+        /// <param name="analyzerOptions">Analyzer options</param>
         /// <param name="additionalLocations">
         /// An optional set of additional locations related to the diagnostic.
         /// Typically, these are locations of other items referenced in the message.
@@ -40,6 +41,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticDescriptor descriptor,
             Location location,
             NotificationOption2 notificationOption,
+            AnalyzerOptions analyzerOptions,
             IEnumerable<Location>? additionalLocations,
             ImmutableDictionary<string, string?>? properties,
             params object[] messageArgs)
@@ -59,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 message = new LocalizableStringWithArguments(descriptor.MessageFormat, messageArgs);
             }
 
-            return CreateWithMessage(descriptor, location, notificationOption, additionalLocations, properties, message);
+            return CreateWithMessage(descriptor, location, notificationOption, analyzerOptions, additionalLocations, properties, message);
         }
 
         /// <summary>
@@ -68,6 +70,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
         /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
         /// <param name="notificationOption">Notification option of the diagnostic.</param>
+        /// <param name="analyzerOptions">Analyzer options.</param>
         /// <param name="additionalLocations">
         /// An optional set of additional locations related to the diagnostic.
         /// Typically, these are locations of other items referenced in the message.
@@ -85,13 +88,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticDescriptor descriptor,
             Location location,
             NotificationOption2 notificationOption,
+            AnalyzerOptions analyzerOptions,
             ImmutableArray<Location> additionalLocations,
             ImmutableArray<Location> additionalUnnecessaryLocations,
             params object[] messageArgs)
         {
             if (additionalUnnecessaryLocations.IsEmpty)
             {
-                return Create(descriptor, location, notificationOption, additionalLocations, ImmutableDictionary<string, string?>.Empty, messageArgs);
+                return Create(descriptor, location, notificationOption, analyzerOptions, additionalLocations, ImmutableDictionary<string, string?>.Empty, messageArgs);
             }
 
             var tagIndices = ImmutableDictionary<string, IEnumerable<int>>.Empty
@@ -100,6 +104,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 descriptor,
                 location,
                 notificationOption,
+                analyzerOptions,
                 additionalLocations.AddRange(additionalUnnecessaryLocations),
                 tagIndices,
                 ImmutableDictionary<string, string?>.Empty,
@@ -112,6 +117,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
         /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
         /// <param name="notificationOption">Notification option for the diagnostic.</param>
+        /// <param name="analyzerOptions">Analyzer options.</param>
         /// <param name="additionalLocations">
         /// An optional set of additional locations related to the diagnostic.
         /// Typically, these are locations of other items referenced in the message.
@@ -133,6 +139,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticDescriptor descriptor,
             Location location,
             NotificationOption2 notificationOption,
+            AnalyzerOptions analyzerOptions,
             ImmutableArray<Location> additionalLocations,
             ImmutableArray<Location> additionalUnnecessaryLocations,
             ImmutableDictionary<string, string?>? properties,
@@ -140,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             if (additionalUnnecessaryLocations.IsEmpty)
             {
-                return Create(descriptor, location, notificationOption, additionalLocations, properties, messageArgs);
+                return Create(descriptor, location, notificationOption, analyzerOptions, additionalLocations, properties, messageArgs);
             }
 
             var tagIndices = ImmutableDictionary<string, IEnumerable<int>>.Empty
@@ -149,6 +156,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 descriptor,
                 location,
                 notificationOption,
+                analyzerOptions,
                 additionalLocations.AddRange(additionalUnnecessaryLocations),
                 tagIndices,
                 properties,
@@ -179,6 +187,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticDescriptor descriptor,
             Location location,
             NotificationOption2 notificationOption,
+            AnalyzerOptions analyzerOptions,
             IEnumerable<Location> additionalLocations,
             IDictionary<string, IEnumerable<int>> tagIndices,
             ImmutableDictionary<string, string?>? properties,
@@ -190,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             properties ??= ImmutableDictionary<string, string?>.Empty;
             properties = properties.AddRange(tagIndices.Select(kvp => new KeyValuePair<string, string?>(kvp.Key, EncodeIndices(kvp.Value, additionalLocations.Count()))));
 
-            return Create(descriptor, location, notificationOption, additionalLocations, properties, messageArgs);
+            return Create(descriptor, location, notificationOption, analyzerOptions, additionalLocations, properties, messageArgs);
 
             static string EncodeIndices(IEnumerable<int> indices, int additionalLocationsLength)
             {
@@ -213,6 +222,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
         /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
         /// <param name="notificationOption">Notification option for the diagnostic.</param>
+        /// <param name="analyzerOptions">Analyzer options.</param>
         /// <param name="additionalLocations">
         /// An optional set of additional locations related to the diagnostic.
         /// Typically, these are locations of other items referenced in the message.
@@ -229,6 +239,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticDescriptor descriptor,
             Location location,
             NotificationOption2 notificationOption,
+            AnalyzerOptions analyzerOptions,
             IEnumerable<Location>? additionalLocations,
             ImmutableDictionary<string, string?>? properties,
             LocalizableString message)
@@ -253,11 +264,24 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 descriptor.HelpLinkUri,
                 location,
                 additionalLocations,
-                GetEffectiveCustomTags(descriptor, notificationOption),
+                GetEffectiveCustomTags(descriptor, notificationOption, analyzerOptions),
                 properties);
 
-            static IEnumerable<string> GetEffectiveCustomTags(DiagnosticDescriptor descriptor, NotificationOption2 notificationOption)
+            static IEnumerable<string> GetEffectiveCustomTags(DiagnosticDescriptor descriptor, NotificationOption2 notificationOption, AnalyzerOptions analyzerOptions)
             {
+                // 'CustomSeverityConfigurable' is only enabled when AnalysisLevel >= 9.
+                var skipCustomConfiguration = !analyzerOptions.AnalyzerConfigOptionsProvider.GlobalOptions.IsAnalysisLevelGreaterThanOrEquals(9);
+                if (skipCustomConfiguration)
+                {
+                    foreach (var customTag in descriptor.CustomTags)
+                    {
+                        if (customTag != WellKnownDiagnosticTags.CustomSeverityConfigurable)
+                            yield return customTag;
+                    }
+
+                    yield break;
+                }
+
                 var isCustomConfigured = notificationOption.IsExplicitlySpecified;
                 var hasCustomConfigurableTag = false;
                 foreach (var customTag in descriptor.CustomTags)

--- a/src/Analyzers/Core/Analyzers/MakeFieldReadonly/AbstractMakeFieldReadonlyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/MakeFieldReadonly/AbstractMakeFieldReadonlyDiagnosticAnalyzer.cs
@@ -128,6 +128,7 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
                                     Descriptor,
                                     location,
                                     option.Notification,
+                                    context.Options,
                                     additionalLocations: null,
                                     properties: null);
                                 symbolEndContext.ReportDiagnostic(diagnostic);

--- a/src/Analyzers/Core/Analyzers/NamingStyle/NamingStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/NamingStyle/NamingStyleDiagnosticAnalyzerBase.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             builder["OptionName"] = nameof(NamingStyleOptions.NamingPreferences);
             builder["OptionLanguage"] = compilation.Language;
 
-            return DiagnosticHelper.Create(Descriptor, symbol.Locations.First(), NotificationOption2.ForSeverity(applicableRule.EnforcementLevel), additionalLocations: null, builder.ToImmutable(), failureReason);
+            return DiagnosticHelper.Create(Descriptor, symbol.Locations.First(), NotificationOption2.ForSeverity(applicableRule.EnforcementLevel), options, additionalLocations: null, builder.ToImmutable(), failureReason);
         }
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()

--- a/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
@@ -107,6 +107,7 @@ namespace Microsoft.CodeAnalysis.NewLines.ConsecutiveStatementPlacement
                 this.Descriptor,
                 GetDiagnosticLocation(block),
                 notificationOption,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(nextToken.GetLocation()),
                 properties: null));
         }

--- a/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
@@ -78,6 +78,7 @@ namespace Microsoft.CodeAnalysis.NewLines.MultipleBlankLines
                 this.Descriptor,
                 Location.Create(badTrivia.SyntaxTree!, new TextSpan(badTrivia.SpanStart, 0)),
                 notificationOption,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(token.GetLocation()),
                 properties: null));
         }

--- a/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
                     // If the Severity is not hidden, then just put the user visible portion on the
                     // first token.  That way we don't 
                     context.ReportDiagnostic(
-                        DiagnosticHelper.Create(Descriptor, modifiers.First().GetLocation(), notificationOption, additionalLocations: null, properties: null));
+                        DiagnosticHelper.Create(Descriptor, modifiers.First().GetLocation(), notificationOption, context.Options, additionalLocations: null, properties: null));
                 }
             }
         }

--- a/src/Analyzers/Core/Analyzers/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -141,6 +141,7 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                     Descriptor,
                     GetLocation(operation),
                     optionValue.Notification,
+                    context.Options,
                     additionalLocations: null,
                     properties: null));
             }

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessaryParentheses/AbstractRemoveUnnecessaryParenthesesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessaryParentheses/AbstractRemoveUnnecessaryParenthesesDiagnosticAnalyzer.cs
@@ -114,6 +114,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryParentheses
                 Descriptor,
                 AbstractRemoveUnnecessaryParenthesesDiagnosticAnalyzer<TLanguageKindEnum, TParenthesizedExpressionSyntax>.GetDiagnosticSquiggleLocation(parenthesizedExpression, cancellationToken),
                 preference.Notification,
+                context.Options,
                 additionalLocations,
                 additionalUnnecessaryLocations));
         }

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -515,6 +515,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                             rule,
                             GetDiagnosticLocation(member),
                             NotificationOption2.ForSeverity(rule.DefaultSeverity),
+                            symbolEndContext.Options,
                             additionalLocations: null,
                             properties: null,
                             GetMessage(rule, member));

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -215,6 +215,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     var diagnostic = DiagnosticHelper.Create(s_expressionValueIsUnusedRule,
                                                              value.Syntax.GetLocation(),
                                                              _options.UnusedValueExpressionStatementNotification,
+                                                             context.Options,
                                                              additionalLocations: null,
                                                              properties);
                     context.ReportDiagnostic(diagnostic);
@@ -570,6 +571,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                                 var diagnostic = DiagnosticHelper.Create(s_valueAssignedIsUnusedRule,
                                                                          _symbolStartAnalyzer._compilationAnalyzer.GetDefinitionLocationToFade(unreadWriteOperation),
                                                                          _options.UnusedValueAssignmentSeverity,
+                                                                         context.Options,
                                                                          additionalLocations: null,
                                                                          properties,
                                                                          symbol.Name);

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     isLocalFunctionParameter: parameter.ContainingSymbol.IsLocalFunction());
 
                 var diagnostic = DiagnosticHelper.CreateWithMessage(s_unusedParameterRule, location,
-                    option.Notification, additionalLocations: null, properties: null, message);
+                    option.Notification, analyzerOptions, additionalLocations: null, properties: null, message);
                 reportDiagnostic(diagnostic);
             }
 

--- a/src/Analyzers/Core/Analyzers/SimplifyBooleanExpression/AbstractSimplifyConditionalDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyBooleanExpression/AbstractSimplifyConditionalDiagnosticAnalyzer.cs
@@ -141,6 +141,7 @@ namespace Microsoft.CodeAnalysis.SimplifyBooleanExpression
                     Descriptor,
                     conditionalExpression.GetLocation(),
                     styleOption.Notification,
+                    context.Options,
                     additionalLocations: null,
                     properties));
 

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/AbstractSimplifyInterpolationDiagnosticAnalyzer.cs
@@ -67,6 +67,7 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
                 Descriptor,
                 firstUnnecessaryLocation,
                 option.Notification,
+                context.Options,
                 additionalLocations: [interpolation.Syntax.GetLocation()],
                 additionalUnnecessaryLocations: remainingUnnecessaryLocations));
         }

--- a/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
         protected abstract ImmutableArray<Diagnostic> AnalyzeCodeBlock(CodeBlockAnalysisContext context, SyntaxNode root);
         protected abstract ImmutableArray<Diagnostic> AnalyzeSemanticModel(SemanticModelAnalysisContext context, SyntaxNode root, TextSpanIntervalTree? codeBlockIntervalTree);
 
-        public bool TrySimplify(SemanticModel model, SyntaxNode node, [NotNullWhen(true)] out Diagnostic? diagnostic, TSimplifierOptions options, CancellationToken cancellationToken)
+        public bool TrySimplify(SemanticModel model, SyntaxNode node, [NotNullWhen(true)] out Diagnostic? diagnostic, TSimplifierOptions options, AnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
         {
             if (!CanSimplifyTypeNameExpression(
                     model, node, options,
@@ -139,11 +139,11 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
                 return false;
             }
 
-            diagnostic = CreateDiagnostic(model, options, issueSpan, diagnosticId, inDeclaration);
+            diagnostic = CreateDiagnostic(model, options, analyzerOptions, issueSpan, diagnosticId, inDeclaration);
             return true;
         }
 
-        internal static Diagnostic CreateDiagnostic(SemanticModel model, TSimplifierOptions options, TextSpan issueSpan, string diagnosticId, bool inDeclaration)
+        internal static Diagnostic CreateDiagnostic(SemanticModel model, TSimplifierOptions options, AnalyzerOptions analyzerOptions, TextSpan issueSpan, string diagnosticId, bool inDeclaration)
         {
             DiagnosticDescriptor descriptor;
             NotificationOption2 notificationOption;
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
             var builder = ImmutableDictionary.CreateBuilder<string, string?>();
             builder["OptionName"] = nameof(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess); // TODO: need the actual one
             builder["OptionLanguage"] = model.Language;
-            var diagnostic = DiagnosticHelper.Create(descriptor, tree.GetLocation(issueSpan), notificationOption, additionalLocations: null, builder.ToImmutable());
+            var diagnostic = DiagnosticHelper.Create(descriptor, tree.GetLocation(issueSpan), notificationOption, analyzerOptions, additionalLocations: null, builder.ToImmutable());
 
 #if LOG
             var sourceText = tree.GetText();

--- a/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -402,6 +402,7 @@ internal abstract class AbstractUseAutoPropertyAnalyzer<
             Descriptor,
             fieldNode.GetLocation(),
             result.Notification,
+            context.Options,
             additionalLocations: additionalLocations,
             properties: null);
 

--- a/src/Analyzers/Core/Analyzers/UseCoalesceExpression/AbstractUseCoalesceExpressionForIfNullCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCoalesceExpression/AbstractUseCoalesceExpressionForIfNullCheckDiagnosticAnalyzer.cs
@@ -119,6 +119,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.UseCoalesceExpression
                 Descriptor,
                 ifStatement.GetFirstToken().GetLocation(),
                 option.Notification,
+                context.Options,
                 ImmutableArray.Create(
                     expressionToCoalesce.GetLocation(),
                     ifStatement.GetLocation(),

--- a/src/Analyzers/Core/Analyzers/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableTernaryConditionalCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableTernaryConditionalCheckDiagnosticAnalyzer.cs
@@ -125,6 +125,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
                 Descriptor,
                 conditionalExpression.GetLocation(),
                 option.Notification,
+                context.Options,
                 locations,
                 properties: null));
         }

--- a/src/Analyzers/Core/Analyzers/UseCoalesceExpression/AbstractUseCoalesceExpressionForTernaryConditionalCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCoalesceExpression/AbstractUseCoalesceExpressionForTernaryConditionalCheckDiagnosticAnalyzer.cs
@@ -129,6 +129,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
                 Descriptor,
                 conditionalExpression.GetLocation(),
                 option.Notification,
+                context.Options,
                 locations,
                 properties: null));
         }

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -197,6 +197,7 @@ internal abstract partial class AbstractUseCollectionInitializerDiagnosticAnalyz
             s_descriptor,
             objectCreationExpression.GetFirstToken().GetLocation(),
             notification,
+            context.Options,
             additionalLocations: locations,
             properties));
 
@@ -266,6 +267,7 @@ internal abstract partial class AbstractUseCollectionInitializerDiagnosticAnalyz
                 s_unnecessaryCodeDescriptor,
                 additionalUnnecessaryLocations[0],
                 NotificationOption2.ForSeverity(s_unnecessaryCodeDescriptor.DefaultSeverity),
+                context.Options,
                 additionalLocations: locations,
                 additionalUnnecessaryLocations: additionalUnnecessaryLocations,
                 properties));

--- a/src/Analyzers/Core/Analyzers/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
@@ -159,7 +159,8 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
                             _incrementDescriptor,
                             assignmentToken.GetLocation(),
                             option.Notification,
-                            additionalLocations: ImmutableArray.Create(assignment.GetLocation()),
+                            context.Options,
+                additionalLocations: ImmutableArray.Create(assignment.GetLocation()),
                             properties: ImmutableDictionary.Create<string, string?>()
                                 .Add(UseCompoundAssignmentUtilities.Increment, UseCompoundAssignmentUtilities.Increment)));
                         return;
@@ -178,6 +179,7 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
                             _decrementDescriptor,
                             assignmentToken.GetLocation(),
                             option.Notification,
+                            context.Options,
                             additionalLocations: ImmutableArray.Create(assignment.GetLocation()),
                             properties: ImmutableDictionary.Create<string, string?>()
                                 .Add(UseCompoundAssignmentUtilities.Decrement, UseCompoundAssignmentUtilities.Decrement)));
@@ -190,6 +192,7 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
                 Descriptor,
                 assignmentToken.GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(assignment.GetLocation()),
                 properties: null));
         }

--- a/src/Analyzers/Core/Analyzers/UseConditionalExpression/AbstractUseConditionalExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseConditionalExpression/AbstractUseConditionalExpressionDiagnosticAnalyzer.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
                 Descriptor,
                 ifStatement.GetFirstToken().GetLocation(),
                 option.Notification,
+                context.Options,
                 additionalLocations: ImmutableArray.Create(ifStatement.GetLocation()),
                 properties: canSimplify ? UseConditionalExpressionHelpers.CanSimplifyProperties : null));
         }

--- a/src/Analyzers/Core/Analyzers/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.UseExplicitTupleName
                                 Descriptor,
                                 nameNode.GetLocation(),
                                 option.Notification,
+                                context.Options,
                                 additionalLocations: null,
                                 properties));
                         }

--- a/src/Analyzers/Core/Analyzers/UseIsNullCheck/AbstractUseIsNullForReferenceEqualsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseIsNullCheck/AbstractUseIsNullForReferenceEqualsDiagnosticAnalyzer.cs
@@ -141,6 +141,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                 DiagnosticHelper.Create(
                     Descriptor, nameNode.GetLocation(),
                     option.Notification,
+                    context.Options,
                     additionalLocations, properties));
         }
 

--- a/src/Analyzers/Core/Analyzers/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
@@ -188,6 +188,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
                 Descriptor,
                 conditionalExpression.GetLocation(),
                 option.Notification,
+                context.Options,
                 locations,
                 properties));
         }

--- a/src/Analyzers/Core/Analyzers/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer_IfStatement.cs
+++ b/src/Analyzers/Core/Analyzers/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer_IfStatement.cs
@@ -95,6 +95,7 @@ internal abstract partial class AbstractUseNullPropagationDiagnosticAnalyzer<
             Descriptor,
             ifStatement.GetFirstToken().GetLocation(),
             option.Notification,
+            context.Options,
             ImmutableArray.Create(
                 ifStatement.GetLocation(),
                 trueStatement.GetLocation(),

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -134,6 +134,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 s_descriptor,
                 objectCreationExpression.GetFirstToken().GetLocation(),
                 option.Notification,
+                context.Options,
                 locations,
                 properties: null));
 
@@ -164,6 +165,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                         s_unnecessaryCodeDescriptor,
                         location1,
                         NotificationOption2.ForSeverity(s_unnecessaryCodeDescriptor.DefaultSeverity),
+                        context.Options,
                         additionalLocations: locations,
                         additionalUnnecessaryLocations: [syntaxTree.GetLocation(TextSpan.FromBounds(match.Initializer.FullSpan.End, match.Statement.Span.End))]));
                 }

--- a/src/Analyzers/Core/Analyzers/UseSystemHashCode/UseSystemHashCodeDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseSystemHashCode/UseSystemHashCodeDiagnosticAnalyzer.cs
@@ -80,6 +80,7 @@ namespace Microsoft.CodeAnalysis.UseSystemHashCode
                 Descriptor,
                 diagnosticLocation,
                 option.Notification,
+                context.Options,
                 [operationLocation, declarationLocation],
                 ImmutableDictionary<string, string?>.Empty));
         }

--- a/src/Analyzers/Core/Analyzers/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                 expressionStatement.Syntax.GetLocation());
 
             context.ReportDiagnostic(
-                DiagnosticHelper.Create(Descriptor, throwStatementSyntax.GetLocation(), option.Notification, additionalLocations: allLocations, properties: null));
+                DiagnosticHelper.Create(Descriptor, throwStatementSyntax.GetLocation(), option.Notification, context.Options, additionalLocations: allLocations, properties: null));
         }
 
         private static bool ValueIsAccessed(SemanticModel semanticModel, IConditionalOperation ifOperation, IBlockOperation containingBlock, ISymbol localOrParameter, IExpressionStatementOperation expressionStatement, IAssignmentOperation assignmentExpression)

--- a/src/Analyzers/VisualBasic/Analyzers/AddAccessibilityModifiers/VisualBasicAddAccessibilityModifiersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/AddAccessibilityModifiers/VisualBasicAddAccessibilityModifiersDiagnosticAnalyzer.vb
@@ -67,6 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddAccessibilityModifiers
                 Descriptor,
                 name.GetLocation(),
                 [option].Notification,
+                context.Options,
                 additionalLocations:=additionalLocations,
                 If(modifiersAdded, ModifiersAddedProperties, Nothing)))
         End Sub

--- a/src/Analyzers/VisualBasic/Analyzers/SimplifyObjectCreation/VisualBasicSimplifyObjectCreationDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/SimplifyObjectCreation/VisualBasicSimplifyObjectCreationDiagnosticAnalyzer.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SimplifyObjectCreation
             Dim symbolInfo = context.SemanticModel.GetTypeInfo(objectCreation, cancellationToken)
             If symbolInfo.Type IsNot Nothing AndAlso symbolInfo.Type.Equals(symbolInfo.ConvertedType, SymbolEqualityComparer.Default) Then
                 context.ReportDiagnostic(DiagnosticHelper.Create(Descriptor, variableDeclarator.GetLocation(), styleOption.Notification,
-                    additionalLocations:=Nothing,
+                    context.Options, additionalLocations:=Nothing,
                     properties:=Nothing))
             End If
         End Sub

--- a/src/Analyzers/VisualBasic/Analyzers/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -57,6 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
                     Descriptor,
                     nameColonEquals.GetLocation(),
                     preference.Notification,
+                    context.Options,
                     additionalLocations:=ImmutableArray(Of Location).Empty,
                     additionalUnnecessaryLocations:=ImmutableArray.Create(syntaxTree.GetLocation(fadeSpan))))
         End Sub
@@ -80,6 +81,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
                     Descriptor,
                     syntaxTree.GetLocation(fadeSpan),
                     preference.Notification,
+                    context.Options,
                     additionalLocations:=ImmutableArray(Of Location).Empty,
                     additionalUnnecessaryLocations:=ImmutableArray.Create(syntaxTree.GetLocation(fadeSpan))))
         End Sub

--- a/src/Analyzers/VisualBasic/Analyzers/UseIsNotExpression/VisualBasicUseIsNotDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseIsNotExpression/VisualBasicUseIsNotDiagnosticAnalyzer.vb
@@ -72,6 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseIsNotExpression
                 Descriptor,
                 isKeyword.GetLocation(),
                 styleOption.Notification,
+                syntaxContext.Options,
                 ImmutableArray.Create(notExpression.GetLocation()),
                 properties:=Nothing))
         End Sub

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticsClassificationTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticsClassificationTaggerProviderTests.cs
@@ -101,6 +101,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                         c.ReportDiagnostic(DiagnosticHelper.Create(
                             _rule, primaryLocation,
                             NotificationOption2.Error,
+                            c.Options,
                             additionalLocations: null,
                             properties: null));
                     }
@@ -114,6 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                         c.ReportDiagnostic(DiagnosticHelper.CreateWithLocationTags(
                             _rule, primaryLocation,
                             NotificationOption2.Error,
+                            c.Options,
                             additionalLocations,
                             additionalUnnecessaryLocations));
                     }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
             if (ShouldSkipAnalysis(context.FilterTree, context.Options, context.SemanticModel.Compilation.Options, GetAllNotifications(options), cancellationToken))
                 return [];
 
-            using var simplifier = new TypeSyntaxSimplifierWalker(this, semanticModel, options, ignoredSpans: null, cancellationToken);
+            using var simplifier = new TypeSyntaxSimplifierWalker(this, semanticModel, options, context.Options, ignoredSpans: null, cancellationToken);
             simplifier.Visit(root);
             return simplifier.Diagnostics;
         }
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
             if (ShouldSkipAnalysis(context.FilterTree, context.Options, context.SemanticModel.Compilation.Options, GetAllNotifications(options), context.CancellationToken))
                 return [];
 
-            var simplifier = new TypeSyntaxSimplifierWalker(this, context.SemanticModel, options, ignoredSpans: codeBlockIntervalTree, context.CancellationToken);
+            var simplifier = new TypeSyntaxSimplifierWalker(this, context.SemanticModel, options, context.Options, ignoredSpans: codeBlockIntervalTree, context.CancellationToken);
             simplifier.Visit(root);
             return simplifier.Diagnostics;
         }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Simplification;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
@@ -44,6 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
         private readonly CSharpSimplifyTypeNamesDiagnosticAnalyzer _analyzer;
         private readonly SemanticModel _semanticModel;
         private readonly CSharpSimplifierOptions _options;
+        private readonly AnalyzerOptions _analyzerOptions;
         private readonly TextSpanIntervalTree? _ignoredSpans;
         private readonly CancellationToken _cancellationToken;
 
@@ -72,12 +74,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
             }
         }
 
-        public TypeSyntaxSimplifierWalker(CSharpSimplifyTypeNamesDiagnosticAnalyzer analyzer, SemanticModel semanticModel, CSharpSimplifierOptions options, TextSpanIntervalTree? ignoredSpans, CancellationToken cancellationToken)
+        public TypeSyntaxSimplifierWalker(CSharpSimplifyTypeNamesDiagnosticAnalyzer analyzer, SemanticModel semanticModel, CSharpSimplifierOptions options, AnalyzerOptions analyzerOptions, TextSpanIntervalTree? ignoredSpans, CancellationToken cancellationToken)
             : base(SyntaxWalkerDepth.StructuredTrivia)
         {
             _analyzer = analyzer;
             _semanticModel = semanticModel;
             _options = options;
+            _analyzerOptions = analyzerOptions;
             _ignoredSpans = ignoredSpans;
             _cancellationToken = cancellationToken;
 
@@ -287,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
         /// </summary>
         private bool TrySimplify(SyntaxNode node)
         {
-            if (!_analyzer.TrySimplify(_semanticModel, node, out var diagnostic, _options, _cancellationToken))
+            if (!_analyzer.TrySimplify(_semanticModel, node, out var diagnostic, _options, _analyzerOptions, _cancellationToken))
                 return false;
 
             DiagnosticsBuilder.Add(diagnostic);

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -101,6 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 DiagnosticHelper.Create(
                     Descriptor, isExpression.GetLocation(),
                     styleOption.Notification,
+                    context.Options,
                     SpecializedCollections.EmptyCollection<Location>(),
                     ImmutableDictionary<string, string?>.Empty));
         }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
@@ -96,6 +96,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
                             this.Descriptor,
                             token.GetLocation(),
                             NotificationOption2.Silent,
+                            context.Options,
                             additionalLocations: null,
                             properties));
                     }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDiagnosticAnalyzer.cs
@@ -81,6 +81,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
                                     this.Descriptor,
                                     Location.Create(context.SemanticModel.SyntaxTree, diag.Span),
                                     NotificationOption2.Warning,
+                                    context.Options,
                                     additionalLocations: null,
                                     properties: null,
                                     diag.Message));

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
                             Descriptor,
                             Location.Create(context.SemanticModel.SyntaxTree, diag.Span),
                             NotificationOption2.Warning,
+                            context.Options,
                             additionalLocations: null,
                             properties: null,
                             diag.Message));

--- a/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.PreferFrameworkType
             {
                 context.ReportDiagnostic(DiagnosticHelper.Create(
                     Descriptor, typeNode.GetLocation(),
-                    optionValue.Notification, additionalLocations: null,
+                    optionValue.Notification, context.Options, additionalLocations: null,
                     PreferFrameworkTypeConstants.Properties));
             }
 

--- a/src/Features/Core/Portable/SimplifyThisOrMe/AbstractSimplifyThisOrMeDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/SimplifyThisOrMe/AbstractSimplifyThisOrMeDiagnosticAnalyzer.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis.SimplifyThisOrMe
 
             context.ReportDiagnostic(DiagnosticHelper.Create(
                 Descriptor, thisExpression.GetLocation(), notification,
+                context.Options,
                 ImmutableArray.Create(memberAccessExpression.GetLocation()),
                 builder.ToImmutable()));
         }

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
@@ -4,6 +4,7 @@
 
 Imports System.Collections.Immutable
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Shared.Collections
 Imports Microsoft.CodeAnalysis.Text
@@ -38,6 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         Private ReadOnly _analyzer As VisualBasicSimplifyTypeNamesDiagnosticAnalyzer
         Private ReadOnly _semanticModel As SemanticModel
         Private ReadOnly _options As VisualBasicSimplifierOptions
+        Private ReadOnly _analyzerOptions As AnalyzerOptions
         Private ReadOnly _ignoredSpans As TextSpanIntervalTree
         Private ReadOnly _cancellationToken As CancellationToken
 
@@ -67,12 +69,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             End Get
         End Property
 
-        Public Sub New(analyzer As VisualBasicSimplifyTypeNamesDiagnosticAnalyzer, semanticModel As SemanticModel, options As VisualBasicSimplifierOptions, ignoredSpans As TextSpanIntervalTree, cancellationToken As CancellationToken)
+        Public Sub New(analyzer As VisualBasicSimplifyTypeNamesDiagnosticAnalyzer, semanticModel As SemanticModel, options As VisualBasicSimplifierOptions, analyzerOptions As AnalyzerOptions, ignoredSpans As TextSpanIntervalTree, cancellationToken As CancellationToken)
             MyBase.New(SyntaxWalkerDepth.StructuredTrivia)
 
             _analyzer = analyzer
             _semanticModel = semanticModel
             _options = options
+            _analyzerOptions = analyzerOptions
             _ignoredSpans = ignoredSpans
             _cancellationToken = cancellationToken
 
@@ -185,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
 
         Private Function TrySimplify(node As SyntaxNode) As Boolean
             Dim diagnostic As Diagnostic = Nothing
-            If Not _analyzer.TrySimplify(_semanticModel, node, diagnostic, _options, _cancellationToken) Then
+            If Not _analyzer.TrySimplify(_semanticModel, node, diagnostic, _options, _analyzerOptions, _cancellationToken) Then
                 Return False
             End If
 

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
                 Return ImmutableArray(Of Diagnostic).Empty
             End If
 
-            Dim simplifier As New TypeSyntaxSimplifierWalker(Me, semanticModel, simplifierOptions, ignoredSpans:=Nothing, cancellationToken)
+            Dim simplifier As New TypeSyntaxSimplifierWalker(Me, semanticModel, simplifierOptions, context.Options, ignoredSpans:=Nothing, cancellationToken)
             simplifier.Visit(root)
             Return simplifier.Diagnostics
         End Function
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             End If
 
             Dim configOptions = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.SemanticModel.SyntaxTree)
-            Dim simplifier As New TypeSyntaxSimplifierWalker(Me, context.SemanticModel, simplifierOptions, ignoredSpans:=codeBlockIntervalTree, context.CancellationToken)
+            Dim simplifier As New TypeSyntaxSimplifierWalker(Me, context.SemanticModel, simplifierOptions, context.Options, ignoredSpans:=codeBlockIntervalTree, context.CancellationToken)
             simplifier.Visit(root)
             Return simplifier.Diagnostics
         End Function

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/AnalyzerConfigOptionsExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/AnalyzerConfigOptionsExtensions.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
@@ -54,6 +51,16 @@ namespace Microsoft.CodeAnalysis
 
             value = default!;
             return false;
+        }
+
+        public static bool IsAnalysisLevelGreaterThanOrEquals(this AnalyzerConfigOptions analyzerConfigOptions, int minAnalysisLevel)
+        {
+            // See https://github.com/dotnet/roslyn/pull/70794 for details.
+            const string AnalysisLevelKey = "build_property.EffectiveAnalysisLevelStyle";
+
+            return analyzerConfigOptions.TryGetValue(AnalysisLevelKey, out var value)
+                && double.TryParse(value, out var version)
+                && version >= minAnalysisLevel;
         }
     }
 }


### PR DESCRIPTION
Fixes #72094

Recently, as part of implementing support for #52991, we started respecting `option_name = option_value:severity` in build. As part of this change, if user has conflicting severity configurations from `option_name = option_value:severity` and `dotnet_diagnostic.IDExxxx.severity`, the former was given preference. We knew that this would likely break some customers, hence added functionality to guard this feature by enabling it only when AnalysisLevel was >= 9.0. However, that guard was only implemented for command line build path. This meant the feature was still being enabled by default in the IDE live analysis, which was unintentional. We now ensure that we respect the AnalysisLevel value even for this path and filter out CustomSeverityConfigurable custom tag for AnalysisLevel less than 9.

**NOTE:** Even though this PR touches almost all the IDE analyzer files, the fix is only limited to one change, rest all are cascaded changes. I'll add a comment on the PR to point out this fix.

**SDK bug**
As part of this change, I also identified a bug in the SDK targets: https://github.com/dotnet/sdk/blob/3075c3bc8d8aa4e0ffcf2945459ef2ee383e3ae0/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets#L117-L120 We shouldn't be conditioning the inclusion of CodeStyle targets file on `EnforceCodeStyleInBuild` as we want the target to execute even for live analysis for IDE analyzers shipping inside VS, not only when enabled on build. Fix to remove that condition is required to ensure we thread in AnalysisLevel property value to the analyzers for live analysis when `EnforceCodeStyleInBuild = false`. I have created https://github.com/dotnet/sdk/pull/38968 for fixing the SDK issue.