### PR TITLE
Make shadow copy logic a bit smarter

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,7 +49,7 @@
           "msbuild",
           "-p:RunAnalyzersDuringBuild=false",
           "-p:GenerateFullPaths=true",
-          "src/Compilers/CSharp/csc/csc.csproj"
+          "src/Compilers/CSharp/csc/AnyCpu/csc.csproj"
         ],
         "problemMatcher": "$msCompile",
         "group": "build"

--- a/src/Compilers/Core/Portable/AssemblyUtilities.cs
+++ b/src/Compilers/Core/Portable/AssemblyUtilities.cs
@@ -13,28 +13,8 @@ using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
-    internal static class AssemblyUtilities
+    internal static partial class AssemblyUtilities
     {
-        /// <summary>
-        /// Given a path to an assembly, returns its MVID (Module Version ID).
-        /// May throw.
-        /// </summary>
-        /// <exception cref="IOException">If the file at <paramref name="filePath"/> does not exist or cannot be accessed.</exception>
-        /// <exception cref="BadImageFormatException">If the file is not an assembly or is somehow corrupted.</exception>
-        public static Guid ReadMvid(string filePath)
-        {
-            RoslynDebug.Assert(PathUtilities.IsAbsolute(filePath));
-
-            using (var reader = new PEReader(FileUtilities.OpenRead(filePath)))
-            {
-                var metadataReader = reader.GetMetadataReader();
-                var mvidHandle = metadataReader.GetModuleDefinition().Mvid;
-                var fileMvid = metadataReader.GetGuid(mvidHandle);
-
-                return fileMvid;
-            }
-        }
-
         /// <summary>
         /// Given a path to an assembly, finds the paths to all of its satellite
         /// assemblies.

--- a/src/Compilers/Core/Portable/AssemblyUtilitiesCore.cs
+++ b/src/Compilers/Core/Portable/AssemblyUtilitiesCore.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis;
+
+namespace Roslyn.Utilities;
+
+/// <summary>
+/// This partial contains methods that must be shared by source with the workspaces layer
+/// </summary>
+internal static partial class AssemblyUtilities
+{
+    /// <summary>
+    /// Given a path to an assembly, returns its MVID (Module Version ID).
+    /// May throw.
+    /// </summary>
+    /// <exception cref="IOException">If the file at <paramref name="filePath"/> does not exist or cannot be accessed.</exception>
+    /// <exception cref="BadImageFormatException">If the file is not an assembly or is somehow corrupted.</exception>
+    public static Guid ReadMvid(string filePath)
+    {
+        RoslynDebug.Assert(PathUtilities.IsAbsolute(filePath));
+
+        using (var reader = new PEReader(FileUtilities.OpenRead(filePath)))
+        {
+            var metadataReader = reader.GetMetadataReader();
+            var mvidHandle = metadataReader.GetModuleDefinition().Mvid;
+            var fileMvid = metadataReader.GetGuid(mvidHandle);
+
+            return fileMvid;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis
 
         protected override string PreparePathToLoad(string originalAnalyzerPath, ImmutableHashSet<string> cultureNames)
         {
-            var mvid = ReadMvid(originalAnalyzerPath);
+            var mvid = AssemblyUtilities.ReadMvid(originalAnalyzerPath);
             if (_mvidPathMap.TryGetValue(mvid, out Task<string>? copyTask))
             {
                 return copyTask.Result;
@@ -233,20 +233,6 @@ namespace Microsoft.CodeAnalysis
             Directory.CreateDirectory(directory);
 
             return (directory, mutex);
-        }
-
-        private static Guid ReadMvid(string filePath)
-        {
-            RoslynDebug.Assert(PathUtilities.IsAbsolute(filePath));
-
-            using (var reader = new PEReader(FileUtilities.OpenRead(filePath)))
-            {
-                var metadataReader = reader.GetMetadataReader();
-                var mvidHandle = metadataReader.GetModuleDefinition().Mvid;
-                var fileMvid = metadataReader.GetGuid(mvidHandle);
-
-                return fileMvid;
-            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -10,6 +10,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Immutable;
+using Roslyn.Utilities;
+using System.Reflection.PortableExecutable;
+using System.Reflection.Metadata;
+
+
+
 
 #if NETCOREAPP
 using System.Runtime.Loader;
@@ -35,14 +41,11 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         private readonly Lazy<(string directory, Mutex)> _shadowCopyDirectoryAndMutex;
 
-        /// <summary>
-        /// Used to generate unique names for per-assembly directories. Should be updated with <see cref="Interlocked.Increment(ref int)"/>.
-        /// </summary>
-        private int _assemblyDirectoryId;
+        private readonly ConcurrentDictionary<Guid, Task<string>> _mvidPathMap = new ConcurrentDictionary<Guid, Task<string>>();
 
         internal string BaseDirectory => _baseDirectory;
 
-        internal int CopyCount => _assemblyDirectoryId;
+        internal int CopyCount => _mvidPathMap.Count;
 
 #if NETCOREAPP
         public ShadowCopyAnalyzerAssemblyLoader(string baseDirectory)
@@ -131,26 +134,50 @@ namespace Microsoft.CodeAnalysis
 
         protected override string PreparePathToLoad(string originalAnalyzerPath, ImmutableHashSet<string> cultureNames)
         {
-            var analyzerFileName = Path.GetFileName(originalAnalyzerPath);
-            var shadowDirectory = CreateUniqueDirectoryForAssembly();
-            var shadowAnalyzerPath = Path.Combine(shadowDirectory, analyzerFileName);
-            copyFile(originalAnalyzerPath, shadowAnalyzerPath);
-
-            if (cultureNames.IsEmpty)
+            var mvid = ReadMvid(originalAnalyzerPath);
+            if (_mvidPathMap.TryGetValue(mvid, out Task<string>? copyTask))
             {
+                return copyTask.Result;
+            }
+
+            var tcs = new TaskCompletionSource<string>();
+            var task = _mvidPathMap.GetOrAdd(mvid, tcs.Task);
+            if (object.ReferenceEquals(task, tcs.Task))
+            {
+                // This thread won and we need to do the copy.
+                var shadowAnalyzerPath = copyAnalyzerContents();
+                tcs.SetResult(shadowAnalyzerPath);
                 return shadowAnalyzerPath;
             }
-
-            var originalDirectory = Path.GetDirectoryName(originalAnalyzerPath)!;
-            var satelliteFileName = GetSatelliteFileName(analyzerFileName);
-            foreach (var cultureName in cultureNames)
+            else
             {
-                var originalSatellitePath = Path.Combine(originalDirectory, cultureName, satelliteFileName);
-                var shadowSatellitePath = Path.Combine(shadowDirectory, cultureName, satelliteFileName);
-                copyFile(originalSatellitePath, shadowSatellitePath);
+                // This thread lost and we need to wait for the winner to finish the copy.
+                return task.Result;
             }
 
-            return shadowAnalyzerPath;
+            string copyAnalyzerContents()
+            {
+                var analyzerFileName = Path.GetFileName(originalAnalyzerPath);
+                var shadowDirectory = Path.Combine(_shadowCopyDirectoryAndMutex.Value.directory, mvid.ToString());
+                var shadowAnalyzerPath = Path.Combine(shadowDirectory, analyzerFileName);
+                copyFile(originalAnalyzerPath, shadowAnalyzerPath);
+
+                if (cultureNames.IsEmpty)
+                {
+                    return shadowAnalyzerPath;
+                }
+
+                var originalDirectory = Path.GetDirectoryName(originalAnalyzerPath)!;
+                var satelliteFileName = GetSatelliteFileName(analyzerFileName);
+                foreach (var cultureName in cultureNames)
+                {
+                    var originalSatellitePath = Path.Combine(originalDirectory, cultureName, satelliteFileName);
+                    var shadowSatellitePath = Path.Combine(shadowDirectory, cultureName, satelliteFileName);
+                    copyFile(originalSatellitePath, shadowSatellitePath);
+                }
+
+                return shadowAnalyzerPath;
+            }
 
             static void copyFile(string originalPath, string shadowCopyPath)
             {
@@ -191,16 +218,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private string CreateUniqueDirectoryForAssembly()
-        {
-            int directoryId = Interlocked.Increment(ref _assemblyDirectoryId);
-
-            string directory = Path.Combine(_shadowCopyDirectoryAndMutex.Value.directory, directoryId.ToString());
-
-            Directory.CreateDirectory(directory);
-            return directory;
-        }
-
         private (string directory, Mutex mutex) CreateUniqueDirectoryForProcess()
         {
             string guid = Guid.NewGuid().ToString("N").ToLowerInvariant();
@@ -211,6 +228,20 @@ namespace Microsoft.CodeAnalysis
             Directory.CreateDirectory(directory);
 
             return (directory, mutex);
+        }
+
+        private static Guid ReadMvid(string filePath)
+        {
+            RoslynDebug.Assert(PathUtilities.IsAbsolute(filePath));
+
+            using (var reader = new PEReader(FileUtilities.OpenRead(filePath)))
+            {
+                var metadataReader = reader.GetMetadataReader();
+                var mvidHandle = metadataReader.GetModuleDefinition().Mvid;
+                var fileMvid = metadataReader.GetGuid(mvidHandle);
+
+                return fileMvid;
+            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -142,9 +142,17 @@ namespace Microsoft.CodeAnalysis
             if (object.ReferenceEquals(task, tcs.Task))
             {
                 // This thread won and we need to do the copy.
-                var shadowAnalyzerPath = copyAnalyzerContents();
-                tcs.SetResult(shadowAnalyzerPath);
-                return shadowAnalyzerPath;
+                try
+                {
+                    var shadowAnalyzerPath = copyAnalyzerContents();
+                    tcs.SetResult(shadowAnalyzerPath);
+                    return shadowAnalyzerPath;
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                    throw;
+                }
             }
             else
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -14,9 +14,6 @@ using Roslyn.Utilities;
 using System.Reflection.PortableExecutable;
 using System.Reflection.Metadata;
 
-
-
-
 #if NETCOREAPP
 using System.Runtime.Loader;
 #endif

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -40,6 +40,7 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\DefaultAnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\DefaultAnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\ShadowCopyAnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\ShadowCopyAnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\Text\SourceHashAlgorithms.cs" Link="Text\SourceHashAlgorithms.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\AssemblyUtilitiesCore.cs" Link="AssemblyUtilitiesCore.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="AnalyzerRunner" />


### PR DESCRIPTION
The shadow copy infrastructure for analyzer does a defensive shadow copy of an analyzer every time a load was requested. There was no attempt at de-duping these request. That means if the _same_ analyzer is passed to 10 compilations in a build, 10 shadow copies will be made. That is done even though the CLR is only ever going to load the first one.

This change mades the shadow copy infrastructure smarter by only creating one shadow copy per MVID. That is a reliable identifier that can be used in these circumstance.

This reduced the number of shadow copy events when building Roslyn.sln from 268 to 53. The total number of DLL copies this avoids is much higher because a shadow copy event copies an analyzer and all of its supporting resource assemblies.