### PR TITLE
Avoid performing a defensive copy for enum parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -5068,6 +5068,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.Parameter:
                     return IsAnyReadOnly(addressKind) ||
+                        ((BoundParameter)expression).Type.TypeKind == TypeKind.Enum ||
                         ((BoundParameter)expression).ParameterSymbol.RefKind is not (RefKind.In or RefKind.RefReadOnlyParameter);
 
                 case BoundKind.Local:

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -5067,9 +5067,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
 
                 case BoundKind.Parameter:
+                    var parameter = (BoundParameter)expression;
+                    var isEnumTypeParam = parameter.Type is TypeParameterSymbol typeParameter &&
+                                          typeParameter.ConstraintTypesNoUseSiteDiagnostics.Count(x =>
+                                              x.SpecialType == SpecialType.System_Enum) > 0;
                     return IsAnyReadOnly(addressKind) ||
-                        ((BoundParameter)expression).Type.TypeKind == TypeKind.Enum ||
-                        ((BoundParameter)expression).ParameterSymbol.RefKind is not (RefKind.In or RefKind.RefReadOnlyParameter);
+                        parameter.Type.TypeKind == TypeKind.Enum ||
+                        isEnumTypeParam ||
+                        parameter.ParameterSymbol.RefKind is not (RefKind.In or RefKind.RefReadOnlyParameter);
 
                 case BoundKind.Local:
                     // locals have home unless they are byval stack locals or ref-readonly

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -1459,7 +1459,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72016")]
         public void InParamEnum()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -1460,6 +1460,41 @@ class Program
         }
 
         [Fact]
+        public void InParamEnum()
+        {
+            var text = @"
+class Program
+{
+    static void Main()
+    {
+        Enum1 v = Enum1.Value1;
+        System.Console.WriteLine(M(v));
+    }
+
+    static string M(in Enum1 x) => x.ToString();
+
+    public enum Enum1
+    {
+        Value1
+    }
+}
+
+";
+
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: "Value1");
+
+            comp.VerifyIL("Program.M", @"
+{
+  // Code size       13 (0xd)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  constrained. ""Program.Enum1""
+  IL_0007:  callvirt   ""string object.ToString()""
+  IL_000c:  ret
+}");
+        }
+
+        [Fact]
         public void InParamConv()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -1494,6 +1494,76 @@ class Program
 }");
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72016")]
+        public void InParamEnumTypeParam()
+        {
+            var text = @"
+class Program
+{
+    static void Main()
+    {
+        Enum1 v = Enum1.Value1;
+        System.Console.WriteLine(M(v));
+    }
+
+    static string M<T>(in T x) where T : System.Enum => x.ToString();
+
+    public enum Enum1
+    {
+        Value1
+    }
+}
+
+";
+
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: "Value1");
+
+            comp.VerifyIL("Program.M<T>", @"
+{
+  // Code size       13 (0xd)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  constrained. ""T""
+  IL_0007:  callvirt   ""string object.ToString()""
+  IL_000c:  ret
+}");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72016")]
+        public void InParamEnumTypeParamStruct()
+        {
+            var text = @"
+class Program
+{
+    static void Main()
+    {
+        Enum1 v = Enum1.Value1;
+        System.Console.WriteLine(M(v));
+    }
+
+    static string M<T>(in T x) where T : struct, System.Enum => x.ToString();
+
+    public enum Enum1
+    {
+        Value1
+    }
+}
+
+";
+
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: "Value1");
+
+            comp.VerifyIL("Program.M<T>", @"
+{
+  // Code size       13 (0xd)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  constrained. ""T""
+  IL_0007:  callvirt   ""string object.ToString()""
+  IL_000c:  ret
+}");
+        }
+
         [Fact]
         public void InParamConv()
         {


### PR DESCRIPTION
Closes #72016 

There is not really a way allowed by the spec (as discussed in the issue) to have an enum's methods or properties cause side effects so we should not perform defensive copies on them even if they are in or ref readonly. This pr changes that.