### PR TITLE
Improve behavior of SyntaxRemoveOptions.AddElasticMarker

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveCodeFixProvider.cs
@@ -5,18 +5,14 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirective
 {
@@ -53,63 +49,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryNullableDirec
             CodeActionOptionsProvider fallbackOptions,
             CancellationToken cancellationToken)
         {
-            // We first group the nullable directives by the token they are attached This allows to replace each token
-            // separately even if they have multiple nullable directives.
-            var nullableDirectives = diagnostics
-                .Select(d => d.Location.FindNode(findInsideTrivia: true, getInnermostNodeForTie: true, cancellationToken))
-                .OfType<NullableDirectiveTriviaSyntax>();
-
-            foreach (var (token, directives) in nullableDirectives.GroupBy(d => d.ParentTrivia.Token))
+            foreach (var diagnostic in diagnostics)
             {
-                var leadingTrivia = token.LeadingTrivia;
-                var nullableDirectiveIndices = nullableDirectives
-                    .Select(x => leadingTrivia.IndexOf(x.ParentTrivia));
-
-                // Walk backwards through the nullable directives on the token.  That way our indices stay correct as we
-                // are removing later directives.
-                foreach (var index in nullableDirectiveIndices.OrderByDescending(x => x))
-                {
-                    // Remove the directive itself.
-                    leadingTrivia = leadingTrivia.RemoveAt(index);
-
-                    // If we have a blank line both before and after the directive, then remove the one that follows to
-                    // keep the code clean.
-                    if (HasPrecedingBlankLine(leadingTrivia, index - 1) &&
-                        HasFollowingBlankLine(leadingTrivia, index))
-                    {
-                        // Delete optional following whitespace.
-                        if (leadingTrivia[index].IsWhitespace())
-                            leadingTrivia = leadingTrivia.RemoveAt(index);
-
-                        // Then the following blank line.
-                        leadingTrivia = leadingTrivia.RemoveAt(index);
-                    }
-                }
-
-                // Update the token and replace it within its parent.
-                var node = token.GetRequiredParent();
-                editor.ReplaceNode(
-                    node,
-                    node.ReplaceToken(token, token.WithLeadingTrivia(leadingTrivia)));
+                var nullableDirective = diagnostic.Location.FindNode(findInsideTrivia: true, getInnermostNodeForTie: true, cancellationToken);
+                editor.RemoveNode(nullableDirective, SyntaxRemoveOptions.AddElasticMarker);
             }
 
             return Task.CompletedTask;
-        }
-
-        private static bool HasPrecedingBlankLine(SyntaxTriviaList leadingTrivia, int index)
-        {
-            if (index >= 0 && leadingTrivia[index].IsWhitespace())
-                index--;
-
-            return index >= 0 && leadingTrivia[index].IsEndOfLine();
-        }
-
-        private static bool HasFollowingBlankLine(SyntaxTriviaList leadingTrivia, int index)
-        {
-            if (index < leadingTrivia.Count && leadingTrivia[index].IsWhitespace())
-                index++;
-
-            return index < leadingTrivia.Count && leadingTrivia[index].IsEndOfLine();
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -296,8 +296,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
                 }
 
-                // make every operation forced
-                return CreateAdjustSpacesOperation(Math.Max(0, operation.Space), AdjustSpacesOption.ForceSpaces);
+                // make every operation forced, except at the end of the file
+                var option = currentToken.IsKind(SyntaxKind.EndOfFileToken) ? AdjustSpacesOption.PreserveSpaces : AdjustSpacesOption.ForceSpaces;
+                return CreateAdjustSpacesOperation(Math.Max(0, operation.Space), option);
             }
 
             return operation;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -860,8 +860,8 @@ namespace Microsoft.CodeAnalysis.Formatting
             // it has line break right before it
             if (trivia2.IsElastic())
             {
-                // eat up consecutive elastic trivia or next line
-                if (trivia1.IsElastic() || IsEndOfLine(trivia1))
+                // eat up consecutive elastic trivia or first or next line
+                if (trivia1.IsElastic() || trivia1.RawKind == 0 || IsEndOfLine(trivia1))
                 {
                     return LineColumnDelta.Default;
                 }


### PR DESCRIPTION
This change updates the behavior of AddElasticMarker during syntax node removal to collapse consecutive newlines surrounding the removed node such that the total number of blank lines appearing at the location of the removed node does not increase.

This is a dramatic simplification based on #72150.