### PR TITLE
Params parameter is implicitly scoped if and only if `params` is explicitly specified in source.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
            ScopedKind scope,
            string name,
            bool isDiscard,
-           bool isParams,
+           bool hasParamsModifier,
            Location location)
-           : base(owner, ordinal, refKind, name, location, syntaxRef, isParams, isExtensionMethodThis: false, scope)
+           : base(owner, ordinal, refKind, name, location, syntaxRef, hasParamsModifier: hasParamsModifier, isParams: hasParamsModifier, isExtensionMethodThis: false, scope)
         {
             _parameterType = parameterType;
             _attributeLists = attributeLists;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         refKind,
                         syntax.Identifier,
                         ordinal,
-                        isParams: paramsKeyword.Kind() != SyntaxKind.None,
+                        hasParamsModifier: paramsKeyword.Kind() != SyntaxKind.None,
                         isExtensionMethodThis: ordinal == 0 && thisKeyword.Kind() != SyntaxKind.None,
                         addRefReadOnlyModifier,
                         scope,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             RefKind refKind,
             SyntaxToken identifier,
             int ordinal,
-            bool isParams,
+            bool hasParamsModifier,
             bool isExtensionMethodThis,
             bool addRefReadOnlyModifier,
             ScopedKind scope,
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var name = identifier.ValueText;
             var location = new SourceLocation(identifier);
 
-            if (isParams && parameterType.IsSZArray())
+            if (hasParamsModifier && parameterType.IsSZArray())
             {
                 // touch the constructor in order to generate proper use-site diagnostics
                 Binder.ReportUseSiteDiagnosticForSynthesizedAttribute(context.Compilation,
@@ -69,12 +69,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     name,
                     location,
                     syntax.GetReference(),
-                    isParams,
+                    hasParamsModifier: hasParamsModifier,
+                    isParams: hasParamsModifier,
                     isExtensionMethodThis,
                     scope);
             }
 
-            if (!isParams &&
+            if (!hasParamsModifier &&
                 !isExtensionMethodThis &&
                 (syntax.Default == null) &&
                 (syntax.AttributeLists.Count == 0) &&
@@ -91,7 +92,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 name,
                 location,
                 syntax.GetReference(),
-                isParams,
+                hasParamsModifier: hasParamsModifier,
+                isParams: hasParamsModifier,
                 isExtensionMethodThis,
                 scope);
         }
@@ -133,7 +135,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     _name,
                     _location,
                     this.SyntaxReference,
-                    newIsParams,
+                    hasParamsModifier: HasParamsModifier,
+                    isParams: newIsParams,
                     this.IsExtensionMethodThis,
                     this.DeclaredScope);
             }
@@ -150,7 +153,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _name,
                 _location,
                 this.SyntaxReference,
-                newIsParams,
+                hasParamsModifier: HasParamsModifier,
+                isParams: newIsParams,
                 this.IsExtensionMethodThis,
                 this.DeclaredScope);
         }
@@ -220,6 +224,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal ScopedKind DeclaredScope => _scope;
 
+        /// <summary>
+        /// Reflects presence of `params` modifier in source
+        /// </summary>
+        protected abstract bool HasParamsModifier { get; }
+
         internal abstract override ScopedKind EffectiveScope { get; }
 
         protected ScopedKind CalculateEffectiveScopeIgnoringAttributes()
@@ -232,7 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     return ScopedKind.ScopedRef;
                 }
-                else if (IsParams && Type.IsRefLikeType)
+                else if (HasParamsModifier && Type.IsRefLikeType)
                 {
                     return ScopedKind.ScopedValue;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceSimpleParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceSimpleParameterSymbol.cs
@@ -57,6 +57,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
+        protected override bool HasParamsModifier
+        {
+            get { return false; }
+        }
+
         public override bool IsParamsArray
         {
             get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public SynthesizedAccessorValueParameterSymbol(SourceMemberMethodSymbol accessor, int ordinal)
             : base(accessor, ordinal, RefKind.None, ParameterSymbol.ValueParameterName, accessor.TryGetFirstLocation(),
                    syntaxRef: null,
+                   hasParamsModifier: false,
                    isParams: false,
                    isExtensionMethodThis: false,
                    scope: ScopedKind.None)


### PR DESCRIPTION
See https://github.com/dotnet/csharplang/blob/main/proposals/params-collections.md#resolved-consider-enforcing-scoped-or-params-across-overrides