### PR TITLE
Avoid URI serialization issues in override completion by passing full text document identifier

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/DefaultLspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/DefaultLspCompletionResultCreationService.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
                     {
                         CommandIdentifier = CompleteComplexEditCommand,
                         Title = nameof(CompleteComplexEditCommand),
-                        Arguments = [textDocumentIdentifier.Uri, textEdit, isSnippetString, lspOffset]
+                        Arguments = [textDocumentIdentifier, textEdit, isSnippetString, lspOffset]
                     };
                 }
             }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -294,7 +294,7 @@ class A { }";
 
         Assert.Equal(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand, resolvedItem.Command.CommandIdentifier);
         Assert.Equal(nameof(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand), resolvedItem.Command.Title);
-        Assert.Equal(completionParams.TextDocument.Uri, ProtocolConversions.CreateAbsoluteUri((string)resolvedItem.Command.Arguments[0]));
+        AssertJsonEquals(completionParams.TextDocument, resolvedItem.Command.Arguments[0]);
         AssertJsonEquals(expectedEdit, resolvedItem.Command.Arguments[1]);
         Assert.Equal(false, resolvedItem.Command.Arguments[2]);
         Assert.Equal((long)14, resolvedItem.Command.Arguments[3]);
@@ -855,7 +855,7 @@ public class C
                 Assert.Equal(nameof(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand), resolvedItem.Command.Title);
                 Assert.Equal(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand, resolvedItem.Command.CommandIdentifier);
 
-                Assert.Equal(completionParams.TextDocument.Uri, ProtocolConversions.CreateAbsoluteUri((string)resolvedItem.Command.Arguments[0]));
+                AssertJsonEquals(completionParams.TextDocument, resolvedItem.Command.Arguments[0]);
 
                 var expectedEdit = new TextEdit { Range = new LSP.Range { Start = new(0, 5), End = new(0, 5) }, NewText = "ComplexItem" };
                 AssertJsonEquals(expectedEdit, resolvedItem.Command.Arguments[1]);
@@ -912,7 +912,7 @@ public class C
         Assert.Equal(nameof(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand), resolvedItem.Command.Title);
         Assert.Equal(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand, resolvedItem.Command.CommandIdentifier);
 
-        Assert.Equal(completionParams.TextDocument.Uri, ProtocolConversions.CreateAbsoluteUri((string)resolvedItem.Command.Arguments[0]));
+        AssertJsonEquals(completionParams.TextDocument, resolvedItem.Command.Arguments[0]);
 
         var expectedEdit = new TextEdit { Range = new LSP.Range { Start = new(7, 4), End = new(7, 13) }, NewText = "public override global::System.Boolean AbstractMethod(global::System.Int32 x)\r\n    {\r\n        throw new System.NotImplementedException();\r\n    }" };
         AssertJsonEquals(expectedEdit, resolvedItem.Command.Arguments[1]);


### PR DESCRIPTION
An issue was caught by the vscode-csharp integration tests where override completion was broken with the latest roslyn on Windows.  I'm not sure exactly when this regressed, but possibly related to changes made for xaml support.

I wasn't able to track down the exact cause - but on Windows the URI sent from the server in the completion resolve command is getting serialized as just the local path (e.g. not including the `file:///` part).  The vscode client is expecting a URI string, and when it tries to deserialize, it fails.

This inconsistency in serialization is likely because there's no explicit serializer for the `Uri` type defined, so it ends up being up to the whims of the serialization library.  Instead, we should just pass the `TextDocumentIdentifier` which already defines an explicit and consistent URI serializer.

Requires client side change here - https://github.com/dotnet/vscode-csharp/pull/6920