### PR TITLE
Fix the log contention in correctness legs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -383,19 +383,22 @@ stages:
       - task: PowerShell@2
         displayName: Restore
         inputs:
+          pwsh: true
           filePath: eng/build.ps1
           arguments: -configuration Release -prepareMachine -ci -restore -binaryLogName Restore.binlog 
 
       - task: PowerShell@2
         displayName: Build
         inputs:
+          pwsh: true
           filePath: eng/build.ps1
           arguments: -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLogName Build.binlog
 
       - script: $(Build.SourcesDirectory)\artifacts\bin\BuildBoss\Release\net472\BuildBoss.exe  -r "$(Build.SourcesDirectory)/" -c Release -p Roslyn.sln
         displayName: Validate Build Artifacts
 
-      - script: eng/validate-rules-missing-documentation.cmd -ci
+      - pwsh: |
+           ./eng/validate-rules-missing-documentation.ps1 -ci
         displayName: Validate rules missing documentation
 
       - pwsh: |
@@ -404,7 +407,7 @@ stages:
         condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
 
       - pwsh: |
-          ./eng/validate-code-formatting.ps1 -rootDirectory $(Build.SourcesDirectory)\src -includeDirectories Compilers\CSharp\Portable\Generated\, Compilers\VisualBasic\Portable\Generated\, ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\
+          ./eng/validate-code-formatting.ps1 -ci -rootDirectory $(Build.SourcesDirectory)\src -includeDirectories Compilers\CSharp\Portable\Generated\, Compilers\VisualBasic\Portable\Generated\, ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\ 
         displayName: Validate Generated Syntax Files
         condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -398,7 +398,7 @@ stages:
         displayName: Validate Build Artifacts
 
       - pwsh: |
-           ./eng/validate-rules-missing-documentation.ps1 -ci
+          ./eng/validate-rules-missing-documentation.ps1 -ci
         displayName: Validate rules missing documentation
 
       - pwsh: |

--- a/eng/generate-compiler-code.ps1
+++ b/eng/generate-compiler-code.ps1
@@ -116,6 +116,7 @@ function Get-ToolPath($projectRelativePath) {
 try {
   . (Join-Path $PSScriptRoot "build-utils.ps1")
   Push-Location $RepoRoot
+  $prepareMachine = $ci
 
   $dotnet = Ensure-DotnetSdk
   $boundTreeGenProject = Get-ToolPath 'BoundTreeGenerator\CompilersBoundTreeGenerator.csproj'

--- a/eng/generate-compiler-code.ps1
+++ b/eng/generate-compiler-code.ps1
@@ -4,7 +4,7 @@
 [CmdletBinding(PositionalBinding=$false)]
 param ([string]$configuration = "Debug", 
        [switch]$test = $false,
-       [bool]$ci = $false)
+       [switch]$ci = $false)
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"

--- a/eng/generate-compiler-code.ps1
+++ b/eng/generate-compiler-code.ps1
@@ -3,7 +3,8 @@
 # the generator source files. 
 [CmdletBinding(PositionalBinding=$false)]
 param ([string]$configuration = "Debug", 
-       [switch]$test = $false)
+       [switch]$test = $false,
+       [bool]$ci = $false)
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
@@ -136,11 +137,11 @@ try {
   Run-IOperation $coreDir $operationsProject
   Run-GetText
 
-  exit 0
+  ExitWithExitCode 0
 }
 catch {
   Write-Host $_
-  exit 1
+  ExitWithExitCode 1
 }
 finally {
   Pop-Location

--- a/eng/pipelines/build-bootstrap.yml
+++ b/eng/pipelines/build-bootstrap.yml
@@ -7,10 +7,12 @@ parameters:
 steps:
     - template: checkout-windows-task.yml
 
-    - script: eng\make-bootstrap.cmd -ci -toolset ${{parameters.toolset}} -name "ci-bootstrap"
+    - pwsh: |
+        ./eng/make-bootstrap.cmd -ci -toolset ${{parameters.toolset}} -name "ci-bootstrap"
       displayName: Build Bootstrap Compiler
 
-    - script: eng/test-build-correctness.cmd -configuration Release -enableDumps -bootstrapDir $(Build.SourcesDirectory)/artifacts/bootstrap/ci-bootstrap
+    - pwsh: |
+        ./eng/test-build-correctness.ps1 -ci -configuration Release -enableDumps -bootstrapDir $(Build.SourcesDirectory)/artifacts/bootstrap/ci-bootstrap
       displayName: Build - Validate correctness
 
     - template: publish-logs.yml

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -33,6 +33,7 @@ try {
 
   . (Join-Path $PSScriptRoot "build-utils.ps1")
   Push-Location $RepoRoot
+  $prepareMachine = $ci
 
   if ($enableDumps) {
     $key = "HKLM:\\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps"

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -65,14 +65,14 @@ try {
   Exec-DotNet "tool run dotnet-format whitespace . --folder --include-generated --include src/Compilers/CSharp/Portable/Generated/ src/Compilers/VisualBasic/Portable/Generated/ src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Generated/ --verify-no-changes"
   Write-Host ""
 
-  exit 0
+  ExitWithExitCode 0
 }
 catch {
   Write-Host $_
   Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
   Write-Host "##vso[task.logissue type=error]How to investigate bootstrap failures: https://github.com/dotnet/roslyn/blob/main/docs/compilers/Bootstrap%20Builds.md#Investigating"
-  exit 1
+  ExitWithExitCode 1
 }
 finally {
   if ($enableDumps) {

--- a/eng/validate-code-formatting.ps1
+++ b/eng/validate-code-formatting.ps1
@@ -1,6 +1,8 @@
 param (
     [string]$rootDirectory,
-    [string[]]$includeDirectories
+    [string[]]$includeDirectories,
+    [bool]$ci = $false,
+    [bool]$prepareMachine = $false
 )
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
@@ -11,11 +13,11 @@ try {
 
   Exec-DotNet "tool run dotnet-format -v detailed whitespace $rootDirectory --folder --include-generated --include $includeDirectories --verify-no-changes"
 
-  exit 0
+  ExitWithExitCode 0
 }
 catch {
   Write-Host $_
-  exit 1
+  ExitWithExitCode 1
 }
 finally {
   Pop-Location

--- a/eng/validate-code-formatting.ps1
+++ b/eng/validate-code-formatting.ps1
@@ -1,8 +1,7 @@
 param (
     [string]$rootDirectory,
     [string[]]$includeDirectories,
-    [bool]$ci = $false,
-    [bool]$prepareMachine = $false
+    [bool]$ci = $false
 )
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
@@ -10,6 +9,7 @@ $ErrorActionPreference="Stop"
 try {
   . (Join-Path $PSScriptRoot "build-utils.ps1")
   Push-Location $RepoRoot
+  $prepareMachine = $ci
 
   Exec-DotNet "tool run dotnet-format -v detailed whitespace $rootDirectory --folder --include-generated --include $includeDirectories --verify-no-changes"
 

--- a/eng/validate-code-formatting.ps1
+++ b/eng/validate-code-formatting.ps1
@@ -1,7 +1,7 @@
 param (
     [string]$rootDirectory,
     [string[]]$includeDirectories,
-    [bool]$ci = $false
+    [switch]$ci = $false
 )
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"


### PR DESCRIPTION
The PS1 scripts are not using `ExitWithExitCode` thus they are not properly killing the compiler server and msbuild hence the logs are unreadable.