### PR TITLE
Do not return nonexistent kinds in `SyntaxFacts`' methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -77,6 +77,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Represents <c>..</c> token.</summary>
         DotDotToken = 8222,
 
+        // Values ranging from 8193 (TildeToken) to 8287 (GreaterThanGreaterThanGreaterThanEqualsToken) are reserved for punctuation kinds.
+        // This gap is included within that range. So if you add a value here make sure `SyntaxFacts.GetPunctuationKinds` includes it in the returned enumeration
+
         // additional xml tokens
         /// <summary>Represents <c>/&gt;</c> token.</summary>
         SlashGreaterThanToken = 8232, // xml empty element end
@@ -94,6 +97,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         XmlProcessingInstructionStartToken = 8238, // <?
         /// <summary>Represents <c>?&gt;</c> token.</summary>
         XmlProcessingInstructionEndToken = 8239, // ?>
+
+        // Values ranging from 8193 (TildeToken) to 8287 (GreaterThanGreaterThanGreaterThanEqualsToken) are reserved for punctuation kinds.
+        // This gap is included within that range. So if you add a value here make sure `SyntaxFacts.GetPunctuationKinds` includes it in the returned enumeration
 
         // compound punctuation
         /// <summary>Represents <c>||</c> token.</summary>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             yield return SyntaxKind.TrueKeyword;
             yield return SyntaxKind.FalseKeyword;
             yield return SyntaxKind.DefaultKeyword;
-            yield return SyntaxKind.HiddenKeyword;
+
             for (int i = (int)SyntaxKind.ElifKeyword; i <= (int)SyntaxKind.RestoreKeyword; i++)
             {
                 Debug.Assert(Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i));

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -176,11 +176,26 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public static IEnumerable<SyntaxKind> GetPunctuationKinds()
         {
-            for (int i = (int)SyntaxKind.TildeToken; i <= (int)SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken; i++)
+            for (int i = (int)SyntaxKind.TildeToken; i <= (int)SyntaxKind.DotDotToken; i++)
             {
                 Debug.Assert(Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i));
                 yield return (SyntaxKind)i;
             }
+
+            for (int i = (int)SyntaxKind.SlashGreaterThanToken; i <= (int)SyntaxKind.XmlProcessingInstructionEndToken; i++)
+            {
+                Debug.Assert(Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i));
+                yield return (SyntaxKind)i;
+            }
+
+            for (int i = (int)SyntaxKind.BarBarToken; i <= (int)SyntaxKind.QuestionQuestionEqualsToken; i++)
+            {
+                Debug.Assert(Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i));
+                yield return (SyntaxKind)i;
+            }
+
+            yield return SyntaxKind.GreaterThanGreaterThanGreaterThanToken;
+            yield return SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken;
         }
 
         public static bool IsPunctuationOrKeyword(SyntaxKind kind)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -1148,7 +1148,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             for (int i = (int)SyntaxKind.YieldKeyword; i <= (int)SyntaxKind.FileKeyword; i++)
             {
-                yield return (SyntaxKind)i;
+                // 8441 corresponds to a deleted kind (DataKeyword) that was previously shipped.
+                if (i != 8441)
+                    yield return (SyntaxKind)i;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -17,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             for (int i = (int)SyntaxKind.BoolKeyword; i <= (int)SyntaxKind.ImplicitKeyword; i++)
             {
+                Debug.Assert(Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i));
                 yield return (SyntaxKind)i;
             }
         }
@@ -145,6 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             yield return SyntaxKind.HiddenKeyword;
             for (int i = (int)SyntaxKind.ElifKeyword; i <= (int)SyntaxKind.RestoreKeyword; i++)
             {
+                Debug.Assert(Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i));
                 yield return (SyntaxKind)i;
             }
         }
@@ -174,6 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             for (int i = (int)SyntaxKind.TildeToken; i <= (int)SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken; i++)
             {
+                Debug.Assert(Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i));
                 yield return (SyntaxKind)i;
             }
         }
@@ -1150,7 +1155,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // 8441 corresponds to a deleted kind (DataKeyword) that was previously shipped.
                 if (i != 8441)
+                {
+                    Debug.Assert(Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i));
                     yield return (SyntaxKind)i;
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -3603,6 +3603,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(LexerCache.MaxKeywordLength, max);
         }
 
+        [Fact]
+        public void TestNoKind8441InKeywordKinds()
+        {
+            var reservedKeywords = SyntaxFacts.GetReservedKeywordKinds();
+            Assert.DoesNotContain((SyntaxKind)8441, reservedKeywords);
+
+            var contextualKeywords = SyntaxFacts.GetContextualKeywordKinds();
+            Assert.DoesNotContain((SyntaxKind)8441, contextualKeywords);
+
+            var keywords = SyntaxFacts.GetKeywordKinds();
+            Assert.DoesNotContain((SyntaxKind)8441, keywords);
+        }
+
         [WorkItem(545781, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545781")]
         [Fact]
         public void DecimalLiteralsOtherCulture()

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -3603,19 +3603,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(LexerCache.MaxKeywordLength, max);
         }
 
-        [Fact]
-        public void TestNoKind8441InKeywordKinds()
-        {
-            var reservedKeywords = SyntaxFacts.GetReservedKeywordKinds();
-            Assert.DoesNotContain((SyntaxKind)8441, reservedKeywords);
-
-            var contextualKeywords = SyntaxFacts.GetContextualKeywordKinds();
-            Assert.DoesNotContain((SyntaxKind)8441, contextualKeywords);
-
-            var keywords = SyntaxFacts.GetKeywordKinds();
-            Assert.DoesNotContain((SyntaxKind)8441, keywords);
-        }
-
         [WorkItem(545781, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545781")]
         [Fact]
         public void DecimalLiteralsOtherCulture()

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
@@ -276,5 +276,18 @@ void goo()
                 }
             }
         }
+
+        [Fact]
+        public void TestNoKind8441InKeywordKinds()
+        {
+            var reservedKeywords = SyntaxFacts.GetReservedKeywordKinds();
+            Assert.DoesNotContain((SyntaxKind)8441, reservedKeywords);
+
+            var contextualKeywords = SyntaxFacts.GetContextualKeywordKinds();
+            Assert.DoesNotContain((SyntaxKind)8441, contextualKeywords);
+
+            var keywords = SyntaxFacts.GetKeywordKinds();
+            Assert.DoesNotContain((SyntaxKind)8441, keywords);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
@@ -289,5 +289,14 @@ void goo()
             var keywords = SyntaxFacts.GetKeywordKinds();
             Assert.DoesNotContain((SyntaxKind)8441, keywords);
         }
+
+        [Fact]
+        public void TestAllPunctuationKindsExist()
+        {
+            foreach (var punctuationKind in SyntaxFacts.GetPunctuationKinds())
+            {
+                Assert.True(Enum.IsDefined(typeof(SyntaxKind), punctuationKind));
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
@@ -313,13 +313,16 @@ void goo()
             {
                 if (Enum.IsDefined(typeof(SyntaxKind), (SyntaxKind)i))
                 {
-                    Assert.Contains(i, returnedKindsInts);
+                    Assert.True(returnedKindsInts.Remove(i));
                 }
                 else
                 {
                     Assert.DoesNotContain(i, returnedKindsInts);
                 }
             }
+
+            // We've already removed all expected kinds from the set. It should be empty now
+            Assert.Empty(returnedKindsInts);
         }
 
         [Fact]
@@ -327,15 +330,17 @@ void goo()
         {
             var returnedKindsInts = SyntaxFacts.GetPreprocessorKeywordKinds().Select(static k => (int)k).ToHashSet();
 
-            Assert.Contains((int)SyntaxKind.TrueKeyword, returnedKindsInts);
-            Assert.Contains((int)SyntaxKind.FalseKeyword, returnedKindsInts);
-            Assert.Contains((int)SyntaxKind.DefaultKeyword, returnedKindsInts);
-            Assert.Contains((int)SyntaxKind.HiddenKeyword, returnedKindsInts);
+            Assert.True(returnedKindsInts.Remove((int)SyntaxKind.TrueKeyword));
+            Assert.True(returnedKindsInts.Remove((int)SyntaxKind.FalseKeyword));
+            Assert.True(returnedKindsInts.Remove((int)SyntaxKind.DefaultKeyword));
 
             for (int i = (int)SyntaxKind.ElifKeyword; i < (int)SyntaxKind.ReferenceKeyword; i++)
             {
-                Assert.Contains(i, returnedKindsInts);
+                Assert.True(returnedKindsInts.Remove(i));
             }
+
+            // We've already removed all expected kinds from the set. It should be empty now
+            Assert.Empty(returnedKindsInts);
         }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactsTest.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactsTest.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.IO
+Imports System.Reflection
 Imports System.Text
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -1260,6 +1261,17 @@ End Module
     <InlineData("Alice", False)>
     Public Sub TestIsReservedTupleElementName(elementName As String, isReserved As Boolean)
         Assert.Equal(isReserved, SyntaxFacts.IsReservedTupleElementName(elementName))
+    End Sub
+
+    <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72300")>
+    Public Sub TestAllKindsReturnedFromGetKindsMethodsExist()
+        For Each method In GetType(SyntaxFacts).GetMethods(BindingFlags.Public Or BindingFlags.Static)
+            If method.ReturnType = GetType(IEnumerable(Of SyntaxKind)) AndAlso method.GetParameters().Length = 0 Then
+                For Each kind As SyntaxKind In DirectCast(method.Invoke(Nothing, Nothing), IEnumerable(Of SyntaxKind))
+                    Assert.True([Enum].IsDefined(GetType(SyntaxKind), kind), $"Nonexistent kind '{kind}' returned from method '{method.Name}'")
+                Next
+            End If
+        Next
     End Sub
 
 End Class


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/72300