### PR TITLE
Bump vulnerable transitive dependencies

### DIFF
--- a/src/CodeStyle/Core/Tests/UnitTestUtilities/Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj
+++ b/src/CodeStyle/Core/Tests/UnitTestUtilities/Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj
@@ -40,6 +40,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit" />
+    <!-- fix of vulnerability in 6.3.3 coming via Microsoft.CodeAnalysis.*.Testing.XUnit -->
+    <PackageReference Include="NuGet.Packaging" VersionOverride="6.3.4" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <!-- TODO: Remove the below project references to test utility projects once all analyzer/code fix tests are switched to Microsoft.CodeAnalysis.Testing -->

--- a/src/Tools/Source/RunTests/RunTests.csproj
+++ b/src/Tools/Source/RunTests/RunTests.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.Win32.Registry" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" />
+    <!-- fix of vulnerability in 6.0.0 coming via Microsoft.TeamFoundationServer.Client -->
+    <PackageReference Include="System.Security.Cryptography.Xml" VersionOverride="6.0.1" />
     <ProjectReference Include="..\..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
   </ItemGroup>
 

--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="Microsoft.Build" VersionOverride="17.3.2" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Framework" VersionOverride="17.3.2" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="17.3.2" ExcludeAssets="Runtime" PrivateAssets="All" />
+    <!-- fix of vulnerability in 6.0.0 coming via Microsoft.Build.Tasks.Core -->
+    <PackageReference Include="System.Security.Cryptography.Xml" VersionOverride="6.0.1" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.CommandLine" />

--- a/src/Workspaces/CoreTestUtilities/Microsoft.CodeAnalysis.Workspaces.Test.Utilities.csproj
+++ b/src/Workspaces/CoreTestUtilities/Microsoft.CodeAnalysis.Workspaces.Test.Utilities.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit" />
+    <!-- fix of vulnerability in 6.3.3 coming via Microsoft.CodeAnalysis.*.Testing.XUnit -->
+    <PackageReference Include="NuGet.Packaging" VersionOverride="6.3.4" />
     <PackageReference Include="xunit.extensibility.core" Version="$(xunitextensibilitycoreVersion)" />
     <PackageReference Include="xunit.extensibility.execution" Version="$(xunitextensibilityexecutionVersion)" />
     <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />


### PR DESCRIPTION
Fixes "critical" CG alerts.

Full CI run which doesn't skip the CG analysis (unlike PR runs): https://dev.azure.com/dnceng-public/public/_build/results?buildId=579620&view=results. No "critical" CG alerts should be reported there. (The failing macOS leg can be ignored, that's failing in `main` as well.)