### PR TITLE
Pass full paths to make-bootstrap

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -425,13 +425,15 @@ stages:
       - template: eng/pipelines/variables-build.yml
         parameters:
           configuration: Debug
+      - name: bootstrapDir
+        value: $(Build.SourcesDirectory)/artifacts/bootstrap/determinism
     steps:
       - template: eng/pipelines/checkout-windows-task.yml
 
-      - script: eng/make-bootstrap.cmd -name determinism
+      - pwsh: eng/make-bootstrap.ps1 -output $(bootstrapDir)
         displayName: Build Bootstrap Compiler
 
-      - script: eng/test-determinism.cmd -configuration Debug -bootstrapDir $(Build.SourcesDirectory)/artifacts/bootstrap/determinism
+      - pwsh: eng/test-determinism.ps1 -configuration Debug -bootstrapDir $(bootstrapDir)
         displayName: Build - Validate determinism
 
       - template: eng/pipelines/publish-logs.yml

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -752,8 +752,7 @@ try {
   if ($bootstrap -and $bootstrapDir -eq "") {
     Write-Host "Building bootstrap Compiler"
     $bootstrapDir = Join-Path (Join-Path $ArtifactsDir "bootstrap") "build"
-    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-ouptut $bootstrapDir -force -ci:$ci"
-    $bootstrapDir = Join-Path (Join-Path $ArtifactsDir "bootstrap") "build"
+    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-output $bootstrapDir -force -ci:$ci"
   }
 
   if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -751,7 +751,8 @@ try {
 
   if ($bootstrap -and $bootstrapDir -eq "") {
     Write-Host "Building bootstrap Compiler"
-    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-name build -force -ci:$ci"
+    $bootstrapDir = Join-Path (Join-Path $ArtifactsDir "bootstrap") "build"
+    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-ouptut $bootstrapDir -force -ci:$ci"
     $bootstrapDir = Join-Path (Join-Path $ArtifactsDir "bootstrap") "build"
   }
 

--- a/eng/pipelines/build-bootstrap.yml
+++ b/eng/pipelines/build-bootstrap.yml
@@ -4,19 +4,16 @@ parameters:
   type: string
   default: ''
 
-variables:
-- name: bootstrapDir
-  value: $(Build.SourcesDirectory)/artifacts/bootstrap/ci-bootstrap
-
 steps:
     - template: checkout-windows-task.yml
 
     - pwsh: |
-        ./eng/make-bootstrap.ps1 -ci -toolset ${{parameters.toolset}} -output $(bootstrapDir))
+        ./eng/make-bootstrap.ps1 -ci -toolset ${{parameters.toolset}} -output '$(Build.SourcesDirectory)/artifacts/bootstrap/ci-bootstrap'
+
       displayName: Build Bootstrap Compiler
 
     - pwsh: |
-        ./eng/test-build-correctness.ps1 -ci -configuration Release -enableDumps -bootstrapDir $(bootstrapDir)
+        ./eng/test-build-correctness.ps1 -ci -configuration Release -enableDumps -bootstrapDir '$(Build.SourcesDirectory)/artifacts/bootstrap/ci-bootstrap'
       displayName: Build - Validate correctness
 
     - template: publish-logs.yml

--- a/eng/pipelines/build-bootstrap.yml
+++ b/eng/pipelines/build-bootstrap.yml
@@ -4,15 +4,19 @@ parameters:
   type: string
   default: ''
 
+variables:
+- name: bootstrapDir
+  value: $(Build.SourcesDirectory)/artifacts/bootstrap/ci-bootstrap
+
 steps:
     - template: checkout-windows-task.yml
 
     - pwsh: |
-        ./eng/make-bootstrap.cmd -ci -toolset ${{parameters.toolset}} -name "ci-bootstrap"
+        ./eng/make-bootstrap.ps1 -ci -toolset ${{parameters.toolset}} -output $(bootstrapDir))
       displayName: Build Bootstrap Compiler
 
     - pwsh: |
-        ./eng/test-build-correctness.ps1 -ci -configuration Release -enableDumps -bootstrapDir $(Build.SourcesDirectory)/artifacts/bootstrap/ci-bootstrap
+        ./eng/test-build-correctness.ps1 -ci -configuration Release -enableDumps -bootstrapDir $(bootstrapDir)
       displayName: Build - Validate correctness
 
     - template: publish-logs.yml

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -46,7 +46,7 @@ try {
   if ($bootstrapDir -eq "") {
     Write-Host "Building bootstrap compiler"
     $bootstrapDir = Join-Path $ArtifactsDir "bootstrap" "correctness"
-    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "output $bootstrapDir -ci:$ci"
+    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-output $bootstrapDir -ci:$ci"
   }
 
   Write-Host "Building Roslyn"

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -45,8 +45,8 @@ try {
 
   if ($bootstrapDir -eq "") {
     Write-Host "Building bootstrap compiler"
-    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-name correctness -ci:$ci"
     $bootstrapDir = Join-Path $ArtifactsDir "bootstrap" "correctness"
+    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "output $bootstrapDir -ci:$ci"
   }
 
   Write-Host "Building Roslyn"

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -285,8 +285,8 @@ try {
 
   if ($bootstrapDir -eq "") {
     Write-Host "Building bootstrap compiler"
-    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-name determinism -ci:$ci"
     $bootstrapDir = Join-Path $ArtifactsDir "bootstrap" "determinism"
+    Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-output $bootstrapDir -ci:$ci"
   }
 
   Run-Test


### PR DESCRIPTION
This changes the make-bootstrap command to accept a full path to the directory where the bootstrap toolset goes vs. a name.

Commands that call make-bootstrap need to know what the full path of the bootstrap toolset is cause it is how we specify it during build. The old way meant that all callers had to _know_ what the full dir was based on a name. That spread the logic of where the make-bootstrap script put the toolset into every caller. Inefficent.

Further locally it made debugging bootstrap toolsets more difficult than it needed to be. Much easier to move it outside of _artifacts_ so that we can easily delet _artifacts_ between profiling runs.