### PR TITLE
Handle OperatorDeclaration when adding a member

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -803,8 +803,14 @@ internal sealed class CSharpSyntaxGenerator : SyntaxGenerator
                              .WithBody(null);
 
                     case SyntaxKind.OperatorDeclaration:
-                        return ((OperatorDeclarationSyntax)member)
-                                 .WithModifiers(default)
+                        var operatorDeclaration = (OperatorDeclarationSyntax)member;
+                        var abstractVirtualModifiers = operatorDeclaration.Modifiers.Where(x =>
+                            x.Kind() == SyntaxKind.AbstractKeyword
+                            || x.Kind() == SyntaxKind.VirtualKeyword
+                            || x.Kind() == SyntaxKind.PublicKeyword);
+                        return operatorDeclaration
+                                 .WithModifiers(SyntaxTokenList.Create(abstractVirtualModifiers.ToArray()))
+                                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword))
                                  .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
                                  .WithBody(null);
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -808,9 +808,10 @@ internal sealed class CSharpSyntaxGenerator : SyntaxGenerator
                         x.Kind() == SyntaxKind.AbstractKeyword
                         || x.Kind() == SyntaxKind.VirtualKeyword
                         || x.Kind() == SyntaxKind.PublicKeyword);
+                    var modifiersToken = SyntaxFactory.TokenList(abstractVirtualModifiers);
+                    modifiersToken = modifiersToken.Insert(0, SyntaxFactory.Token(SyntaxKind.StaticKeyword));
                     return operatorDeclaration
-                        .WithModifiers(SyntaxTokenList.Create(abstractVirtualModifiers.ToArray()))
-                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword))
+                        .WithModifiers(modifiersToken)
                         .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
                         .WithBody(null);
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -802,23 +802,23 @@ internal sealed class CSharpSyntaxGenerator : SyntaxGenerator
                              .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
                              .WithBody(null);
 
-                    case SyntaxKind.OperatorDeclaration:
-                        var operatorDeclaration = (OperatorDeclarationSyntax)member;
-                        var abstractVirtualModifiers = operatorDeclaration.Modifiers.Where(x =>
-                            x.Kind() == SyntaxKind.AbstractKeyword
-                            || x.Kind() == SyntaxKind.VirtualKeyword
-                            || x.Kind() == SyntaxKind.PublicKeyword);
-                        return operatorDeclaration
-                                 .WithModifiers(SyntaxTokenList.Create(abstractVirtualModifiers.ToArray()))
-                                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword))
-                                 .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
-                                 .WithBody(null);
+                case SyntaxKind.OperatorDeclaration:
+                    var operatorDeclaration = (OperatorDeclarationSyntax)member;
+                    var abstractVirtualModifiers = operatorDeclaration.Modifiers.Where(x =>
+                        x.Kind() == SyntaxKind.AbstractKeyword
+                        || x.Kind() == SyntaxKind.VirtualKeyword
+                        || x.Kind() == SyntaxKind.PublicKeyword);
+                    return operatorDeclaration
+                        .WithModifiers(SyntaxTokenList.Create(abstractVirtualModifiers.ToArray()))
+                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword))
+                        .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                        .WithBody(null);
 
-                    case SyntaxKind.PropertyDeclaration:
-                        var property = (PropertyDeclarationSyntax)member;
-                        return property
-                            .WithModifiers(default)
-                            .WithAccessorList(WithoutBodies(property.AccessorList));
+                case SyntaxKind.PropertyDeclaration:
+                    var property = (PropertyDeclarationSyntax)member;
+                    return property
+                        .WithModifiers(default)
+                        .WithAccessorList(WithoutBodies(property.AccessorList));
 
                 case SyntaxKind.IndexerDeclaration:
                     var indexer = (IndexerDeclarationSyntax)member;

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -802,11 +802,17 @@ internal sealed class CSharpSyntaxGenerator : SyntaxGenerator
                              .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
                              .WithBody(null);
 
-                case SyntaxKind.PropertyDeclaration:
-                    var property = (PropertyDeclarationSyntax)member;
-                    return property
-                        .WithModifiers(default)
-                        .WithAccessorList(WithoutBodies(property.AccessorList));
+                    case SyntaxKind.OperatorDeclaration:
+                        return ((OperatorDeclarationSyntax)member)
+                                 .WithModifiers(default)
+                                 .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                                 .WithBody(null);
+
+                    case SyntaxKind.PropertyDeclaration:
+                        var property = (PropertyDeclarationSyntax)member;
+                        return property
+                            .WithModifiers(default)
+                            .WithAccessorList(WithoutBodies(property.AccessorList));
 
                 case SyntaxKind.IndexerDeclaration:
                     var indexer = (IndexerDeclarationSyntax)member;

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -2736,7 +2736,15 @@ public class C
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.ClassDeclaration("d"), [Generator.MethodDeclaration("m")]));
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.StructDeclaration("s"), [Generator.MethodDeclaration("m")]));
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.InterfaceDeclaration("i"), [Generator.MethodDeclaration("m")]));
-            AssertMemberNamesEqual("", Generator.AddMembers(Generator.InterfaceDeclaration("i"), [Generator.OperatorDeclaration(OperatorKind.Addition)]));
+            var interfaceOperator = Generator.AddMembers(Generator.InterfaceDeclaration("i"),
+                [Generator.OperatorDeclaration(OperatorKind.Addition)]);
+            VerifySyntax<InterfaceDeclarationSyntax>(interfaceOperator,
+                """
+                interface i
+                {
+                    static void operator +();
+                }
+                """);
             AssertMemberNamesEqual("v", Generator.AddMembers(Generator.EnumDeclaration("e"), [Generator.EnumMember("v")]));
             AssertMemberNamesEqual("n2", Generator.AddMembers(Generator.NamespaceDeclaration("n"), [Generator.NamespaceDeclaration("n2")]));
             AssertMemberNamesEqual("n", Generator.AddMembers(Generator.CompilationUnit(), [Generator.NamespaceDeclaration("n")]));

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -2780,7 +2780,7 @@ public class C
                 }
                 """);
         }
-        
+
         [Fact]
         public void TestRemoveMembers()
         {

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -2736,15 +2737,7 @@ public class C
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.ClassDeclaration("d"), [Generator.MethodDeclaration("m")]));
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.StructDeclaration("s"), [Generator.MethodDeclaration("m")]));
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.InterfaceDeclaration("i"), [Generator.MethodDeclaration("m")]));
-            var interfaceOperator = Generator.AddMembers(Generator.InterfaceDeclaration("i"),
-                [Generator.OperatorDeclaration(OperatorKind.Addition)]);
-            VerifySyntax<InterfaceDeclarationSyntax>(interfaceOperator,
-                """
-                interface i
-                {
-                    static void operator +();
-                }
-                """);
+            AssertMemberNamesEqual("", Generator.AddMembers(Generator.InterfaceDeclaration("i"), [Generator.OperatorDeclaration(OperatorKind.Addition)]));
             AssertMemberNamesEqual("v", Generator.AddMembers(Generator.EnumDeclaration("e"), [Generator.EnumMember("v")]));
             AssertMemberNamesEqual("n2", Generator.AddMembers(Generator.NamespaceDeclaration("n"), [Generator.NamespaceDeclaration("n2")]));
             AssertMemberNamesEqual("n", Generator.AddMembers(Generator.CompilationUnit(), [Generator.NamespaceDeclaration("n")]));
@@ -2757,6 +2750,37 @@ public class C
             AssertMemberNamesEqual(new[] { "n1", "n2" }, Generator.AddMembers(Generator.CompilationUnit(declarations: [Generator.NamespaceDeclaration("n1")]), [Generator.NamespaceDeclaration("n2")]));
         }
 
+        [Fact]
+        public void TestAddOperatorMembersToInterface()
+        {
+            VerifySyntax<InterfaceDeclarationSyntax>(Generator.AddMembers(Generator.InterfaceDeclaration("i"),
+                    [Generator.OperatorDeclaration(OperatorKind.Addition)]),
+                """
+                interface i
+                {
+                    static void operator +();
+                }
+                """);
+
+            VerifySyntax<InterfaceDeclarationSyntax>(Generator.AddMembers(Generator.InterfaceDeclaration("i"),
+                    [Generator.OperatorDeclaration(OperatorKind.Addition, modifiers: DeclarationModifiers.Abstract)]),
+                """
+                interface i
+                {
+                    static abstract void operator +();
+                }
+                """);
+
+            VerifySyntax<InterfaceDeclarationSyntax>(Generator.AddMembers(Generator.InterfaceDeclaration("i"),
+                    [Generator.OperatorDeclaration(OperatorKind.Addition, modifiers: DeclarationModifiers.Virtual)]),
+                """
+                interface i
+                {
+                    static virtual void operator +();
+                }
+                """);
+        }
+        
         [Fact]
         public void TestRemoveMembers()
         {

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -2736,6 +2736,7 @@ public class C
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.ClassDeclaration("d"), [Generator.MethodDeclaration("m")]));
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.StructDeclaration("s"), [Generator.MethodDeclaration("m")]));
             AssertMemberNamesEqual("m", Generator.AddMembers(Generator.InterfaceDeclaration("i"), [Generator.MethodDeclaration("m")]));
+            AssertMemberNamesEqual("", Generator.AddMembers(Generator.InterfaceDeclaration("i"), [Generator.OperatorDeclaration(OperatorKind.Addition)]));
             AssertMemberNamesEqual("v", Generator.AddMembers(Generator.EnumDeclaration("e"), [Generator.EnumMember("v")]));
             AssertMemberNamesEqual("n2", Generator.AddMembers(Generator.NamespaceDeclaration("n"), [Generator.NamespaceDeclaration("n2")]));
             AssertMemberNamesEqual("n", Generator.AddMembers(Generator.CompilationUnit(), [Generator.NamespaceDeclaration("n")]));


### PR DESCRIPTION
Closes #67019 

Added an assert in the appropriate test to make sure it no longer throws and actually handles this case.