### PR TITLE
Allow frozen snapshots to store stale information about filepaths

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal readonly struct FilePathToDocumentIdsMap
+    {
+        private static readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> s_emptyMap
+            = ImmutableDictionary.Create<string, ImmutableArray<DocumentId>>(StringComparer.OrdinalIgnoreCase);
+        public static readonly FilePathToDocumentIdsMap Empty = new(s_emptyMap);
+
+        private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> _map;
+
+        private FilePathToDocumentIdsMap(ImmutableDictionary<string, ImmutableArray<DocumentId>> map)
+        {
+            _map = map;
+        }
+
+        public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
+                => _map.TryGetValue(filePath, out documentIdsWithPath);
+
+        public static bool operator ==(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
+            => left._map == right._map;
+
+        public static bool operator !=(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
+            => !(left == right);
+
+        public override int GetHashCode()
+            => throw new NotSupportedException();
+
+        public override bool Equals([NotNullWhen(true)] object? obj)
+            => obj is FilePathToDocumentIdsMap map && Equals(map);
+
+        public Builder ToBuilder()
+            => new(_map.ToBuilder());
+
+        public readonly struct Builder
+        {
+            private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder _builder;
+
+            public Builder(ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder builder)
+            {
+                _builder = builder;
+            }
+
+            public FilePathToDocumentIdsMap ToImmutable()
+                => new(_builder.ToImmutable());
+
+            public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
+                => _builder.TryGetValue(filePath, out documentIdsWithPath);
+
+            public void MultiAdd(string filePath, DocumentId documentId)
+                => _builder.MultiAdd(filePath, documentId);
+
+            public void MultiRemove(string filePath, DocumentId documentId)
+                => _builder.MultiRemove(filePath, documentId);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
@@ -9,24 +9,37 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
 
+/// <summary>
+/// Helper type that keeps track of all the file paths for all the documents in a solution snapshot and all the document
+/// ids each maps to.
+/// </summary>
 internal readonly struct FilePathToDocumentIdsMap
 {
     private static readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> s_emptyMap
         = ImmutableDictionary.Create<string, ImmutableArray<DocumentId>>(StringComparer.OrdinalIgnoreCase);
-    public static readonly FilePathToDocumentIdsMap Empty = new(s_emptyMap);
+    public static readonly FilePathToDocumentIdsMap Empty = new(isFrozen: false, s_emptyMap);
 
+    /// <summary>
+    /// Whether or not this map corresponds to a frozen solution.  Frozen solutions commonly drop many documents
+    /// (because only documents whose trees have been parsed are kept out).  To keep things fast, instead of actually
+    /// dropping all those files from our <see cref="_map"/> we instead only keep track of added documents and mark that
+    /// we're frozen.  Then, when a client actually asks for the document ids in a particular solution, we only return the
+    /// actual set present in that solution instance.
+    /// </summary>
+    public readonly bool IsFrozen;
     private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> _map;
 
-    private FilePathToDocumentIdsMap(ImmutableDictionary<string, ImmutableArray<DocumentId>> map)
+    private FilePathToDocumentIdsMap(bool isFrozen, ImmutableDictionary<string, ImmutableArray<DocumentId>> map)
     {
+        IsFrozen = isFrozen;
         _map = map;
     }
 
     public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
-            => _map.TryGetValue(filePath, out documentIdsWithPath);
+        => _map.TryGetValue(filePath, out documentIdsWithPath);
 
     public static bool operator ==(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
-        => left._map == right._map;
+        => left.IsFrozen == right.IsFrozen && left._map == right._map;
 
     public static bool operator !=(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
         => !(left == right);
@@ -38,19 +51,24 @@ internal readonly struct FilePathToDocumentIdsMap
         => obj is FilePathToDocumentIdsMap map && Equals(map);
 
     public Builder ToBuilder()
-        => new(_map.ToBuilder());
+        => new(IsFrozen, _map.ToBuilder());
+
+    public FilePathToDocumentIdsMap ToFrozen()
+        => IsFrozen ? this : new(isFrozen: true, _map);
 
     public readonly struct Builder
     {
+        private readonly bool _isFrozen;
         private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder _builder;
 
-        public Builder(ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder builder)
+        public Builder(bool isFrozen, ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder builder)
         {
+            _isFrozen = isFrozen;
             _builder = builder;
         }
 
         public FilePathToDocumentIdsMap ToImmutable()
-            => new(_builder.ToImmutable());
+            => new(_isFrozen, _builder.ToImmutable());
 
         public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
             => _builder.TryGetValue(filePath, out documentIdsWithPath);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
@@ -73,10 +73,23 @@ internal readonly struct FilePathToDocumentIdsMap
         public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
             => _builder.TryGetValue(filePath, out documentIdsWithPath);
 
-        public void MultiAdd(string filePath, DocumentId documentId)
-            => _builder.MultiAdd(filePath, documentId);
+        public void MultiAdd(string? filePath, DocumentId documentId)
+        {
+            if (RoslynString.IsNullOrEmpty(filePath))
+                return;
 
-        public void MultiRemove(string filePath, DocumentId documentId)
-            => _builder.MultiRemove(filePath, documentId);
+            _builder.MultiAdd(filePath, documentId);
+        }
+
+        public void MultiRemove(string? filePath, DocumentId documentId)
+        {
+            if (RoslynString.IsNullOrEmpty(filePath))
+                return;
+
+            if (!this.TryGetValue(filePath, out var documentIdsWithPath) || !documentIdsWithPath.Contains(documentId))
+                throw new ArgumentException($"The given documentId was not found");
+
+            _builder.MultiRemove(filePath, documentId);
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
@@ -7,59 +7,58 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis
+namespace Microsoft.CodeAnalysis;
+
+internal readonly struct FilePathToDocumentIdsMap
 {
-    internal readonly struct FilePathToDocumentIdsMap
+    private static readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> s_emptyMap
+        = ImmutableDictionary.Create<string, ImmutableArray<DocumentId>>(StringComparer.OrdinalIgnoreCase);
+    public static readonly FilePathToDocumentIdsMap Empty = new(s_emptyMap);
+
+    private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> _map;
+
+    private FilePathToDocumentIdsMap(ImmutableDictionary<string, ImmutableArray<DocumentId>> map)
     {
-        private static readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> s_emptyMap
-            = ImmutableDictionary.Create<string, ImmutableArray<DocumentId>>(StringComparer.OrdinalIgnoreCase);
-        public static readonly FilePathToDocumentIdsMap Empty = new(s_emptyMap);
+        _map = map;
+    }
 
-        private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> _map;
+    public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
+            => _map.TryGetValue(filePath, out documentIdsWithPath);
 
-        private FilePathToDocumentIdsMap(ImmutableDictionary<string, ImmutableArray<DocumentId>> map)
+    public static bool operator ==(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
+        => left._map == right._map;
+
+    public static bool operator !=(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
+        => !(left == right);
+
+    public override int GetHashCode()
+        => throw new NotSupportedException();
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is FilePathToDocumentIdsMap map && Equals(map);
+
+    public Builder ToBuilder()
+        => new(_map.ToBuilder());
+
+    public readonly struct Builder
+    {
+        private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder _builder;
+
+        public Builder(ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder builder)
         {
-            _map = map;
+            _builder = builder;
         }
+
+        public FilePathToDocumentIdsMap ToImmutable()
+            => new(_builder.ToImmutable());
 
         public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
-                => _map.TryGetValue(filePath, out documentIdsWithPath);
+            => _builder.TryGetValue(filePath, out documentIdsWithPath);
 
-        public static bool operator ==(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
-            => left._map == right._map;
+        public void MultiAdd(string filePath, DocumentId documentId)
+            => _builder.MultiAdd(filePath, documentId);
 
-        public static bool operator !=(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
-            => !(left == right);
-
-        public override int GetHashCode()
-            => throw new NotSupportedException();
-
-        public override bool Equals([NotNullWhen(true)] object? obj)
-            => obj is FilePathToDocumentIdsMap map && Equals(map);
-
-        public Builder ToBuilder()
-            => new(_map.ToBuilder());
-
-        public readonly struct Builder
-        {
-            private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder _builder;
-
-            public Builder(ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder builder)
-            {
-                _builder = builder;
-            }
-
-            public FilePathToDocumentIdsMap ToImmutable()
-                => new(_builder.ToImmutable());
-
-            public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
-                => _builder.TryGetValue(filePath, out documentIdsWithPath);
-
-            public void MultiAdd(string filePath, DocumentId documentId)
-                => _builder.MultiAdd(filePath, documentId);
-
-            public void MultiRemove(string filePath, DocumentId documentId)
-                => _builder.MultiRemove(filePath, documentId);
-        }
+        public void MultiRemove(string filePath, DocumentId documentId)
+            => _builder.MultiRemove(filePath, documentId);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
@@ -73,7 +73,7 @@ internal readonly struct FilePathToDocumentIdsMap
         public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
             => _builder.TryGetValue(filePath, out documentIdsWithPath);
 
-        public void MultiAdd(string? filePath, DocumentId documentId)
+        public void Add(string? filePath, DocumentId documentId)
         {
             if (RoslynString.IsNullOrEmpty(filePath))
                 return;
@@ -81,7 +81,7 @@ internal readonly struct FilePathToDocumentIdsMap
             _builder.MultiAdd(filePath, documentId);
         }
 
-        public void MultiRemove(string? filePath, DocumentId documentId)
+        public void Remove(string? filePath, DocumentId documentId)
         {
             if (RoslynString.IsNullOrEmpty(filePath))
                 return;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1160,8 +1160,8 @@ internal sealed partial class SolutionCompilationState
                     oldDocumentState != newDocumentState &&
                     oldDocumentState.FilePath != newDocumentState.FilePath)
                 {
-                    SolutionState.RemoveDocumentFilePath(oldDocumentState, filePathToDocumentIdsMapBuilder);
-                    SolutionState.AddDocumentFilePath(newDocumentState, filePathToDocumentIdsMapBuilder);
+                    filePathToDocumentIdsMapBuilder.MultiRemove(oldDocumentState.FilePath, oldDocumentState.Id);
+                    filePathToDocumentIdsMapBuilder.MultiAdd(newDocumentState.FilePath, newDocumentState.Id);
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1148,6 +1148,13 @@ internal sealed partial class SolutionCompilationState
             if (oldStates.Equals(newStates))
                 return;
 
+            // We want to make sure that all the documents in the new-state are properly represented in the file map.
+            // It's ok if old-state documents are still in the map as GetDocumentIdsWithFilePath will filter them out
+            // later since we're producing a frozen-partial map.
+            // 
+            // Iterating over the new-states has an additional benefit.  For projects that haven't ever been looked at
+            // (so they haven't really parsed any documents), this will results in empty new-states.  So this loop will
+            // be almost a no-op for most non-relevant projects.
             foreach (var (documentId, newDocumentState) in newStates.States)
             {
                 if (!oldStates.TryGetState(documentId, out var oldDocumentState))

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1114,9 +1114,9 @@ internal sealed partial class SolutionCompilationState
 
             if (oldProjectState != newProjectState)
             {
-                CheckDocumentStates(filePathToDocumentIdsMapBuilder, oldProjectState.DocumentStates, newProjectState.DocumentStates);
-                CheckDocumentStates(filePathToDocumentIdsMapBuilder, oldProjectState.AdditionalDocumentStates, newProjectState.AdditionalDocumentStates);
-                CheckDocumentStates(filePathToDocumentIdsMapBuilder, oldProjectState.AnalyzerConfigDocumentStates, newProjectState.AnalyzerConfigDocumentStates);
+                AddMissingOrChangedFilePathMappings(filePathToDocumentIdsMapBuilder, oldProjectState.DocumentStates, newProjectState.DocumentStates);
+                AddMissingOrChangedFilePathMappings(filePathToDocumentIdsMapBuilder, oldProjectState.AdditionalDocumentStates, newProjectState.AdditionalDocumentStates);
+                AddMissingOrChangedFilePathMappings(filePathToDocumentIdsMapBuilder, oldProjectState.AnalyzerConfigDocumentStates, newProjectState.AnalyzerConfigDocumentStates);
             }
         }
 
@@ -1140,7 +1140,7 @@ internal sealed partial class SolutionCompilationState
 
         return newCompilationState;
 
-        static void CheckDocumentStates<TDocumentState>(
+        static void AddMissingOrChangedFilePathMappings<TDocumentState>(
             FilePathToDocumentIdsMap.Builder filePathToDocumentIdsMapBuilder,
             TextDocumentStates<TDocumentState> oldStates,
             TextDocumentStates<TDocumentState> newStates) where TDocumentState : TextDocumentState

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1113,7 +1113,7 @@ internal sealed partial class SolutionCompilationState
         var newIdToProjectStateMap = newIdToProjectStateMapBuilder.ToImmutable();
         var newIdToTrackerMap = newIdToTrackerMapBuilder.ToImmutable();
 
-        var filePathToDocumentIdsMap = filePathToDocumentIdsMapChanged
+        FilePathToDocumentIdsMap? filePathToDocumentIdsMap = filePathToDocumentIdsMapChanged
             ? filePathToDocumentIdsMapBuilder.ToImmutable()
             : null;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1114,9 +1114,9 @@ internal sealed partial class SolutionCompilationState
 
             if (oldProjectState != newProjectState)
             {
-                CheckDocumentStates(oldProjectState.DocumentStates, newProjectState.DocumentStates);
-                CheckDocumentStates(oldProjectState.AdditionalDocumentStates, newProjectState.AdditionalDocumentStates);
-                CheckDocumentStates(oldProjectState.AnalyzerConfigDocumentStates, newProjectState.AnalyzerConfigDocumentStates);
+                CheckDocumentStates(filePathToDocumentIdsMapBuilder, oldProjectState.DocumentStates, newProjectState.DocumentStates);
+                CheckDocumentStates(filePathToDocumentIdsMapBuilder, oldProjectState.AdditionalDocumentStates, newProjectState.AdditionalDocumentStates);
+                CheckDocumentStates(filePathToDocumentIdsMapBuilder, oldProjectState.AnalyzerConfigDocumentStates, newProjectState.AnalyzerConfigDocumentStates);
             }
         }
 
@@ -1140,7 +1140,8 @@ internal sealed partial class SolutionCompilationState
 
         return newCompilationState;
 
-        void CheckDocumentStates<TDocumentState>(
+        static void CheckDocumentStates<TDocumentState>(
+            FilePathToDocumentIdsMap.Builder filePathToDocumentIdsMapBuilder,
             TextDocumentStates<TDocumentState> oldStates,
             TextDocumentStates<TDocumentState> newStates) where TDocumentState : TextDocumentState
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1150,7 +1150,7 @@ internal sealed partial class SolutionCompilationState
 
             // Keep track of files that are definitely added.  Make sure the added doc is in the file path map.
             foreach (var documentId in newStates.GetAddedStateIds(oldStates))
-                SolutionState.AddDocumentFilePath(newStates.GetRequiredState(documentId), filePathToDocumentIdsMapBuilder);
+                filePathToDocumentIdsMapBuilder.Add(newStates.GetRequiredState(documentId).FilePath, documentId);
 
             // Now go through the states that are in both sets.  We have to check these all as it is possible for
             // document to change its file path without its id changing.
@@ -1160,8 +1160,8 @@ internal sealed partial class SolutionCompilationState
                     oldDocumentState != newDocumentState &&
                     oldDocumentState.FilePath != newDocumentState.FilePath)
                 {
-                    filePathToDocumentIdsMapBuilder.MultiRemove(oldDocumentState.FilePath, oldDocumentState.Id);
-                    filePathToDocumentIdsMapBuilder.MultiAdd(newDocumentState.FilePath, newDocumentState.Id);
+                    filePathToDocumentIdsMapBuilder.Remove(oldDocumentState.FilePath, oldDocumentState.Id);
+                    filePathToDocumentIdsMapBuilder.Add(newDocumentState.FilePath, newDocumentState.Id);
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -24,60 +24,6 @@ namespace Microsoft.CodeAnalysis
         ProjectState OldProjectState,
         ProjectState NewProjectState);
 
-    internal readonly struct FilePathToDocumentIdsMap
-    {
-        private static readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> s_emptyMap
-            = ImmutableDictionary.Create<string, ImmutableArray<DocumentId>>(StringComparer.OrdinalIgnoreCase);
-        public static readonly FilePathToDocumentIdsMap Empty = new(s_emptyMap);
-
-        private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> _map;
-
-        private FilePathToDocumentIdsMap(ImmutableDictionary<string, ImmutableArray<DocumentId>> map)
-        {
-            _map = map;
-        }
-
-        public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
-                => _map.TryGetValue(filePath, out documentIdsWithPath);
-
-        public static bool operator ==(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
-            => left._map == right._map;
-
-        public static bool operator !=(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
-            => !(left == right);
-
-        public override int GetHashCode()
-            => throw new NotSupportedException();
-
-        public override bool Equals([NotNullWhen(true)] object? obj)
-            => obj is FilePathToDocumentIdsMap map && Equals(map);
-
-        public Builder ToBuilder()
-            => new(_map.ToBuilder());
-
-        public readonly struct Builder
-        {
-            private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder _builder;
-
-            public Builder(ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder builder)
-            {
-                _builder = builder;
-            }
-
-            public FilePathToDocumentIdsMap ToImmutable()
-                => new(_builder.ToImmutable());
-
-            public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
-                => _builder.TryGetValue(filePath, out documentIdsWithPath);
-
-            public void MultiAdd(string filePath, DocumentId documentId)
-                => _builder.MultiAdd(filePath, documentId);
-
-            public void MultiRemove(string filePath, DocumentId documentId)
-                => _builder.MultiRemove(filePath, documentId);
-        }
-    }
-
     /// <summary>
     /// Represents a set of projects and their source code documents.
     ///

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -417,17 +417,7 @@ namespace Microsoft.CodeAnalysis
         private static void AddDocumentFilePaths(IEnumerable<TextDocumentState> documentStates, FilePathToDocumentIdsMap.Builder builder)
         {
             foreach (var documentState in documentStates)
-                AddDocumentFilePath(documentState, builder);
-        }
-
-        public static void AddDocumentFilePath(TextDocumentState documentState, FilePathToDocumentIdsMap.Builder builder)
-        {
-            var filePath = documentState.FilePath;
-
-            if (RoslynString.IsNullOrEmpty(filePath))
-                return;
-
-            builder.MultiAdd(filePath, documentState.Id);
+                builder.MultiAdd(documentState.FilePath, documentState.Id);
         }
 
         public FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithRemovedDocuments(IEnumerable<TextDocumentState> documentStates)
@@ -440,19 +430,7 @@ namespace Microsoft.CodeAnalysis
         private static void RemoveDocumentFilePaths(IEnumerable<TextDocumentState> documentStates, FilePathToDocumentIdsMap.Builder builder)
         {
             foreach (var documentState in documentStates)
-                RemoveDocumentFilePath(documentState, builder);
-        }
-
-        public static void RemoveDocumentFilePath(TextDocumentState documentState, FilePathToDocumentIdsMap.Builder builder)
-        {
-            var filePath = documentState.FilePath;
-            if (RoslynString.IsNullOrEmpty(filePath))
-                return;
-
-            if (!builder.TryGetValue(filePath, out var documentIdsWithPath) || !documentIdsWithPath.Contains(documentState.Id))
-                throw new ArgumentException($"The given documentId was not found in '{nameof(_filePathToDocumentIdsMap)}'.");
-
-            builder.MultiRemove(filePath, documentState.Id);
+                builder.MultiRemove(documentState.FilePath, documentState.Id);
         }
 
         private FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithFilePath(DocumentId documentId, string? oldFilePath, string? newFilePath)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis
         private static void AddDocumentFilePaths(IEnumerable<TextDocumentState> documentStates, FilePathToDocumentIdsMap.Builder builder)
         {
             foreach (var documentState in documentStates)
-                builder.MultiAdd(documentState.FilePath, documentState.Id);
+                builder.Add(documentState.FilePath, documentState.Id);
         }
 
         public FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithRemovedDocuments(IEnumerable<TextDocumentState> documentStates)
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis
         private static void RemoveDocumentFilePaths(IEnumerable<TextDocumentState> documentStates, FilePathToDocumentIdsMap.Builder builder)
         {
             foreach (var documentState in documentStates)
-                builder.MultiRemove(documentState.FilePath, documentState.Id);
+                builder.Remove(documentState.FilePath, documentState.Id);
         }
 
         private FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithFilePath(DocumentId documentId, string? oldFilePath, string? newFilePath)
@@ -442,15 +442,8 @@ namespace Microsoft.CodeAnalysis
 
             var builder = _filePathToDocumentIdsMap.ToBuilder();
 
-            if (!RoslynString.IsNullOrEmpty(oldFilePath))
-            {
-                builder.MultiRemove(oldFilePath, documentId);
-            }
-
-            if (!RoslynString.IsNullOrEmpty(newFilePath))
-            {
-                builder.MultiAdd(newFilePath, documentId);
-            }
+            builder.Remove(oldFilePath, documentId);
+            builder.Add(newFilePath, documentId);
 
             return builder.ToImmutable();
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1207,7 +1207,15 @@ namespace Microsoft.CodeAnalysis
             return result.ToImmutableAndClear();
 
             bool ContainsAnyDocument(DocumentId documentId)
-                => this.ContainsDocument(documentId) || this.ContainsAdditionalDocument(documentId) || this.ContainsAnalyzerConfigDocument(documentId);
+            {
+                var project = this.GetProjectState(documentId.ProjectId);
+                if (project is null)
+                    return false;
+
+                return project.DocumentStates.Contains(documentId)
+                    || project.AdditionalDocumentStates.Contains(documentId)
+                    || project.AnalyzerConfigDocumentStates.Contains(documentId);
+            }
         }
 
         public static ProjectDependencyGraph CreateDependencyGraph(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
@@ -214,7 +214,7 @@ namespace Roslyn.Utilities
         {
             if (dictionary.TryGetValue(key, out var collection))
             {
-                if (collection.Length == 1)
+                if (collection.Length == 1 && EqualityComparer<TValue>.Default.Equals(collection[0], value))
                 {
                     dictionary.Remove(key);
                 }


### PR DESCRIPTION
Should be reviewed one commit at a time. 

This is a mitigation for the perf hit we found when fixing some bugs in frozen partial snapshots.  Specifically, frozen partial snapshots could end up with solution snapshots with an incorrect file-path-to-document-id map.  That was bad as features could ask about documents the solution said were linked to the original document, but weren't actually in the solution snapshot itself.  Tests demonstrated this happening, and we had asserts and contract calls related to tracking this down.

The original fix was to be very correct in bringing that map up to date when making a frozen snapshot.  However, we've seen a several percent regression due to this work.  Specifically, it is common to freeze a project, and end up dumping all the documents from it.  This happens since we only keep documents we have syntax trees for.  However, dumping all the documents from a project leads to excessive churn in the map we have.

The mitigation in this PR is to allow frozen snapshots (but only frozen snapshots) to contain a superset of documents in that map.  Then, when retrieving the list of related documents, we check the ids against what is actually in the solution and we filter out anything missing.  From the client's perspective, the list is correct, just with the computation pushed out to the point it is requested.  As almost no features (using frozen snapshots) actually ask for linked documents (or, if they do, they ask for one document only) this saves all that extra correctness work that would go unnoticed.