### PR TITLE
Defer creating compilation caches till needed

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1139,11 +1139,9 @@ namespace Microsoft.CodeAnalysis
         // hash code conflicts, but seems to do the trick. The size is mostly arbitrary. My guess
         // is that there are maybe a couple dozen analyzers in the solution and each one has
         // ~0-2 unique well-known types, and the chance of hash collision is very low.
-        private readonly ConcurrentCache<string, INamedTypeSymbol?> _getTypeCache =
-            new ConcurrentCache<string, INamedTypeSymbol?>(50, ReferenceEqualityComparer.Instance);
+        private ConcurrentCache<string, INamedTypeSymbol?>? _getTypeCache;
 
-        private readonly ConcurrentCache<string, ImmutableArray<INamedTypeSymbol>> _getTypesCache =
-            new ConcurrentCache<string, ImmutableArray<INamedTypeSymbol>>(50, ReferenceEqualityComparer.Instance);
+        private ConcurrentCache<string, ImmutableArray<INamedTypeSymbol>>? _getTypesCache;
 
         /// <summary>
         /// Gets the type within the compilation's assembly and all referenced assemblies (other than
@@ -1187,12 +1185,15 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         public INamedTypeSymbol? GetTypeByMetadataName(string fullyQualifiedMetadataName)
         {
-            if (!_getTypeCache.TryGetValue(fullyQualifiedMetadataName, out INamedTypeSymbol? val))
+            var getTypeCache = RoslynLazyInitializer.EnsureInitialized(
+                ref _getTypeCache, static () => new ConcurrentCache<string, INamedTypeSymbol?>(50, ReferenceEqualityComparer.Instance));
+
+            if (!getTypeCache.TryGetValue(fullyQualifiedMetadataName, out INamedTypeSymbol? val))
             {
                 val = CommonGetTypeByMetadataName(fullyQualifiedMetadataName);
-                var result = _getTypeCache.TryAdd(fullyQualifiedMetadataName, val);
+                var result = getTypeCache.TryAdd(fullyQualifiedMetadataName, val);
                 Debug.Assert(result
-                 || !_getTypeCache.TryGetValue(fullyQualifiedMetadataName, out var addedType) // Could fail if the type was already evicted from the cache
+                 || !getTypeCache.TryGetValue(fullyQualifiedMetadataName, out var addedType) // Could fail if the type was already evicted from the cache
                  || ReferenceEquals(addedType, val));
             }
             return val;
@@ -1215,12 +1216,15 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         public ImmutableArray<INamedTypeSymbol> GetTypesByMetadataName(string fullyQualifiedMetadataName)
         {
-            if (!_getTypesCache.TryGetValue(fullyQualifiedMetadataName, out ImmutableArray<INamedTypeSymbol> val))
+            var getTypesCache = RoslynLazyInitializer.EnsureInitialized(
+                ref _getTypesCache, static () => new ConcurrentCache<string, ImmutableArray<INamedTypeSymbol>>(50, ReferenceEqualityComparer.Instance));
+
+            if (!getTypesCache.TryGetValue(fullyQualifiedMetadataName, out ImmutableArray<INamedTypeSymbol> val))
             {
                 val = getTypesByMetadataNameImpl();
-                var result = _getTypesCache.TryAdd(fullyQualifiedMetadataName, val);
+                var result = getTypesCache.TryAdd(fullyQualifiedMetadataName, val);
                 Debug.Assert(result
-                    || !_getTypesCache.TryGetValue(fullyQualifiedMetadataName, out var addedArray) // Could fail if the type was already evicted from the cache
+                    || !getTypesCache.TryGetValue(fullyQualifiedMetadataName, out var addedArray) // Could fail if the type was already evicted from the cache
                     || Enumerable.SequenceEqual(addedArray, val, ReferenceEqualityComparer.Instance));
             }
 


### PR DESCRIPTION
Traces show that creating compilations ends up costing a fair amount in these up front cache allocations: 

![image](https://github.com/dotnet/roslyn/assets/4564579/b8389235-efed-4e32-90fd-0c46ad08fc72)

We can defer making these collections as they are not actually needed in many cases.  Note: The compiler itself does not call these for the work it does.  These are called by IDE clients trying to find a particular type.  This avoids that cost for lots of the intermediary compilations created during normal typing that are never examined at all.

--

Note: teh top line is also of interest.  But that one is more critical to the compiler (it's the _typeToNullableVersion map), so i'm more wary about touching that guy as i'm not sure the implications.  It is something we could consider though.  