### PR TITLE
Disable CodeQL in unofficial builds

### DIFF
--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -23,6 +23,10 @@ variables:
     value: true
   - name: _DevDivDropAccessToken
     value: $(System.AccessToken)
+  - name: Codeql.Enabled
+    value: false
+  - name: Codeql.SkipTaskAutoInjection
+    value: true
 
 steps:
 - template: eng/pipelines/checkout-windows-task.yml

--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -48,6 +48,12 @@ pr:
       - CONTRIBUTING.md
       - README.md
 
+variables:
+- name: Codeql.Enabled
+  value: false
+- name: Codeql.SkipTaskAutoInjection
+  value: true
+
 parameters:
 - name: poolName
   displayName: Pool Name

--- a/azure-pipelines-integration-dartlab.yml
+++ b/azure-pipelines-integration-dartlab.yml
@@ -27,6 +27,10 @@ resources:
 variables:
 - name: XUNIT_LOGS
   value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
+- name: Codeql.Enabled
+  value: false
+- name: Codeql.SkipTaskAutoInjection
+  value: true
 
 stages:
 - template: \stages\visual-studio\agent.yml@DartLabTemplates

--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -34,6 +34,12 @@ pr:
     - release/dev17.2
     - release/dev17.3
 
+variables:
+- name: Codeql.Enabled
+  value: false
+- name: Codeql.SkipTaskAutoInjection
+  value: true
+
 parameters:
 - name: poolName
   displayName: Pool Name

--- a/azure-pipelines-integration-scouting.yml
+++ b/azure-pipelines-integration-scouting.yml
@@ -11,6 +11,12 @@ schedules:
     - main
     - main-vs-deps
 
+variables:
+- name: Codeql.Enabled
+  value: false
+- name: Codeql.SkipTaskAutoInjection
+  value: true
+
 parameters:
 - name: poolName
   displayName: Pool Name

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -44,7 +44,13 @@ pr:
       - README.md
       - src/Compilers/*
       - src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/README.md
- 
+
+variables:
+- name: Codeql.Enabled
+  value: false
+- name: Codeql.SkipTaskAutoInjection
+  value: true
+
 parameters:
 - name: poolName
   displayName: Pool Name

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -42,6 +42,11 @@ variables:
   - name: _DevDivDropAccessToken
     value: $(System.AccessToken)
 
+  - name: Codeql.Enabled
+    value: false
+  - name: Codeql.SkipTaskAutoInjection
+    value: true
+
 stages:
 - stage: build
   displayName: Build and Test

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -16,6 +16,12 @@ pr: none
 # - features/*
 # - demos/*
 
+variables:
+- name: Codeql.Enabled
+  value: false
+- name: Codeql.SkipTaskAutoInjection
+  value: true
+
 parameters:
 - name: poolName
   displayName: Pool Name

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,11 @@ variables:
   - name: HelixApiAccessToken
     value: ''
 
+  - name: Codeql.Enabled
+    value: false
+  - name: Codeql.SkipTaskAutoInjection
+    value: true
+
   # Set pool / queue name variables depending on which instance we're running in.
   - name: PoolName
     ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
It was disabling shared compilation, making the builds timeout (only when it actually executed - once every 72 hours).