### PR TITLE
Small optimization around ProjectState modification operations

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -765,6 +765,9 @@ internal partial class ProjectState
 
     public ProjectState AddDocuments(ImmutableArray<DocumentState> documents)
     {
+        if (documents.IsEmpty)
+            return this;
+
         Debug.Assert(!documents.Any(d => DocumentStates.Contains(d.Id)));
 
         return With(
@@ -774,6 +777,9 @@ internal partial class ProjectState
 
     public ProjectState AddAdditionalDocuments(ImmutableArray<AdditionalDocumentState> documents)
     {
+        if (documents.IsEmpty)
+            return this;
+
         Debug.Assert(!documents.Any(d => AdditionalDocumentStates.Contains(d.Id)));
 
         return With(
@@ -783,6 +789,9 @@ internal partial class ProjectState
 
     public ProjectState AddAnalyzerConfigDocuments(ImmutableArray<AnalyzerConfigDocumentState> documents)
     {
+        if (documents.IsEmpty)
+            return this;
+
         Debug.Assert(!documents.Any(d => AnalyzerConfigDocumentStates.Contains(d.Id)));
 
         var newAnalyzerConfigDocumentStates = AnalyzerConfigDocumentStates.AddRange(documents);
@@ -811,6 +820,9 @@ internal partial class ProjectState
 
     public ProjectState RemoveDocuments(ImmutableArray<DocumentId> documentIds)
     {
+        if (documentIds.IsEmpty)
+            return this;
+
         // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
         // for removed documents.
         return With(
@@ -821,6 +833,9 @@ internal partial class ProjectState
 
     public ProjectState RemoveAdditionalDocuments(ImmutableArray<DocumentId> documentIds)
     {
+        if (documentIds.IsEmpty)
+            return this;
+
         return With(
             projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
             additionalDocumentStates: AdditionalDocumentStates.RemoveRange(documentIds));
@@ -828,6 +843,9 @@ internal partial class ProjectState
 
     public ProjectState RemoveAnalyzerConfigDocuments(ImmutableArray<DocumentId> documentIds)
     {
+        if (documentIds.IsEmpty)
+            return this;
+
         var newAnalyzerConfigDocumentStates = AnalyzerConfigDocumentStates.RemoveRange(documentIds);
 
         return CreateNewStateForChangedAnalyzerConfigDocuments(newAnalyzerConfigDocumentStates);
@@ -835,6 +853,9 @@ internal partial class ProjectState
 
     public ProjectState RemoveAllDocuments()
     {
+        if (DocumentStates.IsEmpty && AdditionalDocumentStates.IsEmpty && AnalyzerConfigDocumentStates.IsEmpty)
+            return this;
+
         // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
         // for removed documents.
         return With(


### PR DESCRIPTION
Ensure ProjectState modification operations would actually create a modified ProjectState before creating the new ProjectState

When opening Roslyn.sln, I see 32800 ProjectState.AddDocument calls, of which 6700 are sending in an empty array to add. Similarly, I see 6700 ProjectState.RemoveAllDocuments calls, of which 4700 are called on ProjectState instances where the DocumentStates/AdditionalDocumentStates/AnalyzerConfigDocumentStates are all empty.