### PR TITLE
Small optimization around ProjectState modification operations

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -765,6 +765,9 @@ internal partial class ProjectState
 
     public ProjectState AddDocuments(ImmutableArray<DocumentState> documents)
     {
+        if (documents.IsEmpty)
+            return this;
+
         Debug.Assert(!documents.Any(d => DocumentStates.Contains(d.Id)));
 
         return With(
@@ -774,6 +777,9 @@ internal partial class ProjectState
 
     public ProjectState AddAdditionalDocuments(ImmutableArray<AdditionalDocumentState> documents)
     {
+        if (documents.IsEmpty)
+            return this;
+
         Debug.Assert(!documents.Any(d => AdditionalDocumentStates.Contains(d.Id)));
 
         return With(
@@ -783,6 +789,9 @@ internal partial class ProjectState
 
     public ProjectState AddAnalyzerConfigDocuments(ImmutableArray<AnalyzerConfigDocumentState> documents)
     {
+        if (documents.IsEmpty)
+            return this;
+
         Debug.Assert(!documents.Any(d => AnalyzerConfigDocumentStates.Contains(d.Id)));
 
         var newAnalyzerConfigDocumentStates = AnalyzerConfigDocumentStates.AddRange(documents);
@@ -811,6 +820,9 @@ internal partial class ProjectState
 
     public ProjectState RemoveDocuments(ImmutableArray<DocumentId> documentIds)
     {
+        if (documentIds.IsEmpty)
+            return this;
+
         // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
         // for removed documents.
         return With(
@@ -821,6 +833,9 @@ internal partial class ProjectState
 
     public ProjectState RemoveAdditionalDocuments(ImmutableArray<DocumentId> documentIds)
     {
+        if (documentIds.IsEmpty)
+            return this;
+
         return With(
             projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
             additionalDocumentStates: AdditionalDocumentStates.RemoveRange(documentIds));
@@ -828,13 +843,19 @@ internal partial class ProjectState
 
     public ProjectState RemoveAnalyzerConfigDocuments(ImmutableArray<DocumentId> documentIds)
     {
+        if (documentIds.IsEmpty)
+            return this;
+
         var newAnalyzerConfigDocumentStates = AnalyzerConfigDocumentStates.RemoveRange(documentIds);
 
         return CreateNewStateForChangedAnalyzerConfigDocuments(newAnalyzerConfigDocumentStates);
     }
 
-    public ProjectState RemoveAllDocuments()
+    public ProjectState RemoveAllNormalDocuments()
     {
+        if (DocumentStates.IsEmpty)
+            return this;
+
         // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
         // for removed documents.
         return With(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -823,15 +823,11 @@ internal partial class ProjectState
         if (documentIds.IsEmpty)
             return this;
 
-        var newDocumentStates = DocumentStates.RemoveRange(documentIds);
-        if (newDocumentStates.IsEmpty)
-            return this;
-
         // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
         // for removed documents.
         return With(
             projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
-            documentStates: newDocumentStates,
+            documentStates: DocumentStates.RemoveRange(documentIds),
             analyzerConfigSet: ComputeAnalyzerConfigOptionsValueSource(AnalyzerConfigDocumentStates));
     }
 
@@ -840,13 +836,9 @@ internal partial class ProjectState
         if (documentIds.IsEmpty)
             return this;
 
-        var newAdditionalDocumentStates = AdditionalDocumentStates.RemoveRange(documentIds);
-        if (newAdditionalDocumentStates.IsEmpty)
-            return this;
-
         return With(
             projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
-            additionalDocumentStates: newAdditionalDocumentStates);
+            additionalDocumentStates: AdditionalDocumentStates.RemoveRange(documentIds));
     }
 
     public ProjectState RemoveAnalyzerConfigDocuments(ImmutableArray<DocumentId> documentIds)
@@ -855,8 +847,6 @@ internal partial class ProjectState
             return this;
 
         var newAnalyzerConfigDocumentStates = AnalyzerConfigDocumentStates.RemoveRange(documentIds);
-        if (newAnalyzerConfigDocumentStates.IsEmpty)
-            return this;
 
         return CreateNewStateForChangedAnalyzerConfigDocuments(newAnalyzerConfigDocumentStates);
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -823,11 +823,15 @@ internal partial class ProjectState
         if (documentIds.IsEmpty)
             return this;
 
+        var newDocumentStates = DocumentStates.RemoveRange(documentIds);
+        if (newDocumentStates.IsEmpty)
+            return this;
+
         // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
         // for removed documents.
         return With(
             projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
-            documentStates: DocumentStates.RemoveRange(documentIds),
+            documentStates: newDocumentStates,
             analyzerConfigSet: ComputeAnalyzerConfigOptionsValueSource(AnalyzerConfigDocumentStates));
     }
 
@@ -836,9 +840,13 @@ internal partial class ProjectState
         if (documentIds.IsEmpty)
             return this;
 
+        var newAdditionalDocumentStates = AdditionalDocumentStates.RemoveRange(documentIds);
+        if (newAdditionalDocumentStates.IsEmpty)
+            return this;
+
         return With(
             projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
-            additionalDocumentStates: AdditionalDocumentStates.RemoveRange(documentIds));
+            additionalDocumentStates: newAdditionalDocumentStates);
     }
 
     public ProjectState RemoveAnalyzerConfigDocuments(ImmutableArray<DocumentId> documentIds)
@@ -847,6 +855,8 @@ internal partial class ProjectState
             return this;
 
         var newAnalyzerConfigDocumentStates = AnalyzerConfigDocumentStates.RemoveRange(documentIds);
+        if (newAnalyzerConfigDocumentStates.IsEmpty)
+            return this;
 
         return CreateNewStateForChangedAnalyzerConfigDocuments(newAnalyzerConfigDocumentStates);
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.cs
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis
                         // other.  It also means that if we're in the process of parsing documents in that chain, that
                         // we'll see the results of how far we've gotten if someone asks for a frozen snapshot midway
                         // through.
-                        var initialProjectState = this.ProjectState.RemoveAllDocuments();
+                        var initialProjectState = this.ProjectState.RemoveAllNormalDocuments();
                         var initialCompilation = this.CreateEmptyCompilation();
 
                         var translationActionsBuilder = ImmutableList.CreateBuilder<TranslationAction>();
@@ -723,7 +723,7 @@ namespace Microsoft.CodeAnalysis
 
                     // Transition us to a state that only has documents for the files we've already parsed.
                     var frozenProjectState = this.ProjectState
-                        .RemoveAllDocuments()
+                        .RemoveAllNormalDocuments()
                         .AddDocuments(documentsWithTreesBuilder.ToImmutableAndClear());
 
                     // Defer creating these compilations.  It's common to freeze projects (as part of a solution freeze)


### PR DESCRIPTION
Ensure ProjectState modification operations would actually create a modified ProjectState before creating the new ProjectState

When opening Roslyn.sln, I see 32800 ProjectState.AddDocument calls, of which 6700 are sending in an empty array to add. Similarly, I see 6700 ProjectState.RemoveAllDocuments calls, of which 4700 are called on ProjectState instances where the DocumentStates/AdditionalDocumentStates/AnalyzerConfigDocumentStates are all empty.