### PR TITLE
Avoid synthesizing the parameterless struct constructor unnecessarily

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -4663,7 +4663,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 //kick out early if we've seen everything we're looking for
-                if (hasInstanceConstructor && hasStaticConstructor)
+                if (hasInstanceConstructor &&
+                    hasParameterlessInstanceConstructor &&
+                    hasStaticConstructor)
                 {
                     break;
                 }


### PR DESCRIPTION
The parameterless struct constructor was synthesized unnecessarily if other instance constructors and a `static` constructor were declared before the parameterless constructor. The result was duplicate, ambiguous parameterless constructors.