### PR TITLE
Fix compiler vsix deployment

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -195,6 +195,7 @@
     <PackageVersion Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
     <PackageVersion Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageVersion Include="System.Resources.Extensions" Version="7.0.0" />

--- a/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
+++ b/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="System.Collections.Immutable" IncludeInVsix="true" />
     <PackageReference Include="System.Memory" IncludeInVsix="true" />
     <PackageReference Include="System.Reflection.Metadata" IncludeInVsix="true" />
+    <PackageReference Include="System.Numerics.Vectors" IncludeInVsix="true" />
     <PackageReference Include="System.Text.Encoding.CodePages" IncludeInVsix="true" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" IncludeInVsix="true" />
     <PackageReference Include="System.Threading.Tasks.Extensions" IncludeInVsix="true" />


### PR DESCRIPTION
The compiler vsix was not deploying system.numerics.vectors which caused csc to fail to launch on builds in VS.

The vsix that actually gets inserted *does* include the dll, so this is only a problem for local F5 / integration test scenarios.