### PR TITLE
Explicitly use dotnet pwsh in scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -490,7 +490,7 @@ stages:
     steps:
       - template: eng/pipelines/checkout-windows-task.yml
 
-      - script: .\eng\test-rebuild.cmd -ci -configuration Release -bootstrap
+      - pwsh: ./eng/test-rebuild.ps1 -ci -configuration Release -bootstrap
         displayName: Run BuildValidator
 
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -490,6 +490,9 @@ stages:
     steps:
       - template: eng/pipelines/checkout-windows-task.yml
 
+      - pwsh: ./eng/tool-restore.ps1
+        displayName: Restore local tools
+
       - pwsh: ./eng/test-rebuild.ps1 -ci -configuration Release -bootstrap
         displayName: Run BuildValidator
 

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,7 +8,7 @@
       ]
     },
     "powershell": {
-      "version": "7.0.0",
+      "version": "7.4.1",
       "commands": [
         "pwsh"
       ]

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -172,7 +172,8 @@ function Exec-Script([string]$script, [string]$scriptArgs = "", [switch]$useCons
   if ($args -ne "") {
     throw "Extra arguments passed to Exec-Script: $args"
   }
-  Exec-CommandCore -command "dotnet" -commandArgs "pwsh -noprofile -executionPolicy RemoteSigned -file `"$script`" $scriptArgs" -useConsole:$useConsole -echoCommand:$echoCommand
+  $dotnet = Ensure-DotNetSdk
+  Exec-CommandCore -command $dotnet -commandArgs "pwsh -noprofile -executionPolicy RemoteSigned -file `"$script`" $scriptArgs" -useConsole:$useConsole -echoCommand:$echoCommand
 }
 
 # Handy function for executing a dotnet command without having to track down the 

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -302,8 +302,6 @@ function Unsubst-TempDir() {
 function Stop-Processes() {
   Write-Host 'Killing running build processes Roslyn style...'
   foreach ($processName in $processesToStopOnExit) {
-    Get-Process -Name $processName -ErrorAction SilentlyContinue 
-      ? { $_.ProcessId -ne $PID }
-      | Stop-Process
+    Get-Process -Name $processName -ErrorAction SilentlyContinue ? { $_.ProcessId -ne $PID } | Stop-Process
   }
 }

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -294,3 +294,16 @@ function Unsubst-TempDir() {
     $env:TMP=$originalTemp
   }
 }
+
+# Override the arcade Stop-Process so that we can avoid having the Powershell
+# process kill itself on exit
+# 
+# https://github.com/dotnet/arcade/issues/14532
+function Stop-Processes() {
+  Write-Host 'Killing running build processes Roslyn style...'
+  foreach ($processName in $processesToStopOnExit) {
+    Get-Process -Name $processName -ErrorAction SilentlyContinue 
+      ? { $_.ProcessId -ne $PID }
+      | Stop-Process
+  }
+}

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -172,7 +172,7 @@ function Exec-Script([string]$script, [string]$scriptArgs = "", [switch]$useCons
   if ($args -ne "") {
     throw "Extra arguments passed to Exec-Script: $args"
   }
-  Exec-CommandCore -command "pwsh" -commandArgs "-noprofile -executionPolicy RemoteSigned -file `"$script`" $scriptArgs" -useConsole:$useConsole -echoCommand:$echoCommand
+  Exec-CommandCore -command "dotnet" -commandArgs "pwsh -noprofile -executionPolicy RemoteSigned -file `"$script`" $scriptArgs" -useConsole:$useConsole -echoCommand:$echoCommand
 }
 
 # Handy function for executing a dotnet command without having to track down the 

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -185,7 +185,6 @@ function Exec-DotNet([string]$commandArgs = "", [switch]$useConsole = $true, [sw
   Exec-CommandCore -command $dotnet -commandArgs $commandArgs -useConsole:$useConsole -echoCommand:$echoCommand
 }
 
-
 # Ensure the proper .NET Core SDK is available. Returns the location to the dotnet.exe.
 function Ensure-DotnetSdk() {
   $dotnetInstallDir = (InitializeDotNetCli -install:$true)

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -753,6 +753,7 @@ try {
     Write-Host "Building bootstrap Compiler"
     $bootstrapDir = Join-Path (Join-Path $ArtifactsDir "bootstrap") "build"
     Exec-Script (Join-Path $PSScriptRoot "make-bootstrap.ps1") "-output $bootstrapDir -force -ci:$ci"
+    Write-Host "After bootstrap compiler"
   }
 
   if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -791,8 +791,6 @@ catch {
   ExitWithExitCode 1
 }
 finally {
-  if (Test-Path Function:\Unsubst-TempDir) {
-    Unsubst-TempDir
-  }
+  Unsubst-TempDir
   Pop-Location
 }

--- a/eng/generate-compiler-code.cmd
+++ b/eng/generate-compiler-code.cmd
@@ -1,3 +1,3 @@
 @echo off
-pwsh -noprofile -executionPolicy RemoteSigned -file "%~dp0\generate-compiler-code.ps1" %* 
+dotnet pwsh -noprofile -executionPolicy RemoteSigned -file "%~dp0\generate-compiler-code.ps1" %* 
 

--- a/eng/make-bootstrap.cmd
+++ b/eng/make-bootstrap.cmd
@@ -1,2 +1,2 @@
 @echo off
-pwsh -noprofile -file "%~dp0\make-bootstrap.ps1" %* 
+dotnet pwsh -noprofile -file "%~dp0\make-bootstrap.ps1" %* 

--- a/eng/make-bootstrap.ps1
+++ b/eng/make-bootstrap.ps1
@@ -72,6 +72,7 @@ try {
   Exec-DotNet "build --no-restore /t:Clean $projectPath"
   Exec-DotNet "build-server shutdown"
 
+  Write-Host "Bootstrap compiler built successfully"
   ExitWithExitCode 0
 }
 catch {

--- a/eng/pipelines/build-bootstrap.yml
+++ b/eng/pipelines/build-bootstrap.yml
@@ -7,6 +7,9 @@ parameters:
 steps:
     - template: checkout-windows-task.yml
 
+    - pwsh: ./eng/tool-restore.ps1
+      displayName: Restore local tools
+
     - pwsh: |
         ./eng/make-bootstrap.ps1 -ci -toolset ${{parameters.toolset}} -output '$(Build.SourcesDirectory)/artifacts/bootstrap/ci-bootstrap'
 

--- a/eng/pipelines/test-integration-helix.yml
+++ b/eng/pipelines/test-integration-helix.yml
@@ -16,7 +16,6 @@ parameters:
         oopCoreClr: false
         lspEditor: false
         runName: 64
-  
 
 stages:
 - stage: Windows_${{ parameters.configuration }}_Build

--- a/eng/test-build-correctness.cmd
+++ b/eng/test-build-correctness.cmd
@@ -1,2 +1,2 @@
 @echo off
-pwsh -noprofile -file "%~dp0\test-build-correctness.ps1" %*
+dotnet pwsh -noprofile -file "%~dp0\test-build-correctness.ps1" %*

--- a/eng/test-determinism.cmd
+++ b/eng/test-determinism.cmd
@@ -1,2 +1,2 @@
 @echo off
-pwsh -noprofile -file "%~dp0\test-determinism.ps1" %*
+dotnet pwsh -noprofile -file "%~dp0\test-determinism.ps1" %*

--- a/eng/test-rebuild.cmd
+++ b/eng/test-rebuild.cmd
@@ -1,2 +1,2 @@
 @echo off
-pwsh -noprofile -file "%~dp0\test-rebuild.ps1" %*
+dotnet pwsh -noprofile -file "%~dp0\test-rebuild.ps1" %*

--- a/eng/tool-restore.ps1
+++ b/eng/tool-restore.ps1
@@ -1,0 +1,25 @@
+# This script is used to restore tools into repo. It's useful in CI where we need to get
+# a few base tools, like pwsh, established before we can run the main build.
+#
+# Generally this is not necessary for developer machines as they run Restore.cmd (or 
+# an equivalent) which gets the necessary tools on their machine.
+
+Set-StrictMode -version 3.0
+$ErrorActionPreference="Stop"
+
+try {
+
+  . (Join-Path $PSScriptRoot "build-utils.ps1")
+  $dotnet = Ensure-DotNetSdk
+  Exec-Command $dotnet "tool restore"
+}
+catch {
+  Write-Host $_
+  Write-Host $_.Exception
+  Write-Host $_.ScriptStackTrace
+  ExitWithExitCode 1
+}
+finally {
+  Unsubst-TempDir
+  Pop-Location
+}

--- a/eng/validate-rules-missing-documentation.cmd
+++ b/eng/validate-rules-missing-documentation.cmd
@@ -1,2 +1,2 @@
 @echo off
-pwsh -noprofile -executionPolicy RemoteSigned -file "%~dp0\validate-rules-missing-documentation.ps1" %*
+dotnetpwsh -noprofile -executionPolicy RemoteSigned -file "%~dp0\validate-rules-missing-documentation.ps1" %*

--- a/eng/validate-rules-missing-documentation.cmd
+++ b/eng/validate-rules-missing-documentation.cmd
@@ -1,2 +1,2 @@
 @echo off
-dotnetpwsh -noprofile -executionPolicy RemoteSigned -file "%~dp0\validate-rules-missing-documentation.ps1" %*
+dotnet pwsh -noprofile -executionPolicy RemoteSigned -file "%~dp0\validate-rules-missing-documentation.ps1" %*


### PR DESCRIPTION
This changes our cmd/ps1 scripts to explicitly use `dotnet pwsh` instead of `pwsh`. The former is guaranteed to be in our enlistment as it's installed as a local tool. The latter, while present on most machines including CI, is not guaranteed to be on all developer machines.