### PR TITLE
Reduce allocations in NodeStateTable.GetPackedState

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -204,7 +204,16 @@ namespace Microsoft.CodeAnalysis
             {
                 for (int i = 0; i < state.Count; i++)
                 {
-                    pooled.Builder.Append(state.GetState(i).ToString()[0]);
+                    var packedChar = state.GetState(i) switch
+                    {
+                        EntryState.Added => 'A',
+                        EntryState.Removed => 'R',
+                        EntryState.Modified => 'M',
+                        EntryState.Cached => 'C',
+                        _ => throw ExceptionUtilities.Unreachable(),
+                    };
+
+                    pooled.Builder.Append(packedChar);
                 }
                 pooled.Builder.Append(',');
             }


### PR DESCRIPTION
Boxing of the EntryState enum shows up in the RichCopyTest.CopyPlain test numbers as almost 1% of allocations. This code just needs to map EntryState values to a character for packing.

*** old allocations from profile
![image](https://github.com/dotnet/roslyn/assets/6785178/ec78c075-704b-4949-9d17-6684f56129fd)