### PR TITLE
Reduce allocations in InputNodes by specifying initial capacity

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -45,20 +45,8 @@ namespace Microsoft.CodeAnalysis
             var inputItems = _getInput(graphState);
             TimeSpan elapsedTime = stopwatch.Elapsed;
 
-            HashSet<T> itemsSet;
-            PooledHashSet<T>? pooledItemsSet;
-
             // create a mutable hashset of the new items we can check against
-            if (_inputComparer == EqualityComparer<T>.Default)
-            {
-                pooledItemsSet = PooledHashSet<T>.GetInstance();
-                itemsSet = pooledItemsSet;
-            }
-            else
-            {
-                pooledItemsSet = null;
-                itemsSet = new HashSet<T>(_inputComparer);
-            }
+            var itemsSet = (_inputComparer == EqualityComparer<T>.Default) ? PooledHashSet<T>.GetInstance() : new HashSet<T>(_inputComparer);
 
 #if NETCOREAPP
             itemsSet.EnsureCapacity(inputItems.Length);
@@ -115,7 +103,7 @@ namespace Microsoft.CodeAnalysis
             var newTable = tableBuilder.ToImmutableAndFree();
             this.LogTables(previousTable, newTable, inputItems);
 
-            pooledItemsSet?.Free();
+            (itemsSet as PooledHashSet<T>)?.Free();
 
             return newTable;
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -44,8 +45,25 @@ namespace Microsoft.CodeAnalysis
             var inputItems = _getInput(graphState);
             TimeSpan elapsedTime = stopwatch.Elapsed;
 
+            HashSet<T> itemsSet;
+            PooledHashSet<T>? pooledItemsSet;
+
             // create a mutable hashset of the new items we can check against
-            HashSet<T> itemsSet = new HashSet<T>(_inputComparer);
+            if (_inputComparer == EqualityComparer<T>.Default)
+            {
+                pooledItemsSet = PooledHashSet<T>.GetInstance();
+                itemsSet = pooledItemsSet;
+            }
+            else
+            {
+                pooledItemsSet = null;
+                itemsSet = new HashSet<T>(_inputComparer);
+            }
+
+#if NETCOREAPP
+            itemsSet.EnsureCapacity(inputItems.Length);
+#endif
+
             foreach (var item in inputItems)
             {
                 var added = itemsSet.Add(item);
@@ -96,6 +114,9 @@ namespace Microsoft.CodeAnalysis
 
             var newTable = tableBuilder.ToImmutableAndFree();
             this.LogTables(previousTable, newTable, inputItems);
+
+            pooledItemsSet?.Free();
+
             return newTable;
 
         }
@@ -116,7 +137,7 @@ namespace Microsoft.CodeAnalysis
                 return;
             }
 
-            var tableBuilder = NodeStateTable<T>.Empty.ToBuilder(_name, stepTrackingEnabled: false);
+            var tableBuilder = NodeStateTable<T>.Empty.ToBuilder(_name, stepTrackingEnabled: false, tableCapacity: inputs.Length);
             foreach (var input in inputs)
             {
                 tableBuilder.AddEntry(input, EntryState.Added, TimeSpan.Zero, stepInputs: default, EntryState.Added);


### PR DESCRIPTION
Resizes from adds inside InputNode after not specifying an initial capactity look to account for roughly1% of allocations in the RichCopyTest speedometer test. Additionally, we can use a pooled hashset inside UpdateStateTable when using the default comparer (which is the standard case I see hit in manual testing).

*** old allocations from RichCopyTest.CopyPlain speedometer run
![image](https://github.com/dotnet/roslyn/assets/6785178/3a9215a1-6a23-485f-950e-c3330c37269f)