### PR TITLE
Roslyn non-source-only build fixes

### DIFF
--- a/src/CodeStyle/Core/Tests/LegacyTestFramework/Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities.csproj
+++ b/src/CodeStyle/Core/Tests/LegacyTestFramework/Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net472</TargetFramework>
     <DefineConstants>$(DefineConstants),CODE_STYLE</DefineConstants>
     <IsShipping>false</IsShipping>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\..\..\Features\DiagnosticsTestUtilities\CodeActionsLegacy\AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs" Link="TestFramework\AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs" />

--- a/src/CodeStyle/Core/Tests/UnitTestUtilities/Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj
+++ b/src/CodeStyle/Core/Tests/UnitTestUtilities/Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net472</TargetFramework>
     <DefineConstants>$(DefineConstants),CODE_STYLE</DefineConstants>
     <IsShipping>false</IsShipping>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\..\..\Features\DiagnosticsTestUtilities\CodeActions\AnalyzerProperty.cs" Link="AnalyzerProperty.cs" />

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -47,7 +47,7 @@
          https://github.com/dotnet/dotnet/blob/main/repo-projects/roslyn.proj. For definitions of the TargetRid
          and other common properties, see https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md -->
     <RuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)' == ''">win-x64;win-x86;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(TargetRid)' == ''">win-x64;win-x86;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>
   </PropertyGroup>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -42,7 +42,10 @@
     <PublishDir Condition="'$(RuntimeIdentifier)' == ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/neutral</PublishDir>
 
     <!-- List of runtime identifiers that we want to publish an executable for. -->
-    <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid. -->
+    <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid.
+         TargetRid is provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
+         https://github.com/dotnet/dotnet/blob/main/repo-projects/roslyn.proj. For definitions of the TargetRid
+         and other common properties, see https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md -->
     <RuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)' == ''">win-x64;win-x86;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -41,8 +41,10 @@
     <PublishDir Condition="'$(RuntimeIdentifier)' != ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <PublishDir Condition="'$(RuntimeIdentifier)' == ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/neutral</PublishDir>
 
-    <!-- List of runtime identifiers that we want to publish an executable for -->
-    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <!-- List of runtime identifiers that we want to publish an executable for. -->
+    <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid. -->
+    <RuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)' == ''">win-x64;win-x86;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>
   </PropertyGroup>

--- a/src/NuGet/VS.ExternalAPIs.Roslyn.Package/VS.ExternalAPIs.Roslyn.Package.csproj
+++ b/src/NuGet/VS.ExternalAPIs.Roslyn.Package/VS.ExternalAPIs.Roslyn.Package.csproj
@@ -19,10 +19,6 @@
       "The assembly '...' is not inside the 'lib' folder and hence it won't be added as a reference when the package is installed into a project."
     -->
     <NoWarn>$(NoWarn);NU5100</NoWarn>
-
-    <!-- Work around missing project dependencies. VS features not needed at this time:
-         https://github.com/dotnet/source-build/issues/3981. -->
-    <ExcludeFromVerticalBuild>true</ExcludeFromVerticalBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Setup/DevDivVsix/CompilersPackage/CompilersPackage.targets
+++ b/src/Setup/DevDivVsix/CompilersPackage/CompilersPackage.targets
@@ -42,13 +42,12 @@
     </Copy>
   </Target>
 
-  <!-- TODO: https://github.com/dotnet/source-build/issues/3981 for where this should be excluded in vertical modes. -->
   <Target Name="_GenerateSwrFile"
           AfterTargets="Build"
           BeforeTargets="SwixBuild"
           DependsOnTargets="_SetSwrFilePath;InitializeDesktopCompilerArtifacts;_PrepareDesktopCompilerArtifactsForOptimization;ApplyOptimizations"
           Outputs="$(_SwrFilePath)"
-          Condition="'$(DotNetBuildFromSource)' != 'true' and '$(DotNetBuildVertical)' != 'true'">
+          Condition="'$(DotNetBuildFromSource)' != 'true'">
 
     <ItemGroup>
       <_File Include="@(DesktopCompilerArtifact)">

--- a/src/Setup/Directory.Build.props
+++ b/src/Setup/Directory.Build.props
@@ -2,8 +2,5 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <!-- TODO: https://github.com/dotnet/source-build/issues/3981
-          Remove if necessary. -->
-    <ExcludeFromVerticalBuild>true</ExcludeFromVerticalBuild>
   </PropertyGroup>
 </Project>

--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -2,8 +2,5 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <!-- TODO: https://github.com/dotnet/source-build/issues/3981
-         Remove if necessary. -->
-    <ExcludeFromVerticalBuild>true</ExcludeFromVerticalBuild>
   </PropertyGroup>
 </Project>

--- a/src/Tools/ExternalAccess/AspNetCore/Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj
+++ b/src/Tools/ExternalAccess/AspNetCore/Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj
@@ -14,7 +14,6 @@
     </PackageDescription>
     <!-- Referenced by dotnet/aspnetcore and included in SDK. Required for source build/vertical build. -->
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
-    <ExcludeFromVerticalBuild>false</ExcludeFromVerticalBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -12,7 +12,6 @@
       A supporting package for Razor:
       https://github.com/dotnet/razor
     </PackageDescription>
-    <ExcludeFromVerticalBuild>false</ExcludeFromVerticalBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+++ b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
@@ -10,7 +10,12 @@
     <!-- Xunit analyzer doesn't recognize benchmark attributes -->
     <NoWarn>$(NoWarn),xUnit1013</NoWarn>
     <UseWpf>true</UseWpf>
-    <IsTestProject>true</IsTestProject>
+    <!-- This project is not a test project in context of how this repo views test projects.
+         Marking it as such will change TFMs, bring in additional targets, and generally fail to build.
+         However, it is a 'test' type project and depends on other test utility projects that may be built in
+         every build invocation. For intance, when building officially in the VMR, test and test utility projects are excluded.
+         So, when test projects are excluded, exclude this benchmark project. -->
+    <ExcludeFromDotNetBuild Condition="'$(DotNetBuildTests)' != 'true'">true</ExcludeFromDotNetBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />

--- a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+++ b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
@@ -10,6 +10,7 @@
     <!-- Xunit analyzer doesn't recognize benchmark attributes -->
     <NoWarn>$(NoWarn),xUnit1013</NoWarn>
     <UseWpf>true</UseWpf>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />

--- a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+++ b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
@@ -14,7 +14,9 @@
          Marking it as such will change TFMs, bring in additional targets, and generally fail to build.
          However, it is a 'test' type project and depends on other test utility projects that may be built in
          every build invocation. For intance, when building officially in the VMR, test and test utility projects are excluded.
-         So, when test projects are excluded, exclude this benchmark project. -->
+         So, when test projects are excluded, exclude this benchmark project.
+         See https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md for information
+         on controls. -->
     <ExcludeFromDotNetBuild Condition="'$(DotNetBuildTests)' != 'true'">true</ExcludeFromDotNetBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
+++ b/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
@@ -10,6 +10,7 @@
     <LangVersion>11</LangVersion>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
+++ b/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
@@ -14,7 +14,9 @@
          Marking it as such will change TFMs, bring in additional targets, and generally fail to build.
          However, it is a 'test' type project and depends on other test utility projects that may be built in
          every build invocation. For intance, when building officially in the VMR, test and test utility projects are excluded.
-         So, when test projects are excluded, exclude this benchmark project. -->
+         So, when test projects are excluded, exclude this benchmark project.
+         See https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md for information
+         on controls. -->
     <ExcludeFromDotNetBuild Condition="'$(DotNetBuildTests)' != 'true'">true</ExcludeFromDotNetBuild>
   </PropertyGroup>
 

--- a/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
+++ b/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
@@ -10,7 +10,12 @@
     <LangVersion>11</LangVersion>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
-    <IsTestProject>true</IsTestProject>
+    <!-- This project is not a test project in context of how this repo views test projects.
+         Marking it as such will change TFMs, bring in additional targets, and generally fail to build.
+         However, it is a 'test' type project and depends on other test utility projects that may be built in
+         every build invocation. For intance, when building officially in the VMR, test and test utility projects are excluded.
+         So, when test projects are excluded, exclude this benchmark project. -->
+    <ExcludeFromDotNetBuild Condition="'$(DotNetBuildTests)' != 'true'">true</ExcludeFromDotNetBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
@@ -10,7 +10,6 @@
     <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
     <IsShipping>false</IsShipping>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
-    <ExcludeFromVerticalBuild>false</ExcludeFromVerticalBuild>
   </PropertyGroup>
   <ItemGroup>
     <!-- Make sure to reference the same version of Microsoft.CodeAnalysis.Analyzers as the rest of the build -->

--- a/src/VisualStudio/Directory.Build.props
+++ b/src/VisualStudio/Directory.Build.props
@@ -2,8 +2,5 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <!-- TODO: https://github.com/dotnet/source-build/issues/3981
-         Remove if necessary. -->
-    <ExcludeFromVerticalBuild>true</ExcludeFromVerticalBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
These changes make it possible to build roslyn in non-source-only modes in the VMR:
- Remove some vertical build (non-source-only) exclusions that were added during the PoC phase of the VMR
- When packing the language server nuget package, Pack only the rid that the current vertical is building.
- Mark a couple benchmark projects as IsTestProject. Tests are excluded by default when building the VMR
- Mark a couple of test utility projects as test utility projects. When not building tests, these projects are excluded from the build.