### PR TITLE
Merge the finally block during data flow analysis

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -5812,6 +5812,28 @@ class C
         [Theory]
         [InlineData(nameof(PreferDiscard))]
         [InlineData(nameof(PreferUnusedLocal))]
+        public async Task AssignedInCatchClause_UsedInFinally2(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+                """
+                int count;
+                try
+                {
+                    if (0 == 1) { }
+                    System.Console.WriteLine();
+                }
+                finally
+                {
+                    [|count|] = 3;
+                }
+                
+                if (count == 0) { }
+                """, optionName);
+        }
+
+        [Theory]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
         public async Task AssignedInCatchFilter_UsedAfterTryCatch(string optionName)
         {
             await TestMissingInRegularAndScriptAsync(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/CustomDataFlowAnalysis.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/CustomDataFlowAnalysis.cs
@@ -297,6 +297,10 @@ internal static class CustomDataFlowAnalysis<TBlockAnalysisData>
                                               dispatchedExceptionsFromRegions,
                                               cancellationToken);
             }
+            else
+            {
+                currentAnalysisData = mergedAnalysisData;
+            }
 
             if (!continueDispatchAfterFinally.TryGetValue(@finally, out var dispatch))
             {
@@ -331,6 +335,9 @@ internal static class CustomDataFlowAnalysis<TBlockAnalysisData>
                                 return;
                             }
 
+                            analyzer.SetCurrentAnalysisData(blocks[enclosing.NestedRegions[1].FirstBlockOrdinal],
+                                                            currentAnalysisData,
+                                                            cancellationToken);
                             break;
 
                         case ControlFlowRegionKind.TryAndCatch:


### PR DESCRIPTION
Closes #64044 

This one was complex so I'll break down what happened:

- We get to the first block analysis in the try block and get it done
- We jump to analyze the finally block on its own in case of an exception, but crucially, the actual analysis result is not persisted in the block map. The only reference left of it is the current results
- We come back to the try block, second block, but this overwrites the current results so now, no one knows that the write inside the finally is reachable from blocks below the try finally
- We eventually get to the block below the try finally and see the read, but the write is no longer part of the current results so it thinks the write is unreachable when it is.

In other words, if a write happens in a finally block of a try finally which had a try block containing more than one block, the information of the writes of the finally is lost when analyzing the second block of the try. If the try only has one block, this accidentally works because the current results end up being used for the blocks below. This is why commenting either lines would workaround the issue: there must be 2 or more control flow blocks inside the try.

This pr does 2 changes to address this:
- When we are done with a finally and it's set to continue with the exception dispatch, we persist the results to block map
- When we are about to exit the try block and out of the try finally, we merge the results we had in try with the ones in the finally so blocks below are aware the finally block is reachable