### PR TITLE
Remove a field from MultiDictionary.ValueSet

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (parameterMap == null)
             {
                 var parameters = _methodSymbol.Parameters;
-                parameterMap = new MultiDictionary<string, ParameterSymbol>(parameters.Length, EqualityComparer<string>.Default);
+                parameterMap = new MultiDictionary<string, ParameterSymbol>(parameters.Length);
                 foreach (var parameter in parameters)
                 {
                     if ((this.Flags & BinderFlags.InEEMethodBinder) != 0 && parameter.Type.IsDisplayClassType())

--- a/src/Compilers/CSharp/Portable/Binder/WithPrimaryConstructorParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithPrimaryConstructorParametersBinder.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (parameterMap == null)
             {
                 var parameters = _lazyPrimaryCtorWithParameters.Parameters;
-                parameterMap = new MultiDictionary<string, ParameterSymbol>(parameters.Length, EqualityComparer<string>.Default);
+                parameterMap = new MultiDictionary<string, ParameterSymbol>(parameters.Length);
                 foreach (var parameter in parameters)
                 {
                     parameterMap.Add(parameter.Name, parameter);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (!interfacesAndTheirBases[@interface].Contains(@interface))
+                if (!interfacesAndTheirBases[@interface].Contains(@interface, this.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.ValueComparer))
                 {
                     continue;
                 }
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // We ideally want to identify the interface location in the base list with an exact match but
             // will fall back and use the first derived interface if exact interface is not present.
             // this is the similar logic as the VB implementation.
-            Debug.Assert(this.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics[implementedInterface].Contains(implementedInterface));
+            Debug.Assert(this.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics[implementedInterface].Contains(implementedInterface, this.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.ValueComparer));
             var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
 
             NamedTypeSymbol directInterface = null;
@@ -460,7 +460,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (set.Count != 0)
             {
-                if (set.Contains(@interface))
+                if (set.Contains(@interface, currType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.ValueComparer))
                 {
                     result = HasBaseTypeDeclaringInterfaceResult.ExactMatch;
                     return true;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2050,7 +2050,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var @interface = interfaceMember.ContainingType;
 
             SourceMemberContainerTypeSymbol snt = null;
-            if (implementingType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics[@interface].Contains(@interface))
+            if (implementingType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics[@interface].Contains(@interface, implementingType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.ValueComparer))
             {
                 snt = implementingType as SourceMemberContainerTypeSymbol;
             }

--- a/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
@@ -164,6 +164,11 @@ namespace Roslyn.Utilities
                 return new ValueSet(set.Add(v));
             }
 
+            public bool Contains(V v)
+            {
+                throw new InvalidOperationException("Call Contains method with equality comparer");
+            }
+
             public bool Contains(V v, IEqualityComparer<V> comparer)
             {
                 var set = _value as ImmutableHashSet<V>;

--- a/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
@@ -100,8 +100,6 @@ namespace Roslyn.Utilities
             // Stores either a single V or an ImmutableHashSet<V>
             private readonly object? _value;
 
-            private readonly IEqualityComparer<V> _equalityComparer;
-
             public int Count
             {
                 get
@@ -128,10 +126,9 @@ namespace Roslyn.Utilities
                 }
             }
 
-            public ValueSet(object? value, IEqualityComparer<V>? equalityComparer = null)
+            public ValueSet(object? value)
             {
                 _value = value;
-                _equalityComparer = equalityComparer ?? ImmutableHashSet<V>.Empty.KeyComparer;
             }
 
             IEnumerator IEnumerable.GetEnumerator()
@@ -149,46 +146,33 @@ namespace Roslyn.Utilities
                 return new Enumerator(this);
             }
 
-            public ValueSet Add(V v)
+            public ValueSet Add(V v, IEqualityComparer<V> comparer)
             {
                 Debug.Assert(_value != null);
 
                 var set = _value as ImmutableHashSet<V>;
                 if (set == null)
                 {
-                    if (_equalityComparer.Equals((V)_value!, v))
+                    if (comparer.Equals((V)_value!, v))
                     {
                         return this;
                     }
 
-                    set = ImmutableHashSet.Create(_equalityComparer, (V)_value!);
+                    set = ImmutableHashSet.Create(comparer, (V)_value!);
                 }
 
-                return new ValueSet(set.Add(v), _equalityComparer);
-            }
-
-            public bool Contains(V v)
-            {
-                var set = _value as ImmutableHashSet<V>;
-                if (set == null)
-                {
-                    return _equalityComparer.Equals((V)_value!, v);
-                }
-
-                return set.Contains(v);
+                return new ValueSet(set.Add(v));
             }
 
             public bool Contains(V v, IEqualityComparer<V> comparer)
             {
-                foreach (V other in this)
+                var set = _value as ImmutableHashSet<V>;
+                if (set == null)
                 {
-                    if (comparer.Equals(other, v))
-                    {
-                        return true;
-                    }
+                    return comparer.Equals((V)_value!, v);
                 }
 
-                return false;
+                return set.Contains(v);
             }
 
             public V Single()
@@ -205,7 +189,7 @@ namespace Roslyn.Utilities
 
         private readonly Dictionary<K, ValueSet> _dictionary;
 
-        private readonly IEqualityComparer<V>? _valueComparer;
+        public IEqualityComparer<V> ValueComparer { get; }
 
         public int Count => _dictionary.Count;
 
@@ -215,7 +199,7 @@ namespace Roslyn.Utilities
 
         public Dictionary<K, ValueSet>.ValueCollection Values => _dictionary.Values;
 
-        private readonly ValueSet _emptySet = new(null, null);
+        private readonly ValueSet _emptySet = new(null);
 
         // Returns an empty set if there is no such key in the dictionary.
         public ValueSet this[K k]
@@ -227,13 +211,13 @@ namespace Roslyn.Utilities
         }
 
         public MultiDictionary()
+            : this(0)
         {
-            _dictionary = new Dictionary<K, ValueSet>();
         }
 
         public MultiDictionary(IEqualityComparer<K> comparer)
+            : this(0, comparer)
         {
-            _dictionary = new Dictionary<K, ValueSet>(comparer);
         }
 
         public void EnsureCapacity(int capacity)
@@ -243,10 +227,10 @@ namespace Roslyn.Utilities
 #endif
         }
 
-        public MultiDictionary(int capacity, IEqualityComparer<K> comparer, IEqualityComparer<V>? valueComparer = null)
+        public MultiDictionary(int capacity, IEqualityComparer<K>? comparer = null, IEqualityComparer<V>? valueComparer = null)
         {
             _dictionary = new Dictionary<K, ValueSet>(capacity, comparer);
-            _valueComparer = valueComparer;
+            ValueComparer = valueComparer ?? EqualityComparer<V>.Default;
         }
 
         public bool Add(K k, V v)
@@ -255,7 +239,7 @@ namespace Roslyn.Utilities
 
             if (_dictionary.TryGetValue(k, out ValueSet set))
             {
-                updated = set.Add(v);
+                updated = set.Add(v, ValueComparer);
                 if (updated.Equals(set))
                 {
                     return false;
@@ -263,7 +247,7 @@ namespace Roslyn.Utilities
             }
             else
             {
-                updated = new ValueSet(v, _valueComparer);
+                updated = new ValueSet(v);
             }
 
             _dictionary[k] = updated;

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyDataForAssemblyBeingBuilt.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyDataForAssemblyBeingBuilt.cs
@@ -85,7 +85,10 @@ namespace Microsoft.CodeAnalysis
 
                 for (int i = 0; i < _referencedAssemblyData.Length; i++)
                 {
-                    Debug.Assert(assemblies[_referencedAssemblyData[i].Identity.Name].Contains((_referencedAssemblyData[i], i + 1)));
+#if DEBUG
+                    var valueSet = assemblies[_referencedAssemblyData[i].Identity.Name];
+                    Debug.Assert(valueSet.Contains((_referencedAssemblyData[i], i + 1), assemblies.ValueComparer));
+#endif
                     boundReferences[i] = new AssemblyReferenceBinding(_referencedAssemblyData[i].Identity, i + 1);
                 }
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
@@ -180,7 +180,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim errorReported As Boolean = False        ' was an error already reported?
                 Dim interfaceNamedType As NamedTypeSymbol = DirectCast(interfaceType, NamedTypeSymbol)
 
-                If Not containingType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics(interfaceNamedType).Contains(interfaceNamedType) Then
+                If Not containingType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics(interfaceNamedType).Contains(interfaceNamedType, containingType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.ValueComparer) Then
                     ' Class doesn't implement the interface that was named
                     Binder.ReportDiagnostic(diagBag, interfaceName, ERRID.ERR_InterfaceNotImplemented1,
                                             interfaceType)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -480,7 +480,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Gets the implements location for a particular interface, which must be implemented but might be indirectly implemented.
         ' Also gets the direct interface it was inherited through
         Private Function GetImplementsLocation(implementedInterface As NamedTypeSymbol, ByRef directInterface As NamedTypeSymbol) As Location
-            Debug.Assert(Me.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics(implementedInterface).Contains(implementedInterface))
+            Debug.Assert(Me.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics(implementedInterface).Contains(implementedInterface, Me.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.ValueComparer))
 
             ' Find the directly implemented interface that "implementedIface" was inherited through.
             directInterface = Nothing

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
@@ -142,7 +142,7 @@ internal abstract class AbstractTypeImportCompletionProvider<AliasDeclarationTyp
             // check if the type name is in the dictionary.
             // It is done in this way to avoid calling ImportCompletionItem.GetTypeName for all the CompletionItems
             if (!aliasTargetNamespaceToTypeNameMap.IsEmpty
-                && aliasTargetNamespaceToTypeNameMap[containingNamespace].Contains(ImportCompletionItem.GetTypeName(item)))
+                && aliasTargetNamespaceToTypeNameMap[containingNamespace].Contains(ImportCompletionItem.GetTypeName(item), aliasTargetNamespaceToTypeNameMap.ValueComparer))
             {
                 return false;
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -64,7 +64,7 @@ internal partial class SymbolTreeInfo
     public MultiDictionary<string, ExtensionMethodInfo>.ValueSet GetExtensionMethodInfoForReceiverType(string typeName)
         => _receiverTypeNameToExtensionMethodMap != null
             ? _receiverTypeNameToExtensionMethodMap[typeName]
-            : new MultiDictionary<string, ExtensionMethodInfo>.ValueSet(null, null);
+            : new MultiDictionary<string, ExtensionMethodInfo>.ValueSet(null);
 
     public bool ContainsExtensionMethod => _receiverTypeNameToExtensionMethodMap?.Count > 0;
 


### PR DESCRIPTION
Instead of keeping this field once per key in a MultiDictionary, we instead utilize the existing MultiDictionary's reference to a value comparer. This required plumbing through the value comparer to a couple methods on the ValueSet, but will slightly reduce the size and allocation footprint of MultiDictionary objects.