### PR TITLE
Reduce closure and Lazy allocations inside CSharpCompilation.ctor

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorEasyOut.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorEasyOut.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            BinaryOperatorSignature signature = this.Compilation.builtInOperators.GetSignature(easyOut);
+            BinaryOperatorSignature signature = this.Compilation.BuiltInOperators.GetSignature(easyOut);
 
             Conversion leftConversion = Conversions.FastClassifyConversion(leftType, signature.LeftType);
             Conversion rightConversion = Conversions.FastClassifyConversion(rightType, signature.RightType);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -719,7 +719,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                this.Compilation.builtInOperators.GetSimpleBuiltInOperators(kind, operators, skipNativeIntegerOperators: !left.Type.IsNativeIntegerOrNullableThereof() && !right.Type.IsNativeIntegerOrNullableThereof());
+                this.Compilation.BuiltInOperators.GetSimpleBuiltInOperators(kind, operators, skipNativeIntegerOperators: !left.Type.IsNativeIntegerOrNullableThereof() && !right.Type.IsNativeIntegerOrNullableThereof());
 
                 // SPEC 7.3.4: For predefined enum and delegate operators, the only operators
                 // considered are those defined by an enum or delegate type that is the binding
@@ -734,7 +734,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isUtf8ByteRepresentation(left) &&
                     isUtf8ByteRepresentation(right))
                 {
-                    this.Compilation.builtInOperators.GetUtf8ConcatenationBuiltInOperator(left.Type, operators);
+                    this.Compilation.BuiltInOperators.GetUtf8ConcatenationBuiltInOperator(left.Type, operators);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorEasyOut.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorEasyOut.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            UnaryOperatorSignature signature = this.Compilation.builtInOperators.GetSignature(easyOut);
+            UnaryOperatorSignature signature = this.Compilation.BuiltInOperators.GetSignature(easyOut);
 
             Conversion? conversion = Conversions.FastClassifyConversion(operandType, signature.OperandType);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // specification to match the previous implementation.
 
             var operators = ArrayBuilder<UnaryOperatorSignature>.GetInstance();
-            this.Compilation.builtInOperators.GetSimpleBuiltInOperators(kind, operators, skipNativeIntegerOperators: !operand.Type.IsNativeIntegerOrNullableThereof());
+            this.Compilation.BuiltInOperators.GetSimpleBuiltInOperators(kind, operators, skipNativeIntegerOperators: !operand.Type.IsNativeIntegerOrNullableThereof());
 
             GetEnumOperations(kind, operand, operators);
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private Imports? _lazyPreviousSubmissionImports;
         private AliasSymbol? _lazyGlobalNamespaceAlias;  // alias symbol used to resolve "global::".
 
-        private NamedTypeSymbol? _lazyScriptClass;
+        private NamedTypeSymbol? _lazyScriptClass = ErrorTypeSymbol.UnknownResultType;
 
         // The type of host object model if available.
         private TypeSymbol? _lazyHostObjectTypeSymbol;
@@ -93,11 +93,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Manages anonymous types declared in this compilation. Unifies types that are structurally equivalent.
         /// </summary>
-        private AnonymousTypeManager? _anonymousTypeManager;
+        private AnonymousTypeManager? _lazyAnonymousTypeManager;
 
         private NamespaceSymbol? _lazyGlobalNamespace;
 
-        private BuiltInOperators? _builtInOperators;
+        private BuiltInOperators? _lazyBuiltInOperators;
 
         /// <summary>
         /// The <see cref="SourceAssemblySymbol"/> for this compilation. Do not access directly, use Assembly property
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Cache of T to Nullable&lt;T&gt;.
         /// </summary>
-        private ConcurrentCache<TypeSymbol, NamedTypeSymbol>? _typeToNullableVersion;
+        private ConcurrentCache<TypeSymbol, NamedTypeSymbol>? _lazyTypeToNullableVersion;
 
         /// <summary>Lazily caches SyntaxTrees by their mapped path. Used to look up the syntax tree referenced by an interceptor (temporary compat behavior).</summary>
         /// <remarks>Must be removed prior to interceptors stable release.</remarks>
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return InterlockedOperations.Initialize(ref _builtInOperators, static self => new BuiltInOperators(self), this);
+                return InterlockedOperations.Initialize(ref _lazyBuiltInOperators, static self => new BuiltInOperators(self), this);
             }
         }
 
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return InterlockedOperations.Initialize(ref _anonymousTypeManager, static self => new AnonymousTypeManager(self), this);
+                return InterlockedOperations.Initialize(ref _lazyAnonymousTypeManager, static self => new AnonymousTypeManager(self), this);
             }
         }
 
@@ -479,7 +479,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(assemblyName, references, features, isSubmission, semanticModelProvider, eventQueue)
         {
             _options = options;
-            _lazyScriptClass = ErrorTypeSymbol.UnknownResultType;
 
             this.LanguageVersion = CommonLanguageVersion(syntaxAndDeclarations.ExternalSyntaxTrees);
 
@@ -1656,7 +1655,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return InterlockedOperations.Initialize(ref _typeToNullableVersion, static () => new ConcurrentCache<TypeSymbol, NamedTypeSymbol>(size: 100));
+                return InterlockedOperations.Initialize(ref _lazyTypeToNullableVersion, static () => new ConcurrentCache<TypeSymbol, NamedTypeSymbol>(size: 100));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => InterlockedOperations.Initialize(ref _builtInOperators, static self => new BuiltInOperators(self), this);
 
         internal AnonymousTypeManager AnonymousTypeManager
-            => InterlockedOperations.Initialize(ref _anonymousTypeManager, self => new AnonymousTypeManager(self), this);
+            => InterlockedOperations.Initialize(ref _anonymousTypeManager, static self => new AnonymousTypeManager(self), this);
 
         internal override CommonAnonymousTypeManager CommonAnonymousTypeManager
         {
@@ -1490,8 +1490,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // _scriptClass is allowed to be null, thus why a bool is used to track initialization
                 if (!_scriptClassInitialized)
                 {
-                    _scriptClassInitialized = true;
                     Interlocked.CompareExchange(ref _scriptClass, BindScriptClass(), null);
+                    _scriptClassInitialized = true;
                 }
 
                 return _scriptClass;
@@ -1519,17 +1519,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Global imports (including those from previous submissions, if there are any).
         /// </summary>
         internal ImmutableArray<NamespaceOrTypeAndUsingDirective> GlobalImports
-        {
-            get
-            {
-                if (_globalImports.IsDefault)
-                {
-                    ImmutableInterlocked.InterlockedInitialize(ref _globalImports, BindGlobalImports());
-                }
-
-                return _globalImports;
-            }
-        }
+            => InterlockedOperations.Initialize(ref _globalImports, () => BindGlobalImports());
 
         private ImmutableArray<NamespaceOrTypeAndUsingDirective> BindGlobalImports()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     public partial class CSharpCompilation
     {
-        private WellKnownMembersSignatureComparer? _wellKnownMemberSignatureComparer;
+        private WellKnownMembersSignatureComparer? _lazyWellKnownMemberSignatureComparer;
 
         /// <summary>
         /// An array of cached well known types available for use in this Compilation.
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool _needsGeneratedAttributes_IsFrozen;
 
         internal WellKnownMembersSignatureComparer WellKnownMemberSignatureComparer
-            => InterlockedOperations.Initialize(ref _wellKnownMemberSignatureComparer, static self => new WellKnownMembersSignatureComparer(self), this);
+            => InterlockedOperations.Initialize(ref _lazyWellKnownMemberSignatureComparer, static self => new WellKnownMembersSignatureComparer(self), this);
 
         /// <summary>
         /// Returns a value indicating which embedded attributes should be generated during emit phase.

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     public partial class CSharpCompilation
     {
-        internal readonly WellKnownMembersSignatureComparer WellKnownMemberSignatureComparer;
+        private WellKnownMembersSignatureComparer? _wellKnownMemberSignatureComparer;
 
         /// <summary>
         /// An array of cached well known types available for use in this Compilation.
@@ -34,6 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool _usesNullableAttributes;
         private int _needsGeneratedAttributes;
         private bool _needsGeneratedAttributes_IsFrozen;
+
+        internal WellKnownMembersSignatureComparer WellKnownMemberSignatureComparer
+            => InterlockedOperations.Initialize(ref _wellKnownMemberSignatureComparer, static self => new WellKnownMembersSignatureComparer(self), this);
 
         /// <summary>
         /// Returns a value indicating which embedded attributes should be generated during emit phase.

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -1537,7 +1537,7 @@ class Program
                 static void verifyUnaryOperators(CSharpCompilation comp, UnaryOperatorKind operatorKind, bool skipNativeIntegerOperators)
                 {
                     var builder = ArrayBuilder<UnaryOperatorSignature>.GetInstance();
-                    comp.builtInOperators.GetSimpleBuiltInOperators(operatorKind, builder, skipNativeIntegerOperators);
+                    comp.BuiltInOperators.GetSimpleBuiltInOperators(operatorKind, builder, skipNativeIntegerOperators);
                     var operators = builder.ToImmutableAndFree();
                     int expectedSigned = skipNativeIntegerOperators ? 0 : 1;
                     int expectedUnsigned = skipNativeIntegerOperators ? 0 : (operatorKind == UnaryOperatorKind.UnaryMinus) ? 0 : 1;
@@ -1548,7 +1548,7 @@ class Program
                 static void verifyBinaryOperators(CSharpCompilation comp, BinaryOperatorKind operatorKind, bool skipNativeIntegerOperators)
                 {
                     var builder = ArrayBuilder<BinaryOperatorSignature>.GetInstance();
-                    comp.builtInOperators.GetSimpleBuiltInOperators(operatorKind, builder, skipNativeIntegerOperators);
+                    comp.BuiltInOperators.GetSimpleBuiltInOperators(operatorKind, builder, skipNativeIntegerOperators);
                     var operators = builder.ToImmutableAndFree();
                     int expected = skipNativeIntegerOperators ? 0 : 1;
                     verifyOperators(operators, (op, signed) => isNativeInt(op.LeftType, signed), expected, expected);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -4789,7 +4789,7 @@ False
                 static void verifyUnaryOperators(CSharpCompilation comp, UnaryOperatorKind operatorKind, bool skipNativeIntegerOperators)
                 {
                     var builder = ArrayBuilder<UnaryOperatorSignature>.GetInstance();
-                    comp.builtInOperators.GetSimpleBuiltInOperators(operatorKind, builder, skipNativeIntegerOperators);
+                    comp.BuiltInOperators.GetSimpleBuiltInOperators(operatorKind, builder, skipNativeIntegerOperators);
                     var operators = builder.ToImmutableAndFree();
                     int expectedSigned = skipNativeIntegerOperators ? 0 : 1;
                     int expectedUnsigned = skipNativeIntegerOperators ? 0 : (operatorKind == UnaryOperatorKind.UnaryMinus) ? 0 : 1;
@@ -4800,7 +4800,7 @@ False
                 static void verifyBinaryOperators(CSharpCompilation comp, BinaryOperatorKind operatorKind, bool skipNativeIntegerOperators)
                 {
                     var builder = ArrayBuilder<BinaryOperatorSignature>.GetInstance();
-                    comp.builtInOperators.GetSimpleBuiltInOperators(operatorKind, builder, skipNativeIntegerOperators);
+                    comp.BuiltInOperators.GetSimpleBuiltInOperators(operatorKind, builder, skipNativeIntegerOperators);
                     var operators = builder.ToImmutableAndFree();
                     int expected = skipNativeIntegerOperators ? 0 : 1;
                     verifyOperators(operators, (op, signed) => isNativeInt(op.LeftType, signed), expected, expected);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -7593,7 +7593,7 @@ public class RubyTime
             }
             else
             {
-                signature = compilation.builtInOperators.GetSignature(result);
+                signature = compilation.BuiltInOperators.GetSignature(result);
 
                 if ((object)underlying != (object)type)
                 {
@@ -8232,14 +8232,14 @@ class Module1
                 else if ((op == BinaryOperatorKind.Addition || op == BinaryOperatorKind.Subtraction) &&
                     leftType.IsEnumType() && (rightType.IsIntegralType() || rightType.IsCharType()) &&
                     (result = OverloadResolution.BinopEasyOut.OpKind(op, leftType.EnumUnderlyingTypeOrSelf(), rightType)) != BinaryOperatorKind.Error &&
-                    TypeSymbol.Equals((signature = compilation.builtInOperators.GetSignature(result)).RightType, leftType.EnumUnderlyingTypeOrSelf(), TypeCompareKind.ConsiderEverything2))
+                    TypeSymbol.Equals((signature = compilation.BuiltInOperators.GetSignature(result)).RightType, leftType.EnumUnderlyingTypeOrSelf(), TypeCompareKind.ConsiderEverything2))
                 {
                     signature = new BinaryOperatorSignature(signature.Kind | BinaryOperatorKind.EnumAndUnderlying, leftType, signature.RightType, leftType);
                 }
                 else if ((op == BinaryOperatorKind.Addition || op == BinaryOperatorKind.Subtraction) &&
                     rightType.IsEnumType() && (leftType.IsIntegralType() || leftType.IsCharType()) &&
                     (result = OverloadResolution.BinopEasyOut.OpKind(op, leftType, rightType.EnumUnderlyingTypeOrSelf())) != BinaryOperatorKind.Error &&
-                    TypeSymbol.Equals((signature = compilation.builtInOperators.GetSignature(result)).LeftType, rightType.EnumUnderlyingTypeOrSelf(), TypeCompareKind.ConsiderEverything2))
+                    TypeSymbol.Equals((signature = compilation.BuiltInOperators.GetSignature(result)).LeftType, rightType.EnumUnderlyingTypeOrSelf(), TypeCompareKind.ConsiderEverything2))
                 {
                     signature = new BinaryOperatorSignature(signature.Kind | BinaryOperatorKind.EnumAndUnderlying, signature.LeftType, rightType, rightType);
                 }
@@ -8355,7 +8355,7 @@ class Module1
             }
             else
             {
-                signature = compilation.builtInOperators.GetSignature(result);
+                signature = compilation.BuiltInOperators.GetSignature(result);
             }
 
             Assert.NotNull(symbol1);


### PR DESCRIPTION
Additionally, lazily create a couple members that don't appear to be used on most instances. Together, these account for about 0.8% of all allocations in the CopyPlainText speedometer test.

*** Previous allocations from test profile
![image](https://github.com/dotnet/roslyn/assets/6785178/db764b82-7402-451a-8830-280c7f5e31a2)