### PR TITLE
Reduce allocations required to create a TransformNode

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
@@ -76,20 +76,13 @@ namespace Microsoft.CodeAnalysis
                     var stopwatch = SharedStopwatch.StartNew();
                     // generate the new entries
                     ImmutableArray<TOutput> newOutputs;
-                    if (_wrapUserFunc)
-                    {
-                        try
-                        {
-                            newOutputs = _func(entry.Item, cancellationToken);
-                        }
-                        catch (Exception e) when (!ExceptionUtilities.IsCurrentOperationBeingCancelled(e, cancellationToken))
-                        {
-                            throw new UserFunctionException(e);
-                        }
-                    }
-                    else
+                    try
                     {
                         newOutputs = _func(entry.Item, cancellationToken);
+                    }
+                    catch (Exception e) when (_wrapUserFunc && !ExceptionUtilities.IsCurrentOperationBeingCancelled(e, cancellationToken))
+                    {
+                        throw new UserFunctionException(e);
                     }
 
                     if (entry.State != EntryState.Modified || !tableBuilder.TryModifyEntries(newOutputs, _comparer, stopwatch.Elapsed, inputs, entry.State))

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
@@ -19,25 +19,27 @@ namespace Microsoft.CodeAnalysis
         private readonly IEqualityComparer<TOutput> _comparer;
         private readonly IIncrementalGeneratorNode<TInput> _sourceNode;
         private readonly string? _name;
+        private readonly bool _wrapUserFunc;
 
-        public TransformNode(IIncrementalGeneratorNode<TInput> sourceNode, Func<TInput, CancellationToken, TOutput> userFunc, IEqualityComparer<TOutput>? comparer = null, string? name = null)
-            : this(sourceNode, userFunc: (i, token) => ImmutableArray.Create(userFunc(i, token)), comparer, name)
+        public TransformNode(IIncrementalGeneratorNode<TInput> sourceNode, Func<TInput, CancellationToken, TOutput> userFunc, bool wrapUserFunc = false, IEqualityComparer<TOutput>? comparer = null, string? name = null)
+            : this(sourceNode, userFunc: (i, token) => ImmutableArray.Create(userFunc(i, token)), wrapUserFunc, comparer, name)
         {
         }
 
-        public TransformNode(IIncrementalGeneratorNode<TInput> sourceNode, Func<TInput, CancellationToken, ImmutableArray<TOutput>> userFunc, IEqualityComparer<TOutput>? comparer = null, string? name = null)
+        public TransformNode(IIncrementalGeneratorNode<TInput> sourceNode, Func<TInput, CancellationToken, ImmutableArray<TOutput>> userFunc, bool wrapUserFunc = false, IEqualityComparer<TOutput>? comparer = null, string? name = null)
         {
             _sourceNode = sourceNode;
             _func = userFunc;
+            _wrapUserFunc = wrapUserFunc;
             _comparer = comparer ?? EqualityComparer<TOutput>.Default;
             _name = name;
         }
 
         public IIncrementalGeneratorNode<TOutput> WithComparer(IEqualityComparer<TOutput> comparer)
-            => new TransformNode<TInput, TOutput>(_sourceNode, _func, comparer, _name);
+            => new TransformNode<TInput, TOutput>(_sourceNode, _func, _wrapUserFunc, comparer, _name);
 
         public IIncrementalGeneratorNode<TOutput> WithTrackingName(string name)
-            => new TransformNode<TInput, TOutput>(_sourceNode, _func, _comparer, name);
+            => new TransformNode<TInput, TOutput>(_sourceNode, _func, _wrapUserFunc, _comparer, name);
 
         public NodeStateTable<TOutput> UpdateStateTable(DriverStateTable.Builder builder, NodeStateTable<TOutput>? previousTable, CancellationToken cancellationToken)
         {
@@ -73,7 +75,22 @@ namespace Microsoft.CodeAnalysis
                 {
                     var stopwatch = SharedStopwatch.StartNew();
                     // generate the new entries
-                    var newOutputs = _func(entry.Item, cancellationToken);
+                    ImmutableArray<TOutput> newOutputs;
+                    if (_wrapUserFunc)
+                    {
+                        try
+                        {
+                            newOutputs = _func(entry.Item, cancellationToken);
+                        }
+                        catch (Exception e) when (!ExceptionUtilities.IsCurrentOperationBeingCancelled(e, cancellationToken))
+                        {
+                            throw new UserFunctionException(e);
+                        }
+                    }
+                    else
+                    {
+                        newOutputs = _func(entry.Item, cancellationToken);
+                    }
 
                     if (entry.State != EntryState.Modified || !tableBuilder.TryModifyEntries(newOutputs, _comparer, stopwatch.Elapsed, inputs, entry.State))
                     {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
@@ -13,16 +13,16 @@ namespace Microsoft.CodeAnalysis
     public static class IncrementalValueProviderExtensions
     {
         // 1 => 1 transform 
-        public static IncrementalValueProvider<TResult> Select<TSource, TResult>(this IncrementalValueProvider<TSource> source, Func<TSource, CancellationToken, TResult> selector) => new IncrementalValueProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector.WrapUserFunction(source.CatchAnalyzerExceptions)), source.CatchAnalyzerExceptions);
+        public static IncrementalValueProvider<TResult> Select<TSource, TResult>(this IncrementalValueProvider<TSource> source, Func<TSource, CancellationToken, TResult> selector) => new IncrementalValueProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector, wrapUserFunc: source.CatchAnalyzerExceptions), source.CatchAnalyzerExceptions);
 
-        public static IncrementalValuesProvider<TResult> Select<TSource, TResult>(this IncrementalValuesProvider<TSource> source, Func<TSource, CancellationToken, TResult> selector) => new IncrementalValuesProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector.WrapUserFunction(source.CatchAnalyzerExceptions)), source.CatchAnalyzerExceptions);
+        public static IncrementalValuesProvider<TResult> Select<TSource, TResult>(this IncrementalValuesProvider<TSource> source, Func<TSource, CancellationToken, TResult> selector) => new IncrementalValuesProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector, wrapUserFunc: source.CatchAnalyzerExceptions), source.CatchAnalyzerExceptions);
 
         // 1 => many (or none) transform
-        public static IncrementalValuesProvider<TResult> SelectMany<TSource, TResult>(this IncrementalValueProvider<TSource> source, Func<TSource, CancellationToken, ImmutableArray<TResult>> selector) => new IncrementalValuesProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector.WrapUserFunction(source.CatchAnalyzerExceptions)), source.CatchAnalyzerExceptions);
+        public static IncrementalValuesProvider<TResult> SelectMany<TSource, TResult>(this IncrementalValueProvider<TSource> source, Func<TSource, CancellationToken, ImmutableArray<TResult>> selector) => new IncrementalValuesProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector, wrapUserFunc: source.CatchAnalyzerExceptions), source.CatchAnalyzerExceptions);
 
         public static IncrementalValuesProvider<TResult> SelectMany<TSource, TResult>(this IncrementalValueProvider<TSource> source, Func<TSource, CancellationToken, IEnumerable<TResult>> selector) => new IncrementalValuesProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector.WrapUserFunctionAsImmutableArray(source.CatchAnalyzerExceptions)), source.CatchAnalyzerExceptions);
 
-        public static IncrementalValuesProvider<TResult> SelectMany<TSource, TResult>(this IncrementalValuesProvider<TSource> source, Func<TSource, CancellationToken, ImmutableArray<TResult>> selector) => new IncrementalValuesProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector.WrapUserFunction(source.CatchAnalyzerExceptions)), source.CatchAnalyzerExceptions);
+        public static IncrementalValuesProvider<TResult> SelectMany<TSource, TResult>(this IncrementalValuesProvider<TSource> source, Func<TSource, CancellationToken, ImmutableArray<TResult>> selector) => new IncrementalValuesProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector, wrapUserFunc: source.CatchAnalyzerExceptions), source.CatchAnalyzerExceptions);
 
         public static IncrementalValuesProvider<TResult> SelectMany<TSource, TResult>(this IncrementalValuesProvider<TSource> source, Func<TSource, CancellationToken, IEnumerable<TResult>> selector) => new IncrementalValuesProvider<TResult>(new TransformNode<TSource, TResult>(source.Node, selector.WrapUserFunctionAsImmutableArray(source.CatchAnalyzerExceptions)), source.CatchAnalyzerExceptions);
 


### PR DESCRIPTION
Instead of wrapping the user function and passing that into the TransformNode ctor, we instead give the option of passing in a flag to indicate whether the TransformNode should do the try/catch itself.

This looks to save about 0.5% in allocations in the RichCopyTest.CopyPlain speedometer via [results here](https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms-vseng.pit-vsengPerf.pit-hub?targetBuild=34703.55.dn-bot.240304.222618.533385&targetBranch=main&targetPerfBuildId=9182221&runGroup=Speedometer&since=2024-03-04&baselineBuild=34703.55&baselineBranch=main) from [this test insertion](https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/533385).