### PR TITLE
WIP: Attempt at reducing the file I/O under the AnalyzerAssemblyLoader folder.

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -261,7 +261,7 @@ Delta: Gamma: Beta: Test B
         }
 
         /// <summary>
-        /// The loaders should not actually look at the contents of the disk until a <see cref="AnalyzerAssemblyLoader.LoadFromPath(string)"/>
+        /// The loaders should not actually look at the contents of the disk until a <see cref="AnalyzerAssemblyLoader.LoadFromPath(string, bool)"/>
         /// call has occurred. This is historical behavior that doesn't have a clear reason for existing. There
         /// is strong suspicion it's to delay loading of analyzers until absolutely necessary. As such we're
         /// enshrining the behavior here so it is not _accidentally_ changed.
@@ -1337,7 +1337,7 @@ Delta.2: Test D2
                 var analyzerPath = tempDir.CreateFile("AnalyzerWithLoc.dll").CopyContentFrom(testFixture.AnalyzerWithLoc).Path;
                 var analyzerResourcesPath = tempDir.CreateDirectory("en-GB").CreateFile("AnalyzerWithLoc.resources.dll").CopyContentFrom(testFixture.AnalyzerWithLocResourceEnGB).Path;
                 loader.AddDependencyLocation(analyzerPath);
-                var assembly = loader.LoadFromPath(analyzerPath);
+                var assembly = loader.LoadFromPath(analyzerPath, prepareSatelliteAssemblies: true);
                 var methodInfo = assembly
                     .GetType("AnalyzerWithLoc.Util")!
                     .GetMethod("Exec", BindingFlags.Static | BindingFlags.Public)!;

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
@@ -748,6 +748,6 @@ public class Generator : ISourceGenerator
     {
         public void AddDependencyLocation(string fullPath) { }
         public bool IsHostAssembly(Assembly assembly) => false;
-        public Assembly LoadFromPath(string fullPath) => throw new Exception();
+        public Assembly LoadFromPath(string fullPath, bool prepareResourceAssemblies = false) => throw new Exception();
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
@@ -748,6 +748,7 @@ public class Generator : ISourceGenerator
     {
         public void AddDependencyLocation(string fullPath) { }
         public bool IsHostAssembly(Assembly assembly) => false;
-        public Assembly LoadFromPath(string fullPath, bool prepareResourceAssemblies = false) => throw new Exception();
+        public Assembly LoadFromPath(string fullPath) => throw new Exception();
+        public Assembly LoadFromPath(string fullPath, bool prepareResourceAssemblies) => throw new Exception();
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis
                 var assemblyPath = Path.Combine(Directory, simpleName + ".dll");
                 if (_loader.IsAnalyzerDependencyPath(assemblyPath))
                 {
-                    (_, var loadPath, _) = _loader.GetAssemblyInfoForPath(assemblyPath);
+                    (_, var loadPath) = _loader.GetAssemblyInfoForPath(assemblyPath);
                     return loadCore(loadPath);
                 }
 
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis
                 var assemblyPath = Path.Combine(Directory, unmanagedDllName + ".dll");
                 if (_loader.IsAnalyzerDependencyPath(assemblyPath))
                 {
-                    (_, var loadPath, _) = _loader.GetAssemblyInfoForPath(assemblyPath);
+                    (_, var loadPath) = _loader.GetAssemblyInfoForPath(assemblyPath);
                     return LoadUnmanagedDllFromPath(loadPath);
                 }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -100,6 +100,7 @@ namespace Microsoft.CodeAnalysis
                 // it's instance. Repeated calls to this method, even if the underlying 
                 // file system contents, should reuse the results of the first call.
                 _ = _analyzerAssemblyInfoMap.TryAdd(fullPath, null);
+                _ = _analyzerSatelliteAssemblyInfoMap.TryAdd(fullPath, null);
             }
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
     /// to <see cref="AddDependencyLocation(string)"/>.
     /// </summary>
     /// <remarks>
-    /// This type generally assumes that files on disk aren't changing, since it ensure that two calls to <see cref="LoadFromPath(string, bool)"/>
+    /// This type generally assumes that files on disk aren't changing, since it ensure that two calls to <see cref="LoadFromPath(string)"/>
     /// will always return the same thing, per that interface's contract.
     /// </remarks>
     internal abstract partial class AnalyzerAssemblyLoader : IAnalyzerAssemblyLoaderInternal
@@ -104,16 +104,23 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public Assembly LoadFromPath(string originalAnalyzerPath, bool prepareSatelliteAssemblies = false)
+        public Assembly LoadFromPath(string originalAnalyzerPath, bool prepareSatelliteAssemblies)
         {
-            CompilerPathUtilities.RequireAbsolutePath(originalAnalyzerPath, nameof(originalAnalyzerPath));
-
-            (AssemblyName? assemblyName, _) = GetAssemblyInfoForPath(originalAnalyzerPath);
+            var result = LoadFromPath(originalAnalyzerPath);
 
             if (prepareSatelliteAssemblies)
             {
                 GetSatelliteAssemblyInfoForPath(originalAnalyzerPath);
             }
+
+            return result;
+        }
+
+        public Assembly LoadFromPath(string originalAnalyzerPath)
+        {
+            CompilerPathUtilities.RequireAbsolutePath(originalAnalyzerPath, nameof(originalAnalyzerPath));
+
+            (AssemblyName? assemblyName, _) = GetAssemblyInfoForPath(originalAnalyzerPath);
 
             // Not a managed assembly, nothing else to do
             if (assemblyName is null)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
     /// to <see cref="AddDependencyLocation(string)"/>.
     /// </summary>
     /// <remarks>
-    /// This type generally assumes that files on disk aren't changing, since it ensure that two calls to <see cref="LoadFromPath(string)"/>
+    /// This type generally assumes that files on disk aren't changing, since it ensure that two calls to <see cref="LoadFromPath(string, bool)"/>
     /// will always return the same thing, per that interface's contract.
     /// </remarks>
     internal abstract partial class AnalyzerAssemblyLoader : IAnalyzerAssemblyLoaderInternal
@@ -104,11 +104,16 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public Assembly LoadFromPath(string originalAnalyzerPath)
+        public Assembly LoadFromPath(string originalAnalyzerPath, bool prepareSatelliteAssemblies = false)
         {
             CompilerPathUtilities.RequireAbsolutePath(originalAnalyzerPath, nameof(originalAnalyzerPath));
 
             (AssemblyName? assemblyName, _) = GetAssemblyInfoForPath(originalAnalyzerPath);
+
+            if (prepareSatelliteAssemblies)
+            {
+                GetSatelliteAssemblyInfoForPath(originalAnalyzerPath);
+            }
 
             // Not a managed assembly, nothing else to do
             if (assemblyName is null)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -32,7 +32,11 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The default implementation is to simply load in place.
         /// </summary>
-        protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> satelliteCultureNames) => fullPath;
+        protected override string PreparePathToLoad(string fullPath) => fullPath;
+
+        protected override void PrepareSatelliteAssembliesToLoad(string assemblyFilePath, ImmutableHashSet<string> resourceAssemblyCultureNames)
+        {
+        }
 
         /// <summary>
         /// Return an <see cref="IAnalyzerAssemblyLoader"/> which does not lock assemblies on disk that is

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/IAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/IAnalyzerAssemblyLoader.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Handles loading analyzer assemblies and their dependencies.
     /// 
-    /// Before an analyzer assembly is loaded with <see cref="LoadFromPath(string)"/>,
+    /// Before an analyzer assembly is loaded with <see cref="LoadFromPath(string, bool)"/>,
     /// its location and the location of all of its dependencies must first be specified
     /// by calls to <see cref="AddDependencyLocation(string)"/>.
     /// </summary>
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="fullPath" /> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="fullPath" /> is not a full path.</exception>
-        Assembly LoadFromPath(string fullPath);
+        Assembly LoadFromPath(string fullPath, bool prepareSatelliteAssemblies = false);
 
         /// <summary>
         /// Adds a file to consider when loading an analyzer or its dependencies.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/IAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/IAnalyzerAssemblyLoader.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Handles loading analyzer assemblies and their dependencies.
     /// 
-    /// Before an analyzer assembly is loaded with <see cref="LoadFromPath(string, bool)"/>,
+    /// Before an analyzer assembly is loaded with <see cref="LoadFromPath(string)"/>,
     /// its location and the location of all of its dependencies must first be specified
     /// by calls to <see cref="AddDependencyLocation(string)"/>.
     /// </summary>
@@ -37,7 +37,9 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="fullPath" /> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="fullPath" /> is not a full path.</exception>
-        Assembly LoadFromPath(string fullPath, bool prepareSatelliteAssemblies = false);
+        Assembly LoadFromPath(string fullPath);
+
+        Assembly LoadFromPath(string fullPath, bool prepareSatelliteAssemblies);
 
         /// <summary>
         /// Adds a file to consider when loading an analyzer or its dependencies.

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -52,4 +52,4 @@ static Microsoft.CodeAnalysis.DocumentationCommentId.CreateDeclarationId(Microso
 [RSEXPERIMENTAL001]Microsoft.CodeAnalysis.SemanticModelOptions.DisableNullableAnalysis = 2 -> Microsoft.CodeAnalysis.SemanticModelOptions
 [RSEXPERIMENTAL001]Microsoft.CodeAnalysis.Compilation.GetSemanticModel(Microsoft.CodeAnalysis.SyntaxTree! syntaxTree, Microsoft.CodeAnalysis.SemanticModelOptions options) -> Microsoft.CodeAnalysis.SemanticModel!
 abstract Microsoft.CodeAnalysis.SemanticModel.NullableAnalysisIsDisabled.get -> bool
-~Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader.LoadFromPath(string fullPath, bool prepareSatelliteAssemblies = false) -> System.Reflection.Assembly
+~Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader.LoadFromPath(string fullPath, bool prepareSatelliteAssemblies) -> System.Reflection.Assembly

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -52,3 +52,4 @@ static Microsoft.CodeAnalysis.DocumentationCommentId.CreateDeclarationId(Microso
 [RSEXPERIMENTAL001]Microsoft.CodeAnalysis.SemanticModelOptions.DisableNullableAnalysis = 2 -> Microsoft.CodeAnalysis.SemanticModelOptions
 [RSEXPERIMENTAL001]Microsoft.CodeAnalysis.Compilation.GetSemanticModel(Microsoft.CodeAnalysis.SyntaxTree! syntaxTree, Microsoft.CodeAnalysis.SemanticModelOptions options) -> Microsoft.CodeAnalysis.SemanticModel!
 abstract Microsoft.CodeAnalysis.SemanticModel.NullableAnalysisIsDisabled.get -> bool
+~Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader.LoadFromPath(string fullPath, bool prepareSatelliteAssemblies = false) -> System.Reflection.Assembly

--- a/src/Compilers/Test/Core/Mocks/TestAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Test/Core/Mocks/TestAnalyzerAssemblyLoader.cs
@@ -28,7 +28,10 @@ namespace Roslyn.Test.Utilities
         public void AddDependencyLocation(string fullPath)
             => _addDependencyLocation?.Invoke(fullPath);
 
-        public Assembly LoadFromPath(string fullPath, bool prepareResourceAssemblies = false)
+        public Assembly LoadFromPath(string fullPath)
+            => LoadFromPath(fullPath, prepareResourceAssemblies: false);
+
+        public Assembly LoadFromPath(string fullPath, bool prepareResourceAssemblies)
             => (_loadFromPath != null) ? _loadFromPath(fullPath) : Assembly.LoadFrom(fullPath);
     }
 }

--- a/src/Compilers/Test/Core/Mocks/TestAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Test/Core/Mocks/TestAnalyzerAssemblyLoader.cs
@@ -28,7 +28,7 @@ namespace Roslyn.Test.Utilities
         public void AddDependencyLocation(string fullPath)
             => _addDependencyLocation?.Invoke(fullPath);
 
-        public Assembly LoadFromPath(string fullPath)
+        public Assembly LoadFromPath(string fullPath, bool prepareResourceAssemblies = false)
             => (_loadFromPath != null) ? _loadFromPath(fullPath) : Assembly.LoadFrom(fullPath);
     }
 }

--- a/src/Scripting/Core/Hosting/CommandLine/NotImplementedAnalyzerLoader.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/NotImplementedAnalyzerLoader.cs
@@ -20,5 +20,10 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         {
             throw new NotImplementedException();
         }
+
+        public Assembly LoadFromPath(string fullPath, bool prepareSatelliteAssemblies)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -709,8 +709,10 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
         private class MissingAnalyzerLoader : AnalyzerAssemblyLoader
         {
-            protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> cultureNames)
+            protected override string PreparePathToLoad(string fullPath)
                 => throw new FileNotFoundException(fullPath);
+            protected override void PrepareSatelliteAssembliesToLoad(string assemblyFilePath, ImmutableHashSet<string> resourceAssemblyCultureNames)
+                => throw new NotImplementedException();
         }
 
         private class MissingMetadataReference : PortableExecutableReference

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
@@ -21,10 +21,14 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             _baseDirectory = baseDirectory;
         }
 
-        protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> cultureNames)
+        protected override string PreparePathToLoad(string fullPath)
         {
             var fixedPath = Path.GetFullPath(Path.Combine(_baseDirectory, Path.GetFileName(fullPath)));
             return File.Exists(fixedPath) ? fixedPath : fullPath;
+        }
+
+        protected override void PrepareSatelliteAssembliesToLoad(string assemblyFilePath, ImmutableHashSet<string> resourceAssemblyCultureNames)
+        {
         }
     }
 }


### PR DESCRIPTION
Assemblies and their corresponding resource dlls are copied/deleted under this folder on solution open. When opening Rosly, I see about 700 dlls copied/deleted under this folder. Over 90% of these dlls are resource dlls, not something in use for my setup.

This change is very rough, but attempts to separate the code that ensures the assembly is shadow-copied properly, from the code that ensures that it's supporting resource assemblies are shadow-copied properly.

There are probably great reasons why this isn't possible, but I wanted to create a commit to continue an earlier convesation I had with Jard about this. With this change locally, I see over 90% reduction in the number of these file I/O operations.