### PR TITLE
Change CI queues to regular

### DIFF
--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -65,7 +65,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.scout.amd64.open
+  default: windows.vs2022preview.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -62,7 +62,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.scout.amd64.open
+  default: windows.vs2022preview.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open


### PR DESCRIPTION
Should unblock PRs failing on flaky tests in the scouting queue. And in general, I think the non-scouting CI jobs should not use scouting queues unless necessary.