### PR TITLE
Don't recommend readonly after readonly

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/ReadOnlyKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ReadOnlyKeywordRecommenderTests.cs
@@ -298,8 +298,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         }
 
         [Fact]
-        public async Task TestAfterPartial()
-            => await VerifyKeywordAsync(@"partial $$");
+        public async Task TestNotAfterPartial()
+            => await VerifyAbsenceAsync(@"partial $$");
 
         [Fact]
         public async Task TestAfterAbstract()
@@ -437,9 +437,29 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         }
 
         [Fact]
-        public async Task TestAfterReadOnly()
+        public async Task TestNotAfterPublicReadOnly()
         {
-            await VerifyKeywordAsync(
+            await VerifyAbsenceAsync(
+                """
+                class C {
+                    public readonly $$
+                """);
+        }
+
+        [Fact]
+        public async Task TestNotAfterReadOnlyPartial()
+        {
+            await VerifyAbsenceAsync(
+                """
+                class C {
+                    readonly partial $$
+                """);
+        }
+
+        [Fact]
+        public async Task TestNotAfterReadOnly()
+        {
+            await VerifyAbsenceAsync(
                 """
                 class C {
                     readonly $$

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ReadOnlyKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ReadOnlyKeywordRecommender.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders;
 
@@ -50,8 +52,8 @@ internal class ReadOnlyKeywordRecommender : AbstractSyntacticSingleKeywordRecomm
 
     private static bool IsValidContextForType(CSharpSyntaxContext context, CancellationToken cancellationToken)
     {
-        return context.IsTypeDeclarationContext(validModifiers: SyntaxKindSet.AllTypeModifiers,
-            validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: true, cancellationToken);
+        return context.IsTypeDeclarationContext(validModifiers: SyntaxKindSet.AllTypeModifiers.Except([SyntaxKind.ReadOnlyKeyword]).ToSet(),
+            validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: false, cancellationToken);
     }
 
     private static bool IsStructAccessorContext(CSharpSyntaxContext context)


### PR DESCRIPTION
Closes #72372 

This pr does 2 changes to address the issue:
- disallow the readonly modifier to appear in the declaration
- disallow partial

On the second point, this is because while it is possible to have both readonly and partial, it is not possible to have readonly appear AFTER partial while being syntactically valid. This means that effectively, if we already have partial, readonly shouldn't be recommended.

While investigating, I found that existing tests seemed to have enforced the opposite. Particularly, it seemed there was a test that was testing that readonly was recommended right after it. I changed those tests too.