### PR TITLE
Fix crash in 'import completion' with alias to non-named type

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -12579,5 +12579,21 @@ namespace N
                 Await state.AssertCompletionItemsDoNotContainAny("B1")
             End Using
         End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/72392")>
+        Public Async Function AliasToDynamicType(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System = dynamic;
+$$
+                </Document>,
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.CSharp12)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertCompletionItemsContain("System", displayTextSuffix:="")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
@@ -71,7 +71,15 @@ internal abstract class AbstractTypeImportCompletionProvider<AliasDeclarationTyp
         {
             foreach (var symbol in scope.Aliases)
             {
-                if (symbol is { Target: ITypeSymbol { TypeKind: not TypeKind.Error } target })
+                if (symbol is
+                    {
+                        Target: ITypeSymbol
+                        {
+                            Name: not null,
+                            ContainingNamespace: not null,
+                            TypeKind: not TypeKind.Error
+                        } target
+                    })
                 {
                     // If the target type is a type constructs from generics type, e.g.
                     // using AliasBar = Bar<int>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/72392