### PR TITLE
Reduce File I/O under the AnalyzerAssemblyLoader folder

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -5,23 +5,21 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+
 #if NETCOREAPP
 using Roslyn.Test.Utilities.CoreClr;
 using System.Runtime.Loader;
@@ -367,11 +365,32 @@ Delta: Gamma: Beta: Test B
 
                 if (path.EndsWith(".resources.dll", StringComparison.Ordinal))
                 {
-                    return loader.GetRealSatelliteLoadPath(path) ?? "";
+                    return getRealSatelliteLoadPath(path) ?? "";
                 }
                 return loader.GetRealAnalyzerLoadPath(path ?? "");
             }
 
+            // When PreparePathToLoad is overridden this returns the most recent
+            // real path for the given analyzer satellite assembly path
+            string? getRealSatelliteLoadPath(string originalSatelliteFullPath)
+            {
+                // This is a satellite assembly, need to find the mapped path of the real assembly, then 
+                // adjust that mapped path for the suffix of the satellite assembly
+                //
+                // Example of dll and it's corresponding satellite assembly
+                //
+                //  c:\some\path\en-GB\util.resources.dll
+                //  c:\some\path\util.dll
+                var assemblyFileName = Path.ChangeExtension(Path.GetFileNameWithoutExtension(originalSatelliteFullPath), ".dll");
+
+                var assemblyDir = Path.GetDirectoryName(originalSatelliteFullPath)!;
+                var cultureInfo = CultureInfo.GetCultureInfo(Path.GetFileName(assemblyDir));
+                assemblyDir = Path.GetDirectoryName(assemblyDir)!;
+
+                // Real assembly is located in the directory above this one
+                var assemblyPath = Path.Combine(assemblyDir, assemblyFileName);
+                return loader.GetSatelliteInfoForPath(assemblyPath, cultureInfo);
+            }
         }
 
         private static void VerifyAssemblies(AnalyzerAssemblyLoader loader, IEnumerable<Assembly> assemblies, int? copyCount, params string[] assemblyPaths)
@@ -1347,8 +1366,31 @@ Delta.2: Test D2
                 // dlls don't apply for this count.
                 VerifyDependencyAssemblies(loader, copyCount: 1, analyzerPath, analyzerResourcesPath);
             });
-
         }
+
+        [Theory]
+        [CombinatorialData]
+        public void AssemblyLoading_ResourcesInParent(AnalyzerTestKind kind)
+        {
+            Run(kind, static (AnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                using var temp = new TempRoot();
+                var tempDir = temp.CreateDirectory();
+                var analyzerPath = tempDir.CreateFile("AnalyzerWithLoc.dll").CopyContentFrom(testFixture.AnalyzerWithLoc).Path;
+                var analyzerResourcesPath = tempDir.CreateDirectory("es").CreateFile("AnalyzerWithLoc.resources.dll").CopyContentFrom(testFixture.AnalyzerWithLocResourceEnGB).Path;
+                loader.AddDependencyLocation(analyzerPath);
+                var assembly = loader.LoadFromPath(analyzerPath);
+                var methodInfo = assembly
+                    .GetType("AnalyzerWithLoc.Util")!
+                    .GetMethod("Exec", BindingFlags.Static | BindingFlags.Public)!;
+                methodInfo.Invoke(null, ["es-ES"]);
+
+                // The copy count is 1 here as only one real assembly was copied, the resource 
+                // dlls don't apply for this count.
+                VerifyDependencyAssemblies(loader, copyCount: 1, analyzerPath, analyzerResourcesPath);
+            });
+        }
+
 #if NETCOREAPP
 
         [Theory]

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -389,7 +389,7 @@ Delta: Gamma: Beta: Test B
 
                 // Real assembly is located in the directory above this one
                 var assemblyPath = Path.Combine(assemblyDir, assemblyFileName);
-                return loader.GetSatelliteInfoForPath(assemblyPath, cultureInfo);
+                return loader.GetRealSatelliteLoadPath(assemblyPath, cultureInfo);
             }
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -149,11 +149,11 @@ namespace Microsoft.CodeAnalysis
                 // loader has a mode where it loads from Stream though and the runtime will not handle
                 // that automatically. Rather than bifurate our loading behavior between Disk and
                 // Stream both modes just handle satellite loading directly
-                if (!string.IsNullOrEmpty(assemblyName.CultureName) && simpleName.EndsWith(".resources", StringComparison.Ordinal))
+                if (assemblyName.CultureInfo is not null && simpleName.EndsWith(".resources", StringComparison.Ordinal))
                 {
                     var analyzerFileName = Path.ChangeExtension(simpleName, ".dll");
                     var analyzerFilePath = Path.Combine(Directory, analyzerFileName);
-                    var satelliteLoadPath = _loader.GetSatelliteInfoForPath(analyzerFilePath, assemblyName.CultureName);
+                    var satelliteLoadPath = _loader.GetSatelliteInfoForPath(analyzerFilePath, assemblyName.CultureInfo);
                     if (satelliteLoadPath is not null)
                     {
                         return loadCore(satelliteLoadPath);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis
                 var assemblyPath = Path.Combine(Directory, simpleName + ".dll");
                 if (_loader.IsAnalyzerDependencyPath(assemblyPath))
                 {
-                    (_, var loadPath, _) = _loader.GetAssemblyInfoForPath(assemblyPath);
+                    (_, var loadPath) = _loader.GetAssemblyInfoForPath(assemblyPath);
                     return loadCore(loadPath);
                 }
 
@@ -166,7 +166,8 @@ namespace Microsoft.CodeAnalysis
                 // be necessary but msbuild target defaults have caused a number of customers to 
                 // fall into this path. See discussion here for where it comes up
                 // https://github.com/dotnet/roslyn/issues/56442
-                if (_loader.GetBestPath(assemblyName) is string bestRealPath)
+                var (_, bestRealPath) = _loader.GetBestPath(assemblyName);
+                if (bestRealPath is not null)
                 {
                     return loadCore(bestRealPath);
                 }
@@ -193,7 +194,7 @@ namespace Microsoft.CodeAnalysis
                 var assemblyPath = Path.Combine(Directory, unmanagedDllName + ".dll");
                 if (_loader.IsAnalyzerDependencyPath(assemblyPath))
                 {
-                    (_, var loadPath, _) = _loader.GetAssemblyInfoForPath(assemblyPath);
+                    (_, var loadPath) = _loader.GetAssemblyInfoForPath(assemblyPath);
                     return LoadUnmanagedDllFromPath(loadPath);
                 }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     var analyzerFileName = Path.ChangeExtension(simpleName, ".dll");
                     var analyzerFilePath = Path.Combine(Directory, analyzerFileName);
-                    var satelliteLoadPath = _loader.GetSatelliteInfoForPath(analyzerFilePath, assemblyName.CultureInfo);
+                    var satelliteLoadPath = _loader.GetRealSatelliteLoadPath(analyzerFilePath, assemblyName.CultureInfo);
                     if (satelliteLoadPath is not null)
                     {
                         return loadCore(satelliteLoadPath);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Desktop.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis
                 var assemblyName = new AssemblyName(args.Name);
                 var simpleName = assemblyName.Name;
                 var isSatelliteAssembly =
-                    !string.IsNullOrEmpty(assemblyName.CultureName) &&
+                    assemblyName.CultureInfo is not null &&
                     simpleName.EndsWith(".resources", StringComparison.Ordinal);
 
                 if (isSatelliteAssembly)
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis
                 var (originalPath, realPath) = GetBestPath(assemblyName);
                 if (isSatelliteAssembly && originalPath is not null)
                 {
-                    realPath = GetSatelliteInfoForPath(originalPath, assemblyName.CultureName);
+                    realPath = GetSatelliteInfoForPath(originalPath, assemblyName.CultureInfo);
                 }
 
                 if (realPath is not null)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Desktop.cs
@@ -100,24 +100,25 @@ namespace Microsoft.CodeAnalysis
         {
             try
             {
+                const string resourcesExtension = ".resources";
                 var assemblyName = new AssemblyName(args.Name);
                 var simpleName = assemblyName.Name;
                 var isSatelliteAssembly =
                     assemblyName.CultureInfo is not null &&
-                    simpleName.EndsWith(".resources", StringComparison.Ordinal);
+                    simpleName.EndsWith(resourcesExtension, StringComparison.Ordinal);
 
                 if (isSatelliteAssembly)
                 {
                     // Satellite assemblies should get the best path information using the
                     // non-resource part of the assembly name. Once the path information is obtained
                     // GetSatelliteInfoForPath will translate to the resource assembly path.
-                    assemblyName.Name = simpleName[..^".resources".Length];
+                    assemblyName.Name = simpleName[..^resourcesExtension.Length];
                 }
 
                 var (originalPath, realPath) = GetBestPath(assemblyName);
                 if (isSatelliteAssembly && originalPath is not null)
                 {
-                    realPath = GetSatelliteInfoForPath(originalPath, assemblyName.CultureInfo);
+                    realPath = GetRealSatelliteLoadPath(originalPath, assemblyName.CultureInfo);
                 }
 
                 if (realPath is not null)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis
         protected override string PrepareSatelliteAssemblyToLoad(string assemblyFilePath, string cultureName)
         {
             var directory = Path.GetDirectoryName(assemblyFilePath)!;
-            var fileName = Path.GetFileName(assemblyFilePath);
+            var fileName = GetSatelliteFileName(Path.GetFileName(assemblyFilePath));
 
             return Path.Combine(directory, cultureName, fileName);
         }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected override string PreparePathToLoad(string fullPath) => fullPath;
 
-        protected override void PrepareSatelliteAssembliesToLoad(string assemblyFilePath, ImmutableHashSet<string> resourceAssemblyCultureNames)
+        protected override void PrepareSatelliteAssemblyToLoad(string assemblyFilePath, string cultureName)
         {
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -34,8 +34,15 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected override string PreparePathToLoad(string fullPath) => fullPath;
 
-        protected override void PrepareSatelliteAssemblyToLoad(string assemblyFilePath, string cultureName)
+        /// <summary>
+        /// The default implementation is to simply load in place.
+        /// </summary>
+        protected override string PrepareSatelliteAssemblyToLoad(string assemblyFilePath, string cultureName)
         {
+            var directory = Path.GetDirectoryName(assemblyFilePath)!;
+            var fileName = Path.GetFileName(assemblyFilePath);
+
+            return Path.Combine(directory, cultureName, fileName);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -32,7 +32,11 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The default implementation is to simply load in place.
         /// </summary>
-        protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> satelliteCultureNames) => fullPath;
+        protected override string PreparePathToLoad(string fullPath) => fullPath;
+
+        protected override void PrepareSatelliteAssembliesToLoad(string assemblyFilePath, ImmutableHashSet<string> resourceAssemblyCultureNames)
+        {
+        }
 
         /// <summary>
         /// Return an <see cref="IAnalyzerAssemblyLoader"/> which does not lock assemblies on disk that is

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -143,13 +143,11 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        protected override void PrepareSatelliteAssemblyToLoad(string originalAnalyzerPath, string cultureName)
+        protected override string PrepareSatelliteAssemblyToLoad(string originalAnalyzerPath, string cultureName)
         {
             var mvid = AssemblyUtilities.ReadMvid(originalAnalyzerPath);
 
-            PrepareLoad(_mvidSatelliteAssemblyPathMap, (mvid, cultureName), copyAnalyzerContents);
-
-            return;
+            return PrepareLoad(_mvidSatelliteAssemblyPathMap, (mvid, cultureName), copyAnalyzerContents);
 
             string copyAnalyzerContents()
             {
@@ -164,7 +162,7 @@ namespace Microsoft.CodeAnalysis
                 var shadowSatellitePath = Path.Combine(shadowDirectory, cultureName, satelliteFileName);
                 CopyFile(originalSatellitePath, shadowSatellitePath);
 
-                return shadowAnalyzerPath;
+                return shadowSatellitePath;
             }
         }
 

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -712,7 +712,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             protected override string PreparePathToLoad(string fullPath)
                 => throw new FileNotFoundException(fullPath);
 
-            protected override void PrepareSatelliteAssembliesToLoad(string fullPath, ImmutableHashSet<string> resourceAssemblyCultureNames)
+            protected override void PrepareSatelliteAssemblyToLoad(string fullPath, string cultureName)
                 => throw new FileNotFoundException(fullPath);
         }
 

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -709,7 +709,10 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
         private class MissingAnalyzerLoader : AnalyzerAssemblyLoader
         {
-            protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> cultureNames)
+            protected override string PreparePathToLoad(string fullPath)
+                => throw new FileNotFoundException(fullPath);
+
+            protected override void PrepareSatelliteAssembliesToLoad(string fullPath, ImmutableHashSet<string> resourceAssemblyCultureNames)
                 => throw new FileNotFoundException(fullPath);
         }
 

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -712,7 +712,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             protected override string PreparePathToLoad(string fullPath)
                 => throw new FileNotFoundException(fullPath);
 
-            protected override void PrepareSatelliteAssemblyToLoad(string fullPath, string cultureName)
+            protected override string PrepareSatelliteAssemblyToLoad(string fullPath, string cultureName)
                 => throw new FileNotFoundException(fullPath);
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.IO;
 
 namespace Microsoft.CodeAnalysis.Remote.Diagnostics
@@ -27,8 +26,10 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             return File.Exists(fixedPath) ? fixedPath : fullPath;
         }
 
-        protected override void PrepareSatelliteAssemblyToLoad(string fullPath, string cultureName)
+        protected override string PrepareSatelliteAssemblyToLoad(string fullPath, string cultureName)
         {
+            var fixedPath = Path.GetFullPath(Path.Combine(_baseDirectory, cultureName, Path.GetFileName(fullPath)));
+            return File.Exists(fixedPath) ? fixedPath : fullPath;
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
@@ -21,10 +21,14 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             _baseDirectory = baseDirectory;
         }
 
-        protected override string PreparePathToLoad(string fullPath, ImmutableHashSet<string> cultureNames)
+        protected override string PreparePathToLoad(string fullPath)
         {
             var fixedPath = Path.GetFullPath(Path.Combine(_baseDirectory, Path.GetFileName(fullPath)));
             return File.Exists(fixedPath) ? fixedPath : fullPath;
+        }
+
+        protected override void PrepareSatelliteAssembliesToLoad(string fullPath, ImmutableHashSet<string> resourceAssemblyCultureNames)
+        {
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoader.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             return File.Exists(fixedPath) ? fixedPath : fullPath;
         }
 
-        protected override void PrepareSatelliteAssembliesToLoad(string fullPath, ImmutableHashSet<string> resourceAssemblyCultureNames)
+        protected override void PrepareSatelliteAssemblyToLoad(string fullPath, string cultureName)
         {
         }
     }


### PR DESCRIPTION
Assemblies and their corresponding resource dlls are copied/deleted under this folder on solution open. When opening Roslyn, I see about 700 dlls copied/deleted under this folder. Over 90% of these dlls are resource dlls, not something in use for my setup.
 
This change separates the code that ensures the assembly is shadow-copied properly, from the code that ensures the supporting resource assemblies are shadow-copied properly.
 
With this change there is a 90% reduction in the number of files shadow copied into the AnalyzerAssemblyLoader folder during roslyn solution load.
 
Did a [test insertion](https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/535134) with a [speedometer run](https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms-vseng.pit-vsengPerf.pit-hub?targetBuild=34709.26.dn-bot.240311.030810.535134&targetBranch=main&targetPerfBuildId=9219236&runGroup=Speedometer&since=2024-03-10&baselineBuild=34709.26&baselineBranch=main) to make sure it did what I thought. Below images are from RichCopyTest.CopyPlain speedometer run, RoslynCodeAnalysisService process, FileIO/Create events for dlls filtered under AnalyzerAssemblyLoader folder
 
*** old (313 records): 
![image](https://github.com/dotnet/roslyn/assets/6785178/411af550-3b21-4c1a-8d0a-568d898b0a1c)

 *** new (106 records) 
![image](https://github.com/dotnet/roslyn/assets/6785178/1dd5fd0c-5572-4f16-87df-fc4a85ab256f)
 
I also looked at the CompletionText.Completion speedometer data and it decreased from 227 records to 52.