### PR TITLE
Add support for PrimaryConstructorBaseType to SpeculativeAnalyser

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -1108,6 +1108,23 @@ public class UseCollectionExpressionForArrayTests
     }
 
     [Fact]
+    public async Task TestTargetTypedArgumentPrimaryConstructor1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                       class C(int[] x);
+                       class C2() : C([|[|new|] int[]|] { 1, 2, 3 });
+                       """,
+            FixedCode = """
+                        class C(int[] x);
+                        class C2() : C([1, 2, 3]);
+                        """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
     public async Task TestNotTargetTypedArgument2()
     {
         await new VerifyCS.Test

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
@@ -85,7 +85,8 @@ internal class SpeculationAnalyzer : AbstractSpeculationAnalyzer<
                           SyntaxKind.ThisConstructorInitializer or
                           SyntaxKind.BaseConstructorInitializer or
                           SyntaxKind.EqualsValueClause or
-                          SyntaxKind.ArrowExpressionClause;
+                          SyntaxKind.ArrowExpressionClause or
+                          SyntaxKind.PrimaryConstructorBaseType;
 
     protected override void ValidateSpeculativeSemanticModel(SemanticModel speculativeSemanticModel, SyntaxNode nodeToSpeculate)
     {
@@ -156,6 +157,10 @@ internal class SpeculationAnalyzer : AbstractSpeculationAnalyzer<
 
             case SyntaxKind.ArrowExpressionClause:
                 semanticModel.TryGetSpeculativeSemanticModel(position, (ArrowExpressionClauseSyntax)nodeToSpeculate, out speculativeModel);
+                return speculativeModel;
+
+            case SyntaxKind.PrimaryConstructorBaseType:
+                semanticModel.TryGetSpeculativeSemanticModel(position, (PrimaryConstructorBaseTypeSyntax)nodeToSpeculate, out speculativeModel);
                 return speculativeModel;
         }
 


### PR DESCRIPTION
Closes #72337 

This syntax kind wasn't supported by the speculative analyser which was needed for this. Adding the case for it is all that was needed.