### PR TITLE
Cap signing file size to avoid OOMs

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -9,6 +9,7 @@
       Reduce the parallelism from the default (16) so that we can avoid OOMs.
     -->
     <SignToolRepackParallelism>10</SignToolRepackParallelism>
+    <SignToolRepackMaximumParallelFileSize>64</SignToolRepackMaximumParallelFileSize>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/13799#issuecomment-1981181415