### PR TITLE
Move Linux to building Roslyn.sln

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -37,7 +37,7 @@ usage()
   echo "  --prepareMachine           Prepare machine for CI run, clean up processes after build"
   echo "  --warnAsError              Treat all warnings as errors"
   echo "  --sourceBuild              Simulate building for source-build"
-  echo "  --solution                 Soluton to build (Default is Compilers.slnf)"
+  echo "  --solution                 Soluton to build (Default is Roslyn.sln)"
   echo ""
   echo "Command line arguments starting with '/p:' are passed through to MSBuild."
 }
@@ -78,7 +78,7 @@ prepare_machine=false
 warn_as_error=false
 properties=""
 source_build=false
-solution_to_build="Compilers.slnf"
+solution_to_build="Roslyn.sln"
 
 args=""
 


### PR DESCRIPTION
Now that we can fully build Roslyn.sln on Linux moving it to be our default build.