### PR TITLE
Only use absolute URIs for TextDocumentLocation

### DIFF
--- a/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchResultPreviewPanel.cs
+++ b/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchResultPreviewPanel.cs
@@ -4,11 +4,11 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Core.Imaging;
 using Microsoft.VisualStudio.Search.Data;
 using Microsoft.VisualStudio.Search.UI.PreviewPanel.Models;
 using Microsoft.VisualStudio.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.NavigateTo;
 
@@ -31,6 +31,8 @@ internal sealed partial class RoslynSearchItemsSourceProvider
             ImageId icon)
             : base(title, icon)
         {
+            Contract.ThrowIfFalse(uri.IsAbsoluteUri, $"{nameof(TextDocumentLocation)} assumes the URI is an absolute URI and invokes {nameof(Uri.LocalPath)}.");
+
             UserInterface = new CodeEditorModel(
                 nameof(RoslynSearchResultPreviewPanel),
                 new VisualStudio.Threading.AsyncLazy<TextDocumentLocation>(() =>

--- a/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchResultViewFactory.cs
+++ b/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchResultViewFactory.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Elfie.Diagnostics;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Search.Data;
 
@@ -63,8 +65,23 @@ internal sealed partial class RoslynSearchItemsSourceProvider
             if (filePath is null)
                 return null;
 
-            if (!Uri.TryCreate(filePath, UriKind.RelativeOrAbsolute, out var uri))
-                return null;
+            Uri? absoluteUri;
+            if (document.IsSourceGeneratedDocument)
+            {
+                absoluteUri = ProtocolConversions.CreateUriFromSourceGeneratedFilePath(filePath);
+            }
+            else
+            {
+                try
+                {
+                    absoluteUri = ProtocolConversions.CreateAbsoluteUri(filePath);
+                }
+                catch (UriFormatException)
+                {
+                    // Unable to create an absolute URI for this path
+                    return null;
+                }
+            }
 
             var projectGuid = _provider._workspace.GetProjectGuid(document.Project.Id);
             if (projectGuid == Guid.Empty)
@@ -74,7 +91,7 @@ internal sealed partial class RoslynSearchItemsSourceProvider
             {
                 new RoslynSearchResultPreviewPanel(
                     _provider,
-                    uri,
+                    absoluteUri,
                     projectGuid,
                     roslynResult.SearchResult.NavigableItem.SourceSpan.ToSpan(),
                     searchResultView.Title.Text,


### PR DESCRIPTION
Verified manually that navigation from All In One Search is now functional, though previews still do not work (presumably because the editor does not recognize the `source-generated:///` URIs.