### PR TITLE
[17.10] Bump roslyn-sdk and System.Security.Cryptography.Xml

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -3,7 +3,7 @@
     <!-- Versions used by several individual references below -->
     <RoslynDiagnosticsNugetPackageVersion>3.11.0-beta1.24081.1</RoslynDiagnosticsNugetPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview.23468.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23411.1</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.24121.1</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.187-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
     <!-- CodeStyleAnalyzerVersion should we updated together with version of dotnet-format in dotnet-tools.json -->
     <CodeStyleAnalyzerVersion>4.8.0-3.final</CodeStyleAnalyzerVersion>
@@ -274,7 +274,7 @@
     <PackageVersion Include="System.CodeDom" Version="7.0.0" />
     <PackageVersion Include="InputSimulatorPlus" Version="1.0.7" />
     <PackageVersion Include="UIAComWrapper" Version="1.1.0.14" />
-    <PackageVersion Include="DiffPlex" Version="1.5.0" />
+    <PackageVersion Include="DiffPlex" Version="1.7.2" />
     <PackageVersion Include="xunit" Version="$(xunitVersion)" />
     <PackageVersion Include="xunit.analyzers" Version="0.12.0-pre.20" />
     <PackageVersion Include="xunit.assert" Version="$(xunitVersion)" />
@@ -305,6 +305,8 @@
     When it updates its referenced System.Data.SqlClient version this should be removed
     -->
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <!-- fix of vulnerability in 6.0.0 coming via Microsoft.TeamFoundationServer.Client -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.1" />
     <!--
       Infra
     -->

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateEqualsAndGetHas
             public ImmutableArray<string> MemberNames;
             public Action<ImmutableArray<PickMembersOption>> OptionsCallback;
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 // If we're a dialog test, then mixin our mock and initialize its values to the ones the test asked for.
                 var workspace = new AdhocWorkspace(s_composition.GetHostServices());
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateEqualsAndGetHas
                 service.MemberNames = MemberNames;
                 service.OptionsCallback = OptionsCallback;
 
-                return workspace;
+                return Task.FromResult<Workspace>(workspace);
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -3420,7 +3420,7 @@ static int Do[||]Something()
 
             private readonly bool _testPreselection;
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 var hostServices = s_testServices.GetHostServices();
 
@@ -3432,7 +3432,7 @@ static int Do[||]Something()
                 testOptionsService.CreateNew = _createNew;
                 testOptionsService.ExpectedPrecheckedMembers = _testPreselection ? _selection : ImmutableArray<string>.Empty;
 
-                return workspace;
+                return Task.FromResult<Workspace>(workspace);
             }
         }
 

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
@@ -3065,7 +3065,7 @@ End Namespace"
 
             Private ReadOnly _newType As Boolean
 
-            Protected Overrides Function CreateWorkspaceImpl() As Workspace
+            Protected Overrides Function CreateWorkspaceImplAsync() As Task(Of Workspace)
                 Dim hostServices = s_testServices.GetHostServices()
                 Dim workspace = New AdhocWorkspace(hostServices)
                 Dim optionsService = DirectCast(workspace.Services.GetRequiredService(Of IMoveStaticMembersOptionsService)(), TestMoveStaticMembersService)
@@ -3079,7 +3079,7 @@ End Namespace"
                 End If
                 optionsService.CreateNew = _newType
 
-                Return workspace
+                Return Task.FromResult(Of Workspace)(workspace)
             End Function
         End Class
 

--- a/src/Features/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
@@ -4682,37 +4682,23 @@ public class ConvertToRecordCodeRefactoringTests
 
     #endregion
 
-    private static void AddSolutionTransform(List<Func<Solution, ProjectId, Solution>> solutionTransforms)
-    {
-        solutionTransforms.Add((solution, projectId) =>
-        {
-            var project = solution.GetProject(projectId)!;
-
-            var compilationOptions = (CSharpCompilationOptions)project.CompilationOptions!;
-            // enable nullable
-            compilationOptions = compilationOptions.WithNullableContextOptions(NullableContextOptions.Enable);
-            solution = solution
-                .WithProjectCompilationOptions(projectId, compilationOptions)
-                .WithProjectMetadataReferences(projectId, TargetFrameworkUtil.GetReferences(TargetFramework.Net60));
-
-            return solution;
-        });
-    }
-
     private class RefactoringTest : VerifyCSRefactoring.Test
     {
         public RefactoringTest()
         {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
             LanguageVersion = LanguageVersion.CSharp10;
-            AddSolutionTransform(SolutionTransforms);
             MarkupOptions = MarkupOptions.UseFirstDescriptor;
         }
 
-        protected override Workspace CreateWorkspaceImpl()
+        protected override CompilationOptions CreateCompilationOptions()
         {
-            var workspace = new AdhocWorkspace();
+            var compilationOptions = (CSharpCompilationOptions)base.CreateCompilationOptions();
 
-            return workspace;
+            // enable nullable
+            compilationOptions = compilationOptions.WithNullableContextOptions(NullableContextOptions.Enable);
+
+            return compilationOptions;
         }
     }
 
@@ -4744,8 +4730,18 @@ public class ConvertToRecordCodeRefactoringTests
     {
         public CodeFixTest()
         {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
             LanguageVersion = LanguageVersion.CSharp10;
-            AddSolutionTransform(SolutionTransforms);
+        }
+
+        protected override CompilationOptions CreateCompilationOptions()
+        {
+            var compilationOptions = (CSharpCompilationOptions)base.CreateCompilationOptions();
+
+            // enable nullable
+            compilationOptions = compilationOptions.WithNullableContextOptions(NullableContextOptions.Enable);
+
+            return compilationOptions;
         }
     }
 

--- a/src/Features/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/Features/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -48,11 +48,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
                 return SpecializedCollections.SingletonEnumerable(new CSharpExtractClassCodeRefactoringProvider(service));
             }
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 var unusedCompilationOptions = new CSharpCompilationOptions(OutputKind.NetModule);
                 var unusedParseOptions = new CSharpParseOptions(LanguageVersion.CSharp1);
-                return TestWorkspace.Create(WorkspaceKind, LanguageNames.CSharp, unusedCompilationOptions, unusedParseOptions);
+                return Task.FromResult<Workspace>(TestWorkspace.Create(WorkspaceKind, LanguageNames.CSharp, unusedCompilationOptions, unusedParseOptions));
             }
         }
 

--- a/src/Features/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
@@ -113,16 +113,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             protected override FixAllContext CreateFixAllContext(
                 Document? document,
+                TextSpan? diagnosticSpan,
                 Project project,
                 CodeFixProvider codeFixProvider,
                 FixAllScope scope,
                 string? codeActionEquivalenceKey,
                 IEnumerable<string> diagnosticIds,
+                DiagnosticSeverity minimumSeverity,
                 FixAllContext.DiagnosticProvider fixAllDiagnosticProvider,
                 CancellationToken cancellationToken)
                 => new(new FixAllState(
                     fixAllProvider: NoOpFixAllProvider.Instance,
-                    diagnosticSpan: null,
+                    diagnosticSpan,
                     document,
                     project,
                     codeFixProvider,

--- a/src/Features/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -124,14 +124,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             private static readonly TestComposition s_editorFeaturesOOPComposition = FeaturesTestCompositions.Features.WithTestHostParts(TestHost.OutOfProcess);
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 if (TestHost == TestHost.InProcess)
-                    return base.CreateWorkspaceImpl();
+                    return base.CreateWorkspaceImplAsync();
 
                 var hostServices = s_editorFeaturesOOPComposition.GetHostServices();
                 var workspace = new AdhocWorkspace(hostServices);
-                return workspace;
+                return Task.FromResult<Workspace>(workspace);
             }
 #endif
         }

--- a/src/Features/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
@@ -110,14 +110,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             private static readonly TestComposition s_editorFeaturesOOPComposition = FeaturesTestCompositions.Features.WithTestHostParts(TestHost.OutOfProcess);
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 if (TestHost == TestHost.InProcess)
-                    return base.CreateWorkspaceImpl();
+                    return base.CreateWorkspaceImplAsync();
 
                 var hostServices = s_editorFeaturesOOPComposition.GetHostServices();
                 var workspace = new AdhocWorkspace(hostServices);
-                return workspace;
+                return Task.FromResult<Workspace>(workspace);
             }
 
 #endif


### PR DESCRIPTION
Backport of https://github.com/dotnet/roslyn/pull/72242. Just to make CG errors go away, doesn't need to go through servicing on its own.

Unfortunately this cannot be simply backported to 17.9 as well since that branch is not on central package management.