### PR TITLE
Suppress Lock conversion warnings when using object equality operators

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -640,7 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // If this is an object equality operator, we will suppress Lock conversion warnings.
                 var needsFilterDiagnostics =
                     resultOperatorKind is BinaryOperatorKind.ObjectEqual or BinaryOperatorKind.ObjectNotEqual &&
-                    diagnostics.DiagnosticBag is not null;
+                    diagnostics.AccumulatesDiagnostics;
                 var conversionDiagnostics = needsFilterDiagnostics ? BindingDiagnosticBag.GetInstance(template: diagnostics) : diagnostics;
 
                 resultLeft = CreateConversion(left, best.LeftConversion, signature.LeftType, conversionDiagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -658,7 +658,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         foreach (var diagnostic in sourceBag.AsEnumerableWithoutResolution())
                         {
-                            if ((ErrorCode)diagnostic.Code is not ErrorCode.WRN_ConvertingLock)
+                            var code = diagnostic is DiagnosticWithInfo { HasLazyInfo: true, LazyInfo.Code: var lazyCode } ? lazyCode : diagnostic.Code;
+                            if ((ErrorCode)code is not ErrorCode.WRN_ConvertingLock)
                             {
                                 diagnostics.Add(diagnostic);
                             }

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             right = MakeRValue(right, diagnostics)
 
             ' Suppress Lock conversion warnings for Is operator.
-            Dim needsFilterDiagnostics = diagnostics.DiagnosticBag IsNot Nothing
+            Dim needsFilterDiagnostics = diagnostics.AccumulatesDiagnostics
             Dim conversionDiagnostics = If(needsFilterDiagnostics, BindingDiagnosticBag.GetInstance(diagnostics), diagnostics)
 
             left = ValidateAndConvertIsExpressionArgument(left, right, [isNot], conversionDiagnostics)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
@@ -54,7 +54,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If Not sourceBag.IsEmptyWithoutResolution Then
                     For Each diagnostic In sourceBag.AsEnumerableWithoutResolution()
-                        If diagnostic.Code <> ERRID.WRN_ConvertingLock Then
+                        Dim code As Integer
+                        Dim diagnosticWithInfo = TryCast(diagnostic, DiagnosticWithInfo)
+                        If diagnosticWithInfo IsNot Nothing AndAlso diagnosticWithInfo.HasLazyInfo Then
+                            code = diagnosticWithInfo.LazyInfo.Code
+                        Else
+                            code = diagnostic.Code
+                        End If
+
+                        If code <> ERRID.WRN_ConvertingLock Then
                             diagnostics.Add(diagnostic)
                         End If
                     Next

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/SyncLockTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/SyncLockTests.vb
@@ -984,5 +984,90 @@ BC42508: A value of type 'System.Threading.Lock' converted to a different type w
   IL_002b:  ret
 }]]>)
         End Sub
+
+        <Fact>
+        Public Sub LockType_ObjectEquality()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Threading
+
+Module Program
+    Sub Main()
+        Dim l As Lock = New Lock()
+
+        If l IsNot Nothing Then
+            Console.Write("1")
+        End If
+
+        If l Is Nothing Then
+            Throw New Exception
+        End If
+
+        If l IsNot Nothing Then
+            Console.Write("2")
+        End If
+
+        If l Is Nothing Then
+            Throw New Exception
+        End If
+
+        If Not (l Is Nothing) Then
+            Console.Write("3")
+        End If
+
+        If Not (l IsNot Nothing) Then
+            Throw New Exception
+        End If
+
+        Dim l2 As Lock = New Lock()
+
+        If l Is l2 Then
+            Throw New Exception
+        End If
+
+        If l IsNot l2 Then
+            Console.Write("4")
+        End If
+
+        If ReferenceEquals(l, l2) Then
+            Throw New Exception
+        End If
+
+        If (CObj(l)) Is l2 Then
+            Throw New Exception
+        End If
+
+        If (CObj(l)) IsNot l2 Then
+            Console.Write("5")
+        End If
+
+        If l Is New Lock() Then
+            Throw New Exception
+        End If
+    End Sub
+End Module
+
+Namespace System.Threading
+    Public Class Lock
+    End Class
+End Namespace
+]]>.Value
+            Dim comp = CreateCompilation(source, options:=TestOptions.ReleaseExe)
+            Dim verifier = CompileAndVerify(comp, expectedOutput:="12345")
+            verifier.Diagnostics.AssertTheseDiagnostics(<![CDATA[
+BC42508: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        If ReferenceEquals(l, l2) Then
+                           ~
+BC42508: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        If ReferenceEquals(l, l2) Then
+                              ~~
+BC42508: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        If (CObj(l)) Is l2 Then
+                 ~
+BC42508: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in SyncLock statement.
+        If (CObj(l)) IsNot l2 Then
+                 ~
+]]>)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/71888
Speclet update: https://github.com/dotnet/csharplang/pull/7989