### PR TITLE
Collection expressions: IOperation and Add method with params array

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -830,7 +830,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int argIndex = collectionInitializer.InvokedAsExtensionMethod ? 1 : 0;
                 var arg = collectionInitializer.Arguments[argIndex];
                 Debug.Assert(!collectionInitializer.DefaultArguments[argIndex]);
-                if (collectionInitializer.Expanded && collectionInitializer.AddMethod.Parameters[argIndex].IsParams)
+                if (collectionInitializer.Expanded && argIndex == collectionInitializer.AddMethod.ParameterCount - 1)
                 {
                     if (arg is BoundArrayCreation { IsParamsArray: true, InitializerOpt.Initializers: [var element] })
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -829,6 +829,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 int argIndex = collectionInitializer.InvokedAsExtensionMethod ? 1 : 0;
                 var arg = collectionInitializer.Arguments[argIndex];
+                Debug.Assert(!collectionInitializer.DefaultArguments[argIndex]);
                 if (collectionInitializer.Expanded && collectionInitializer.AddMethod.Parameters[argIndex].IsParams)
                 {
                     if (arg is BoundArrayCreation { IsParamsArray: true, InitializerOpt.Initializers: [var element] })

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -33678,7 +33678,7 @@ partial class Program
                 }
                 """;
             string assemblyName = GetUniqueName();
-            var comp = CreateCompilation(new AssemblyIdentity(assemblyName, new Version(1, 0, 0, 0)),  sourceA1, references: TargetFrameworkUtil.StandardReferences);
+            var comp = CreateCompilation(new AssemblyIdentity(assemblyName, new Version(1, 0, 0, 0)), sourceA1, references: TargetFrameworkUtil.StandardReferences);
             var refA1 = comp.EmitToImageReference();
 
             string sourceB = """

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -33580,12 +33580,20 @@ partial class Program
         public void Add_ParamsArray_08()
         {
             string sourceA = """
+                using System;
                 using System.Collections;
                 using System.Collections.Generic;
                 class MyCollection : IEnumerable<object>
                 {
                     private List<object> _list = new();
-                    public void Add(params object[] x) => _list.AddRange(x);
+                    public void Add(params object[] x)
+                    {
+                        Console.Write("Add: ");
+                        foreach (var i in x)
+                            Console.Write("{0}, ", i);
+                        Console.WriteLine();
+                        _list.AddRange(x);
+                    }
                     public IEnumerator<object> GetEnumerator() => _list.GetEnumerator();
                     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
                 }
@@ -33606,7 +33614,12 @@ partial class Program
 
             var comp = CreateCompilation([sourceB1, sourceA, s_collectionExtensions], options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "[1, 2, 3], ");
+            CompileAndVerify(comp, expectedOutput: """
+                Add: 1, 
+                Add: 2, 
+                Add: 3, 
+                [1, 2, 3], 
+                """);
 
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """
@@ -33635,7 +33648,11 @@ partial class Program
 
             comp = CreateCompilation([sourceB2, sourceA, s_collectionExtensions], options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "[1, 2, 3], ");
+            CompileAndVerify(comp, expectedOutput: """
+                Add: 1, 
+                Add: 2, 3, 
+                [1, 2, 3], 
+                """);
 
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -33650,6 +33650,56 @@ partial class Program
                 """);
         }
 
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72461")]
+        [Fact]
+        public void Add_ParamsArray_09()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                abstract class MyCollectionBase 
+                {
+                    public abstract void Add(params object[] x);
+                }
+                class MyCollection : MyCollectionBase, IEnumerable<object>
+                {
+                    private List<object> _list = new();
+                    public override void Add(object[] x) => _list.AddRange(x);
+                    public IEnumerator<object> GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                """;
+
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        object x = 1;
+                        object[] y = [2, 3];
+                        MyCollection z = /*<bind>*/[x, ..y]/*</bind>*/;
+                        z.Report();
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation([sourceB, sourceA, s_collectionExtensions], options: TestOptions.ReleaseExe);
+            comp.VerifyEmitDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "[1, 2, 3], ");
+
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (2 elements, ConstructMethod: MyCollection..ctor()) (OperationKind.CollectionExpression, Type: MyCollection) (Syntax: '[x, ..y]')
+                  Elements(2):
+                      ILocalReferenceOperation: x (OperationKind.LocalReference, Type: System.Object) (Syntax: 'x')
+                      ISpreadOperation (ElementType: System.Object) (OperationKind.Spread, Type: null) (Syntax: '..y')
+                        Operand:
+                          ILocalReferenceOperation: y (OperationKind.LocalReference, Type: System.Object[]) (Syntax: 'y')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """);
+        }
+
         [Fact]
         public void SynthesizedReadOnlyList_SingleElement()
         {

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -33191,7 +33191,39 @@ partial class Program
 
             var comp = CreateCompilation(source, options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "(a, b), (c, d), ");
+            var verifier = CompileAndVerify(comp, expectedOutput: "(a, b), (c, d), ");
+
+            verifier.VerifyIL("Extensions.Add<T>(this System.Collections.Generic.ICollection<T>, params T[])", """
+                {
+                  // Code size       32 (0x20)
+                  .maxstack  2
+                  .locals init (T[] V_0,
+                                int V_1,
+                                T V_2) //element
+                  IL_0000:  ldarg.1
+                  IL_0001:  stloc.0
+                  IL_0002:  ldc.i4.0
+                  IL_0003:  stloc.1
+                  IL_0004:  br.s       IL_0019
+                  IL_0006:  ldloc.0
+                  IL_0007:  ldloc.1
+                  IL_0008:  ldelem     "T"
+                  IL_000d:  stloc.2
+                  IL_000e:  ldarg.0
+                  IL_000f:  ldloc.2
+                  IL_0010:  callvirt   "void System.Collections.Generic.ICollection<T>.Add(T)"
+                  IL_0015:  ldloc.1
+                  IL_0016:  ldc.i4.1
+                  IL_0017:  add
+                  IL_0018:  stloc.1
+                  IL_0019:  ldloc.1
+                  IL_001a:  ldloc.0
+                  IL_001b:  ldlen
+                  IL_001c:  conv.i4
+                  IL_001d:  blt.s      IL_0006
+                  IL_001f:  ret
+                }
+                """);
 
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -33432,12 +33432,19 @@ partial class Program
         public void Add_ParamsArray_06()
         {
             string sourceA = """
+                using System;
                 using System.Collections;
                 using System.Collections.Generic;
                 class MyCollection : IEnumerable
                 {
                     private List<MyCollection> _list = new();
-                    public void Add(params MyCollection[] x) => _list.AddRange(x);
+                    public void Add(params MyCollection[] x)
+                    {
+                        Console.Write("Add: ");
+                        x.Report();
+                        Console.WriteLine();
+                        _list.AddRange(x);
+                    }
                     public IEnumerator<MyCollection> GetEnumerator() => _list.GetEnumerator();
                     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
                 }
@@ -33458,7 +33465,10 @@ partial class Program
 
             var comp = CreateCompilation([sourceB1, sourceA, s_collectionExtensions], options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "[[]], ");
+            CompileAndVerify(comp, expectedOutput: """
+                Add: [[]], 
+                [[]], 
+                """);
 
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """
@@ -33485,7 +33495,10 @@ partial class Program
 
             comp = CreateCompilation([sourceB2, sourceA, s_collectionExtensions], options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "[], ");
+            CompileAndVerify(comp, expectedOutput: """
+                Add: [], 
+                [], 
+                """);
 
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """


### PR DESCRIPTION
For a collection with an `Add(params T[])` method, `Binder.GetUnderlyingCollectionExpressionElement` was returning the array rather than the element in the array.

Fixes #72461