### PR TITLE
WIP: Perform fewer operations on the ImmutableDictionary held onto by FilePathToDocumentIdsMap

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/FilePathToDocumentIdsMap.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Roslyn.Utilities;
@@ -17,29 +18,33 @@ internal readonly struct FilePathToDocumentIdsMap
 {
     private static readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> s_emptyMap
         = ImmutableDictionary.Create<string, ImmutableArray<DocumentId>>(StringComparer.OrdinalIgnoreCase);
-    public static readonly FilePathToDocumentIdsMap Empty = new(isFrozen: false, s_emptyMap);
+    public static readonly FilePathToDocumentIdsMap Empty = new(isFrozen: false, lazyMap: new Lazy<ImmutableDictionary<string, ImmutableArray<DocumentId>>>(() => s_emptyMap));
 
     /// <summary>
     /// Whether or not this map corresponds to a frozen solution.  Frozen solutions commonly drop many documents
     /// (because only documents whose trees have been parsed are kept out).  To keep things fast, instead of actually
-    /// dropping all those files from our <see cref="_map"/> we instead only keep track of added documents and mark that
+    /// dropping all those files from our <see cref="_lazyMap"/> we instead only keep track of added documents and mark that
     /// we're frozen.  Then, when a client actually asks for the document ids in a particular solution, we only return the
     /// actual set present in that solution instance.
     /// </summary>
     public readonly bool IsFrozen;
-    private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> _map;
+    private readonly Lazy<ImmutableDictionary<string, ImmutableArray<DocumentId>>> _lazyMap;
 
-    private FilePathToDocumentIdsMap(bool isFrozen, ImmutableDictionary<string, ImmutableArray<DocumentId>> map)
+    private FilePathToDocumentIdsMap(bool isFrozen, Lazy<ImmutableDictionary<string, ImmutableArray<DocumentId>>> lazyMap)
     {
         IsFrozen = isFrozen;
-        _map = map;
+        _lazyMap = lazyMap;
     }
 
     public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
-        => _map.TryGetValue(filePath, out documentIdsWithPath);
+    {
+        return _lazyMap.Value.TryGetValue(filePath, out documentIdsWithPath);
+    }
 
     public static bool operator ==(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
-        => left.IsFrozen == right.IsFrozen && left._map == right._map;
+    {
+        return left.IsFrozen == right.IsFrozen && left._lazyMap.Value == right._lazyMap.Value;
+    }
 
     public static bool operator !=(FilePathToDocumentIdsMap left, FilePathToDocumentIdsMap right)
         => !(left == right);
@@ -51,34 +56,74 @@ internal readonly struct FilePathToDocumentIdsMap
         => obj is FilePathToDocumentIdsMap map && Equals(map);
 
     public Builder ToBuilder()
-        => new(IsFrozen, _map.ToBuilder());
+    {
+        return new(IsFrozen, _lazyMap);
+    }
 
     public FilePathToDocumentIdsMap ToFrozen()
-        => IsFrozen ? this : new(isFrozen: true, _map);
+    {
+        return IsFrozen ? this : new(isFrozen: true, _lazyMap);
+    }
 
-    public readonly struct Builder
+    public class Builder
     {
         private readonly bool _isFrozen;
-        private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder _builder;
+        private readonly Lazy<ImmutableDictionary<string, ImmutableArray<DocumentId>>> _lazyMap;
 
-        public Builder(bool isFrozen, ImmutableDictionary<string, ImmutableArray<DocumentId>>.Builder builder)
+        private readonly List<ChangeKind> _changeKinds = new();
+        private List<(string FilePath, DocumentId DocumentId)>? _itemData;
+        private List<IEnumerable<TextDocumentState>>? _rangeData;
+
+        public Builder(bool isFrozen, Lazy<ImmutableDictionary<string, ImmutableArray<DocumentId>>> lazyMap)
         {
             _isFrozen = isFrozen;
-            _builder = builder;
+            _lazyMap = lazyMap;
         }
 
         public FilePathToDocumentIdsMap ToImmutable()
-            => new(_isFrozen, _builder.ToImmutable());
+        {
+            return new(_isFrozen, new Lazy<ImmutableDictionary<string, ImmutableArray<DocumentId>>>(GetMap));
+        }
 
-        public bool TryGetValue(string filePath, out ImmutableArray<DocumentId> documentIdsWithPath)
-            => _builder.TryGetValue(filePath, out documentIdsWithPath);
+        internal enum ChangeKind
+        {
+            Add,
+            AddRange,
+            Remove,
+            RemoveRange
+        }
+
+        public void AddRange(IEnumerable<TextDocumentState> documentStates)
+        {
+            _changeKinds.Add(ChangeKind.AddRange);
+
+            if (_rangeData is null)
+                _rangeData = [];
+
+            _rangeData.Add(documentStates);
+        }
 
         public void Add(string? filePath, DocumentId documentId)
         {
             if (RoslynString.IsNullOrEmpty(filePath))
                 return;
 
-            _builder.MultiAdd(filePath, documentId);
+            _changeKinds.Add(ChangeKind.Add);
+
+            if (_itemData is null)
+                _itemData = [];
+
+            _itemData.Add((filePath, documentId));
+        }
+
+        public void RemoveRange(IEnumerable<TextDocumentState> documentStates)
+        {
+            _changeKinds.Add(ChangeKind.RemoveRange);
+
+            if (_rangeData is null)
+                _rangeData = [];
+
+            _rangeData.Add(documentStates);
         }
 
         public void Remove(string? filePath, DocumentId documentId)
@@ -86,10 +131,56 @@ internal readonly struct FilePathToDocumentIdsMap
             if (RoslynString.IsNullOrEmpty(filePath))
                 return;
 
-            if (!this.TryGetValue(filePath, out var documentIdsWithPath) || !documentIdsWithPath.Contains(documentId))
-                throw new ArgumentException($"The given documentId was not found");
+            _changeKinds.Add(ChangeKind.Remove);
 
-            _builder.MultiRemove(filePath, documentId);
+            if (_itemData is null)
+                _itemData = [];
+
+            _itemData.Add((filePath, documentId));
+        }
+
+        private ImmutableDictionary<string, ImmutableArray<DocumentId>> GetMap()
+        {
+            var itemIndex = 0;
+            var rangeIndex = 0;
+            var builder = _lazyMap.Value.ToBuilder();
+
+            foreach (var changeKind in _changeKinds)
+            {
+                switch (changeKind)
+                {
+                    case ChangeKind.Add:
+                        var addItemData = _itemData![itemIndex];
+                        itemIndex++;
+                        builder.MultiAdd(addItemData.FilePath, addItemData.DocumentId);
+                        break;
+                    case ChangeKind.AddRange:
+                        var addRangeData = _rangeData![rangeIndex];
+                        rangeIndex++;
+                        foreach (var textDocumentData in addRangeData)
+                        {
+                            if (!RoslynString.IsNullOrEmpty(textDocumentData.FilePath))
+                                builder.MultiAdd(textDocumentData.FilePath, textDocumentData.Id);
+                        }
+                        break;
+                    case ChangeKind.Remove:
+                        var removeItemData = _itemData![itemIndex];
+                        itemIndex++;
+                        builder.MultiRemove(removeItemData.FilePath, removeItemData.DocumentId);
+                        break;
+                    case ChangeKind.RemoveRange:
+                        var removeRangeData = _rangeData![rangeIndex];
+                        rangeIndex++;
+                        foreach (var textDocumentData in removeRangeData)
+                        {
+                            if (!RoslynString.IsNullOrEmpty(textDocumentData.FilePath))
+                                builder.MultiRemove(textDocumentData.FilePath, textDocumentData.Id);
+                        }
+                        break;
+                }
+            }
+
+            return builder.ToImmutable();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -416,8 +416,7 @@ internal sealed partial class SolutionState
 
     private static void AddDocumentFilePaths(IEnumerable<TextDocumentState> documentStates, FilePathToDocumentIdsMap.Builder builder)
     {
-        foreach (var documentState in documentStates)
-            builder.Add(documentState.FilePath, documentState.Id);
+        builder.AddRange(documentStates);
     }
 
     public FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithRemovedDocuments(IEnumerable<TextDocumentState> documentStates)
@@ -429,8 +428,7 @@ internal sealed partial class SolutionState
 
     private static void RemoveDocumentFilePaths(IEnumerable<TextDocumentState> documentStates, FilePathToDocumentIdsMap.Builder builder)
     {
-        foreach (var documentState in documentStates)
-            builder.Remove(documentState.FilePath, documentState.Id);
+        builder.RemoveRange(documentStates);
     }
 
     private FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithFilePath(DocumentId documentId, string? oldFilePath, string? newFilePath)


### PR DESCRIPTION
These ImmutableDictionary modifications continuously show up in nearly every profile I look at. I have noticed that some of these immutable dictionaries are modified, but then the resultant dictionary is never queried. Instead, by storing the operations in Lists, building up the modifications can be fairly inexpensive. At the point where the immutable dictionary is queried, we can then lazily build up the dictionary.

This is definitely a WIP. Going to create a draft PR for this and see how ci tests go and start a perf run to see if it at least takes a chunk out these immutable dictionary allocations.