### PR TITLE
Fix InvalidCastException when initializing the properties of an undeclared class inside a lambda function

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
@@ -122,16 +122,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             For Each initializer In node.Initializers
                 ' Ignore assignments in object initializers, only reference the value
-                Debug.Assert(initializer.Kind = BoundKind.AssignmentOperator)
-                Dim assignment = DirectCast(initializer, BoundAssignmentOperator)
-                Debug.Assert(assignment.LeftOnTheRightOpt Is Nothing)
+                Dim boundExpression As BoundExpression = initializer
+                If boundExpression.Kind = BoundKind.AssignmentOperator Then
+                    Dim assignment = DirectCast(initializer, BoundAssignmentOperator)
+                    Debug.Assert(assignment.LeftOnTheRightOpt Is Nothing)
 
-                Dim propertyAccess = TryCast(assignment.Left, BoundPropertyAccess)
-                If propertyAccess IsNot Nothing Then
-                    CheckRefReturningPropertyAccess(propertyAccess)
+                    boundExpression = assignment.Right
+                    Dim propertyAccess = TryCast(assignment.Left, BoundPropertyAccess)
+                    If propertyAccess IsNot Nothing Then
+                        CheckRefReturningPropertyAccess(propertyAccess)
+                    End If
                 End If
 
-                Me.Visit(assignment.Right)
+                Me.Visit(boundExpression)
             Next
 
             Me._expressionTreePlaceholders.Remove(placeholder)

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -2015,7 +2015,7 @@ End Module
             CompileAndVerify(source, references:={Net40.SystemCore}).VerifyDiagnostics()
         End Sub
 
-        <Fact>
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72456")>
         Public Sub UndeclaredClassInLambdaFunction()
             Dim source =
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -2016,6 +2016,31 @@ End Module
         End Sub
 
         <Fact>
+        Public Sub UndeclaredClassInLambdaFunction()
+            Dim source =
+<compilation>
+    <file name="expr.vb"><![CDATA[
+Imports System
+Imports System.Linq.Expressions
+Module Program
+    Public Function CreateExpression() As Expression(Of Func(Of Object))
+        Return Function() (New UndeclaredClass() With {.Name = "testName"})
+    End Function
+End Module
+]]>
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntime(source, {LinqAssemblyRef})
+            AssertTheseDiagnostics(compilation.GetDiagnostics(),
+<expected>
+BC30002: Type 'UndeclaredClass' is not defined.
+        Return Function() (New UndeclaredClass() With {.Name = "testName"})
+                               ~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact>
         <WorkItem(577271, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/577271")>
         Public Sub Bug577271()
             Dim file = <file name="expr.vb"><![CDATA[

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CompilationCreationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CompilationCreationTests.vb
@@ -2150,40 +2150,6 @@ End Class
             CheckCompilationSyntaxTrees(compilation4, tree2, tree3)
         End Sub
 
-        <Fact>
-        Public Sub CompilationDiagnosticsWorkForUndeclaredClassInLambdaFunction()
-            'Expected: error BC30002: Type 'UndeclaredClass' is not defined.
-            Dim source = "
-Imports System
-Imports System.Linq.Expressions
-Public Class Library
-    Public Function CreateExpression() As Expression(Of Func(Of Object))
-        Return Function() (New UndeclaredClass() With {.Name = ""testName""})
-    End Function
-End Class"
-
-            ' Create a syntax tree from the code
-            Dim syntaxTree As SyntaxTree = VisualBasicSyntaxTree.ParseText(source)
-
-            ' Add required metadata references
-            Dim references As MetadataReference() = {MscorlibRef, LinqAssemblyRef}
-
-            ' Define compilation options
-            Dim options As New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-
-            ' Create a compilation
-            Dim compilation As VisualBasicCompilation = VisualBasicCompilation.Create("VB", {syntaxTree}, references, options)
-
-            ' Get Diagnostics
-            Dim diagnostics As ImmutableArray(Of Diagnostic) = compilation.GetDiagnostics()
-
-            ' Assert
-            Assert.Equal(1, diagnostics.Length)
-            Dim diagnostic = diagnostics.First()
-            Assert.Equal("BC30002", diagnostic.Id)
-            Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity)
-        End Sub
-
         <WorkItem(578706, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/578706")>
         <Fact>
         Public Sub DeclaringCompilationOfAddedModule()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/72456.

Building the following snippet in a VB project breaks the compilation:
```vb
Imports System
Imports System.Linq.Expressions
Module Program
    Public Function CreateExpression() As Expression(Of Func(Of Object))
        Return Function() (New UndeclaredClass() With {.Name = "testName"})
    End Function
End Module
```

There is a difference between `VisualBasic` and `CSharp` when getting diagnostics for the snippet above. The latter checks for the initializer type while the former forces a `DirectCast` which throws an `InvalidCastException`. This PR checks the type before forcing the cast similar to the `CSharp` approach.

### Expected result
`Error BC30002: Type 'UndeclaredClass' is not defined.`
### Actual result
Compilation breaks with the following trace:
```
System.InvalidCastException
  HResult=0x80004002
  Message=Unable to cast object of type 'Microsoft.CodeAnalysis.VisualBasic.BoundLiteral' to type 'Microsoft.CodeAnalysis.VisualBasic.BoundAssignmentOperator'.

This exception was originally thrown at this call stack:
Microsoft.CodeAnalysis.VisualBasic.dll!Microsoft.CodeAnalysis.VisualBasic.DiagnosticsPass.VisitObjectInitializerExpression(Microsoft.CodeAnalysis.VisualBasic.BoundObjectInitializerExpression node) Line 126	Basic
Microsoft.CodeAnalysis.VisualBasic.dll!Microsoft.CodeAnalysis.VisualBasic.BoundObjectInitializerExpression.Accept(Microsoft.CodeAnalysis.VisualBasic.BoundTreeVisitor visitor) Line 3792	Basic
Microsoft.CodeAnalysis.VisualBasic.dll!Microsoft.CodeAnalysis.VisualBasic.BoundTreeWalkerWithStackGuard.VisitExpressionWithoutStackGuard(Microsoft.CodeAnalysis.VisualBasic.BoundExpression node) Line 61	Basic
Microsoft.CodeAnalysis.VisualBasic.dll!Microsoft.CodeAnalysis.VisualBasic.BoundTreeVisitor.VisitExpressionWithStackGuard(Integer recursionDepth, Microsoft.CodeAnalysis.VisualBasic.BoundExpression node) Line 186	Basic
Microsoft.CodeAnalysis.VisualBasic.dll!Microsoft.CodeAnalysis.VisualBasic.BoundTreeWalkerWithStackGuard.Visit(Microsoft.CodeAnalysis.VisualBasic.BoundNode node) Line 50	Basic
Microsoft.CodeAnalysis.VisualBasic.dll!Microsoft.CodeAnalysis.VisualBasic.DiagnosticsPass.Visit(Microsoft.CodeAnalysis.VisualBasic.BoundNode node) Line 208	Basic
...
```