### PR TITLE
Use the project cone information in Scope.FindAssetsAsync

### DIFF
--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -69,17 +69,16 @@ internal partial class SolutionAssetStorage
             AssetHint assetHint, HashSet<Checksum> remainingChecksumsToFind, Dictionary<Checksum, object> result, CancellationToken cancellationToken)
         {
             var solutionState = this.CompilationState;
-            if (ProjectId is null)
-            {
-                if (solutionState.TryGetStateChecksums(out var stateChecksums))
-                    await stateChecksums.FindAsync(solutionState, assetHint, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                Contract.ThrowIfFalse(solutionState.TryGetStateChecksums(ProjectId, out var stateChecksums));
+            SolutionCompilationStateChecksums? stateChecksums;
 
-                await stateChecksums.FindAsync(solutionState, assetHint, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
-            }
+            if (ProjectId is null)
+                solutionState.TryGetStateChecksums(out stateChecksums);
+            else
+                solutionState.TryGetStateChecksums(ProjectId, out stateChecksums);
+
+            Contract.ThrowIfNull(stateChecksums);
+
+            await stateChecksums.FindAsync(solutionState, assetHint, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
         }
 
         public TestAccessor GetTestAccessor()

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -18,11 +18,13 @@ internal partial class SolutionAssetStorage
     internal sealed partial class Scope(
         SolutionAssetStorage storage,
         Checksum solutionChecksum,
+        ProjectId? projectId,
         SolutionCompilationState compilationState) : IDisposable
     {
         private readonly SolutionAssetStorage _storage = storage;
 
         public readonly Checksum SolutionChecksum = solutionChecksum;
+        public readonly ProjectId? ProjectId = projectId;
         public readonly SolutionCompilationState CompilationState = compilationState;
 
         /// <summary>
@@ -67,15 +69,14 @@ internal partial class SolutionAssetStorage
             AssetHint assetHint, HashSet<Checksum> remainingChecksumsToFind, Dictionary<Checksum, object> result, CancellationToken cancellationToken)
         {
             var solutionState = this.CompilationState;
-            if (solutionState.TryGetStateChecksums(out var stateChecksums))
-                await stateChecksums.FindAsync(solutionState, assetHint, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
-
-            foreach (var projectId in solutionState.SolutionState.ProjectIds)
+            if (ProjectId is null)
             {
-                if (remainingChecksumsToFind.Count == 0)
-                    break;
-
-                if (solutionState.TryGetStateChecksums(projectId, out stateChecksums))
+                if (solutionState.TryGetStateChecksums(out var stateChecksums))
+                    await stateChecksums.FindAsync(solutionState, assetHint, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                if (solutionState.TryGetStateChecksums(ProjectId, out var stateChecksums))
                     await stateChecksums.FindAsync(solutionState, assetHint, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -76,8 +76,9 @@ internal partial class SolutionAssetStorage
             }
             else
             {
-                if (solutionState.TryGetStateChecksums(ProjectId, out var stateChecksums))
-                    await stateChecksums.FindAsync(solutionState, assetHint, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfFalse(solutionState.TryGetStateChecksums(ProjectId, out var stateChecksums));
+
+                await stateChecksums.FindAsync(solutionState, assetHint, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -76,7 +76,7 @@ internal partial class SolutionAssetStorage
                 return scope;
             }
 
-            scope = new Scope(this, checksum, compilationState);
+            scope = new Scope(this, checksum, projectId, compilationState);
             _checksumToScope[checksum] = scope;
             return scope;
         }


### PR DESCRIPTION
This avoids full solution level searches in scenarios where a project cone is being searched. This was particularly bad when the AssetHint didn't indicate a project/document.