### PR TITLE
Add a unit test to ensure object initialisers supports completion in collection expressions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -186,6 +186,43 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         }
 
         [Fact]
+        public async Task FieldAndProperty2()
+        {
+            var markup = """
+                public static class TestClass
+                {
+                    private static SimpleRange[] _ranges;
+                
+                    public static void Method()
+                    {
+                        _ranges =
+                        [
+                            new()
+                            {
+                                Start = 1,
+                                End = 3,
+                            },
+                            new()
+                            {
+                                $$
+                            },
+                        ];
+                    }
+                }
+                
+                public struct SimpleRange
+                {
+                    public int Start;
+                    public int End { get; set; }
+                };
+                """;
+
+            await VerifyItemExistsAsync(markup, "Start");
+            await VerifyItemExistsAsync(markup, "End");
+            await VerifyExclusiveAsync(markup, true);
+        }
+
+        [Fact]
         public async Task HidePreviouslyTyped()
         {
             var markup = """


### PR DESCRIPTION
Closes #72400 

This issue was already fixed, but it was pointed out that it should still have a unit test so I am adding one just like the case in the issue.