### PR TITLE
Always log LSP server processId and increase attach timeout

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -57,6 +57,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
 
     var logger = loggerFactory.CreateLogger<Program>();
 
+    logger.Log(serverConfiguration.LaunchDebugger ? LogLevel.Critical : LogLevel.Trace, "Server started with process ID {processId}", Environment.ProcessId);
     if (serverConfiguration.LaunchDebugger)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -66,8 +67,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
         }
         else
         {
-            var timeout = TimeSpan.FromMinutes(1);
-            logger.LogCritical($"Server started with process ID {Environment.ProcessId}");
+            var timeout = TimeSpan.FromMinutes(2);
             logger.LogCritical($"Waiting {timeout:g} for a debugger to attach");
             using var timeoutSource = new CancellationTokenSource(timeout);
             while (!Debugger.IsAttached && !timeoutSource.Token.IsCancellationRequested)


### PR DESCRIPTION
The processId is useful outside of debugging scenarios (for example when requesting more process information in bug reports).  Adjust logging to always report it.

Additionally, increases the timeout waiting for a debugger on non-windows platforms - it can take more than a minute at times to attach.