### PR TITLE
Reduce allocations in SynchronizeAssetsAsync

### DIFF
--- a/src/Workspaces/Core/Portable/Serialization/PooledList.cs
+++ b/src/Workspaces/Core/Portable/Serialization/PooledList.cs
@@ -4,9 +4,8 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Serialization;
 
@@ -15,12 +14,12 @@ namespace Microsoft.CodeAnalysis.Serialization;
 /// </summary>
 internal static class Creator
 {
-    public static PooledObject<HashSet<Checksum>> CreateChecksumSet(ImmutableArray<Checksum> checksums)
+    public static PooledObject<HashSet<Checksum>> CreateChecksumSet(ReadOnlyMemory<Checksum> checksums)
     {
         var items = SharedPools.Default<HashSet<Checksum>>().GetPooledObject();
 
         var hashSet = items.Object;
-        foreach (var checksum in checksums)
+        foreach (var checksum in checksums.Span)
             hashSet.Add(checksum);
 
         return items;

--- a/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -18,11 +19,11 @@ namespace Microsoft.CodeAnalysis.Remote.Testing;
 internal sealed class SimpleAssetSource(ISerializerService serializerService, IReadOnlyDictionary<Checksum, object> map) : IAssetSource
 {
     public ValueTask<ImmutableArray<object>> GetAssetsAsync(
-        Checksum solutionChecksum, AssetHint assetHint, ImmutableArray<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
+        Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
     {
         var results = new List<object>();
 
-        foreach (var checksum in checksums)
+        foreach (var checksum in checksums.Span)
         {
             Contract.ThrowIfFalse(map.TryGetValue(checksum, out var data));
 

--- a/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,5 +26,5 @@ internal interface ISolutionAssetProvider
     /// save substantially on performance by avoiding having to search the full solution tree to find matching items for
     /// a particular checksum.</param>
     ValueTask WriteAssetsAsync(
-        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ImmutableArray<Checksum> checksums, CancellationToken cancellationToken);
+        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ISerializerService serializer,
             SolutionReplicationContext context,
             Checksum solutionChecksum,
-            ImmutableArray<Checksum> checksums,
+            ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {
             using var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken);
@@ -40,8 +41,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
             Debug.Assert(assetMap != null);
 
-            foreach (var checksum in checksums)
+            for (var i = 0; i < checksums.Span.Length; i++)
             {
+                var checksum = checksums.Span[i];
                 var asset = assetMap[checksum];
 
                 // We flush after each item as that forms a reasonably sized chunk of data to want to then send over the

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -4,13 +4,11 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Immutable;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
@@ -31,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Remote
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
             AssetHint assetHint,
-            ImmutableArray<Checksum> checksums,
+            ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {
             // Suppress ExecutionContext flow for asynchronous operations operate on the pipe. In addition to avoiding
@@ -43,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Remote
             using var _ = FlowControlHelper.TrySuppressFlow();
             return WriteAssetsSuppressedFlowAsync(pipeWriter, solutionChecksum, assetHint, checksums, cancellationToken);
 
-            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ImmutableArray<Checksum> checksums, CancellationToken cancellationToken)
+            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
             {
                 // The responsibility is on us (as per the requirements of RemoteCallback.InvokeAsync) to Complete the
                 // pipewriter.  This will signal to streamjsonrpc that the writer passed into it is complete, which will
@@ -68,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Remote
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
             AssetHint assetHint,
-            ImmutableArray<Checksum> checksums,
+            ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {
             var assetStorage = _services.GetRequiredService<ISolutionAssetStorageProvider>().AssetStorage;

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,7 +46,7 @@ internal partial class SolutionAssetStorage
         /// </summary>
         public async Task AddAssetsAsync(
             AssetHint assetHint,
-            ImmutableArray<Checksum> checksums,
+            ReadOnlyMemory<Checksum> checksums,
             Dictionary<Checksum, object> assetMap,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,5 +16,5 @@ namespace Microsoft.CodeAnalysis.Remote;
 internal interface IAssetSource
 {
     ValueTask<ImmutableArray<object>> GetAssetsAsync(
-        Checksum solutionChecksum, AssetHint assetHint, ImmutableArray<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
+        Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
@@ -111,6 +111,9 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
+        public bool ContainsAsset(Checksum checksum)
+            => _assets.ContainsKey(checksum);
+
         public void UpdateLastActivityTime()
             => _lastActivityTime = DateTime.UtcNow;
 

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +19,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
     public async ValueTask<ImmutableArray<object>> GetAssetsAsync(
         Checksum solutionChecksum,
         AssetHint assetHint,
-        ImmutableArray<Checksum> checksums,
+        ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
         CancellationToken cancellationToken)
     {


### PR DESCRIPTION
This method was allocating an ImmutableArray<Checksum> each time it would request asset synchronization. Instead, we can use a pooled checksum array.

![image](https://github.com/dotnet/roslyn/assets/6785178/bf027b58-c41b-4173-addd-7096f231757b)