### PR TITLE
WIP: Reduce allocations in NodeExtensions.LogTables

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class BatchNode<TInput> : IIncrementalGeneratorNode<ImmutableArray<TInput>>
     {
+        private static readonly string? s_tableType = typeof(ImmutableArray<TInput>).FullName;
+
         private readonly IIncrementalGeneratorNode<TInput> _sourceNode;
         private readonly IEqualityComparer<ImmutableArray<TInput>> _comparer;
         private readonly string? _name;
@@ -141,7 +143,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             var newTable = tableBuilder.ToImmutableAndFree();
-            this.LogTables(_name, previousTable, newTable, sourceTable);
+            this.LogTables(_name, s_tableType, previousTable, newTable, sourceTable);
             return newTable;
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/CombineNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/CombineNode.cs
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class CombineNode<TInput1, TInput2> : IIncrementalGeneratorNode<(TInput1, TInput2)>
     {
+        private static readonly string? s_tableType = typeof((TInput1, TInput2)).FullName;
+
         private readonly IIncrementalGeneratorNode<TInput1> _input1;
         private readonly IIncrementalGeneratorNode<TInput2> _input2;
         private readonly IEqualityComparer<(TInput1, TInput2)>? _comparer;
@@ -34,7 +36,7 @@ namespace Microsoft.CodeAnalysis
 
             if (input1Table.IsCached && input2Table.IsCached && previousTable is not null)
             {
-                this.LogTables(_name, previousTable, previousTable, input1Table, input2Table);
+                this.LogTables(_name, s_tableType, previousTable, previousTable, input1Table, input2Table);
                 if (graphState.DriverState.TrackIncrementalSteps)
                 {
                     return RecordStepsForCachedTable(graphState, previousTable, input1Table, input2Table);
@@ -79,7 +81,7 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(tableBuilder.Count == totalEntryItemCount);
 
             var newTable = tableBuilder.ToImmutableAndFree();
-            this.LogTables(_name, previousTable, newTable, input1Table, input2Table);
+            this.LogTables(_name, s_tableType, previousTable, newTable, input1Table, input2Table);
             return newTable;
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -19,6 +19,8 @@ namespace Microsoft.CodeAnalysis
     /// <typeparam name="T">The type of the input</typeparam>
     internal sealed class InputNode<T> : IIncrementalGeneratorNode<T>
     {
+        private static readonly string? s_tableType = typeof(T).FullName;
+
         private readonly Func<DriverStateTable.Builder, ImmutableArray<T>> _getInput;
         private readonly Action<IIncrementalGeneratorOutputNode> _registerOutput;
         private readonly IEqualityComparer<T> _inputComparer;
@@ -132,7 +134,7 @@ namespace Microsoft.CodeAnalysis
             }
             var inputTable = tableBuilder.ToImmutableAndFree();
 
-            this.LogTables(_name, previousTable, newTable, inputTable);
+            this.LogTables(_name, s_tableType, previousTable, newTable, inputTable);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeExtensions.cs
@@ -6,10 +6,10 @@ namespace Microsoft.CodeAnalysis
 {
     internal static class NodeExtensions
     {
-        public static void LogTables<TSelf, TInput>(this IIncrementalGeneratorNode<TSelf> self, string? name, NodeStateTable<TSelf>? previousTable, NodeStateTable<TSelf> newTable, NodeStateTable<TInput> inputTable)
-            => LogTables<TSelf, TInput, TInput>(self, name, previousTable, newTable, inputTable, inputNode2: null);
+        public static void LogTables<TSelf, TInput>(this IIncrementalGeneratorNode<TSelf> self, string? name, string? tableType, NodeStateTable<TSelf>? previousTable, NodeStateTable<TSelf> newTable, NodeStateTable<TInput> inputTable)
+            => LogTables<TSelf, TInput, TInput>(self, name, tableType, previousTable, newTable, inputTable, inputNode2: null);
 
-        public static void LogTables<TSelf, TInput1, TInput2>(this IIncrementalGeneratorNode<TSelf> self, string? name, NodeStateTable<TSelf>? previousTable, NodeStateTable<TSelf> newTable, NodeStateTable<TInput1> inputNode1, NodeStateTable<TInput2>? inputNode2)
+        public static void LogTables<TSelf, TInput1, TInput2>(this IIncrementalGeneratorNode<TSelf> self, string? name, string? tableType, NodeStateTable<TSelf>? previousTable, NodeStateTable<TSelf> newTable, NodeStateTable<TInput1> inputNode1, NodeStateTable<TInput2>? inputNode2)
         {
             if (CodeAnalysisEventSource.Log.IsEnabled())
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class SourceOutputNode<TInput> : IIncrementalGeneratorOutputNode, IIncrementalGeneratorNode<TOutput>
     {
+        private static readonly string? s_tableType = typeof(TOutput).FullName;
+
         private readonly IIncrementalGeneratorNode<TInput> _source;
 
         private readonly Action<SourceProductionContext, TInput, CancellationToken> _action;
@@ -41,7 +43,7 @@ namespace Microsoft.CodeAnalysis
             var sourceTable = graphState.GetLatestStateTableForNode(_source);
             if (sourceTable.IsCached && previousTable is not null)
             {
-                this.LogTables(stepName, previousTable, previousTable, sourceTable);
+                this.LogTables(stepName, s_tableType, previousTable, previousTable, sourceTable);
                 if (graphState.DriverState.TrackIncrementalSteps)
                 {
                     return previousTable.CreateCachedTableWithUpdatedSteps(sourceTable, stepName, EqualityComparer<TOutput>.Default);
@@ -83,7 +85,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             var newTable = tableBuilder.ToImmutableAndFree();
-            this.LogTables(stepName, previousTable, newTable, sourceTable);
+            this.LogTables(stepName, s_tableType, previousTable, newTable, sourceTable);
             return newTable;
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class TransformNode<TInput, TOutput> : IIncrementalGeneratorNode<TOutput>
     {
+        private static readonly string? s_tableType = typeof(TOutput).FullName;
+
         private readonly Func<TInput, CancellationToken, ImmutableArray<TOutput>> _func;
         private readonly IEqualityComparer<TOutput> _comparer;
         private readonly IIncrementalGeneratorNode<TInput> _sourceNode;
@@ -47,7 +49,7 @@ namespace Microsoft.CodeAnalysis
             var sourceTable = builder.GetLatestStateTableForNode(_sourceNode);
             if (sourceTable.IsCached && previousTable is not null)
             {
-                this.LogTables(_name, previousTable, previousTable, sourceTable);
+                this.LogTables(_name, s_tableType, previousTable, previousTable, sourceTable);
                 if (builder.DriverState.TrackIncrementalSteps)
                 {
                     return previousTable.CreateCachedTableWithUpdatedSteps(sourceTable, _name, _comparer);
@@ -95,7 +97,7 @@ namespace Microsoft.CodeAnalysis
             // Can't assert anything about the count of items.  _func may have produced a different amount of items if
             // it's not a 1:1 function.
             var newTable = tableBuilder.ToImmutableAndFree();
-            this.LogTables(_name, previousTable, newTable, sourceTable);
+            this.LogTables(_name, s_tableType, previousTable, newTable, sourceTable);
             return newTable;
         }
 


### PR DESCRIPTION
Creating as a draft PR so I can run a test insertion to validate that this improves the numbers for this codepath.

The call to typeof(T).FullName is showing in speedometer allocation profiles as 0.8% of allocations during the session in the roslyn OOP. Although these allocations only occur when logging is on, it's still nice to get rid of them and improve our numbers and the experience of customers that have this logging on.