### PR TITLE
The RenameFlyout and DisposableToolTip do not use some color tokens correctly

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -2,14 +2,14 @@
              x:ClassModifier="internal"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:rename="clr-namespace:Microsoft.CodeAnalysis.Editor.Implementation.InlineRename"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
-             xmlns:imageutils="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:utils="clr-namespace:Microsoft.CodeAnalysis.Utilities"
-             mc:Ignorable="d" 
+             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+             mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
              MinWidth="200"
              KeyDown="Adornment_KeyDown"
@@ -28,7 +28,9 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Border 
+    <Border
+        Background="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}"
+        BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBorderBrushKey}}"
         BorderThickness="1"
         x:Name="Outline">
         <StackPanel x:Name="MainPanel" Orientation="Vertical" Margin="5" >
@@ -44,18 +46,17 @@
                     HorizontalAlignment="Stretch"/>
 
                 <!-- Expand/Collapse button and glyph -->
-                <Button 
-                    x:Name="ToggleExpandButton" 
-                    Grid.Column="1" 
-                    Click="ToggleExpand" 
-                    Background="Transparent"
-                    imageutils:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Parent.Background, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushToColorConverter}}">
+                <Button
+                    x:Name="ToggleExpandButton"
+                    Grid.Column="1"
+                    Click="ToggleExpand"
+                    Background="Transparent">
                     <Button.Style>
                         <Style TargetType="Button">
                             <Setter Property="Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="Button">
-                                        <Border Name="border" 
+                                        <Border Name="border"
                                         BorderThickness="1"
                                         Background="{TemplateBinding Background}">
                                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
@@ -93,8 +94,8 @@
                 <TextBlock Grid.Column="1" Text="{Binding StatusText}" />
             </Grid>
 
-            <TextBlock 
-                Text="{Binding SearchText}" 
+            <TextBlock
+                Text="{Binding SearchText}"
                 Visibility="{Binding ShowSearchText, Converter={StaticResource BooleanToVisibilityConverter}}"
                 FontWeight="Light"
                 Margin="0,0,0,5" />
@@ -104,20 +105,20 @@
                       Name="OverloadsCheckbox" Visibility="{Binding IsRenameOverloadsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" IsEnabled="{Binding IsRenameOverloadsEditable}" />
                 <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=control, Path=SearchInComments}" Margin="0,5,0,0" IsChecked="{Binding Path=RenameInCommentsFlag, Mode=TwoWay}" />
                 <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=control, Path=SearchInStrings}" Margin="0,5,0,0" IsChecked="{Binding Path=RenameInStringsFlag, Mode=TwoWay}" />
-                <CheckBox Name="FileRenameCheckbox" 
-                    Content="{Binding Path=FileRenameString}" 
+                <CheckBox Name="FileRenameCheckbox"
+                    Content="{Binding Path=FileRenameString}"
                     Margin="0,5,0,0"
-                    IsChecked="{Binding Path=RenameFileFlag, Mode=TwoWay}" 
-                    IsEnabled="{Binding Path=AllowFileRename, Mode=OneWay}" 
+                    IsChecked="{Binding Path=RenameFileFlag, Mode=TwoWay}"
+                    IsEnabled="{Binding Path=AllowFileRename, Mode=OneWay}"
                     Visibility="{Binding Path=ShowFileRename, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
             </StackPanel>
 
-            <TextBlock 
+            <TextBlock
                 x:Name="SubmitTextBlock"
-                Text="{Binding ElementName=control, Path=SubmitText}" 
-                Margin="5, 5, 0, 0" 
+                Text="{Binding ElementName=control, Path=SubmitText}"
+                Margin="5, 5, 0, 0"
                 FontStyle="Italic"
                 />
-    </StackPanel>
+        </StackPanel>
     </Border>
 </rename:InlineRenameAdornment>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -80,10 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 MainPanel.Children.Insert(index + 1, smartRenameControl);
             }
 
-            RefreshColors();
-
             _editorFormatMap = editorFormatMapService.GetEditorFormatMap("text");
-            _editorFormatMap.FormatMappingChanged += FormatMappingChanged;
 
             // Dismiss any current tooltips. Note that this does not disable tooltips
             // from showing up again, so if a user has the mouse unmoved another
@@ -94,20 +91,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         }
 
         internal IRenameUserInput RenameUserInput { get; }
-
-        private void FormatMappingChanged(object sender, FormatItemsEventArgs e)
-        {
-            RefreshColors();
-        }
-
-        private void RefreshColors()
-        {
-            if (_wpfThemeService is not null)
-            {
-                Outline.BorderBrush = new SolidColorBrush(_wpfThemeService.GetThemeColor(EnvironmentColors.AccentBorderColorKey));
-                Background = new SolidColorBrush(_wpfThemeService.GetThemeColor(EnvironmentColors.ToolWindowBackgroundColorKey));
-            }
-        }
 
         private async Task DismissToolTipsAsync()
         {
@@ -178,7 +161,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _textView.LayoutChanged -= TextView_LayoutChanged;
             _textView.ViewportHeightChanged -= TextView_ViewPortChanged;
             _textView.ViewportWidthChanged -= TextView_ViewPortChanged;
-            _editorFormatMap.FormatMappingChanged -= FormatMappingChanged;
 
             // Restore focus back to the textview
             _textView.VisualElement.Focus();
@@ -205,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     break;
 
                 case Key.Tab:
-                    // We don't want tab to lose focus for the adornment, so manually 
+                    // We don't want tab to lose focus for the adornment, so manually
                     // loop focus back to the first item that is focusable.
                     var lastItem = _viewModel.IsExpanded
                         ? FileRenameCheckbox

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/ContentControlService.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/ContentControlService.cs
@@ -59,13 +59,14 @@ namespace Microsoft.CodeAnalysis.Editor.QuickInfo
             // Create the actual tooltip around the region of that text buffer we want to show.
             var toolTip = new ToolTip
             {
-                Content = control,
-                Background = (Brush)Application.Current.Resources[backgroundResourceKey]
+                Content = control
             };
 
-            // Create a preview workspace for this text buffer and open it's corresponding 
-            // document. 
-            // 
+            toolTip.SetResourceReference(Control.BackgroundProperty, backgroundResourceKey);
+
+            // Create a preview workspace for this text buffer and open it's corresponding
+            // document.
+            //
             // our underlying preview tagger and mechanism to attach tagger to associated buffer of
             // opened document will light up automatically
             var workspace = new PreviewWorkspace(document.Project.Solution);
@@ -81,9 +82,10 @@ namespace Microsoft.CodeAnalysis.Editor.QuickInfo
             // Create the actual tooltip around the region of that text buffer we want to show.
             var toolTip = new ToolTip
             {
-                Content = control,
-                Background = (Brush)Application.Current.Resources[backgroundResourceKey]
+                Content = control
             };
+
+            toolTip.SetResourceReference(Control.BackgroundProperty, backgroundResourceKey);
 
             // we have stand alone view that is not associated with roslyn solution
             return new DisposableToolTip(toolTip, workspaceOpt: null);


### PR DESCRIPTION
Fix the incorrect usage of color tokens in the RenameFlyout and DisposableToolTip. The change makes those controls use DynamicResources for the color tokens rather than using the VSColorTheme helper or directly querying the Application-level resource dictionary. The change also removes an invalid set of ImageThemingUtilities.ImageBackgroundColor.

This work is to address issues related to in progress work related to how the Editor handles and supports colors in VS.

These changes are related to this bug:
https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1994113