### PR TITLE
Fix #69628 Analyzer summary should show suppressor ID

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9366,6 +9366,29 @@ public class C { }
         }
 
         [Fact]
+        public void ReportAnalyzerOutput_ShowSuppressorIds()
+        {
+            var srcFile = Temp.CreateFile().WriteAllText(@"class C {}");
+            var srcDirectory = Path.GetDirectoryName(srcFile.Path);
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var csc = CreateCSharpCompiler(
+                responseFile: null,
+                srcDirectory,
+                ["/reportanalyzer", "/t:library", srcFile.Path],
+                analyzers: [new DiagnosticSuppressorForId("Warning01", "Suppressor01")],
+                generators: [new DoNothingGenerator().AsSourceGenerator()]);
+            var exitCode = csc.Run(outWriter);
+            Assert.Equal(0, exitCode);
+            var output = outWriter.ToString();
+            Assert.Contains(CodeAnalysisResources.AnalyzerExecutionTimeColumnHeader, output, StringComparison.Ordinal);
+            Assert.Contains($"{nameof(DiagnosticSuppressorForId)} (Suppressor01)", output, StringComparison.Ordinal);
+            Assert.Contains(CodeAnalysisResources.GeneratorNameColumnHeader, output, StringComparison.Ordinal);
+            Assert.Contains(typeof(DoNothingGenerator).FullName, output, StringComparison.Ordinal);
+            CleanupAllGeneratedFiles(srcFile.Path);
+        }
+
+        [Fact]
         [WorkItem(40926, "https://github.com/dotnet/roslyn/issues/40926")]
         public void SkipAnalyzersParse()
         {

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9353,35 +9353,13 @@ public class C { }
                 responseFile: null,
                 srcDirectory,
                 new[] { "/reportanalyzer", "/t:library", srcFile.Path },
-                analyzers: new[] { new WarningDiagnosticAnalyzer() },
+                analyzers: [new WarningDiagnosticAnalyzer(), new DiagnosticSuppressorForId("Warning01", "Suppressor01")],
                 generators: new[] { new DoNothingGenerator().AsSourceGenerator() });
             var exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
             var output = outWriter.ToString();
             Assert.Contains(CodeAnalysisResources.AnalyzerExecutionTimeColumnHeader, output, StringComparison.Ordinal);
             Assert.Contains($"{nameof(WarningDiagnosticAnalyzer)} (Warning01)", output, StringComparison.Ordinal);
-            Assert.Contains(CodeAnalysisResources.GeneratorNameColumnHeader, output, StringComparison.Ordinal);
-            Assert.Contains(typeof(DoNothingGenerator).FullName, output, StringComparison.Ordinal);
-            CleanupAllGeneratedFiles(srcFile.Path);
-        }
-
-        [Fact]
-        public void ReportAnalyzerOutput_ShowSuppressorIds()
-        {
-            var srcFile = Temp.CreateFile().WriteAllText(@"class C {}");
-            var srcDirectory = Path.GetDirectoryName(srcFile.Path);
-
-            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
-            var csc = CreateCSharpCompiler(
-                responseFile: null,
-                srcDirectory,
-                ["/reportanalyzer", "/t:library", srcFile.Path],
-                analyzers: [new DiagnosticSuppressorForId("Warning01", "Suppressor01")],
-                generators: [new DoNothingGenerator().AsSourceGenerator()]);
-            var exitCode = csc.Run(outWriter);
-            Assert.Equal(0, exitCode);
-            var output = outWriter.ToString();
-            Assert.Contains(CodeAnalysisResources.AnalyzerExecutionTimeColumnHeader, output, StringComparison.Ordinal);
             Assert.Contains($"{nameof(DiagnosticSuppressorForId)} (Suppressor01)", output, StringComparison.Ordinal);
             Assert.Contains(CodeAnalysisResources.GeneratorNameColumnHeader, output, StringComparison.Ordinal);
             Assert.Contains(typeof(DoNothingGenerator).FullName, output, StringComparison.Ordinal);

--- a/src/Compilers/Core/Portable/CommandLine/ReportAnalyzerUtil.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ReportAnalyzerUtil.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
                     executionTime = kvp.Value.TotalSeconds;
                     percentage = (int)(executionTime * 100 / totalAnalyzerExecutionTime);
 
-                    var analyzerIds = string.Join(", ", kvp.Key.SupportedDiagnostics.Select(d => d.Id).Distinct().OrderBy(id => id));
+                    var analyzerIds = string.Join(", ", GetSupportedIds(kvp.Key).Distinct().OrderBy(id => id));
                     var analyzerNameColumn = $"   {kvp.Key} ({analyzerIds})";
                     consoleOutput.WriteLine(GetColumnEntry(executionTime, percentage, analyzerNameColumn, culture));
                 }
@@ -101,6 +101,13 @@ namespace Microsoft.CodeAnalysis
                 consoleOutput.WriteLine();
             }
         }
+
+        private static IEnumerable<string> GetSupportedIds(DiagnosticAnalyzer analyzer)
+            => analyzer switch
+            {
+                DiagnosticSuppressor suppressor => suppressor.SupportedSuppressions.Select(s => s.Id),
+                _ => analyzer.SupportedDiagnostics.Select(d => d.Id),
+            };
 
         private static void ReportGeneratorExecutionTime(TextWriter consoleOutput, GeneratorDriverTimingInfo driverTimingInfo, CultureInfo culture)
         {


### PR DESCRIPTION
This PR fix #69628. 

The fix show the Ids for the supported suppressions when the analyzer report is generated.

Test modified to include checking for Ids.