### PR TITLE
Localize 17.10 branch

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -81,11 +81,11 @@ stages:
     demands: ImageOverride -equals windows.vs2022preview.amd64
 
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.9') }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.10') }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: roslyn
-        MirrorBranch: release/dev17.9
+        MirrorBranch: release/dev17.10
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-ROSLYN'
 


### PR DESCRIPTION
Start to localize 17.10 branch.
Targeting 17.9 to stop the current localization. And the code flow will start the localization on 17.10 branch