### PR TITLE
Add suppressor Ids to ReportAnalyzer output

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9349,17 +9349,20 @@ public class C { }
             var srcDirectory = Path.GetDirectoryName(srcFile.Path);
 
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+
+            var suppressor = new DiagnosticSuppressorForId("CS0078");
             var csc = CreateCSharpCompiler(
                 responseFile: null,
                 srcDirectory,
                 new[] { "/reportanalyzer", "/t:library", srcFile.Path },
-                analyzers: new[] { new WarningDiagnosticAnalyzer() },
+                analyzers: new DiagnosticAnalyzer[] { new WarningDiagnosticAnalyzer(), suppressor },
                 generators: new[] { new DoNothingGenerator().AsSourceGenerator() });
             var exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
             var output = outWriter.ToString();
             Assert.Contains(CodeAnalysisResources.AnalyzerExecutionTimeColumnHeader, output, StringComparison.Ordinal);
             Assert.Contains($"{nameof(WarningDiagnosticAnalyzer)} (Warning01)", output, StringComparison.Ordinal);
+            Assert.Contains($"{nameof(DiagnosticSuppressorForId)} (SPR0001)", output, StringComparison.Ordinal);
             Assert.Contains(CodeAnalysisResources.GeneratorNameColumnHeader, output, StringComparison.Ordinal);
             Assert.Contains(typeof(DoNothingGenerator).FullName, output, StringComparison.Ordinal);
             CleanupAllGeneratedFiles(srcFile.Path);

--- a/src/Compilers/Core/Portable/CommandLine/ReportAnalyzerUtil.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ReportAnalyzerUtil.cs
@@ -92,9 +92,12 @@ namespace Microsoft.CodeAnalysis
                 {
                     executionTime = kvp.Value.TotalSeconds;
                     percentage = (int)(executionTime * 100 / totalAnalyzerExecutionTime);
-
-                    var analyzerIds = string.Join(", ", kvp.Key.SupportedDiagnostics.Select(d => d.Id).Distinct().OrderBy(id => id));
-                    var analyzerNameColumn = $"   {kvp.Key} ({analyzerIds})";
+                    var ids = string.Join(", ", kvp.Key.SupportedDiagnostics.Select(d => d.Id).Distinct().OrderBy(id => id));
+                    if (kvp.Key is DiagnosticSuppressor suppressor)
+                    {
+                        ids = string.Join(", ", suppressor.SupportedSuppressions.Select(d => d.Id).Distinct().OrderBy(id => id));
+                    }
+                    var analyzerNameColumn = $"   {kvp.Key} ({ids})";
                     consoleOutput.WriteLine(GetColumnEntry(executionTime, percentage, analyzerNameColumn, culture));
                 }
 


### PR DESCRIPTION
Add support for ids from `DiagnosticSuppressor.SupportedSuppressions` as mentioned in https://github.com/dotnet/roslyn/issues/69628