### PR TITLE
Reduce allocations in AbstractTypeMap

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -313,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            return result != null ? result.AsImmutableOrNull() : original;
+            return result != null ? ImmutableCollectionsMarshal.AsImmutableArray(result) : original;
         }
 
         internal ImmutableArray<TypeWithAnnotations> SubstituteTypes(ImmutableArray<TypeWithAnnotations> original)
@@ -430,7 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            return result != null ? result.AsImmutableOrNull() : original;
+            return result != null ? ImmutableCollectionsMarshal.AsImmutableArray(result) : original;
         }
     }
 }


### PR DESCRIPTION
Partial fix for https://github.com/dotnet/roslyn/issues/68996

Both SubstituteTypesWithoutModifiers and SubstituteNamedTypes allocate a temporary array that is used to potentially return an immutable array. Previously, this immutable array was allocated if needed, whereas we can not perform the extra allocation by utilizing ImmutableCollectionsMarshal as the array being wrapped is local to this method.