### PR TITLE
Disable diagnostics when solution crawler option is disabled

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             try
             {
-                return await InProcOrRemoteHostAnalyzerRunner.GetSourceGeneratorDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
+                return await _diagnosticAnalyzerRunner.GetSourceGeneratorDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
             }
             catch when (_onAnalysisException != null)
             {

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             return true;
         }
 
-        private static async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> MergeProjectDiagnosticAnalyzerDiagnosticsAsync(
+        private async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> MergeProjectDiagnosticAnalyzerDiagnosticsAsync(
             Project project,
             ImmutableArray<DiagnosticAnalyzer> ideAnalyzers,
             Compilation? compilation,
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
         }
 
-        private static async Task<(ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> results, ImmutableHashSet<Document>? failedDocuments)> UpdateWithDocumentLoadAndGeneratorFailuresAsync(
+        private async Task<(ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> results, ImmutableHashSet<Document>? failedDocuments)> UpdateWithDocumentLoadAndGeneratorFailuresAsync(
             ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> results,
             Project project,
             VersionStamp version,
@@ -542,7 +542,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     others: [],
                     documentIds: null));
 
-            var generatorDiagnostics = await InProcOrRemoteHostAnalyzerRunner.GetSourceGeneratorDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
+            var generatorDiagnostics = await _diagnosticAnalyzerRunner.GetSourceGeneratorDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
             var diagnosticResultBuilder = new DiagnosticAnalysisResultBuilder(project, version);
             foreach (var generatorDiagnostic in generatorDiagnostics)
             {

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -23,13 +23,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal class InProcOrRemoteHostAnalyzerRunner
     {
+        private readonly bool _enabled;
         private readonly IAsynchronousOperationListener _asyncOperationListener;
         public DiagnosticAnalyzerInfoCache AnalyzerInfoCache { get; }
 
         public InProcOrRemoteHostAnalyzerRunner(
+            bool enabled,
             DiagnosticAnalyzerInfoCache analyzerInfoCache,
             IAsynchronousOperationListener? operationListener = null)
         {
+            _enabled = enabled;
             AnalyzerInfoCache = analyzerInfoCache;
             _asyncOperationListener = operationListener ?? AsynchronousOperationListenerProvider.NullListener;
         }
@@ -64,6 +67,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
         {
+            if (!_enabled)
+                return DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty;
+
             var result = await AnalyzeCoreAsync().ConfigureAwait(false);
             Debug.Assert(getTelemetryInfo || result.TelemetryInfo.IsEmpty);
             return result;

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -90,8 +90,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        public static async Task<ImmutableArray<Diagnostic>> GetSourceGeneratorDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        public async Task<ImmutableArray<Diagnostic>> GetSourceGeneratorDiagnosticsAsync(Project project, CancellationToken cancellationToken)
         {
+            if (!_enabled)
+                return [];
+
             var options = project.Solution.Services.GetRequiredService<IWorkspaceConfigurationService>().Options;
             var remoteHostClient = await RemoteHostClient.TryGetClientAsync(project, cancellationToken).ConfigureAwait(false);
             if (remoteHostClient != null)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -62,7 +62,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             _stateManager = new StateManager(workspace, analyzerInfoCache);
             _stateManager.ProjectAnalyzerReferenceChanged += OnProjectAnalyzerReferenceChanged;
 
-            _diagnosticAnalyzerRunner = new InProcOrRemoteHostAnalyzerRunner(analyzerInfoCache, analyzerService.Listener);
+            var enabled = this.AnalyzerService.GlobalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler);
+            _diagnosticAnalyzerRunner = new InProcOrRemoteHostAnalyzerRunner(
+                enabled, analyzerInfoCache, analyzerService.Listener);
         }
 
         internal IGlobalOptionService GlobalOptions => AnalyzerService.GlobalOptions;

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -245,7 +245,7 @@ End Class";
         }
 
         private static InProcOrRemoteHostAnalyzerRunner CreateAnalyzerRunner()
-            => new(new DiagnosticAnalyzerInfoCache());
+            => new(enabled: true, new DiagnosticAnalyzerInfoCache());
 
         private static async Task<DiagnosticAnalysisResult> AnalyzeAsync(TestWorkspace workspace, ProjectId projectId, Type analyzerType, IdeAnalyzerOptions ideOptions, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
This gets us closer to the behavior we have in CI where setting this option disabled solution crawler entirely.  With solution crawler entirely disabled, we didn't even have the DiagnosticsIncrementalAnalyzer created.  Instead, we'd just get a no-op version.

That codepath is gone now, so i'm getting us closer by just having us run all the new codepaths *except* for the actual call to go compute diagnostics.  This avoids all the overhead of callign into OOP, which avoids then doing all the jitting of message-pack, as well as all the costs of serializing/deserializing the messages to/from OOP.

As with the other work to disable things this really needs to be a temporary point in time thing until we just run all this in CI (since none of this accurately measures what a user is actually executing).


[Validation build](https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/537292)