### PR TITLE
Fix potential exception in AssetProvider.SynchronizeAssetsAsync

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -138,6 +138,21 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
             {
                 if (!_assetCache.TryGetAsset<object>(checksum, out _))
                 {
+                    if (missingChecksumsCount == missingChecksums.Length)
+                    {
+                        // This can happen if the asset cache has been modified by another thread during this method's execution.
+                        var newMissingChecksums = new Checksum[missingChecksumsCount * 2];
+                        Array.Copy(missingChecksums, newMissingChecksums, missingChecksumsCount);
+
+                        if (usePool)
+                        {
+                            s_checksumPool.Free(missingChecksums);
+                            usePool = false;
+                        }
+
+                        missingChecksums = newMissingChecksums;
+                    }
+
                     missingChecksums[missingChecksumsCount] = checksum;
                     missingChecksumsCount++;
                 }


### PR DESCRIPTION
In a perf fix I made last week, I assumed _assetCache wouldn't change underneath me during execution of SynchronizeAssetsAsync. That assumption is not true.

Now, if the asset cache changes such that the missingChecksums array is no longer sufficient to hold all missing checksums, then grow the array capacity such that it can hold additional entries that might now be missing.