### PR TITLE
Expose a way for Razor to register capabilities into the AlwaysActivateInProcLanguageClient

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueue.cs
@@ -69,9 +69,18 @@ internal class SemanticTokensRefreshQueue :
 
     public Task OnInitializedAsync(ClientCapabilities clientCapabilities, RequestContext context, CancellationToken _)
     {
+        if (_capabilitiesProvider.GetCapabilities(clientCapabilities).SemanticTokensOptions is not null)
+        {
+            Initialize(clientCapabilities);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Initialize(ClientCapabilities clientCapabilities)
+    {
         if (_semanticTokenRefreshQueue is null
-            && clientCapabilities.Workspace?.SemanticTokens?.RefreshSupport is true
-            && _capabilitiesProvider.GetCapabilities(clientCapabilities).SemanticTokensOptions is not null)
+            && clientCapabilities.Workspace?.SemanticTokens?.RefreshSupport is true)
         {
             // Only send a refresh notification to the client every 2s (if needed) in order to avoid sending too many
             // notifications at once.  This ensures we batch up workspace notifications, but also means we send soon
@@ -85,8 +94,6 @@ internal class SemanticTokensRefreshQueue :
 
             _lspWorkspaceRegistrationService.LspSolutionChanged += OnLspSolutionChanged;
         }
-
-        return Task.CompletedTask;
     }
 
     public async Task TryEnqueueRefreshComputationAsync(Project project, CancellationToken cancellationToken)

--- a/src/Features/LanguageServer/Protocol/LanguageInfoProvider.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageInfoProvider.cs
@@ -11,11 +11,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 {
     internal class LanguageInfoProvider : ILanguageInfoProvider
     {
+        // Constant so that Razor can use it (exposed via EA) otherwise their endpoints won't get hit
+        public const string RazorLanguageName = "Razor";
+
         private static readonly LanguageInformation s_csharpLanguageInformation = new(LanguageNames.CSharp, ".csx");
         private static readonly LanguageInformation s_fsharpLanguageInformation = new(LanguageNames.FSharp, ".fsx");
         private static readonly LanguageInformation s_vbLanguageInformation = new(LanguageNames.VisualBasic, ".vbx");
         private static readonly LanguageInformation s_typeScriptLanguageInformation = new LanguageInformation(InternalLanguageNames.TypeScript, string.Empty);
-        private static readonly LanguageInformation s_razorLanguageInformation = new("Razor", string.Empty);
+        private static readonly LanguageInformation s_razorLanguageInformation = new(RazorLanguageName, string.Empty);
         private static readonly LanguageInformation s_xamlLanguageInformation = new("XAML", string.Empty);
 
         private static readonly Dictionary<string, LanguageInformation> s_extensionToLanguageInformation = new()

--- a/src/Tools/ExternalAccess/Razor/Cohost/Constants.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/Constants.cs
@@ -9,6 +9,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 
 internal static class Constants
 {
+    public const string RazorLanguageName = LanguageInfoProvider.RazorLanguageName;
+
     public const string RazorLSPContentType = "Razor";
 
     public const string RazorLanguageContract = ProtocolConstants.RazorCohostContract;

--- a/src/Tools/ExternalAccess/Razor/Cohost/ExportCohostLspServiceFactoryAttribute.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/ExportCohostLspServiceFactoryAttribute.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.LanguageServer;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+[AttributeUsage(AttributeTargets.Class), MetadataAttribute]
+internal class ExportCohostLspServiceFactoryAttribute(Type handlerType) : ExportLspServiceFactoryAttribute(handlerType, ProtocolConstants.RoslynLspLanguagesContract, WellKnownLspServerKinds.AlwaysActiveVSLspServer);

--- a/src/Tools/ExternalAccess/Razor/Cohost/ExportCohostStatelessLspServiceAttribute.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/ExportCohostStatelessLspServiceAttribute.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.LanguageServer;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+[AttributeUsage(AttributeTargets.Class), MetadataAttribute]
+internal sealed class ExportCohostStatelessLspServiceAttribute(Type handlerType) : ExportStatelessLspServiceAttribute(handlerType, ProtocolConstants.RoslynLspLanguagesContract, WellKnownLspServerKinds.AlwaysActiveVSLspServer);

--- a/src/Tools/ExternalAccess/Razor/Cohost/IRazorCohostDynamicRegistrationService.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/IRazorCohostDynamicRegistrationService.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+internal interface IRazorCohostDynamicRegistrationService
+{
+    Task RegisterAsync(string serializedClientCapabilities, IRazorCohostClientLanguageServerManager razorCohostClientLanguageServerManager, CancellationToken cancellationToken);
+}

--- a/src/Tools/ExternalAccess/Razor/Cohost/IRazorCohostDynamicRegistrationService.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/IRazorCohostDynamicRegistrationService.cs
@@ -9,5 +9,5 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 
 internal interface IRazorCohostDynamicRegistrationService
 {
-    Task RegisterAsync(string serializedClientCapabilities, IRazorCohostClientLanguageServerManager razorCohostClientLanguageServerManager, CancellationToken cancellationToken);
+    Task RegisterAsync(string serializedClientCapabilities, RazorCohostRequestContext requestContext, CancellationToken cancellationToken);
 }

--- a/src/Tools/ExternalAccess/Razor/Cohost/IRazorSemanticTokensRefreshQueue.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/IRazorSemanticTokensRefreshQueue.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+internal interface IRazorSemanticTokensRefreshQueue : ILspService
+{
+    void Initialize(string clientCapabilitiesString);
+
+    Task TryEnqueueRefreshComputationAsync(Project project, CancellationToken cancellationToken);
+}

--- a/src/Tools/ExternalAccess/Razor/Cohost/IRazorSemanticTokensRefreshQueue.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/IRazorSemanticTokensRefreshQueue.cs
@@ -10,6 +10,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 
 internal interface IRazorSemanticTokensRefreshQueue : ILspService
 {
+    /// <summary>
+    /// Initialize the semantic tokens refresh queue in Roslyn
+    /// </summary>
+    /// <remarks>
+    /// This MUST be called synchronously from an IOnInitialized handler, to avoid dual initialization when
+    /// Roslyn and Razor both support semantic tokens
+    /// </remarks>
     void Initialize(string clientCapabilitiesString);
 
     Task TryEnqueueRefreshComputationAsync(Project project, CancellationToken cancellationToken);

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostClientLanguageServerManager.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostClientLanguageServerManager.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+internal class RazorCohostClientLanguageServerManager(IClientLanguageServerManager clientLanguageServerManager) : IRazorCohostClientLanguageServerManager
+{
+    public Task<TResponse> SendRequestAsync<TParams, TResponse>(string methodName, TParams @params, CancellationToken cancellationToken)
+        => clientLanguageServerManager.SendRequestAsync<TParams, TResponse>(methodName, @params, cancellationToken);
+
+    public ValueTask SendRequestAsync(string methodName, CancellationToken cancellationToken)
+        => clientLanguageServerManager.SendRequestAsync(methodName, cancellationToken);
+
+    public ValueTask SendRequestAsync<TParams>(string methodName, TParams @params, CancellationToken cancellationToken)
+        => clientLanguageServerManager.SendRequestAsync<TParams>(methodName, @params, cancellationToken);
+
+    public ValueTask SendNotificationAsync(string methodName, CancellationToken cancellationToken)
+        => clientLanguageServerManager.SendNotificationAsync(methodName, cancellationToken);
+
+    public ValueTask SendNotificationAsync<TParams>(string methodName, TParams @params, CancellationToken cancellationToken)
+        => clientLanguageServerManager.SendNotificationAsync(methodName, @params, cancellationToken);
+}

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostClientLanguageServerManagerFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostClientLanguageServerManagerFactory.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Composition;
-using System.Threading.Tasks;
-using System.Threading;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer;
 
@@ -21,23 +19,5 @@ internal class RazorCohostClientLanguageServerManagerFactory() : ILspServiceFact
         var notificationManager = lspServices.GetRequiredService<IClientLanguageServerManager>();
 
         return new RazorCohostClientLanguageServerManager(notificationManager);
-    }
-
-    internal class RazorCohostClientLanguageServerManager(IClientLanguageServerManager clientLanguageServerManager) : IRazorCohostClientLanguageServerManager
-    {
-        public Task<TResponse> SendRequestAsync<TParams, TResponse>(string methodName, TParams @params, CancellationToken cancellationToken)
-            => clientLanguageServerManager.SendRequestAsync<TParams, TResponse>(methodName, @params, cancellationToken);
-
-        public ValueTask SendRequestAsync(string methodName, CancellationToken cancellationToken)
-            => clientLanguageServerManager.SendRequestAsync(methodName, cancellationToken);
-
-        public ValueTask SendRequestAsync<TParams>(string methodName, TParams @params, CancellationToken cancellationToken)
-            => clientLanguageServerManager.SendRequestAsync<TParams>(methodName, @params, cancellationToken);
-
-        public ValueTask SendNotificationAsync(string methodName, CancellationToken cancellationToken)
-            => clientLanguageServerManager.SendNotificationAsync(methodName, cancellationToken);
-
-        public ValueTask SendNotificationAsync<TParams>(string methodName, TParams @params, CancellationToken cancellationToken)
-            => clientLanguageServerManager.SendNotificationAsync(methodName, @params, cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostServerClientLanguageServerManagerFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorCohostServerClientLanguageServerManagerFactory.cs
@@ -9,11 +9,14 @@ using Microsoft.CodeAnalysis.LanguageServer;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 
+// This will be removed in future when the cohost server is removed, and we move to dynamic registration.
+// It's already marked as Obsolete though, because Roslyn MEF rules :)
+
 [Shared]
-[ExportCohostLspServiceFactory(typeof(IRazorCohostClientLanguageServerManager))]
+[ExportRazorLspServiceFactory(typeof(IRazorCohostClientLanguageServerManager))]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal class RazorCohostClientLanguageServerManagerFactory() : ILspServiceFactory
+internal class RazorCohostServerClientLanguageServerManagerFactory() : ILspServiceFactory
 {
     public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
     {

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorDynamicRegistrationServiceFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorDynamicRegistrationServiceFactory.cs
@@ -48,7 +48,8 @@ internal sealed class RazorDynamicRegistrationServiceFactory([Import(AllowDefaul
             var serializedClientCapabilities = JsonConvert.SerializeObject(clientCapabilities);
             var razorCohostClientLanguageServerManager = new RazorCohostClientLanguageServerManager(_clientLanguageServerManager);
 
-            return _dynamicRegistrationService.RegisterAsync(serializedClientCapabilities, razorCohostClientLanguageServerManager, cancellationToken);
+            var requestContext = new RazorCohostRequestContext(context);
+            return _dynamicRegistrationService.RegisterAsync(serializedClientCapabilities, requestContext, cancellationToken);
         }
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorDynamicRegistrationServiceFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorDynamicRegistrationServiceFactory.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Newtonsoft.Json;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+[ExportCSharpVisualBasicLspServiceFactory(typeof(RazorDynamicRegistrationService), WellKnownLspServerKinds.AlwaysActiveVSLspServer), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class RazorDynamicRegistrationServiceFactory([Import(AllowDefault = true)] IRazorCohostDynamicRegistrationService? dynamicRegistrationService) : ILspServiceFactory
+{
+    public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
+    {
+        var clientLanguageServerManager = lspServices.GetRequiredService<IClientLanguageServerManager>();
+
+        return new RazorDynamicRegistrationService(dynamicRegistrationService, clientLanguageServerManager);
+    }
+
+    private class RazorDynamicRegistrationService : ILspService, IOnInitialized
+    {
+        private readonly IRazorCohostDynamicRegistrationService? _dynamicRegistrationService;
+        private readonly IClientLanguageServerManager _clientLanguageServerManager;
+
+        public RazorDynamicRegistrationService(IRazorCohostDynamicRegistrationService? dynamicRegistrationService, IClientLanguageServerManager clientLanguageServerManager)
+        {
+            _dynamicRegistrationService = dynamicRegistrationService;
+            _clientLanguageServerManager = clientLanguageServerManager;
+        }
+
+        public Task OnInitializedAsync(ClientCapabilities clientCapabilities, RequestContext context, CancellationToken cancellationToken)
+        {
+            if (_dynamicRegistrationService is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            // We use a string to pass capabilities to/from Razor to avoid version issues with the Protocol DLL
+            var serializedClientCapabilities = JsonConvert.SerializeObject(clientCapabilities);
+            var razorCohostClientLanguageServerManager = new RazorCohostClientLanguageServerManager(_clientLanguageServerManager);
+
+            return _dynamicRegistrationService.RegisterAsync(serializedClientCapabilities, razorCohostClientLanguageServerManager, cancellationToken);
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorDynamicRegistrationServiceFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorDynamicRegistrationServiceFactory.cs
@@ -45,7 +45,10 @@ internal sealed class RazorDynamicRegistrationServiceFactory([Import(AllowDefaul
             }
 
             // We use a string to pass capabilities to/from Razor to avoid version issues with the Protocol DLL
-            var serializedClientCapabilities = JsonConvert.SerializeObject(clientCapabilities);
+
+            var serializedClientCapabilities = JsonConvert.SerializeObject(clientCapabilities is VSInternalClientCapabilities internalClientCapabilities
+                ? internalClientCapabilities
+                : clientCapabilities);
             var razorCohostClientLanguageServerManager = new RazorCohostClientLanguageServerManager(_clientLanguageServerManager);
 
             var requestContext = new RazorCohostRequestContext(context);

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorMethodAttribute.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorMethodAttribute.cs
@@ -8,9 +8,13 @@ using Microsoft.CommonLanguageServerProtocol.Framework;
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 
 [MetadataAttribute]
-internal sealed class RazorMethodAttribute : LanguageServerEndpointAttribute
+internal class RazorMethodAttribute : LanguageServerEndpointAttribute
 {
     public RazorMethodAttribute(string method) : base(method, LanguageServerConstants.DefaultLanguageName)
+    {
+    }
+
+    public RazorMethodAttribute(string method, string language) : base(method, language)
     {
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorSemanticTokensRefreshQueueWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorSemanticTokensRefreshQueueWrapper.cs
@@ -31,6 +31,9 @@ internal class RazorSemanticTokensRefreshQueueWrapperFactory() : ILspServiceFact
         public void Initialize(string clientCapabilitiesString)
         {
             var clientCapabilities = JsonConvert.DeserializeObject<VSInternalClientCapabilities>(clientCapabilitiesString) ?? new();
+            // If Roslyn and Razor both support semantic tokens, then this call to Initialize is redundant, but the
+            // Initialize method in the queue itself is resilient to being called twice, so it doesn't actually do
+            // any harm.
             semanticTokensRefreshQueue.Initialize(clientCapabilities);
         }
 

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorSemanticTokensRefreshQueueWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorSemanticTokensRefreshQueueWrapper.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+[ExportRazorLspServiceFactory(typeof(RazorSemanticTokensRefreshQueueWrapper)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class RazorSemanticTokensRefreshQueueWrapperFactory() : ILspServiceFactory
+{
+    public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
+    {
+        var semanticTokensRefreshQueue = lspServices.GetRequiredService<SemanticTokensRefreshQueue>();
+
+        return new RazorSemanticTokensRefreshQueueWrapper(semanticTokensRefreshQueue);
+    }
+
+    internal class RazorSemanticTokensRefreshQueueWrapper(SemanticTokensRefreshQueue semanticTokensRefreshQueue) : ILspService, IDisposable
+    {
+        public void Initialize(ClientCapabilities clientCapabilities)
+            => semanticTokensRefreshQueue.Initialize(clientCapabilities);
+
+        public Task TryEnqueueRefreshComputationAsync(Project project, CancellationToken cancellationToken)
+            => semanticTokensRefreshQueue.TryEnqueueRefreshComputationAsync(project, cancellationToken);
+
+        public void Dispose()
+        {
+            semanticTokensRefreshQueue.Dispose();
+        }
+    }
+}

--- a/src/Workspaces/Remote/ServiceHub/ExternalAccess/Razor/Api/RazorBrokeredServiceImplementation.cs
+++ b/src/Workspaces/Remote/ServiceHub/ExternalAccess/Razor/Api/RazorBrokeredServiceImplementation.cs
@@ -18,10 +18,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Api
         public static ValueTask RunServiceAsync(Func<CancellationToken, ValueTask> implementation, CancellationToken cancellationToken)
             => BrokeredServiceBase.RunServiceImplAsync(implementation, cancellationToken);
 
-        [Obsolete("Use RunServiceAsync (that is passsed a Solution) instead", error: false)]
-        public static ValueTask<Solution> GetSolutionAsync(this RazorPinnedSolutionInfoWrapper solutionInfo, ServiceBrokerClient client, CancellationToken cancellationToken)
-            => RemoteWorkspaceManager.Default.GetSolutionAsync(client, solutionInfo.UnderlyingObject, cancellationToken);
-
         public static ValueTask<T> RunServiceAsync<T>(this RazorPinnedSolutionInfoWrapper solutionInfo, ServiceBrokerClient client, Func<Solution, ValueTask<T>> implementation, CancellationToken cancellationToken)
             => RemoteWorkspaceManager.Default.RunServiceAsync(client, solutionInfo.UnderlyingObject, implementation, cancellationToken);
     }


### PR DESCRIPTION
This will allow Razor to use dynamic registration, and run in the existing "normal" Roslyn LSP server, rather than having us use a separate cohosting server. Once this is consumed on the Razor side, most of the rest of the cohost folder in the EA can be deleted.

There is one hack here that will be unnecessary once we can use the Roslyn protocol types.

Part of https://github.com/dotnet/razor/issues/9519