### PR TITLE
[VB] Make interpolated strings including string or char constants, or whose embedded expressions are only string as optimized as `&` operator or C# (pre 10.0)

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Function
 
-        Private Function InvokeInterpolatedStringFactory(node As BoundInterpolatedStringExpression, factoryType As TypeSymbol, factoryMethodName As String, targetType As TypeSymbol, factory As SyntheticBoundNodeFactory, Optional trustsFormatProvider As Boolean = False) As BoundExpression
+        Private Function InvokeInterpolatedStringFactory(node As BoundInterpolatedStringExpression, factoryType As TypeSymbol, factoryMethodName As String, targetType As TypeSymbol, factory As SyntheticBoundNodeFactory, Optional canHideOptimization As Boolean = False) As BoundExpression
 
             Dim hasErrors As Boolean = False
 
@@ -160,8 +160,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         ' Don't trust format provider everywhen.
                         ' They MAY format literals and embedded strings differently.
-                        ' (trustsFormatProvider = False)
-                        If trustsFormatProvider AndAlso
+                        ' (canHideOptimization = False)
+                        If canHideOptimization AndAlso
                             interpolation.AlignmentOpt Is Nothing AndAlso
                             interpolation.FormatStringOpt Is Nothing AndAlso
                             TryInsertConstantEquivalentIntoLiteral(interpolation.Expression, formatStringBuilderHandle.Builder) Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
@@ -307,14 +307,14 @@ ReturnBadExpression:
             Return contents.AsEnumerable().Aggregate(Of BoundExpression)(
                     Nothing,
                     Function(left, right)
+                        Dim modifiedRight = ConvertElementToConcatenationOperand(right, factory)
                         If left Is Nothing Then
-                            Return ConvertElementToConcatenationOperand(left, factory)
+                            Return modifiedRight
                         End If
                         Return RewriteConcatenateOperator(
                             factory.Binary(
                                 BinaryOperatorKind.Concatenate,
-                                factoryType, left,
-                                ConvertElementToConcatenationOperand(right, factory)
+                                factoryType, left, modifiedRight
                             )
                         )
                     End Function

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
@@ -84,6 +84,47 @@ End Module
 
         End Sub
 
+        <Fact()>
+        Public Sub StringConcatConstEmbedded()
+            CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+        <![CDATA[
+Imports System        
+Module Module1
+
+    Sub Main()
+        Const s = "s"
+        Const c = "c"c
+        Dim v = "v"
+        Console.WriteLine($"ab{c}d{s}tu{v}wxyz")
+    End Sub
+
+End Module
+]]>
+    </file>
+</compilation>,
+expectedOutput:=<![CDATA[
+abcdstuvwxyz
+]]>).
+            VerifyIL("Module1.Main",
+            <![CDATA[
+{
+  // Code size       28 (0x1c)
+  .maxstack  3
+  .locals init (String V_0) //v
+  IL_0000:  ldstr      "v"
+  IL_0005:  stloc.0
+  IL_0006:  ldstr      "abcdstu"
+  IL_000b:  ldloc.0
+  IL_000c:  ldstr      "wxyz"
+  IL_0011:  call       "Function String.Concat(String, String, String) As String"
+  IL_0016:  call       "Sub System.Console.WriteLine(String)"
+  IL_001b:  ret
+}
+]]>)
+        End Sub
+
         <Fact>
         Public Sub InterpolationWithAlignment()
 
@@ -321,6 +362,42 @@ End Module
     </file>
 </compilation>, expectedOutput:="The date/time is 2014-12-18 09:00:00.")
 
+        End Sub
+
+        <Fact>
+        Public Sub NestedInterpolationsToStringConcat()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System.Console
+
+Module Program
+    Sub Main()
+        Const bar = "bar"
+        Dim baz = "baz"
+        Const u = "u"c
+        Write($"foo {$"{bar} {baz} q{u}x"} quux")
+    End Sub
+End Module
+    </file>
+</compilation>, expectedOutput:="foo bar baz qux quux").
+            VerifyIL("Program.Main",
+            <![CDATA[
+{
+  // Code size       28 (0x1c)
+  .maxstack  3
+  .locals init (String V_0) //baz
+  IL_0000:  ldstr      "baz"
+  IL_0005:  stloc.0
+  IL_0006:  ldstr      "foo bar "
+  IL_000b:  ldloc.0
+  IL_000c:  ldstr      " qux quux"
+  IL_0011:  call       "Function String.Concat(String, String, String) As String"
+  IL_0016:  call       "Sub System.Console.Write(String)"
+  IL_001b:  ret
+}
+]]>)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
@@ -401,6 +401,102 @@ End Module
         End Sub
 
         <Fact>
+        Public Sub ExpressionTreeAsIs()
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Imports System.Linq.Expressions
+Imports Microsoft.VisualBasic
+
+Module Program
+    Sub Main()
+        Dim ex As Expression(Of Func(Of String, String)) = Function(str) $"{str}{vbLf}{NameOf(Main)}{str}"
+        Console.Write(ex)
+    End Sub
+End Module
+    </file>
+</compilation>, expectedOutput:="str => Format(""{0}{1}{2}{3}"", new [] {Convert(str), Convert(""" & vbLf & """), Convert(""Main""), Convert(str)})").VerifyIL("Program.Main", <![CDATA[
+    {
+  // Code size      230 (0xe6)
+  .maxstack  11
+  .locals init (System.Linq.Expressions.ParameterExpression V_0)
+  IL_0000:  ldtoken    "String"
+  IL_0005:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_000a:  ldstr      "str"
+  IL_000f:  call       "Function System.Linq.Expressions.Expression.Parameter(System.Type, String) As System.Linq.Expressions.ParameterExpression"
+  IL_0014:  stloc.0
+  IL_0015:  ldnull
+  IL_0016:  ldtoken    "Function String.Format(String, ParamArray Object()) As String"
+  IL_001b:  call       "Function System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle) As System.Reflection.MethodBase"
+  IL_0020:  castclass  "System.Reflection.MethodInfo"
+  IL_0025:  ldc.i4.2
+  IL_0026:  newarr     "System.Linq.Expressions.Expression"
+  IL_002b:  dup
+  IL_002c:  ldc.i4.0
+  IL_002d:  ldstr      "{0}{1}{2}{3}"
+  IL_0032:  ldtoken    "String"
+  IL_0037:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_003c:  call       "Function System.Linq.Expressions.Expression.Constant(Object, System.Type) As System.Linq.Expressions.ConstantExpression"
+  IL_0041:  stelem.ref
+  IL_0042:  dup
+  IL_0043:  ldc.i4.1
+  IL_0044:  ldtoken    "Object"
+  IL_0049:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_004e:  ldc.i4.4
+  IL_004f:  newarr     "System.Linq.Expressions.Expression"
+  IL_0054:  dup
+  IL_0055:  ldc.i4.0
+  IL_0056:  ldloc.0
+  IL_0057:  ldtoken    "Object"
+  IL_005c:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_0061:  call       "Function System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type) As System.Linq.Expressions.UnaryExpression"
+  IL_0066:  stelem.ref
+  IL_0067:  dup
+  IL_0068:  ldc.i4.1
+  IL_0069:  ldstr      "
+"
+  IL_006e:  ldtoken    "String"
+  IL_0073:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_0078:  call       "Function System.Linq.Expressions.Expression.Constant(Object, System.Type) As System.Linq.Expressions.ConstantExpression"
+  IL_007d:  ldtoken    "Object"
+  IL_0082:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_0087:  call       "Function System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type) As System.Linq.Expressions.UnaryExpression"
+  IL_008c:  stelem.ref
+  IL_008d:  dup
+  IL_008e:  ldc.i4.2
+  IL_008f:  ldstr      "Main"
+  IL_0094:  ldtoken    "String"
+  IL_0099:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_009e:  call       "Function System.Linq.Expressions.Expression.Constant(Object, System.Type) As System.Linq.Expressions.ConstantExpression"
+  IL_00a3:  ldtoken    "Object"
+  IL_00a8:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_00ad:  call       "Function System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type) As System.Linq.Expressions.UnaryExpression"
+  IL_00b2:  stelem.ref
+  IL_00b3:  dup
+  IL_00b4:  ldc.i4.3
+  IL_00b5:  ldloc.0
+  IL_00b6:  ldtoken    "Object"
+  IL_00bb:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
+  IL_00c0:  call       "Function System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type) As System.Linq.Expressions.UnaryExpression"
+  IL_00c5:  stelem.ref
+  IL_00c6:  call       "Function System.Linq.Expressions.Expression.NewArrayInit(System.Type, ParamArray System.Linq.Expressions.Expression()) As System.Linq.Expressions.NewArrayExpression"
+  IL_00cb:  stelem.ref
+  IL_00cc:  call       "Function System.Linq.Expressions.Expression.Call(System.Linq.Expressions.Expression, System.Reflection.MethodInfo, ParamArray System.Linq.Expressions.Expression()) As System.Linq.Expressions.MethodCallExpression"
+  IL_00d1:  ldc.i4.1
+  IL_00d2:  newarr     "System.Linq.Expressions.ParameterExpression"
+  IL_00d7:  dup
+  IL_00d8:  ldc.i4.0
+  IL_00d9:  ldloc.0
+  IL_00da:  stelem.ref
+  IL_00db:  call       "Function System.Linq.Expressions.Expression.Lambda(Of System.Func(Of String, String))(System.Linq.Expressions.Expression, ParamArray System.Linq.Expressions.ParameterExpression()) As System.Linq.Expressions.Expression(Of System.Func(Of String, String))"
+  IL_00e0:  call       "Sub System.Console.Write(Object)"
+  IL_00e5:  ret
+}
+]]>)
+        End Sub
+
+        <Fact>
         Public Sub StringToCharArrayConversion()
             Dim verifier = CompileAndVerify(
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
@@ -402,6 +402,7 @@ End Module
 
         <Fact>
         Public Sub ExpressionTreeAsIs()
+            Dim toObject = If(Environment.Version.Major > 4, ", Object", "")
             Dim verifier = CompileAndVerify(
 <compilation>
     <file name="a.vb">
@@ -411,89 +412,12 @@ Imports Microsoft.VisualBasic
 
 Module Program
     Sub Main()
-        Dim ex As Expression(Of Func(Of String, String)) = Function(str) $"{str}{vbLf}{NameOf(Main)}{str}"
+        Dim ex As Expression(Of Func(Of String, String)) = Function(str) $"{str}{ChrW(32)}{NameOf(Main)}{str}"
         Console.Write(ex)
     End Sub
 End Module
     </file>
-</compilation>, expectedOutput:="str => Format(""{0}{1}{2}{3}"", new [] {Convert(str), Convert(""" & vbLf & """), Convert(""Main""), Convert(str)})").VerifyIL("Program.Main", <![CDATA[
-    {
-  // Code size      230 (0xe6)
-  .maxstack  11
-  .locals init (System.Linq.Expressions.ParameterExpression V_0)
-  IL_0000:  ldtoken    "String"
-  IL_0005:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_000a:  ldstr      "str"
-  IL_000f:  call       "Function System.Linq.Expressions.Expression.Parameter(System.Type, String) As System.Linq.Expressions.ParameterExpression"
-  IL_0014:  stloc.0
-  IL_0015:  ldnull
-  IL_0016:  ldtoken    "Function String.Format(String, ParamArray Object()) As String"
-  IL_001b:  call       "Function System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle) As System.Reflection.MethodBase"
-  IL_0020:  castclass  "System.Reflection.MethodInfo"
-  IL_0025:  ldc.i4.2
-  IL_0026:  newarr     "System.Linq.Expressions.Expression"
-  IL_002b:  dup
-  IL_002c:  ldc.i4.0
-  IL_002d:  ldstr      "{0}{1}{2}{3}"
-  IL_0032:  ldtoken    "String"
-  IL_0037:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_003c:  call       "Function System.Linq.Expressions.Expression.Constant(Object, System.Type) As System.Linq.Expressions.ConstantExpression"
-  IL_0041:  stelem.ref
-  IL_0042:  dup
-  IL_0043:  ldc.i4.1
-  IL_0044:  ldtoken    "Object"
-  IL_0049:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_004e:  ldc.i4.4
-  IL_004f:  newarr     "System.Linq.Expressions.Expression"
-  IL_0054:  dup
-  IL_0055:  ldc.i4.0
-  IL_0056:  ldloc.0
-  IL_0057:  ldtoken    "Object"
-  IL_005c:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_0061:  call       "Function System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type) As System.Linq.Expressions.UnaryExpression"
-  IL_0066:  stelem.ref
-  IL_0067:  dup
-  IL_0068:  ldc.i4.1
-  IL_0069:  ldstr      "
-"
-  IL_006e:  ldtoken    "String"
-  IL_0073:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_0078:  call       "Function System.Linq.Expressions.Expression.Constant(Object, System.Type) As System.Linq.Expressions.ConstantExpression"
-  IL_007d:  ldtoken    "Object"
-  IL_0082:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_0087:  call       "Function System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type) As System.Linq.Expressions.UnaryExpression"
-  IL_008c:  stelem.ref
-  IL_008d:  dup
-  IL_008e:  ldc.i4.2
-  IL_008f:  ldstr      "Main"
-  IL_0094:  ldtoken    "String"
-  IL_0099:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_009e:  call       "Function System.Linq.Expressions.Expression.Constant(Object, System.Type) As System.Linq.Expressions.ConstantExpression"
-  IL_00a3:  ldtoken    "Object"
-  IL_00a8:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_00ad:  call       "Function System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type) As System.Linq.Expressions.UnaryExpression"
-  IL_00b2:  stelem.ref
-  IL_00b3:  dup
-  IL_00b4:  ldc.i4.3
-  IL_00b5:  ldloc.0
-  IL_00b6:  ldtoken    "Object"
-  IL_00bb:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-  IL_00c0:  call       "Function System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type) As System.Linq.Expressions.UnaryExpression"
-  IL_00c5:  stelem.ref
-  IL_00c6:  call       "Function System.Linq.Expressions.Expression.NewArrayInit(System.Type, ParamArray System.Linq.Expressions.Expression()) As System.Linq.Expressions.NewArrayExpression"
-  IL_00cb:  stelem.ref
-  IL_00cc:  call       "Function System.Linq.Expressions.Expression.Call(System.Linq.Expressions.Expression, System.Reflection.MethodInfo, ParamArray System.Linq.Expressions.Expression()) As System.Linq.Expressions.MethodCallExpression"
-  IL_00d1:  ldc.i4.1
-  IL_00d2:  newarr     "System.Linq.Expressions.ParameterExpression"
-  IL_00d7:  dup
-  IL_00d8:  ldc.i4.0
-  IL_00d9:  ldloc.0
-  IL_00da:  stelem.ref
-  IL_00db:  call       "Function System.Linq.Expressions.Expression.Lambda(Of System.Func(Of String, String))(System.Linq.Expressions.Expression, ParamArray System.Linq.Expressions.ParameterExpression()) As System.Linq.Expressions.Expression(Of System.Func(Of String, String))"
-  IL_00e0:  call       "Sub System.Console.Write(Object)"
-  IL_00e5:  ret
-}
-]]>)
+</compilation>, expectedOutput:="str => Format(""{0}{1}{2}{3}"", new [] {Convert(str" & toObject & "), Convert( " & toObject & "), Convert(""Main""" & toObject & "), Convert(str" & toObject & ")})")
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
@@ -180,7 +180,7 @@ End Module
         End Sub
 
         <Fact>
-        Public Sub EscapeSequences()
+        Public Sub EscapeSequencesStringConcat()
 
             Dim verifier = CompileAndVerify(
 <compilation>
@@ -195,6 +195,25 @@ Module Program
 End Module
     </file>
 </compilation>, expectedOutput:="Solution: { Ø }")
+
+        End Sub
+
+        <Fact>
+        Public Sub EscapeSequences()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System.Console
+
+Module Program
+    Sub Main()
+        Dim arr As Object() = {}
+        Write($"Solution: {{ { If(arr.Length > 0, String.Join("", "", arr), "Ø") } }} / Length: {arr.Length}")
+    End Sub
+End Module
+    </file>
+</compilation>, expectedOutput:="Solution: { Ø } / Length: 0")
 
         End Sub
 


### PR DESCRIPTION
- Fixes #71839 
- #71801 in VB
- Fixes https://github.com/dotnet/vblang/issues/369

Derived from #72308

Should we separate some tests assuring that the behavior is not changed?

Did not use DefaultInterpolatedStringHandler to make changes minimal. It is sufficient to make interpolated strings as fast as `&` operator.