### PR TITLE
Recover from wrong collection expression target type in nullable walker

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3817,8 +3817,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TargetTypedAnalysisCompletion[node] =
                     (TypeWithAnnotations resultTypeWithAnnotations) =>
                     {
-                        Debug.Assert(TypeSymbol.Equals(resultTypeWithAnnotations.Type, node.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
-
                         var type = resultTypeWithAnnotations.Type;
                         MethodSymbol? constructor = getConstructor(node, type);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3682,13 +3682,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeWithState convertCollection(BoundCollectionExpression node, TypeWithAnnotations targetCollectionType, ArrayBuilder<Func<TypeWithAnnotations, TypeWithState>> completions)
             {
                 var strippedTargetCollectionType = targetCollectionType.Type.StrippedType();
-                Debug.Assert(TypeSymbol.Equals(strippedTargetCollectionType, node.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
 
                 // https://github.com/dotnet/roslyn/issues/68786: Use inferInitialObjectState() to set the initial
                 // state of the instance: see the call to InheritNullableStateOfTrackableStruct() in particular.
 
                 // Process the element conversions now that we have the target-type
                 var (collectionKind, targetElementType) = getCollectionDetails(node, strippedTargetCollectionType);
+
+                // Target type might be wrong in error scenarios.
+                if (!targetElementType.HasType)
+                {
+                    strippedTargetCollectionType = node.Type.StrippedType();
+                    (collectionKind, targetElementType) = getCollectionDetails(node, strippedTargetCollectionType);
+                }
+
+                Debug.Assert(TypeSymbol.Equals(strippedTargetCollectionType, node.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
 
                 // We should analyze the Create method
                 // Tracked by https://github.com/dotnet/roslyn/issues/68786

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -13456,6 +13456,31 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("x", "C.M(string, System.Collections.Generic.IReadOnlyList<D>)").WithLocation(8, 11));
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72541")]
+        public void NamedArgumentConversion_CollectionInitializer()
+        {
+            var source = """
+                #nullable enable
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    static void Main()
+                    {
+                        C.M(y: new() { new D() { } });
+                    }
+                    static void M(string x, List<D> y) { }
+                }
+
+                class D { }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (8,11): error CS7036: There is no argument given that corresponds to the required parameter 'x' of 'C.M(string, List<D>)'
+                //         C.M(y: new() { new D() { } });
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("x", "C.M(string, System.Collections.Generic.List<D>)").WithLocation(8, 11));
+        }
+
         [CombinatorialData]
         [Theory]
         public void CollectionBuilder_01(bool useCompilationReference)

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -13431,6 +13431,31 @@ partial class Program
             Assert.Equal(expectedConversionKind, conversion.Kind);
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72541")]
+        public void NamedArgumentConversion()
+        {
+            var source = """
+                #nullable enable
+                using System.Collections.Generic;
+
+                static class C
+                {
+                    static void Main()
+                    {
+                        C.M(y: [new D { }]);
+                    }
+                    static void M(string x, IReadOnlyList<D> y) { }
+                }
+
+                class D { }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (8,11): error CS7036: There is no argument given that corresponds to the required parameter 'x' of 'C.M(string, IReadOnlyList<D>)'
+                //         C.M(y: [new D { }]);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("x", "C.M(string, System.Collections.Generic.IReadOnlyList<D>)").WithLocation(8, 11));
+        }
+
         [CombinatorialData]
         [Theory]
         public void CollectionBuilder_01(bool useCompilationReference)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/72541.