### PR TITLE
Log build host stack trace in exception handling

### DIFF
--- a/src/Workspaces/Core/MSBuild.BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Rpc/RpcServer.cs
@@ -162,7 +162,7 @@ internal sealed class RpcServer
             if (e is TargetInvocationException)
                 e = e.InnerException ?? e;
 
-            response = new Response { Id = request.Id, Exception = $"An exception of type {e.GetType()} was thrown: {e.Message}" };
+            response = new Response { Id = request.Id, Exception = $"An exception of type {e.GetType()} was thrown: {e.Message}{Environment.NewLine}{e.StackTrace}{Environment.NewLine}----" };
         }
 
         var responseJson = JsonConvert.SerializeObject(response, JsonSettings.SingleLineSerializerSettings);


### PR DESCRIPTION
Was investigating a different issue and noticed that if the buildhost encountered an exception in handling a request, only the language server side stack trace was logged - the buildhost stack trace was dropped.

After:
```
[Error - 4:37:54 PM] [LanguageServerProjectSystem] Failure while loading c:\Users\dabarbet\source\repos\trash\WpfApp1\WpfApp1.csproj: Exception thrown: Microsoft.CodeAnalysis.MSBuild.Rpc.RemoteInvocationException: An exception of type Microsoft.Build.Framework.LoggerException was thrown: Failed to write to log file "C:\Users\dabarbet\LanguageServerDesignTimeBuild-bec82558-3dd7-461c-9da9-32a7ba3b6b24-1.binlog". The process cannot access the file 'C:\Users\dabarbet\LanguageServerDesignTimeBuild-bec82558-3dd7-461c-9da9-32a7ba3b6b24-1.binlog' because it is being used by another process.
   at Microsoft.Build.Logging.BinaryLogger.Initialize(IEventSource eventSource)
   at Microsoft.Build.BackEnd.Logging.LoggingService.InitializeLogger(ILogger logger, IEventSource sourceForLogger)
   at Microsoft.Build.BackEnd.Logging.LoggingService.RegisterDistributedLogger(ILogger centralLogger, LoggerDescription forwardingLogger)
   at Microsoft.Build.BackEnd.Logging.LoggingService.RegisterLogger(ILogger logger)
   at Microsoft.Build.Execution.BuildManager.CreateLoggingService(IEnumerable`1 loggers, IEnumerable`1 forwardingLoggers, ISet`1 warningsAsErrors, ISet`1 warningsNotAsErrors, ISet`1 warningsAsMessages)
   at Microsoft.Build.Execution.BuildManager.<BeginBuild>g__InitializeLoggingService|64_0()
   at Microsoft.Build.Execution.BuildManager.BeginBuild(BuildParameters parameters)
   at Microsoft.CodeAnalysis.MSBuild.Build.ProjectBuildManager.StartBatchBuild(IDictionary`2 globalProperties) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild.BuildHost\Build\ProjectBuildManager.cs:line 203
   at Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.BuildHost.CreateBuildManager() in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild.BuildHost\BuildHost.cs:line 131
   at Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.BuildHost.LoadProjectFileAsync(String projectFilePath, String languageName, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild.BuildHost\BuildHost.cs:line 176
   at Microsoft.CodeAnalysis.MSBuild.Rpc.RpcServer.ProcessRequestAsync(Request request) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild.BuildHost\Rpc\RpcServer.cs:line 142
----
   at Microsoft.CodeAnalysis.MSBuild.Rpc.RpcClient.InvokeCoreAsync(Int32 targetObject, String methodName, List`1 parameters, Type expectedReturnType, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild\Rpc\RpcClient.cs:line 163
   at Microsoft.CodeAnalysis.MSBuild.Rpc.RpcClient.InvokeAsync[T](Int32 targetObject, String methodName, List`1 parameters, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild\Rpc\RpcClient.cs:line 114
   at Microsoft.CodeAnalysis.MSBuild.Rpc.RemoteBuildHost.LoadProjectFileAsync(String projectFilePath, String languageName, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild\Rpc\RemoteBuildHost.cs:line 33
   at Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.LanguageServerProjectSystem.LoadOrReloadProjectAsync(ProjectToLoad projectToLoad, ToastErrorReporter toastErrorReporter, BuildHostProcessManager buildHostProcessManager, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Features\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\HostWorkspace\LanguageServerProjectSystem.cs:line 226
```

Before:
```
[Error - 4:37:54 PM] [LanguageServerProjectSystem] Failure while loading c:\Users\dabarbet\source\repos\trash\WpfApp1\WpfApp1.csproj: Exception thrown: Microsoft.CodeAnalysis.MSBuild.Rpc.RemoteInvocationException: An exception of type Microsoft.Build.Framework.LoggerException was thrown: Failed to write to log file "C:\Users\dabarbet\LanguageServerDesignTimeBuild-bec82558-3dd7-461c-9da9-32a7ba3b6b24-1.binlog". The process cannot access the file 'C:\Users\dabarbet\LanguageServerDesignTimeBuild-bec82558-3dd7-461c-9da9-32a7ba3b6b24-1.binlog' because it is being used by another process.
   at Microsoft.CodeAnalysis.MSBuild.Rpc.RpcClient.InvokeCoreAsync(Int32 targetObject, String methodName, List`1 parameters, Type expectedReturnType, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild\Rpc\RpcClient.cs:line 163
   at Microsoft.CodeAnalysis.MSBuild.Rpc.RpcClient.InvokeAsync[T](Int32 targetObject, String methodName, List`1 parameters, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild\Rpc\RpcClient.cs:line 114
   at Microsoft.CodeAnalysis.MSBuild.Rpc.RemoteBuildHost.LoadProjectFileAsync(String projectFilePath, String languageName, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Workspaces\Core\MSBuild\Rpc\RemoteBuildHost.cs:line 33
   at Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.LanguageServerProjectSystem.LoadOrReloadProjectAsync(ProjectToLoad projectToLoad, ToastErrorReporter toastErrorReporter, BuildHostProcessManager buildHostProcessManager, CancellationToken cancellationToken) in C:\Users\dabarbet\source\repos\roslyn\src\Features\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\HostWorkspace\LanguageServerProjectSystem.cs:line 226
```