### PR TITLE
Fix infinite load loop loading WPF projects in VSCode

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -59,6 +59,15 @@ internal sealed class LoadedProject : IDisposable
 
     private void FileChangedContext_FileChanged(object? sender, string filePath)
     {
+        var mostRecentIntermediateOutputPath = _mostRecentFileInfo?.IntermediateOutputPath;
+        if (mostRecentIntermediateOutputPath is not null
+            && PathUtilities.IsChildPath(mostRecentIntermediateOutputPath, filePath))
+        {
+            // We ignore changes to source files in the obj/ directory to prevent infinite loops caused by
+            // generation recreating .cs, .editorconfig, etc. files during design time build (causing file watcher notifications to reload the proj and rerun design time build).
+            return;
+        }
+
         NeedsReload?.Invoke(this, EventArgs.Empty);
     }
 

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/PropertyNames.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/PropertyNames.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string GenerateFullPaths = nameof(GenerateFullPaths);
         public const string HighEntropyVA = nameof(HighEntropyVA);
         public const string IntermediateAssembly = nameof(IntermediateAssembly);
+        public const string IntermediateOutputPath = nameof(IntermediateOutputPath);
         public const string KeyContainerName = nameof(KeyContainerName);
         public const string KeyOriginatorFile = nameof(KeyOriginatorFile);
         public const string LangVersion = nameof(LangVersion);

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -140,6 +140,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 intermediateOutputFilePath = GetAbsolutePathRelativeToProject(intermediateOutputFilePath);
             }
 
+            var intermediateOutputPath = project.ReadPropertyString(PropertyNames.IntermediateOutputPath);
+            if (!RoslynString.IsNullOrWhiteSpace(intermediateOutputPath))
+            {
+                intermediateOutputPath = GetAbsolutePathRelativeToProject(intermediateOutputPath);
+            }
+
             var projectAssetsFilePath = project.ReadPropertyString(PropertyNames.ProjectAssetsFile);
 
             // Right now VB doesn't have the concept of "default namespace". But we conjure one in workspace 
@@ -181,6 +187,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 outputFilePath,
                 outputRefFilePath,
                 intermediateOutputFilePath,
+                intermediateOutputPath,
                 defaultNamespace,
                 targetFramework,
                 targetFrameworkIdentifier,

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -133,6 +133,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
         [DataMember(Order = 17)]
         public ImmutableArray<PackageReference> PackageReferences { get; }
 
+        [DataMember(Order = 18)]
+        public string? IntermediateOutputPath { get; }
+
         public override string ToString()
             => RoslynString.IsNullOrWhiteSpace(TargetFramework)
                 ? FilePath ?? string.Empty
@@ -145,6 +148,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             string? outputFilePath,
             string? outputRefFilePath,
             string? intermediateOutputFilePath,
+            string? intermediateOutputPath,
             string? defaultNamespace,
             string? targetFramework,
             string? targetFrameworkIdentifier,
@@ -166,6 +170,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             this.OutputFilePath = outputFilePath;
             this.OutputRefFilePath = outputRefFilePath;
             this.IntermediateOutputFilePath = intermediateOutputFilePath;
+            this.IntermediateOutputPath = intermediateOutputPath;
             this.DefaultNamespace = defaultNamespace;
             this.TargetFramework = targetFramework;
             this.TargetFrameworkIdentifier = targetFrameworkIdentifier;
@@ -186,6 +191,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             string? outputFilePath,
             string? outputRefFilePath,
             string? intermediateOutputFilePath,
+            string? intermediateOutputPath,
             string? defaultNamespace,
             string? targetFramework,
             string? targetFrameworkIdentifier,
@@ -205,6 +211,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 outputFilePath,
                 outputRefFilePath,
                 intermediateOutputFilePath,
+                intermediateOutputPath,
                 defaultNamespace,
                 targetFramework,
                 targetFrameworkIdentifier,
@@ -226,6 +233,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 outputFilePath: null,
                 outputRefFilePath: null,
                 intermediateOutputFilePath: null,
+                intermediateOutputPath: null,
                 defaultNamespace: null,
                 targetFramework: null,
                 targetFrameworkIdentifier: null,

--- a/src/Workspaces/Core/MSBuild.BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Rpc/RpcServer.cs
@@ -162,7 +162,7 @@ internal sealed class RpcServer
             if (e is TargetInvocationException)
                 e = e.InnerException ?? e;
 
-            response = new Response { Id = request.Id, Exception = $"An exception of type {e.GetType()} was thrown: {e.Message}" };
+            response = new Response { Id = request.Id, Exception = $"An exception of type {e.GetType()} was thrown: {e.Message}{Environment.NewLine}{e.StackTrace}{Environment.NewLine}----" };
         }
 
         var responseJson = JsonConvert.SerializeObject(response, JsonSettings.SingleLineSerializerSettings);


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6985

XAML generated .g.cs files are recreated every time the design time build runs.  This triggers our VSCode file watchers that look for file changes to .cs files in the workspace.  When we hear about these file changes, we reload the project which runs a design time build.  This triggers the file watcher and puts us in an infinite loop.

Tentative fix - ignore changes to source files in the obj/ folder.  Generally changes to .cs files in obj/ should only(?) happen if something else outside the obj folder changes (e.g. you modify attributes in the csproj that change AssemblyInfo.cs or global usings).  

I do not believe we want to ignore the obj folder entirely - there are files we use from there to determine if restore needs to happen (project.assets.json) or if the folder is entirely deleted we probably want to re-run the design time build to generate it.

TODO - verify file contents
