### PR TITLE
Remove unnecessary string[] allocations

### DIFF
--- a/src/Compilers/Core/Portable/CodeGen/ItemTokenMap.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ItemTokenMap.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
             }
         }
 
-        public IEnumerable<T> GetAllItems()
+        public T[] CopyItems()
         {
             lock (_items)
             {

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -368,11 +368,11 @@ namespace Microsoft.CodeAnalysis.Emit
         }
 
         /// <summary>
-        /// Returns User Strings referenced from the IL in the module.
+        /// Returns copy of User Strings referenced from the IL in the module.
         /// </summary>
-        public IEnumerable<string> GetStrings()
+        public string[] CopyStrings()
         {
-            return _stringsInILMap.GetAllItems();
+            return _stringsInILMap.CopyItems();
         }
 
         public uint GetFakeSymbolTokenForIL(Cci.IReference symbol, SyntaxNode syntaxNode, DiagnosticBag diagnostics)

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -424,7 +424,7 @@ namespace Microsoft.Cci
         private object[] _pseudoSymbolTokenToReferenceMap;
         private UserStringHandle[] _pseudoStringTokenToTokenMap;
         private bool _userStringTokenOverflow;
-        private List<string> _pseudoStringTokenToStringMap;
+        private string[] _pseudoStringTokenToStringMap;
         private ReferenceIndexer _referenceVisitor;
 
         protected readonly MetadataBuilder metadata;
@@ -489,8 +489,8 @@ namespace Microsoft.Cci
 
         private void CreateUserStringIndices()
         {
-            _pseudoStringTokenToStringMap = [.. module.GetStrings()];
-            _pseudoStringTokenToTokenMap = new UserStringHandle[_pseudoStringTokenToStringMap.Count];
+            _pseudoStringTokenToStringMap = module.CopyStrings();
+            _pseudoStringTokenToTokenMap = new UserStringHandle[_pseudoStringTokenToStringMap.Length];
         }
 
         private void CreateIndicesForModule()


### PR DESCRIPTION
The result of the `GetAllItems` call was a fresh `string[]` that was being copied via collection initializer into a `List<T>`. That produces unnecessary allocations. This is particularly problematic because these allocations tend to end up in the LOH.

Changed the API to be more explicit and consumer to not do the unnecessary allocations. This saved 73MB in LOH allocations.