### PR TITLE
Remove unnecessary component load

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -214,7 +214,6 @@ internal sealed class RoslynPackage : AbstractPackage
     {
         await TaskScheduler.Default;
 
-        await GetServiceAsync(typeof(SVsTaskStatusCenterService)).ConfigureAwait(false);
         await GetServiceAsync(typeof(SVsErrorList)).ConfigureAwait(false);
         await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(false);
         await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(false);


### PR DESCRIPTION
Roslyn no longer uses the task-status-center (was used in solution crawler before).  No need to try to load that component.