### PR TITLE
Move to SegmentedList for line indexes

### DIFF
--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -278,8 +279,10 @@ namespace Microsoft.CodeAnalysis.Text
             }
 
             // compute line starts given changes and line starts already computed from previous text
-            var lineStarts = ArrayBuilder<int>.GetInstance(oldLineInfo.Count);
-            lineStarts.Add(0);
+            var lineStarts = new SegmentedList<int>(capacity: oldLineInfo.Count)
+            {
+                0
+            };
 
             // position in the original document
             var position = 0;
@@ -299,7 +302,7 @@ namespace Microsoft.CodeAnalysis.Text
                     {
                         // remove last added line start (it was due to previous CR)
                         // a new line start including the LF will be added next
-                        lineStarts.RemoveLast();
+                        lineStarts.RemoveAt(lineStarts.Count - 1);
                     }
 
                     var lps = oldLineInfo.GetLinePositionSpan(TextSpan.FromBounds(position, change.Span.Start));
@@ -328,7 +331,7 @@ namespace Microsoft.CodeAnalysis.Text
                     {
                         // remove last added line start (it was due to previous CR)
                         // a new line start including the LF will be added next
-                        lineStarts.RemoveLast();
+                        lineStarts.RemoveAt(lineStarts.Count - 1);
                     }
 
                     // Skip first line (it is always at offset 0 and corresponds to the previous line)
@@ -351,7 +354,7 @@ namespace Microsoft.CodeAnalysis.Text
                 {
                     // remove last added line start (it was due to previous CR)
                     // a new line start including the LF will be added next
-                    lineStarts.RemoveLast();
+                    lineStarts.RemoveAt(lineStarts.Count - 1);
                 }
 
                 var lps = oldLineInfo.GetLinePositionSpan(TextSpan.FromBounds(position, oldText.Length));
@@ -361,7 +364,7 @@ namespace Microsoft.CodeAnalysis.Text
                 }
             }
 
-            return new LineInfo(this, lineStarts.ToArrayAndFree());
+            return new LineInfo(this, lineStarts);
         }
 
         internal static class TestAccessor

--- a/src/Compilers/Core/Portable/Text/LargeText.cs
+++ b/src/Compilers/Core/Portable/Text/LargeText.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Text
 {
@@ -232,12 +233,12 @@ namespace Microsoft.CodeAnalysis.Text
             return new LineInfo(this, ParseLineStarts());
         }
 
-        private int[] ParseLineStarts()
+        private SegmentedList<int> ParseLineStarts()
         {
             var position = 0;
             var index = 0;
             var lastCr = -1;
-            var arrayBuilder = ArrayBuilder<int>.GetInstance();
+            var list = new SegmentedList<int>();
 
             // The following loop goes through every character in the text. It is highly
             // performance critical, and thus inlines knowledge about common line breaks
@@ -275,7 +276,7 @@ namespace Microsoft.CodeAnalysis.Text
                         case '\u2028':
                         case '\u2029':
 line_break:
-                            arrayBuilder.Add(position);
+                            list.Add(position);
                             position = index;
                             break;
                     }
@@ -283,8 +284,8 @@ line_break:
             }
 
             // Create a start for the final line.  
-            arrayBuilder.Add(position);
-            return arrayBuilder.ToArrayAndFree();
+            list.Add(position);
+            return list;
         }
     }
 }


### PR DESCRIPTION
This removes ~30MB of LOH allocations when compiling Roslyn