### PR TITLE
Using Segmented collections to avoid LOH allocations

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
@@ -9,6 +9,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Emit;
 using Roslyn.Utilities;
 using EmitContext = Microsoft.CodeAnalysis.Emit.EmitContext;
@@ -28,7 +29,7 @@ namespace Microsoft.Cci
 
         private readonly Dictionary<ITypeDefinition, int> _fieldDefIndex;
         private readonly Dictionary<ITypeDefinition, int> _methodDefIndex;
-        private readonly Dictionary<IMethodDefinition, int> _parameterListIndex;
+        private readonly SegmentedDictionary<IMethodDefinition, int> _parameterListIndex;
 
         private readonly HeapOrReferenceIndex<AssemblyIdentity> _assemblyRefIndex;
         private readonly HeapOrReferenceIndex<string> _moduleRefIndex;
@@ -101,7 +102,7 @@ namespace Microsoft.Cci
 
             _fieldDefIndex = new Dictionary<ITypeDefinition, int>(numTypeDefsGuess, ReferenceEqualityComparer.Instance);
             _methodDefIndex = new Dictionary<ITypeDefinition, int>(numTypeDefsGuess, ReferenceEqualityComparer.Instance);
-            _parameterListIndex = new Dictionary<IMethodDefinition, int>(numMethods, ReferenceEqualityComparer.Instance);
+            _parameterListIndex = new SegmentedDictionary<IMethodDefinition, int>(numMethods, ReferenceEqualityComparer.Instance);
 
             _assemblyRefIndex = new HeapOrReferenceIndex<AssemblyIdentity>(this);
             _moduleRefIndex = new HeapOrReferenceIndex<string>(this);
@@ -430,13 +431,13 @@ namespace Microsoft.Cci
         private readonly struct DefinitionIndex<T> where T : class, IReference
         {
             // IReference to RowId
-            private readonly Dictionary<T, int> _index;
-            private readonly List<T> _rows;
+            private readonly SegmentedDictionary<T, int> _index;
+            private readonly SegmentedList<T> _rows;
 
             public DefinitionIndex(int capacity)
             {
-                _index = new Dictionary<T, int>(capacity, ReferenceEqualityComparer.Instance);
-                _rows = new List<T>(capacity);
+                _index = new SegmentedDictionary<T, int>(capacity, ReferenceEqualityComparer.Instance);
+                _rows = new SegmentedList<T>(capacity);
             }
 
             public bool TryGetValue(T item, out int rowId)

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -278,8 +279,10 @@ namespace Microsoft.CodeAnalysis.Text
             }
 
             // compute line starts given changes and line starts already computed from previous text
-            var lineStarts = ArrayBuilder<int>.GetInstance(oldLineInfo.Count);
-            lineStarts.Add(0);
+            var lineStarts = new SegmentedList<int>(capacity: oldLineInfo.Count)
+            {
+                0
+            };
 
             // position in the original document
             var position = 0;
@@ -299,7 +302,7 @@ namespace Microsoft.CodeAnalysis.Text
                     {
                         // remove last added line start (it was due to previous CR)
                         // a new line start including the LF will be added next
-                        lineStarts.RemoveLast();
+                        lineStarts.RemoveAt(lineStarts.Count - 1);
                     }
 
                     var lps = oldLineInfo.GetLinePositionSpan(TextSpan.FromBounds(position, change.Span.Start));
@@ -328,7 +331,7 @@ namespace Microsoft.CodeAnalysis.Text
                     {
                         // remove last added line start (it was due to previous CR)
                         // a new line start including the LF will be added next
-                        lineStarts.RemoveLast();
+                        lineStarts.RemoveAt(lineStarts.Count - 1);
                     }
 
                     // Skip first line (it is always at offset 0 and corresponds to the previous line)
@@ -351,7 +354,7 @@ namespace Microsoft.CodeAnalysis.Text
                 {
                     // remove last added line start (it was due to previous CR)
                     // a new line start including the LF will be added next
-                    lineStarts.RemoveLast();
+                    lineStarts.RemoveAt(lineStarts.Count - 1);
                 }
 
                 var lps = oldLineInfo.GetLinePositionSpan(TextSpan.FromBounds(position, oldText.Length));
@@ -361,7 +364,7 @@ namespace Microsoft.CodeAnalysis.Text
                 }
             }
 
-            return new LineInfo(this, lineStarts.ToArrayAndFree());
+            return new LineInfo(this, lineStarts);
         }
 
         internal static class TestAccessor

--- a/src/Compilers/Core/Portable/Text/LargeText.cs
+++ b/src/Compilers/Core/Portable/Text/LargeText.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Text
 {
@@ -232,12 +233,12 @@ namespace Microsoft.CodeAnalysis.Text
             return new LineInfo(this, ParseLineStarts());
         }
 
-        private int[] ParseLineStarts()
+        private SegmentedList<int> ParseLineStarts()
         {
             var position = 0;
             var index = 0;
             var lastCr = -1;
-            var arrayBuilder = ArrayBuilder<int>.GetInstance();
+            var list = new SegmentedList<int>();
 
             // The following loop goes through every character in the text. It is highly
             // performance critical, and thus inlines knowledge about common line breaks
@@ -275,7 +276,7 @@ namespace Microsoft.CodeAnalysis.Text
                         case '\u2028':
                         case '\u2029':
 line_break:
-                            arrayBuilder.Add(position);
+                            list.Add(position);
                             position = index;
                             break;
                     }
@@ -283,8 +284,8 @@ line_break:
             }
 
             // Create a start for the final line.  
-            arrayBuilder.Add(position);
-            return arrayBuilder.ToArrayAndFree();
+            list.Add(position);
+            return list;
         }
     }
 }


### PR DESCRIPTION
Profiling revealed that these collections are resulting in large LOH allocations in the compiler. Flipping to Segmented collections to avoid the LOH. In total these changes remove 200MB+ of allocations from the LOH heap. 

This results in significant improvements to the GC when running the compiler 

![image](https://github.com/dotnet/roslyn/assets/146967/d419d032-c1f7-4a56-8de5-89575611a40c)

![image](https://github.com/dotnet/roslyn/assets/146967/3c7fcdc5-ccad-48c0-80b6-a86d1375aaf2)