### PR TITLE
Allow ref-like locals in iterators and async methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1327,8 +1327,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // would be hoisted into a closure for an anonymous function, iterator or async method.
                     // We do that during the actual rewrites.
 
-                    // CS4013: Instance of type '{0}{1}' cannot be used inside an anonymous function, query expression, iterator block or async method
-                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, string.Empty, runtimeArgumentHandleType);
+                    // CS4013: Instance of type '{0}' cannot be used inside an anonymous function, query expression, iterator block or async method
+                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, runtimeArgumentHandleType);
 
                     hasError = true;
                 }
@@ -1998,7 +1998,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                                 if (localSymbol.RefKind == RefKind.None && type.IsRestrictedType(ignoreSpanLikeTypes: true))
                                 {
-                                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, string.Empty, type);
+                                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, type);
                                 }
                                 else
                                 {
@@ -2042,7 +2042,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                                 else if (parameter.Type.IsRestrictedType(ignoreSpanLikeTypes: true))
                                 {
-                                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, string.Empty, parameter.Type);
+                                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, parameter.Type);
                                 }
                                 else
                                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1327,8 +1327,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // would be hoisted into a closure for an anonymous function, iterator or async method.
                     // We do that during the actual rewrites.
 
-                    // CS4013: Instance of type '{0}' cannot be used inside an anonymous function, query expression, iterator block or async method
-                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, runtimeArgumentHandleType);
+                    // CS4013: Instance of type '{0}{1}' cannot be used inside an anonymous function, query expression, iterator block or async method
+                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, string.Empty, runtimeArgumentHandleType);
 
                     hasError = true;
                 }
@@ -1998,7 +1998,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                                 if (localSymbol.RefKind == RefKind.None && type.IsRestrictedType(ignoreSpanLikeTypes: true))
                                 {
-                                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, type);
+                                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, string.Empty, type);
                                 }
                                 else
                                 {
@@ -2042,7 +2042,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                                 else if (parameter.Type.IsRestrictedType(ignoreSpanLikeTypes: true))
                                 {
-                                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, parameter.Type);
+                                    Error(diagnostics, ErrorCode.ERR_SpecialByRefInLambda, node, string.Empty, parameter.Type);
                                 }
                                 else
                                 {
@@ -3182,21 +3182,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Reports an error when a bad special by-ref local was found.
         /// </summary>
-        internal static void CheckRestrictedTypeInAsyncMethod(Symbol containingSymbol, TypeSymbol type, BindingDiagnosticBag diagnostics, SyntaxNode syntax, ErrorCode errorCode = ErrorCode.ERR_BadSpecialByRefLocal)
+        internal static void CheckRestrictedTypeInAsyncMethod(Symbol containingSymbol, TypeSymbol type, BindingDiagnosticBag diagnostics, SyntaxNode syntax)
         {
-            Debug.Assert(errorCode is ErrorCode.ERR_BadSpecialByRefLocal or ErrorCode.ERR_BadSpecialByRefUsing or ErrorCode.ERR_BadSpecialByRefLock);
             if (containingSymbol.Kind == SymbolKind.Method
                 && ((MethodSymbol)containingSymbol).IsAsync
                 && type.IsRestrictedType())
             {
-                if (errorCode == ErrorCode.ERR_BadSpecialByRefLock)
-                {
-                    Error(diagnostics, errorCode, syntax);
-                }
-                else
-                {
-                    Error(diagnostics, errorCode, syntax, type);
-                }
+                CheckFeatureAvailability(syntax, MessageID.IDS_FeatureRefUnsafeInIteratorAsync, diagnostics);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1098,8 +1098,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            CheckRestrictedTypeInAsyncMethod(this.ContainingMemberOrLambda, declTypeOpt.Type, localDiagnostics, typeSyntax);
-
             if (localSymbol.Scope == ScopedKind.ScopedValue && !declTypeOpt.Type.IsErrorTypeOrRefLikeType())
             {
                 localDiagnostics.Add(ErrorCode.ERR_ScopedRefAndRefStructOnly, typeSyntax.Location);
@@ -1165,15 +1163,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected bool CheckRefLocalInAsyncOrIteratorMethod(SyntaxToken identifierToken, BindingDiagnosticBag diagnostics)
         {
-            if (IsInAsyncMethod())
+            if (IsDirectlyInIterator || IsInAsyncMethod())
             {
-                Error(diagnostics, ErrorCode.ERR_BadAsyncLocalType, identifierToken);
-                return true;
-            }
-            else if (IsDirectlyInIterator)
-            {
-                Error(diagnostics, ErrorCode.ERR_BadIteratorLocalType, identifierToken);
-                return true;
+                return !CheckFeatureAvailability(identifierToken, MessageID.IDS_FeatureRefUnsafeInIteratorAsync, diagnostics);
             }
 
             return false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1098,6 +1098,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            CheckRestrictedTypeInAsyncMethod(this.ContainingMemberOrLambda, declTypeOpt.Type, localDiagnostics, typeSyntax);
+
             if (localSymbol.Scope == ScopedKind.ScopedValue && !declTypeOpt.Type.IsErrorTypeOrRefLikeType())
             {
                 localDiagnostics.Add(ErrorCode.ERR_ScopedRefAndRefStructOnly, typeSyntax.Location);

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (builder.InlineArraySpanType == WellKnownType.Unknown && getEnumeratorType.IsRestrictedType() && (IsDirectlyInIterator || IsInAsyncMethod()))
             {
-                diagnostics.Add(ErrorCode.ERR_BadSpecialByRefIterator, foreachKeyword.GetLocation(), getEnumeratorType);
+                CheckFeatureAvailability(foreachKeyword, MessageID.IDS_FeatureRefUnsafeInIteratorAsync, diagnostics);
             }
 
             diagnostics.Add(_syntax.ForEachKeyword, useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (builder.InlineArraySpanType == WellKnownType.Unknown && getEnumeratorType.IsRestrictedType() && (IsDirectlyInIterator || IsInAsyncMethod()))
             {
-                CheckFeatureAvailability(foreachKeyword, MessageID.IDS_FeatureRefUnsafeInIteratorAsync, diagnostics);
+                diagnostics.Add(ErrorCode.ERR_BadSpecialByRefIterator, foreachKeyword.GetLocation(), getEnumeratorType);
             }
 
             diagnostics.Add(_syntax.ForEachKeyword, useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/LockBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LockBinder.cs
@@ -64,13 +64,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _ = diagnostics.ReportUseSite(lockTypeInfo.EnterScopeMethod, exprSyntax) ||
                     diagnostics.ReportUseSite(lockTypeInfo.ScopeType, exprSyntax) ||
                     diagnostics.ReportUseSite(lockTypeInfo.ScopeDisposeMethod, exprSyntax);
-
-                CheckRestrictedTypeInAsyncMethod(
-                    originalBinder.ContainingMemberOrLambda,
-                    lockTypeInfo.ScopeType,
-                    diagnostics,
-                    exprSyntax,
-                    errorCode: ErrorCode.ERR_BadSpecialByRefLock);
             }
 
             BoundStatement stmt = originalBinder.BindPossibleEmbeddedStatement(_syntax.Statement, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(expressionOpt is not null);
                 if (expressionOpt.Type is not null)
                 {
-                    CheckRestrictedTypeInAsyncMethod(originalBinder.ContainingMemberOrLambda, expressionOpt.Type, diagnostics, expressionOpt.Syntax, errorCode: ErrorCode.ERR_BadSpecialByRefUsing);
+                    CheckRestrictedTypeInAsyncMethod(originalBinder.ContainingMemberOrLambda, expressionOpt.Type, diagnostics, expressionOpt.Syntax);
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3851,6 +3851,9 @@ Give the compiler some way to differentiate the methods. For example, you can gi
   <data name="ERR_BadAsyncLacksBody" xml:space="preserve">
     <value>The 'async' modifier can only be used in methods that have a body.</value>
   </data>
+  <data name="ERR_BadSpecialByRefIterator" xml:space="preserve">
+    <value>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</value>
+  </data>
   <data name="ERR_BadSpecialByRefParameter" xml:space="preserve">
     <value>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3810,7 +3810,7 @@ Give the compiler some way to differentiate the methods. For example, you can gi
     <value>__arglist is not allowed in the parameter list of async methods</value>
   </data>
   <data name="ERR_ByRefTypeAndAwait" xml:space="preserve">
-    <value>'await' cannot be used in an expression containing the type '{0}'</value>
+    <value>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</value>
   </data>
   <data name="ERR_UnsafeAsyncArgType" xml:space="preserve">
     <value>Async methods cannot have pointer type parameters</value>
@@ -4188,7 +4188,7 @@ You should consider suppressing the warning only if you're sure that you don't w
     <value>Indexed property '{0}' must have all arguments optional</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_SecurityAttributeMissingAction" xml:space="preserve">
     <value>First argument to a security attribute must be a valid SecurityAction</value>
@@ -7895,5 +7895,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="IDS_FeatureRefUnsafeInIteratorAsync" xml:space="preserve">
     <value>ref and unsafe in async and iterator methods</value>
+  </data>
+  <data name="ERR_RefLocalAcrossAwait" xml:space="preserve">
+    <value>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7894,6 +7894,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Modifiers cannot be placed on using declarations</value>
   </data>
   <data name="IDS_FeatureRefUnsafeInIteratorAsync" xml:space="preserve">
-    <value>Ref and unsafe in async and iterator methods</value>
+    <value>ref and unsafe in async and iterator methods</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3851,14 +3851,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
   <data name="ERR_BadAsyncLacksBody" xml:space="preserve">
     <value>The 'async' modifier can only be used in methods that have a body.</value>
   </data>
-  <data name="ERR_BadSpecialByRefLocal" xml:space="preserve">
-    <value>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</value>
-  </data>
-  <data name="ERR_BadSpecialByRefUsing" xml:space="preserve">
-    <value>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</value>
-  </data>
-  <data name="ERR_BadSpecialByRefIterator" xml:space="preserve">
-    <value>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</value>
+  <data name="ERR_BadSpecialByRefParameter" xml:space="preserve">
+    <value>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</value>
   </data>
   <data name="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync" xml:space="preserve">
     <value>Security attribute '{0}' cannot be applied to an Async method.</value>
@@ -4191,7 +4185,7 @@ You should consider suppressing the warning only if you're sure that you don't w
     <value>Indexed property '{0}' must have all arguments optional</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
+    <value>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_SecurityAttributeMissingAction" xml:space="preserve">
     <value>First argument to a security attribute must be a valid SecurityAction</value>
@@ -5289,12 +5283,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_AnonDelegateCantUseLocal" xml:space="preserve">
     <value>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</value>
-  </data>
-  <data name="ERR_BadIteratorLocalType" xml:space="preserve">
-    <value>Iterators cannot have by-reference locals</value>
-  </data>
-  <data name="ERR_BadAsyncLocalType" xml:space="preserve">
-    <value>Async methods cannot have by-reference locals</value>
   </data>
   <data name="ERR_RefReturningCallAndAwait" xml:space="preserve">
     <value>A reference returned by a call to '{0}' cannot be preserved across 'await' or 'yield' boundary.</value>
@@ -7851,9 +7839,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_ConvertingLock_Title" xml:space="preserve">
     <value>A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.</value>
   </data>
-  <data name="ERR_BadSpecialByRefLock" xml:space="preserve">
-    <value>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</value>
-  </data>
   <data name="IDS_FeatureLockObject" xml:space="preserve">
     <value>Lock object</value>
   </data>
@@ -7904,5 +7889,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_NoModifiersOnUsing" xml:space="preserve">
     <value>Modifiers cannot be placed on using declarations</value>
+  </data>
+  <data name="IDS_FeatureRefUnsafeInIteratorAsync" xml:space="preserve">
+    <value>Ref and unsafe in async and iterator methods</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2286,7 +2286,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CollectionExpressionMissingAdd = 9215,
 
         WRN_ConvertingLock = 9216,
-        // ERR_BadSpecialByRefLock = 9217,
+        // 9217 available for reuse
 
         ERR_CantInferMethTypeArgs_DynamicArgumentWithParamsCollections = 9218,
         ERR_ParamsCollectionAmbiguousDynamicArgument = 9219,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2286,7 +2286,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CollectionExpressionMissingAdd = 9215,
 
         WRN_ConvertingLock = 9216,
-        // 9217 available for reuse
+        ERR_RefLocalAcrossAwait = 9217,
 
         ERR_CantInferMethTypeArgs_DynamicArgumentWithParamsCollections = 9218,
         ERR_ParamsCollectionAmbiguousDynamicArgument = 9219,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1529,7 +1529,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AutoPropsInRoStruct = 8341,
         ERR_FieldlikeEventsInRoStruct = 8342,
         ERR_RefStructInterfaceImpl = 8343,
-        // ERR_BadSpecialByRefIterator = 8344,
+        ERR_BadSpecialByRefIterator = 8344,
         ERR_FieldAutoPropCantBeByRefLike = 8345,
         ERR_StackAllocConversionNotPossible = 8346,
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1111,7 +1111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_NonTaskMainCantBeAsync = 4009,
         ERR_CantConvAsyncAnonFuncReturns = 4010,
         ERR_BadAwaiterPattern = 4011,
-        ERR_BadSpecialByRefLocal = 4012,
+        ERR_BadSpecialByRefParameter = 4012,
         ERR_SpecialByRefInLambda = 4013,
         WRN_UnobservedAwaitableExpression = 4014,
         ERR_SynchronizedAsyncMethod = 4015,
@@ -1429,8 +1429,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_RefAssignmentMustHaveIdentityConversion = 8173,
         ERR_ByReferenceVariableMustBeInitialized = 8174,
         ERR_AnonDelegateCantUseLocal = 8175,
-        ERR_BadIteratorLocalType = 8176,
-        ERR_BadAsyncLocalType = 8177,
+        // ERR_BadIteratorLocalType = 8176,
+        // ERR_BadAsyncLocalType = 8177,
         ERR_RefReturningCallAndAwait = 8178,
         #endregion diagnostics for ref locals and ref returns introduced in C# 7
 
@@ -1529,7 +1529,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AutoPropsInRoStruct = 8341,
         ERR_FieldlikeEventsInRoStruct = 8342,
         ERR_RefStructInterfaceImpl = 8343,
-        ERR_BadSpecialByRefIterator = 8344,
+        // ERR_BadSpecialByRefIterator = 8344,
         ERR_FieldAutoPropCantBeByRefLike = 8345,
         ERR_StackAllocConversionNotPossible = 8346,
 
@@ -2161,7 +2161,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_UnscopedRefAttributeUnsupportedMemberTarget = 9101,
         ERR_UnscopedRefAttributeInterfaceImplementation = 9102,
         ERR_UnrecognizedRefSafetyRulesAttributeVersion = 9103,
-        ERR_BadSpecialByRefUsing = 9104,
+        // ERR_BadSpecialByRefUsing = 9104,
 
         ERR_InvalidPrimaryConstructorParameterReference = 9105,
         ERR_AmbiguousPrimaryConstructorParameterAsColorColorReceiver = 9106,
@@ -2286,7 +2286,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CollectionExpressionMissingAdd = 9215,
 
         WRN_ConvertingLock = 9216,
-        ERR_BadSpecialByRefLock = 9217,
+        // ERR_BadSpecialByRefLock = 9217,
 
         ERR_CantInferMethTypeArgs_DynamicArgumentWithParamsCollections = 9218,
         ERR_ParamsCollectionAmbiguousDynamicArgument = 9219,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -1838,6 +1838,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_AutoPropsInRoStruct:
                 case ErrorCode.ERR_FieldlikeEventsInRoStruct:
                 case ErrorCode.ERR_RefStructInterfaceImpl:
+                case ErrorCode.ERR_BadSpecialByRefIterator:
                 case ErrorCode.ERR_FieldAutoPropCantBeByRefLike:
                 case ErrorCode.ERR_StackAllocConversionNotPossible:
                 case ErrorCode.ERR_EscapeCall:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -622,6 +622,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_InterceptableMethodMustBeOrdinary:
                 case ErrorCode.ERR_PossibleAsyncIteratorWithoutYield:
                 case ErrorCode.ERR_PossibleAsyncIteratorWithoutYieldOrAwait:
+                case ErrorCode.ERR_RefLocalAcrossAwait:
                     // Update src\EditorFeatures\CSharp\LanguageServer\CSharpLspBuildOnlyDiagnostics.cs
                     // whenever new values are added here.
                     return true;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -1533,7 +1533,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_NonTaskMainCantBeAsync:
                 case ErrorCode.ERR_CantConvAsyncAnonFuncReturns:
                 case ErrorCode.ERR_BadAwaiterPattern:
-                case ErrorCode.ERR_BadSpecialByRefLocal:
+                case ErrorCode.ERR_BadSpecialByRefParameter:
                 case ErrorCode.WRN_UnobservedAwaitableExpression:
                 case ErrorCode.ERR_SynchronizedAsyncMethod:
                 case ErrorCode.ERR_BadAsyncReturnExpression:
@@ -1776,8 +1776,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_RefAssignmentMustHaveIdentityConversion:
                 case ErrorCode.ERR_ByReferenceVariableMustBeInitialized:
                 case ErrorCode.ERR_AnonDelegateCantUseLocal:
-                case ErrorCode.ERR_BadIteratorLocalType:
-                case ErrorCode.ERR_BadAsyncLocalType:
                 case ErrorCode.ERR_PredefinedValueTupleTypeNotFound:
                 case ErrorCode.ERR_SemiOrLBraceOrArrowExpected:
                 case ErrorCode.ERR_NewWithTupleTypeSyntax:
@@ -1840,7 +1838,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_AutoPropsInRoStruct:
                 case ErrorCode.ERR_FieldlikeEventsInRoStruct:
                 case ErrorCode.ERR_RefStructInterfaceImpl:
-                case ErrorCode.ERR_BadSpecialByRefIterator:
                 case ErrorCode.ERR_FieldAutoPropCantBeByRefLike:
                 case ErrorCode.ERR_StackAllocConversionNotPossible:
                 case ErrorCode.ERR_EscapeCall:
@@ -2329,7 +2326,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_UnscopedRefAttributeUnsupportedMemberTarget:
                 case ErrorCode.ERR_UnscopedRefAttributeInterfaceImplementation:
                 case ErrorCode.ERR_UnrecognizedRefSafetyRulesAttributeVersion:
-                case ErrorCode.ERR_BadSpecialByRefUsing:
                 case ErrorCode.ERR_InvalidPrimaryConstructorParameterReference:
                 case ErrorCode.ERR_AmbiguousPrimaryConstructorParameterAsColorColorReceiver:
                 case ErrorCode.WRN_CapturedPrimaryConstructorParameterPassedToBase:
@@ -2418,7 +2414,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_CollectionExpressionMissingConstructor:
                 case ErrorCode.ERR_CollectionExpressionMissingAdd:
                 case ErrorCode.WRN_ConvertingLock:
-                case ErrorCode.ERR_BadSpecialByRefLock:
                 case ErrorCode.ERR_CantInferMethTypeArgs_DynamicArgumentWithParamsCollections:
                 case ErrorCode.ERR_ParamsCollectionAmbiguousDynamicArgument:
                 case ErrorCode.WRN_DynamicDispatchToParamsCollectionMethod:

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -282,6 +282,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureLockObject = MessageBase + 12841,
 
         IDS_FeatureParamsCollections = MessageBase + 12842,
+
+        IDS_FeatureRefUnsafeInIteratorAsync = MessageBase + 12843,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -466,6 +468,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureImplicitIndexerInitializer:
                 case MessageID.IDS_FeatureLockObject:
                 case MessageID.IDS_FeatureParamsCollections:
+                case MessageID.IDS_FeatureRefUnsafeInIteratorAsync:
                     return LanguageVersion.Preview;
 
                 // C# 12.0 features.

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.Analysis.Tree.cs
@@ -697,7 +697,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (type.IsRestrictedType() == true)
                     {
-                        _diagnostics.Add(ErrorCode.ERR_SpecialByRefInLambda, syntax.Location, string.Empty, type);
+                        _diagnostics.Add(ErrorCode.ERR_SpecialByRefInLambda, syntax.Location, type);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.Analysis.Tree.cs
@@ -697,7 +697,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (type.IsRestrictedType() == true)
                     {
-                        _diagnostics.Add(ErrorCode.ERR_SpecialByRefInLambda, syntax.Location, type);
+                        _diagnostics.Add(ErrorCode.ERR_SpecialByRefInLambda, syntax.Location, string.Empty, type);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (variable is LocalSymbol local)
                     {
-                        if (local.SynthesizedKind == SynthesizedLocalKind.UserDefined)
+                        if (local.SynthesizedKind is SynthesizedLocalKind.UserDefined or SynthesizedLocalKind.Spill)
                         {
                             reportLocalAcrossAwaitError(diagnostics, local, local.GetFirstLocation());
                         }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -77,13 +77,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var variable = kvp.Key;
 
-                    var (type, refKindPrefix) = variable switch
-                    {
-                        LocalSymbol l => (l.Type, l.RefKind.ToLocalPrefix()),
-                        ParameterSymbol p => (p.Type, p.RefKind.ToParameterPrefix()),
-                        _ => throw ExceptionUtilities.UnexpectedValue(variable),
-                    };
-
                     if (variable is SynthesizedLocal local && local.SynthesizedKind == SynthesizedLocalKind.Spill)
                     {
                         Debug.Assert(local.TypeWithAnnotations.IsRestrictedType());
@@ -91,6 +84,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
+                        var (type, refKindPrefix) = variable switch
+                        {
+                            LocalSymbol l => (l.Type, l.RefKind.ToLocalPrefix()),
+                            ParameterSymbol p => (p.Type, p.RefKind.ToParameterPrefix()),
+                            _ => throw ExceptionUtilities.UnexpectedValue(variable),
+                        };
+
                         foreach (CSharpSyntaxNode syntax in kvp.Value)
                         {
                             // CS4013: Instance of type '{0}{1}' cannot be used inside an anonymous function, query expression, iterator block or async method

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -93,6 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         foreach (CSharpSyntaxNode syntax in kvp.Value)
                         {
+                            // PROTOTYPE: Improve error message (the instance might be usable in iterator/async just not across yield/await)
                             // CS4013: Instance of type '{0}{1}' cannot be used inside an anonymous function, query expression, iterator block or async method
                             diagnostics.Add(ErrorCode.ERR_SpecialByRefInLambda, syntax.Location, refKindPrefix, type);
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else if (parameter.Type.IsRestrictedType())
                 {
-                    diagnostics.Add(ErrorCode.ERR_BadSpecialByRefLocal, getLocation(parameter, location), parameter.Type);
+                    diagnostics.Add(ErrorCode.ERR_BadSpecialByRefParameter, getLocation(parameter, location), parameter.Type);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Člen záznamu {0} musí být čitelná vlastnost instance nebo pole typu {1}, která se bude shodovat s pozičním parametrem {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Pole ref lze deklarovat pouze ve struktuře ref.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Levá strana přiřazení odkazu musí být parametr Ref.</target>
@@ -10535,8 +10540,8 @@ Poskytněte kompilátoru nějaký způsob, jak metody rozlišit. Můžete např�
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'Operátor await nejde použít ve výrazu, který obsahuje typ {0}.</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'Operátor await nejde použít ve výrazu, který obsahuje typ {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ Potlačení upozornění zvažte jenom v případě, když určitě nechcete če
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -267,14 +267,9 @@
         <target state="translated">Člen záznamu {0} musí být čitelná vlastnost instance nebo pole typu {1}, která se bude shodovat s pozičním parametrem {2}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">Prostředek použitého příkazu typu {0} nejde použít v asynchronních metodách ani v asynchronních výrazech lambda.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">parametry ref readonly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Poskytněte kompilátoru nějaký způsob, jak metody rozlišit. Můžete např�
         <target state="translated">Modifikátor async se dá použít jenom v metodách, které mají tělo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Parametry nebo lokální proměnné typu {0} nemůžou být deklarované v asynchronních metodách nebo asynchronních výrazech lambda.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">Výraz foreach nejde použít na enumerátorech typu {0} v asynchronních metodách nebo metodách iterátoru, protože {0} je struktura REF.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">Atribut zabezpečení {0} nejde použít pro metodu Async.</target>
@@ -11127,8 +11117,8 @@ Potlačení upozornění zvažte jenom v případě, když určitě nechcete če
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">Instance typu {0} nelze použít uvnitř vnořené funkce, výrazu dotazu, bloku iterátoru nebo asynchronní metody.</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">Místní hodnotu odkazu {0} nejde použít uvnitř anonymní metody, výrazu lambda nebo výrazu dotazu.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Iterátory nemůžou mít lokální proměnné podle odkazu.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">Asynchronní metody nemůžou mít lokální proměnné podle odkazu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Ein Verweisfeld kann nur in einer Verweisstruktur deklariert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Die linke Seite einer Ref-Zuweisung muss eine Ref-Variable sein.</target>
@@ -10535,8 +10540,8 @@ Unterstützen Sie den Compiler bei der Unterscheidung zwischen den Methoden. Daz
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'"await" kann nicht in einem Ausdruck verwendet werden, der den Typ "{0}" enthält</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'"await" kann nicht in einem Ausdruck verwendet werden, der den Typ "{0}" enthält</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ Sie sollten das Unterdrücken der Warnung nur in Betracht ziehen, wenn Sie siche
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Das Datensatzelement "{0}" muss eine lesbare Instanzeigenschaft oder ein Feld vom Typ "{1}" sein, um dem Positionsparameter "{2}" zu entsprechen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -267,14 +267,9 @@
         <target state="translated">Das Datensatzelement "{0}" muss eine lesbare Instanzeigenschaft oder ein Feld vom Typ "{1}" sein, um dem Positionsparameter "{2}" zu entsprechen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">Eine using-Anweisungsressource vom Typ „{0}“ kann nicht in asynchronen Methoden oder asynchronen Lambdaausdrücken verwendet werden.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">ref readonly-Parameter</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Unterstützen Sie den Compiler bei der Unterscheidung zwischen den Methoden. Daz
         <target state="translated">Der Modifizierer "async" kann nur in Methoden verwendet werden, die über einen Textkörper verfügen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Parameter oder lokale Variablen des Typs "{0}" können nicht in asynchronen Methoden oder in asynchronen Lambdaausdrücken deklariert werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">Die foreach-Anweisung kann nicht für Enumeratoren vom Typ "{0}" in asynchronen oder Iteratormethoden verwendet werden, weil "{0}" eine Referenzstruktur ist.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">Das Sicherheitsattribut "{0}" kann nicht auf eine Async-Methode angewendet werden.</target>
@@ -11127,8 +11117,8 @@ Sie sollten das Unterdrücken der Warnung nur in Betracht ziehen, wenn Sie siche
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">Eine Instanz des Typs "{0}" kann nicht in einer geschachtelten Funktion, einem Abfrageausdruck, einem Iteratorblock oder einer Async-Methode verwendet werden.</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">Der lokale Verweis "{0}" kann nicht in einer anonymen Methode, einem Lambdaausdruck oder einem Abfrageausdruck verwendet werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Iteratoren dürfen keine lokalen by-reference-Elemente aufweisen.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">Asynchrone Methoden dürfen keine lokalen by-reference-Elemente aufweisen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -267,6 +267,11 @@
         <target state="translated">El miembro de registro '{0}' debe ser una propiedad de instancia legible o un campo de tipo '{1}' para coincidir con el parámetro posicional '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Un campo ref solo se puede declarar en una estructura ref.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">La parte izquierda de una asignación de referencias debe ser una variable local.</target>
@@ -10535,8 +10540,8 @@ Indique al compilador alguna forma de diferenciar los métodos. Por ejemplo, pue
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'await' no se puede usar en una expresión que contenga el tipo '{0}'</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'await' no se puede usar en una expresión que contenga el tipo '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ Considere la posibilidad de suprimir la advertencia solo si tiene la seguridad d
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -267,14 +267,9 @@
         <target state="translated">El miembro de registro '{0}' debe ser una propiedad de instancia legible o un campo de tipo '{1}' para coincidir con el parámetro posicional '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">Un recurso de instrucción using de tipo '{0}' no se puede usar en métodos asincrónicos ni expresiones lambda asincrónicas.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">parámetros ref readonly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Indique al compilador alguna forma de diferenciar los métodos. Por ejemplo, pue
         <target state="translated">El modificador 'async' solo se puede usar en métodos que tengan un cuerpo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Los parámetros o locales de tipo '{0}' no pueden declararse en expresiones lambda o métodos asincrónicos.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">La instrucción foreach no puede funcionar en enumeradores de tipo "{0}" en métodos async o iterator porque "{0}" es una estructura ref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">El atributo de seguridad '{0}' no se puede aplicar a un método Async.</target>
@@ -11127,8 +11117,8 @@ Considere la posibilidad de suprimir la advertencia solo si tiene la seguridad d
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">La instancia de tipo "{0}" no se puede usar dentro de una función anidada, una expresión de consulta, un bloque iterador ni un método asincrónico.</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">No se puede usar la variable local de tipo ref '{0}' dentro de un método anónimo, una expresión lambda o una expresión de consulta.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Los iteradores no pueden tener variables locales por referencia.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">Los métodos asincrónicos no pueden tener variables locales por referencia.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Un champ de référence ne peut être déclaré que dans une sructure de référence.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Le côté gauche d’une affectation ref doit être une variable ref.</target>
@@ -10535,8 +10540,8 @@ Permettez au compilateur de différencier les méthodes. Par exemple, vous pouve
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'await' ne peut pas être utilisé dans une expression contenant le type '{0}'</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'await' ne peut pas être utilisé dans une expression contenant le type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ Supprimez l'avertissement seulement si vous êtes sûr de ne pas vouloir attendr
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Le membre d'enregistrement '{0}' doit être une propriété d'instance our champ lisible de type '{1}' pour correspondre au paramètre positionnel '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -267,14 +267,9 @@
         <target state="translated">Le membre d'enregistrement '{0}' doit être une propriété d'instance our champ lisible de type '{1}' pour correspondre au paramètre positionnel '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">Une ressource d’instruction d’utilisation de type '{0}' ne peut pas être utilisée dans des méthodes asynchrones ou des expressions lambda asynchrones.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">paramètres ref readonly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Permettez au compilateur de différencier les méthodes. Par exemple, vous pouve
         <target state="translated">Le modificateur 'async' ne peut être utilisé que dans des méthodes ayant un corps.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Les paramètres ou variables locales de type '{0}' ne peuvent pas être déclarés dans des méthodes asynchrones ou des expressions asynchrones lambda.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">L'instruction foreach ne peut pas fonctionner sur les énumérateurs de type '{0}' dans les méthodes asynchrones ou les méthodes d'itérateurs, car '{0}' est un struct par référence.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">Impossible d'appliquer l'attribut de sécurité '{0}' à une méthode Async.</target>
@@ -11127,8 +11117,8 @@ Supprimez l'avertissement seulement si vous êtes sûr de ne pas vouloir attendr
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">Impossible d'utiliser une instance de type '{0}' dans une fonction imbriquée, une expression de requête, un bloc itérateur ou une méthode async</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">Impossible d'utiliser ref local '{0}' dans une méthode anonyme, une expression lambda ou une expression de requête</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Les itérateurs ne peuvent pas avoir de variables locales par référence</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">Les méthodes async ne peuvent pas avoir de variables locales par référence</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Il membro di record '{0}' deve essere una proprietà di istanza leggibile o campo di tipo '{1}' per corrispondere al parametro posizionale '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Un campo ref può essere dichiarato solo in uno struct ref.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">La parte sinistra di un'assegnazione ref deve essere una variabile ref.</target>
@@ -10535,8 +10540,8 @@ Impostare il compilatore in modo tale da distinguere i metodi, ad esempio assegn
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'non è possibile usare 'await' in un'espressione contenente il tipo '{0}'</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'non è possibile usare 'await' in un'espressione contenente il tipo '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ Come procedura consigliata, è consigliabile attendere sempre la chiamata.
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -267,14 +267,9 @@
         <target state="translated">Il membro di record '{0}' deve essere una proprietà di istanza leggibile o campo di tipo '{1}' per corrispondere al parametro posizionale '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">Non è possibile usare una risorsa di istruzione using di tipo '{0}' in metodi asincroni o espressioni lambda asincrone.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">parametri di sola lettura ref</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Impostare il compilatore in modo tale da distinguere i metodi, ad esempio assegn
         <target state="translated">Il modificatore 'async' può essere usato solo nei metodi con un corpo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Non è possibile dichiarare parametri o variabili locali di tipo '{0}' in metodi asincroni o espressioni lambda asincrone.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">L'istruzione foreach non può funzionare con enumeratori di tipo '{0}' in metodi async o iterator perché '{0}' è uno struct ref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">Non è possibile applicare l'attributo di sicurezza '{0}' a un metodo Async</target>
@@ -11127,8 +11117,8 @@ Come procedura consigliata, è consigliabile attendere sempre la chiamata.
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">L'istanza di tipo '{0}' non può essere usata all'interno di una funzione annidata, un'espressione di query, un blocco iteratore o un metodo asincrono</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">Non è possibile usare la variabile locale ref '{0}' in un metodo anonimo, in un'espressione lambda o in un'espressione di query</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Gli iteratori non possono includere variabili locali per riferimento</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">I metodi Async non possono includere variabili locali per riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">ref フィールドは ref 構造体でのみ宣言できます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">ref 代入の左辺は ref 変数である必要があります。</target>
@@ -10535,8 +10540,8 @@ C# では out と ref を区別しますが、CLR では同じと認識します
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'await' は、型 '{0}' を含む式では使用できません</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'await' は、型 '{0}' を含む式では使用できません</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -267,6 +267,11 @@
         <target state="translated">レコード メンバー '{0}' は、位置指定パラメーター '{2}' に一致させるための型 '{1}' の読み取り可能なインスタンス プロパティまたはフィールドである必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -267,14 +267,9 @@
         <target state="translated">レコード メンバー '{0}' は、位置指定パラメーター '{2}' に一致させるための型 '{1}' の読み取り可能なインスタンス プロパティまたはフィールドである必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">型 '{0}' の using ステートメント リソースは、非同期メソッドまたは非同期ラムダ式では使用できません。</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">ref readonly パラメーター</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ C# では out と ref を区別しますが、CLR では同じと認識します
         <target state="translated">async' 修飾子は、本体があるメソッドでのみ使用できます。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">'{0}' 型のパラメーターまたはローカルは、非同期メソッドまたは非同期ラムダ式で宣言することができません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">'{0}' は ref 構造体であるため、非同期または反復子のメソッド内で型 '{0}' の列挙子に対して foreach ステートメントは機能しません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">セキュリティ属性 '{0}' を非同期メソッドに適用することはできません。</target>
@@ -11127,8 +11117,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">型 '{0}' のインスタンスは、入れ子になった関数、クエリ式、反復子ブロック、または非同期メソッドの中では使用できません</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">匿名メソッド、ラムダ式、クエリ式内で ref ローカル変数 '{0}' は使用できません</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">反復子は参照渡しのローカル変数を持つことができません</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">非同期メソッドは参照渡しのローカル変数を持つことができません</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -267,6 +267,11 @@
         <target state="translated">위치 매개 변수 '{0}'과(와) 일치하려면 레코드 멤버 '{1}'이(가) 유형 '{2}'의 읽을 수 있는 인스턴스 속성 또는 필드여야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">ref 필드는 ref 구조체에서만 선언할 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">ref 할당의 왼쪽은 ref 변수여야 합니다.</target>
@@ -10535,8 +10540,8 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'await'는 '{0}' 형식이 포함된 식에 사용할 수 없습니다.</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'await'는 '{0}' 형식이 포함된 식에 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -267,14 +267,9 @@
         <target state="translated">위치 매개 변수 '{0}'과(와) 일치하려면 레코드 멤버 '{1}'이(가) 유형 '{2}'의 읽을 수 있는 인스턴스 속성 또는 필드여야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">'{0}' 형식의 using 문 리소스는 비동기 메서드 또는 비동기 람다 식에 사용할 수 없습니다.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">ref readonly 매개 변수</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
         <target state="translated">async' 한정자는 본문이 있는 메서드에서만 사용할 수 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">'{0}' 형식의 매개 변수 또는 로컬은 비동기 메서드나 비동기 람다 식에서 선언할 수 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">'{0}'은(는) ref struct이므로 비동기 또는 반복기 메서드의 '{0}' 형식 열거자에서 foreach 문을 수행할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">'{0}' 보안 특성은 비동기 메서드에 적용할 수 없습니다.</target>
@@ -11127,8 +11117,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">'{0}' 형식의 인스턴스는 중첩된 함수, 쿼리 식, 반복기 블록 또는 비동기 메서드 내에서 사용할 수 없습니다.</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">무명 메서드, 람다 식 또는 쿼리 식에는 참조 로컬 '{0}'을(를) 사용할 수 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">반복기에 by-reference 로컬을 사용할 수 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">비동기 메서드에 by-reference 로컬을 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Pole referencyjne można zadeklarować tylko w strukturze referencyjnej.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Lewa strona przypisania referencyjnego musi być zmienną referencyjną.</target>
@@ -10535,8 +10540,8 @@ Musisz umożliwić kompilatorowi rozróżnienie metod. Możesz na przykład nada
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'Operatora „await” nie można użyć w wyrażeniu zawierającym typ „{0}”</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'Operatora „await” nie można użyć w wyrażeniu zawierającym typ „{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ Pominięcie ostrzeżenia należy wziąć pod uwagę tylko w sytuacji, gdy na pew
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Składowa rekordu "{0}" musi być możliwą do odczytu właściwością wystąpienia typu "{1}", aby dopasować parametr pozycyjny "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -267,14 +267,9 @@
         <target state="translated">Składowa rekordu "{0}" musi być możliwą do odczytu właściwością wystąpienia typu "{1}", aby dopasować parametr pozycyjny "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">Zasobu instrukcji przy użyciu typu '{0}' nie można używać w metodach asynchronicznych ani asynchronicznych wyrażeniach lambda.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">parametry tylko do odczytu ref</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Musisz umożliwić kompilatorowi rozróżnienie metod. Możesz na przykład nada
         <target state="translated">Modyfikatora „async” można używać tylko w metodach mających treść.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Parametrów ani elementów lokalnych typu „{0}” nie można deklarować w metodach asynchronicznych ani wyrażeniach lambda.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">Instrukcja foreach nie może działać na modułach wyliczających typu „{0}” w metodach asynchronicznych lub iteratora, ponieważ element „{0}” jest strukturą ref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">Atrybutu zabezpieczeń „{0}” nie można zastosować dla metody asynchronicznej.</target>
@@ -11127,8 +11117,8 @@ Pominięcie ostrzeżenia należy wziąć pod uwagę tylko w sytuacji, gdy na pew
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">Wystąpienia typu „{0}” nie można użyć wewnątrz funkcji zagnieżdżonej, wyrażenia zapytania, bloku iteratora ani metody asynchronicznej</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">Nie można użyć zmiennej lokalnej typu ref „{0}” wewnątrz metody anonimowej, wyrażenia lambda ani wyrażenia zapytania</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Iteratory nie mogą mieć zmiennych lokalnych dostępnych przez odwołanie</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">Metody asynchroniczne nie mogą mieć zmiennych lokalnych dostępnych przez odwołanie</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Um campo ref só pode ser declarado em uma estrutura ref.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">O lado esquerdo de uma atribuição ref deve ser uma variável ref.</target>
@@ -10535,8 +10540,8 @@ Forneça ao compilador alguma forma de diferenciar os métodos. Por exemplo, voc
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'aguardar' não pode ser usado em uma expressão que contém o tipo '{0}'</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'aguardar' não pode ser usado em uma expressão que contém o tipo '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ Você pode suprimir o aviso se tiver certeza de que não vai querer aguardar a c
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -267,6 +267,11 @@
         <target state="translated">O membro do registro '{0}' precisa ser uma propriedade de instância legível ou campo do tipo '{1}' para corresponder ao parâmetro posicional '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -267,14 +267,9 @@
         <target state="translated">O membro do registro '{0}' precisa ser uma propriedade de instância legível ou campo do tipo '{1}' para corresponder ao parâmetro posicional '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">Um recurso de instrução using do tipo "{0}" não pode ser usado em métodos assíncronos ou expressões lambda assíncronas.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">parâmetros ref readonly</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Forneça ao compilador alguma forma de diferenciar os métodos. Por exemplo, voc
         <target state="translated">O modificador 'async' só pode ser usado em métodos que têm um corpo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Os parâmetros ou locais do tipo '{0}' não podem ser declarados nos métodos async ou expressões async lambda.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">a instrução foreach não pode operar em enumeradores do tipo '{0}' em métodos assíncronos ou iteradores porque '{0}' é uma struct de referência.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">Atributo de segurança "{0}" não pode ser aplicado a um método Assíncrono.</target>
@@ -11127,8 +11117,8 @@ Você pode suprimir o aviso se tiver certeza de que não vai querer aguardar a c
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">A instância do tipo '{0}' não pode ser usada dentro de uma função aninhada, expressão de consulta, bloco de iteradores ou método assíncrono</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">Não é possível usar a referência local '{0}' em um método anônimo, expressão lambda ou expressão de consulta</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Os iteradores não podem ter locais por referência</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">Os métodos assíncronos não podem ter locais por referência</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Поле ссылки может быть объявлено только в структуре ссылки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Левая сторона назначения ref должна быть переменной ref.</target>
@@ -10536,8 +10541,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'"await" нельзя использовать в выражении, содержащем тип "{0}"</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'"await" нельзя использовать в выражении, содержащем тип "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11123,8 +11128,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Элемент записи "{0}" должен быть доступным для чтения свойством экземпляра или полем типа "{1}", чтобы соответствовать позиционному параметру "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -267,14 +267,9 @@
         <target state="translated">Элемент записи "{0}" должен быть доступным для чтения свойством экземпляра или полем типа "{1}", чтобы соответствовать позиционному параметру "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">Ресурс оператора использования типа "{0}" нельзя применять в асинхронных методах или асинхронных лямбда-выражениях.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">Параметры ref, доступные только для чтения</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10600,16 +10600,6 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <target state="translated">Модификатор "async" можно использовать только в методах, имеющих тело.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Параметры или локальные переменные типа "{0}" не могут объявляться в асинхронных методах и в асинхронных лямбда-выражениях.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">Оператор foreach нельзя использовать с перечислителями типа "{0}" в методах с модификатором Async или Iterator, так как "{0}" является ссылочной структурой.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">Атрибут безопасности "{0}" нельзя применить к асинхронному методу.</target>
@@ -11128,8 +11118,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">Экземпляр типа "{0}" нельзя использовать внутри вложенной функции, выражения запроса, блока итератора или асинхронного метода.</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12438,16 +12428,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">Невозможно использовать локальную переменную ref "{0}" внутри анонимного метода, лямбда-выражения или выражения запроса</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Итераторы не могут иметь локальных переменных по ссылке</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">Асинхронные методы не могут иметь локальных переменных по ссылке</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -267,6 +267,11 @@
         <target state="translated">{0} kayıt üyesi, {1} konumsal parametresi ile eşleşmesi için {2} türünde okunabilir bir örnek özelliği veya alan olmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">Başvuru alanı yalnızca başvuru yapısında bildirilebilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">ref atamasının sol tarafı, ref değişkeni olmalıdır.</target>
@@ -10535,8 +10540,8 @@ Derleyiciye yöntemleri ayrıştırma yolu verin. Örneğin, bunlara farklı adl
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'await', '{0}' türünü içeren bir ifadede kullanılamaz</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'await', '{0}' türünü içeren bir ifadede kullanılamaz</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ Yalnızca asenkron çağrının tamamlanmasını beklemek istemediğinizden ve �
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -267,14 +267,9 @@
         <target state="translated">{0} kayıt üyesi, {1} konumsal parametresi ile eşleşmesi için {2} türünde okunabilir bir örnek özelliği veya alan olmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">'{0}' türündeki bir using deyimi kaynağı, asenkron yöntemlerde veya asenkron lambda ifadelerinde kullanılamaz.</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">ref salt okunur parametreleri</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Derleyiciye yöntemleri ayrıştırma yolu verin. Örneğin, bunlara farklı adl
         <target state="translated">Async' değiştiricisi yalnızca gövdesi olan metotlarda kullanılabilir.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">Zaman uyumsuz yöntemlerde veya zaman uyumsuz lambda ifadelerinde '{0}' türündeki parametreler veya yerel öğeler bildirilemez.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">'{0}' bir başvuru yapısı olduğundan foreach deyimi, async veya iterator metotlarındaki '{0}' türü numaralandırıcılar üzerinde çalışamaz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">'{0}' güvenlik özniteliği bir Async yöntemine uygulanamaz.</target>
@@ -11127,8 +11117,8 @@ Yalnızca asenkron çağrının tamamlanmasını beklemek istemediğinizden ve �
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">'{0}' türünün örneği iç içe geçmiş bir işlevde, sorgu ifadesinde, yineleyici bloğunda veya zaman uyumsuz bir metotta kullanılamaz</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">'{0}' ref yerel değeri bir anonim metotta, lambda ifadesinde veya sorgu ifadesinde kullanılamaz</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Yineleyiciler başvuruya göre yerel değerlere sahip olamaz</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">Zaman uyumsuz metotlar başvuruya göre yerel değerlere sahip olamaz</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -267,6 +267,11 @@
         <target state="translated">记录成员 '{0}' 必须为类型 '{1}' 的可读实例属性或字段，以匹配位置参数 '{2}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">ref 字段只能在 ref 结构中声明。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">ref 赋值的左侧必须为 ref 变量。</target>
@@ -10535,8 +10540,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'“等待”不能在包含“{0}”类型的表达式中使用</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'“等待”不能在包含“{0}”类型的表达式中使用</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -267,14 +267,9 @@
         <target state="translated">记录成员 '{0}' 必须为类型 '{1}' 的可读实例属性或字段，以匹配位置参数 '{2}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">无法在异步方法或异步 lambda 表达式中使用类型为“{0}”的 using 语句资源。</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">ref readonly 参数</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <target state="translated">只能在具有正文的方法中使用 "async" 修饰符。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">不能在异步方法或异步 lambda 表达式中声明类型“{0}”的参数或局部变量。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">foreach 语句无法在类型“{0}”的枚举器上使用异步或迭代器方法操作，因为“{0}”是 ref 结构。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">安全特性“{0}”不可应用于异步方法。</target>
@@ -11127,8 +11117,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">“{0}”类型的实例不能在嵌套函数、查询表达式、迭代器块或异步方法中使用</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">不能在匿名方法、lambda 表达式或查询表达式内使用 ref 局部变量“{0}”</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">迭代器不能有按引用局部变量</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">异步方法不能有按引用局部变量</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2348,8 +2348,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
-        <source>Ref and unsafe in async and iterator methods</source>
-        <target state="new">Ref and unsafe in async and iterator methods</target>
+        <source>ref and unsafe in async and iterator methods</source>
+        <target state="new">ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -267,6 +267,11 @@
         <target state="translated">記錄成員 '{0}' 必須是類型 '{1}' 的可讀取執行個體屬性或欄位，才能符合位置參數 '{2}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadSpecialByRefIterator">
+        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
+        <target state="new">foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadSpecialByRefParameter">
         <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
         <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1712,6 +1712,11 @@
         <target state="translated">ref 欄位只能在 ref 結構中宣告。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RefLocalAcrossAwait">
+        <source>A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="new">A 'ref' local cannot be preserved across 'await' or 'yield' boundary.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">參考指派的左側必須為 ref 變數。</target>
@@ -10535,8 +10540,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_ByRefTypeAndAwait">
-        <source>'await' cannot be used in an expression containing the type '{0}'</source>
-        <target state="translated">'await' 不得用於包含類型 '{0}' 的運算式中</target>
+        <source>Instance of type '{0}' cannot be preserved across 'await' or 'yield' boundary.</source>
+        <target state="needs-review-translation">'await' 不得用於包含類型 '{0}' 的運算式中</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeAsyncArgType">
@@ -11122,8 +11127,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
+        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -267,14 +267,9 @@
         <target state="translated">記錄成員 '{0}' 必須是類型 '{1}' 的可讀取執行個體屬性或欄位，才能符合位置參數 '{2}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLock">
-        <source>A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</source>
-        <target state="new">A lock statement on a value of type 'System.Threading.Lock' cannot be used in async methods or async lambda expressions.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefUsing">
-        <source>A using statement resource of type '{0}' cannot be used in async methods or async lambda expressions.</source>
-        <target state="translated">類型 '{0}' 的 using 陳述式資源不能用於非同步方法或非同步 Lambda 運算式。</target>
+      <trans-unit id="ERR_BadSpecialByRefParameter">
+        <source>Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
+        <target state="new">Parameters of type '{0}' cannot be declared in async methods or async lambda expressions.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadRefInUsingAlias">
@@ -2345,6 +2340,11 @@
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="translated">ref readonly 參數</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefUnsafeInIteratorAsync">
+        <source>Ref and unsafe in async and iterator methods</source>
+        <target state="new">Ref and unsafe in async and iterator methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">
@@ -10599,16 +10599,6 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <target state="translated">async' 修飾元只可用於具有主體的方法。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefLocal">
-        <source>Parameters or locals of type '{0}' cannot be declared in async methods or async lambda expressions.</source>
-        <target state="translated">類型 '{0}' 的參數或區域變數，不可在非同步方法或非同步 Lambda 運算式中宣告。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadSpecialByRefIterator">
-        <source>foreach statement cannot operate on enumerators of type '{0}' in async or iterator methods because '{0}' is a ref struct.</source>
-        <target state="translated">foreach 陳述式無法對 async 或 iterator 方法中類型 '{0}' 的列舉值進行操作，因為 '{0}' 為 ref struct。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync">
         <source>Security attribute '{0}' cannot be applied to an Async method.</source>
         <target state="translated">安全屬性 '{0}' 無法套用至非同步方法。</target>
@@ -11127,8 +11117,8 @@ You should consider suppressing the warning only if you're sure that you don't w
         <note />
       </trans-unit>
       <trans-unit id="ERR_SpecialByRefInLambda">
-        <source>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</source>
-        <target state="translated">類型 '{0}' 的執行個體不可用於巢狀函式、查詢運算式、迭代區塊或非同步方法中</target>
+        <source>Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</source>
+        <target state="new">Instance of type '{0}{1}' cannot be used inside a nested function, query expression, iterator block or async method</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SecurityAttributeMissingAction">
@@ -12437,16 +12427,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_AnonDelegateCantUseLocal">
         <source>Cannot use ref local '{0}' inside an anonymous method, lambda expression, or query expression</source>
         <target state="translated">無法在匿名方法、Lambda 運算式或查詢運算式中使用參考本機 '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadIteratorLocalType">
-        <source>Iterators cannot have by-reference locals</source>
-        <target state="translated">Iterator 不可有 by-reference local</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_BadAsyncLocalType">
-        <source>Async methods cannot have by-reference locals</source>
-        <target state="translated">非同步方法不可有 by-reference local</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReturningCallAndAwait">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -903,9 +903,9 @@ ref struct S
 
             var expectedDiagnostics = new[]
             {
-                // source(8,28): error CS4007: Instance of type 'S' cannot be preserved across 'await' or 'yield' boundary.
-                //         await foreach (var s in new C())
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "s").WithArguments("S").WithLocation(8, 28)
+                // source(11,34): error CS4007: Instance of type 'S' cannot be preserved across 'await' or 'yield' boundary.
+                //             System.Console.Write(s.F);
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "s.F").WithArguments("S").WithLocation(11, 34)
             };
 
             comp = CreateCompilationWithAsyncIterator(source, parseOptions: TestOptions.RegularNext);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -650,9 +650,9 @@ ref struct S
                 // source(4,65): error CS0306: The type 'S' may not be used as a type argument
                 //     static async System.Collections.Generic.IAsyncEnumerable<S> M()
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "M").WithArguments("S").WithLocation(4, 65),
-                // source(11,24): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // source(11,24): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await foreach (var s in M())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(11, 24));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(11, 24));
         }
 
         [Fact]
@@ -690,9 +690,9 @@ ref struct S
 
             var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
-                // source(8,24): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // source(8,24): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await foreach (var s in new C())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 24));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 24));
 
             comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularNext);
             comp.VerifyEmitDiagnostics();
@@ -849,9 +849,9 @@ ref struct S
 
             var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
-                // source(8,24): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // source(8,24): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await foreach (var s in new C())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 24));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 24));
 
             comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularNext);
             comp.VerifyEmitDiagnostics();
@@ -897,9 +897,9 @@ ref struct S
 
             var comp = CreateCompilationWithAsyncIterator(source, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
-                // source(8,24): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // source(8,24): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await foreach (var s in new C())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 24));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 24));
 
             var expectedDiagnostics = new[]
             {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -903,9 +903,9 @@ ref struct S
 
             var expectedDiagnostics = new[]
             {
-                // source(11,34): error CS4013: Instance of type 'S' cannot be used inside a nested function, query expression, iterator block or async method
-                //             System.Console.Write(s.F);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "s.F").WithArguments("", "S").WithLocation(11, 34)
+                // source(8,28): error CS4007: Instance of type 'S' cannot be preserved across 'await' or 'yield' boundary.
+                //         await foreach (var s in new C())
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "s").WithArguments("S").WithLocation(8, 28)
             };
 
             comp = CreateCompilationWithAsyncIterator(source, parseOptions: TestOptions.RegularNext);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -133,7 +133,7 @@ class C
         // Instrumentation to investigate CI failure: https://github.com/dotnet/roslyn/issues/34207
         private CSharpCompilation CreateCompilationWithAsyncIterator(string source, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
             => CreateCompilationWithTasksExtensions(new[] { (CSharpTestSource)CSharpTestBase.Parse(source, filename: "source", parseOptions), CSharpTestBase.Parse(AsyncStreamsTypes, filename: "AsyncStreamsTypes", parseOptions) },
-                options: options, parseOptions: parseOptions);
+                options: options);
 
         private CSharpCompilation CreateCompilationWithAsyncIterator(CSharpTestSource source, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
             => CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, options: options, parseOptions: parseOptions);
@@ -631,15 +631,186 @@ class C
 ref struct S
 {
 }";
+
+            var expectedDiagnostics = new[]
+            {
+                // source(4,65): error CS0306: The type 'S' may not be used as a type argument
+                //     static async System.Collections.Generic.IAsyncEnumerable<S> M()
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "M").WithArguments("S").WithLocation(4, 65)
+            };
+
             var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+
+            comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+
+            comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
                 // source(4,65): error CS0306: The type 'S' may not be used as a type argument
                 //     static async System.Collections.Generic.IAsyncEnumerable<S> M()
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "M").WithArguments("S").WithLocation(4, 65),
-                // source(11,24): error CS4012: Parameters or locals of type 'S' cannot be declared in async methods or async lambda expressions.
+                // source(11,24): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await foreach (var s in M())
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "var").WithArguments("S").WithLocation(11, 24)
-                );
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(11, 24));
+        }
+
+        [Fact]
+        public void RefStructElementType_NonGeneric()
+        {
+            string source = """
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    public E GetAsyncEnumerator() => new E();
+                    static async Task Main()
+                    {
+                        await foreach (var s in new C())
+                        {
+                            System.Console.Write(s.F);
+                        }
+                    }
+                }
+                class E
+                {
+                    bool _done;
+                    public S Current => new S { F = 123 };
+                    public async Task<bool> MoveNextAsync()
+                    {
+                        await Task.CompletedTask;
+                        return !_done ? (_done = true) : false;
+                    }
+                }
+                ref struct S
+                {
+                    public int F;
+                }
+                """;
+
+            var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular12);
+            comp.VerifyDiagnostics(
+                // source(8,24): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         await foreach (var s in new C())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 24));
+
+            comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularNext);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "123", verify: Verification.FailsILVerify);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("C.<Main>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", """
+                {
+                  // Code size      238 (0xee)
+                  .maxstack  3
+                  .locals init (int V_0,
+                                S V_1, //s
+                                System.Runtime.CompilerServices.TaskAwaiter<bool> V_2,
+                                C.<Main>d__1 V_3,
+                                System.Exception V_4)
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldfld      "int C.<Main>d__1.<>1__state"
+                  IL_0006:  stloc.0
+                  .try
+                  {
+                    IL_0007:  ldloc.0
+                    IL_0008:  brfalse.s  IL_0012
+                    IL_000a:  br.s       IL_000c
+                    IL_000c:  ldloc.0
+                    IL_000d:  ldc.i4.1
+                    IL_000e:  beq.s      IL_0014
+                    IL_0010:  br.s       IL_0016
+                    IL_0012:  br.s       IL_0082
+                    IL_0014:  br.s       IL_0082
+                    IL_0016:  nop
+                    IL_0017:  nop
+                    IL_0018:  ldarg.0
+                    IL_0019:  newobj     "C..ctor()"
+                    IL_001e:  call       "E C.GetAsyncEnumerator()"
+                    IL_0023:  stfld      "E C.<Main>d__1.<>s__1"
+                    IL_0028:  br.s       IL_0044
+                    IL_002a:  ldarg.0
+                    IL_002b:  ldfld      "E C.<Main>d__1.<>s__1"
+                    IL_0030:  callvirt   "S E.Current.get"
+                    IL_0035:  stloc.1
+                    IL_0036:  nop
+                    IL_0037:  ldloc.1
+                    IL_0038:  ldfld      "int S.F"
+                    IL_003d:  call       "void System.Console.Write(int)"
+                    IL_0042:  nop
+                    IL_0043:  nop
+                    IL_0044:  ldarg.0
+                    IL_0045:  ldfld      "E C.<Main>d__1.<>s__1"
+                    IL_004a:  callvirt   "System.Threading.Tasks.Task<bool> E.MoveNextAsync()"
+                    IL_004f:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()"
+                    IL_0054:  stloc.2
+                    IL_0055:  ldloca.s   V_2
+                    IL_0057:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get"
+                    IL_005c:  brtrue.s   IL_009e
+                    IL_005e:  ldarg.0
+                    IL_005f:  ldc.i4.0
+                    IL_0060:  dup
+                    IL_0061:  stloc.0
+                    IL_0062:  stfld      "int C.<Main>d__1.<>1__state"
+                    IL_0067:  ldarg.0
+                    IL_0068:  ldloc.2
+                    IL_0069:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__1.<>u__1"
+                    IL_006e:  ldarg.0
+                    IL_006f:  stloc.3
+                    IL_0070:  ldarg.0
+                    IL_0071:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__1.<>t__builder"
+                    IL_0076:  ldloca.s   V_2
+                    IL_0078:  ldloca.s   V_3
+                    IL_007a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__1)"
+                    IL_007f:  nop
+                    IL_0080:  leave.s    IL_00ed
+                    IL_0082:  ldarg.0
+                    IL_0083:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__1.<>u__1"
+                    IL_0088:  stloc.2
+                    IL_0089:  ldarg.0
+                    IL_008a:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__1.<>u__1"
+                    IL_008f:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<bool>"
+                    IL_0095:  ldarg.0
+                    IL_0096:  ldc.i4.m1
+                    IL_0097:  dup
+                    IL_0098:  stloc.0
+                    IL_0099:  stfld      "int C.<Main>d__1.<>1__state"
+                    IL_009e:  ldarg.0
+                    IL_009f:  ldloca.s   V_2
+                    IL_00a1:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()"
+                    IL_00a6:  stfld      "bool C.<Main>d__1.<>s__2"
+                    IL_00ab:  ldarg.0
+                    IL_00ac:  ldfld      "bool C.<Main>d__1.<>s__2"
+                    IL_00b1:  brtrue     IL_002a
+                    IL_00b6:  ldarg.0
+                    IL_00b7:  ldnull
+                    IL_00b8:  stfld      "E C.<Main>d__1.<>s__1"
+                    IL_00bd:  leave.s    IL_00d9
+                  }
+                  catch System.Exception
+                  {
+                    IL_00bf:  stloc.s    V_4
+                    IL_00c1:  ldarg.0
+                    IL_00c2:  ldc.i4.s   -2
+                    IL_00c4:  stfld      "int C.<Main>d__1.<>1__state"
+                    IL_00c9:  ldarg.0
+                    IL_00ca:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__1.<>t__builder"
+                    IL_00cf:  ldloc.s    V_4
+                    IL_00d1:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+                    IL_00d6:  nop
+                    IL_00d7:  leave.s    IL_00ed
+                  }
+                  IL_00d9:  ldarg.0
+                  IL_00da:  ldc.i4.s   -2
+                  IL_00dc:  stfld      "int C.<Main>d__1.<>1__state"
+                  IL_00e1:  ldarg.0
+                  IL_00e2:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__1.<>t__builder"
+                  IL_00e7:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+                  IL_00ec:  nop
+                  IL_00ed:  ret
+                }
+                """);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3789,9 +3789,11 @@ public class P
                 var comp = CreateCompilationWithMscorlibAndSpan(source, options: options);
                 comp.VerifyDiagnostics();
                 comp.VerifyEmitDiagnostics(
-                    // (9,66): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
-                    //         await Async1(F1(), G(F2(), stackalloc int[] { 1, 2, 3 }, await F3()));
-                    Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await F3()").WithArguments("System.Span<int>").WithLocation(9, 66)
+                    // (8,5): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
+                    //     {
+                    Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, @"{
+        await Async1(F1(), G(F2(), stackalloc int[] { 1, 2, 3 }, await F3()));
+    }").WithArguments("System.Span<int>").WithLocation(8, 5)
                     );
             }
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3789,7 +3789,7 @@ public class P
                 var comp = CreateCompilationWithMscorlibAndSpan(source, options: options);
                 comp.VerifyDiagnostics();
                 comp.VerifyEmitDiagnostics(
-                    // (9,66): error CS4007: 'await' cannot be used in an expression containing the type 'System.Span<int>'
+                    // (9,66): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
                     //         await Async1(F1(), G(F2(), stackalloc int[] { 1, 2, 3 }, await F3()));
                     Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await F3()").WithArguments("System.Span<int>").WithLocation(9, 66)
                     );

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3897,16 +3897,16 @@ public ref struct S
     public bool P2 => true;
 }
 ";
-            CreateCompilation(source, options: TestOptions.DebugDll).VerifyDiagnostics().VerifyEmitDiagnostics(
-                // (9,17): error CS4013: Instance of type 'S' cannot be used inside a nested function, query expression, iterator block or async method
+
+            var expectedDiagnostics = new[]
+            {
+                // (9,17): error CS4007: Instance of type 'S' cannot be preserved across 'await' or 'yield' boundary.
                 //             Q { F: { P1: true } } when await c => r, // error: cached Q.F is alive
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "F").WithArguments("", "S").WithLocation(9, 17)
-                );
-            CreateCompilation(source, options: TestOptions.ReleaseDll).VerifyDiagnostics().VerifyEmitDiagnostics(
-                // (9,17): error CS4013: Instance of type 'S' cannot be used inside a nested function, query expression, iterator block or async method
-                //             Q { F: { P1: true } } when await c => r, // error: cached Q.F is alive
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "F").WithArguments("", "S").WithLocation(9, 17)
-                );
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "F").WithArguments("S").WithLocation(9, 17)
+            };
+
+            CreateCompilation(source, options: TestOptions.DebugDll).VerifyDiagnostics().VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, options: TestOptions.ReleaseDll).VerifyDiagnostics().VerifyEmitDiagnostics(expectedDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3900,12 +3900,12 @@ public ref struct S
             CreateCompilation(source, options: TestOptions.DebugDll).VerifyDiagnostics().VerifyEmitDiagnostics(
                 // (9,17): error CS4013: Instance of type 'S' cannot be used inside a nested function, query expression, iterator block or async method
                 //             Q { F: { P1: true } } when await c => r, // error: cached Q.F is alive
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "F").WithArguments("S").WithLocation(9, 17)
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "F").WithArguments("", "S").WithLocation(9, 17)
                 );
             CreateCompilation(source, options: TestOptions.ReleaseDll).VerifyDiagnostics().VerifyEmitDiagnostics(
                 // (9,17): error CS4013: Instance of type 'S' cannot be used inside a nested function, query expression, iterator block or async method
                 //             Q { F: { P1: true } } when await c => r, // error: cached Q.F is alive
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "F").WithArguments("S").WithLocation(9, 17)
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "F").WithArguments("", "S").WithLocation(9, 17)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -1823,9 +1823,9 @@ class C
 
             var expectedDiagnostics = new[]
             {
-                // (11,19): error CS4013: Instance of type 'ref int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             M(ref i);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "i").WithArguments("ref ", "int").WithLocation(11, 19)
+                // (8,32): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         await foreach (ref var i in new C())
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "i").WithLocation(8, 32)
             };
 
             comp = CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.RegularNext);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -1823,9 +1823,9 @@ class C
 
             var expectedDiagnostics = new[]
             {
-                // (8,32): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         await foreach (ref var i in new C())
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "i").WithLocation(8, 32)
+                // (11,19): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             M(ref i);
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "i").WithLocation(11, 19)
             };
 
             comp = CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.RegularNext);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -1699,9 +1699,9 @@ class C
 
             var comp = CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
-                // (6,32): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (6,32): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await foreach (ref var i in new C())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "i").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(6, 32));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "i").WithArguments("ref and unsafe in async and iterator methods").WithLocation(6, 32));
 
             var expectedDiagnostics = new[]
             {
@@ -1766,9 +1766,9 @@ class C
 
             var comp = CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
-                // (17,41): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (17,41): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await foreach (ref readonly var i in new C())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "i").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(17, 41));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "i").WithArguments("ref and unsafe in async and iterator methods").WithLocation(17, 41));
 
             var expectedOutput = "123";
 
@@ -1817,9 +1817,9 @@ class C
 
             var comp = CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
-                // (8,32): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,32): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await foreach (ref var i in new C())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "i").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 32));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "i").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 32));
 
             var expectedDiagnostics = new[]
             {

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -22592,7 +22592,7 @@ class Program
         }
 
         [ConditionalFact(typeof(CoreClrOnly))]
-        public void UserDefinedIndexer_Warning_17()
+        public void UserDefinedIndexer_Warning_01()
         {
             var src = @"
 [System.Runtime.CompilerServices.InlineArray(4)]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -20182,9 +20182,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (10,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (10,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(10, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(10, 26));
 
             var expectedOutput = "09009";
 
@@ -20644,9 +20644,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (11,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (11,35): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(11, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(11, 35));
 
             var expectedOutput = "01 34 01 01 4";
 
@@ -20859,12 +20859,12 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (10,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (10,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         ref Buffer4<int> buffer = ref GetBuffer();
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "buffer").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(10, 26),
-                // (11,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "buffer").WithArguments("ref and unsafe in async and iterator methods").WithLocation(10, 26),
+                // (11,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in buffer)
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(11, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(11, 26));
 
             var expectedOutput = "09009";
 
@@ -20904,9 +20904,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (10,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (10,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(10, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(10, 26));
 
             var expectedDiagnostics = new[]
             {
@@ -20955,9 +20955,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (10,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (10,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(10, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(10, 26));
 
             var expectedDiagnostics = new[]
             {
@@ -21006,12 +21006,12 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (10,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (10,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         ref Buffer4<int> buffer = ref GetBuffer();
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "buffer").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(10, 26),
-                // (11,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "buffer").WithArguments("ref and unsafe in async and iterator methods").WithLocation(10, 26),
+                // (11,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in buffer)
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(11, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(11, 26));
 
             var expectedDiagnostics = new[]
             {
@@ -21078,9 +21078,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (21,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (21,35): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         ref readonly Buffer4<int> f = ref x.F;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "f").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(21, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "f").WithArguments("ref and unsafe in async and iterator methods").WithLocation(21, 35));
 
             var expectedDiagnostics = new[]
             {
@@ -21126,9 +21126,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (8,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,35): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 35));
 
             var expectedDiagnostics = new[]
             {
@@ -21170,9 +21170,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (8,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,35): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 35));
 
             var expectedDiagnostics = new[]
             {
@@ -21462,9 +21462,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (18,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (18,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(18, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(18, 26));
 
             var expectedOutput = "0090-19";
 
@@ -21784,9 +21784,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (19,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (19,35): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(19, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(19, 35));
 
             var expectedOutput = "01 01 34 01 -14";
 
@@ -21966,12 +21966,12 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (18,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (18,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         ref Buffer4<int> buffer = ref GetBuffer();
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "buffer").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(18, 26),
-                // (19,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "buffer").WithArguments("ref and unsafe in async and iterator methods").WithLocation(18, 26),
+                // (19,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in buffer)
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(19, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(19, 26));
 
             var expectedOutput = "0090-19";
 
@@ -22019,9 +22019,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (18,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (18,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(18, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(18, 26));
 
             var expectedDiagnostics = new[]
             {
@@ -22078,9 +22078,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (18,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (18,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(18, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(18, 26));
 
             var expectedDiagnostics = new[]
             {
@@ -22137,12 +22137,12 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (18,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (18,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         ref Buffer4<int> buffer = ref GetBuffer();
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "buffer").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(18, 26),
-                // (19,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "buffer").WithArguments("ref and unsafe in async and iterator methods").WithLocation(18, 26),
+                // (19,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref int y in buffer)
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(19, 26));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(19, 26));
 
             var expectedDiagnostics = new[]
             {
@@ -22207,9 +22207,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (20,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (20,35): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         ref readonly Buffer4<int> f = ref x.F;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "f").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(20, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "f").WithArguments("ref and unsafe in async and iterator methods").WithLocation(20, 35));
 
             var expectedDiagnostics = new[]
             {
@@ -22254,9 +22254,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (8,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,35): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 35));
 
             var expectedDiagnostics = new[]
             {
@@ -22298,9 +22298,9 @@ class Program
 " + Buffer4Definition;
 
             CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-                // (8,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,35): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 35));
 
             var expectedDiagnostics = new[]
             {

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -4691,7 +4691,7 @@ class Program
 ";
             var comp = CreateCompilation(src + Buffer10Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics(
-                // (24,22): error CS4007: 'await' cannot be used in an expression containing the type 'System.ReadOnlySpan<Buffer10<int>>'
+                // (24,22): error CS4007: Instance of type 'System.ReadOnlySpan<Buffer10<int>>' cannot be preserved across 'await' or 'yield' boundary.
                 //            [Get01()][await FromResult(Get02(x))];
                 Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await FromResult(Get02(x))").WithArguments("System.ReadOnlySpan<Buffer10<int>>").WithLocation(24, 22)
                 );
@@ -4743,9 +4743,9 @@ class Program
 ";
             var comp = CreateCompilation(src + Buffer10Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics(
-                    // (24,13): error CS4007: 'await' cannot be used in an expression containing the type 'System.ReadOnlySpan<int>'
-                    //            [await FromResult(Get02(x))];
-                    Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await FromResult(Get02(x))").WithArguments("System.ReadOnlySpan<int>").WithLocation(24, 13)
+                // (24,13): error CS4007: Instance of type 'System.ReadOnlySpan<int>' cannot be preserved across 'await' or 'yield' boundary.
+                //            [await FromResult(Get02(x))];
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await FromResult(Get02(x))").WithArguments("System.ReadOnlySpan<int>").WithLocation(24, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -22277,7 +22277,7 @@ class Program
             CreateCompilation(src, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void UserDefinedIndexer_Warning_17()
         {
             var src = @"

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -20177,10 +20177,20 @@ class Program
 
     static ref Buffer4<int> GetBuffer() => ref s_buffer;
 }
-";
-            var verifier = CompileAndVerify(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
-                expectedOutput: "0900");
-            verifier.VerifyDiagnostics();
+" + Buffer4Definition;
+
+            CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
+                // (10,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         foreach (ref int y in GetBuffer())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(10, 26));
+
+            var expectedOutput = "0900";
+
+            CompileAndVerify(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            CompileAndVerify(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
         [Fact]
@@ -20623,10 +20633,20 @@ class Program
 
     static ref readonly Buffer4<int> GetBuffer() => ref s_buffer;
 }
-";
-            var verifier = CompileAndVerify(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
-                expectedOutput: "0300");
-            verifier.VerifyDiagnostics();
+" + Buffer4Definition;
+
+            CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
+                // (10,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         foreach (ref readonly int y in GetBuffer())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(10, 35));
+
+            var expectedOutput = "0300";
+
+            CompileAndVerify(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            CompileAndVerify(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
         [Fact]
@@ -21073,10 +21093,20 @@ class Program
 
     static ref Buffer4<int> GetBuffer() => ref s_buffer;
 }
-";
-            var verifier = CompileAndVerify(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
-                expectedOutput: "0090-1");
-            verifier.VerifyDiagnostics();
+" + Buffer4Definition;
+
+            CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
+                // (18,26): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         foreach (ref int y in GetBuffer())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(18, 26));
+
+            var expectedOutput = "0090-1";
+
+            CompileAndVerify(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            CompileAndVerify(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
         [Fact]
@@ -21379,10 +21409,20 @@ class Program
 
     static ref readonly Buffer4<int> GetBuffer() => ref s_buffer;
 }
-";
-            var verifier = CompileAndVerify(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
-                expectedOutput: "0030-1");
-            verifier.VerifyDiagnostics();
+" + Buffer4Definition;
+
+            CreateCompilation(src, parseOptions: TestOptions.Regular12, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
+                // (18,35): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         foreach (ref readonly int y in GetBuffer())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(18, 35));
+
+            var expectedOutput = "0030-1";
+
+            CompileAndVerify(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            CompileAndVerify(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -20910,15 +20910,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (13,13): error CS4013: Instance of type 'ref int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             y *= y;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref ", "int").WithLocation(13, 13),
-                // (13,18): error CS4013: Instance of type 'ref int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             y *= y;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref ", "int").WithLocation(13, 18),
-                // (14,34): error CS4013: Instance of type 'ref int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             System.Console.Write(y);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref ", "int").WithLocation(14, 34)
+                // (10,26): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         foreach (ref int y in GetBuffer())
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(10, 26)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -21015,14 +21009,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (11,9): error CS4013: Instance of type 'ref Buffer4<int>' cannot be used inside a nested function, query expression, iterator block or async method
-                //         foreach (ref int y in buffer)
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, @"foreach (ref int y in buffer)
-        {
-            y *= y;
-            System.Console.Write(y);
-            await System.Threading.Tasks.Task.Yield();
-        }").WithArguments("ref ", "Buffer4<int>").WithLocation(11, 9)
+                // (10,26): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         ref Buffer4<int> buffer = ref GetBuffer();
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "buffer").WithLocation(10, 26)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -21084,17 +21073,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (22,9): error CS4013: Instance of type 'ref readonly Buffer4<int>' cannot be used inside a nested function, query expression, iterator block or async method
-                //         foreach (var y in f)
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, @"foreach (var y in f)
-        {
-            Increment();    
-            System.Console.Write(' ');
-            System.Console.Write(y);
-
-            await Task.Yield();
-            await Task.Delay(2);
-        }").WithArguments("ref readonly ", "Buffer4<int>").WithLocation(22, 9)
+                // (21,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         ref readonly Buffer4<int> f = ref x.F;
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "f").WithLocation(21, 35)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -21176,9 +21157,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (11,34): error CS4013: Instance of type 'ref readonly int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             System.Console.Write(y);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref readonly ", "int").WithLocation(11, 34)
+                // (8,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         foreach (ref readonly int y in GetBuffer())
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(8, 35)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22025,15 +22006,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (21,13): error CS4013: Instance of type 'ref int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             y *= y;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref ", "int").WithLocation(21, 13),
-                // (21,18): error CS4013: Instance of type 'ref int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             y *= y;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref ", "int").WithLocation(21, 18),
-                // (22,34): error CS4013: Instance of type 'ref int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             System.Console.Write(y);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref ", "int").WithLocation(22, 34)
+                // (18,26): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         foreach (ref int y in GetBuffer())
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(18, 26)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22146,14 +22121,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (19,9): error CS4013: Instance of type 'ref Buffer4<int>' cannot be used inside a nested function, query expression, iterator block or async method
-                //         foreach (ref int y in buffer)
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, @"foreach (ref int y in buffer)
-        {
-            y *= y;
-            System.Console.Write(y);
-            yield return 1;
-        }").WithArguments("ref ", "Buffer4<int>").WithLocation(19, 9)
+                // (18,26): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         ref Buffer4<int> buffer = ref GetBuffer();
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "buffer").WithLocation(18, 26)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22213,16 +22183,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (21,9): error CS4013: Instance of type 'ref readonly Buffer4<int>' cannot be used inside a nested function, query expression, iterator block or async method
-                //         foreach (var y in f)
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, @"foreach (var y in f)
-        {
-            Increment();    
-            System.Console.Write(' ');
-            System.Console.Write(y);
-
-            yield return -1;
-        }").WithArguments("ref readonly ", "Buffer4<int>").WithLocation(21, 9)
+                // (20,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         ref readonly Buffer4<int> f = ref x.F;
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "f").WithLocation(20, 35)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22304,9 +22267,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (11,34): error CS4013: Instance of type 'ref readonly int' cannot be used inside a nested function, query expression, iterator block or async method
-                //             System.Console.Write(y);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref readonly ", "int").WithLocation(11, 34)
+                // (8,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         foreach (ref readonly int y in GetBuffer())
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(8, 35)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -20910,9 +20910,15 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (10,26): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(10, 26)
+                // (13,13): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             y *= y;
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(13, 13),
+                // (13,18): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             y *= y;
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(13, 18),
+                // (14,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             System.Console.Write(y);
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(14, 34)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -21009,9 +21015,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (10,26): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         ref Buffer4<int> buffer = ref GetBuffer();
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "buffer").WithLocation(10, 26)
+                // (11,31): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         foreach (ref int y in buffer)
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "buffer").WithLocation(11, 31)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -21073,9 +21079,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (21,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         ref readonly Buffer4<int> f = ref x.F;
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "f").WithLocation(21, 35)
+                // (22,27): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         foreach (var y in f)
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "f").WithLocation(22, 27)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -21157,9 +21163,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (8,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(8, 35)
+                // (11,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             System.Console.Write(y);
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(11, 34)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -21250,9 +21256,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (13,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         foreach (ref readonly int y in x.F)
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(13, 35)
+                // (16,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             System.Console.Write(y);
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(16, 34)
             };
 
             CreateCompilation(src, targetFramework: TargetFramework.Net80, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22098,9 +22104,15 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (18,26): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(18, 26)
+                // (21,13): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             y *= y;
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(21, 13),
+                // (21,18): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             y *= y;
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(21, 18),
+                // (22,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             System.Console.Write(y);
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(22, 34)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22213,9 +22225,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (18,26): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         ref Buffer4<int> buffer = ref GetBuffer();
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "buffer").WithLocation(18, 26)
+                // (19,31): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         foreach (ref int y in buffer)
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "buffer").WithLocation(19, 31)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22275,9 +22287,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (20,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         ref readonly Buffer4<int> f = ref x.F;
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "f").WithLocation(20, 35)
+                // (21,27): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         foreach (var y in f)
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "f").WithLocation(21, 27)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22359,9 +22371,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (8,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(8, 35)
+                // (11,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             System.Console.Write(y);
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(11, 34)
             };
 
             CreateCompilation(src, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net80).VerifyEmitDiagnostics(expectedDiagnostics);
@@ -22448,9 +22460,9 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (11,35): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         foreach (ref readonly int y in x.F)
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(11, 35)
+                // (14,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //             System.Console.Write(y);
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(14, 34)
             };
 
             CreateCompilation(src, targetFramework: TargetFramework.Net80, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -4691,9 +4691,12 @@ class Program
 ";
             var comp = CreateCompilation(src + Buffer10Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics(
-                // (24,22): error CS4007: Instance of type 'System.ReadOnlySpan<Buffer10<int>>' cannot be preserved across 'await' or 'yield' boundary.
-                //            [Get01()][await FromResult(Get02(x))];
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await FromResult(Get02(x))").WithArguments("System.ReadOnlySpan<Buffer10<int>>").WithLocation(24, 22)
+                // (20,12): error CS4007: Instance of type 'System.ReadOnlySpan<Buffer10<int>>' cannot be preserved across 'await' or 'yield' boundary.
+                //         => MemoryMarshal.CreateReadOnlySpan(
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, @"MemoryMarshal.CreateReadOnlySpan(
+                ref Unsafe.As<Buffer10<Buffer10<int>>, Buffer10<int>>(
+                        ref Unsafe.AsRef(in GetC(x).F)),
+                10)").WithArguments("System.ReadOnlySpan<Buffer10<int>>").WithLocation(20, 12)
                 );
         }
 
@@ -4743,9 +4746,12 @@ class Program
 ";
             var comp = CreateCompilation(src + Buffer10Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics(
-                // (24,13): error CS4007: Instance of type 'System.ReadOnlySpan<int>' cannot be preserved across 'await' or 'yield' boundary.
-                //            [await FromResult(Get02(x))];
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await FromResult(Get02(x))").WithArguments("System.ReadOnlySpan<int>").WithLocation(24, 13)
+                // (20,12): error CS4007: Instance of type 'System.ReadOnlySpan<int>' cannot be preserved across 'await' or 'yield' boundary.
+                //         => MemoryMarshal.CreateReadOnlySpan(
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, @"MemoryMarshal.CreateReadOnlySpan(
+                ref Unsafe.As<Buffer10<int>, int>(
+                        ref Unsafe.AsRef(in GetC(x).F[Get01()])),
+                10)").WithArguments("System.ReadOnlySpan<int>").WithLocation(20, 12)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -20173,11 +20173,7 @@ class Program
 }
 ";
             var comp = CreateCompilation(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
-            comp.VerifyDiagnostics(
-                // (6,26): error CS8177: Async methods cannot have by-reference locals
-                //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "y").WithLocation(6, 26)
-                );
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -20617,11 +20613,7 @@ class Program
 }
 ";
             var comp = CreateCompilation(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
-            comp.VerifyDiagnostics(
-                // (6,35): error CS8177: Async methods cannot have by-reference locals
-                //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "y").WithLocation(6, 35)
-                );
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -21056,11 +21048,7 @@ class Program
 }
 ";
             var comp = CreateCompilation(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
-            comp.VerifyDiagnostics(
-                // (6,26): error CS8176: Iterators cannot have by-reference locals
-                //         foreach (ref int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "y").WithLocation(6, 26)
-                );
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -21352,11 +21340,7 @@ class Program
 }
 ";
             var comp = CreateCompilation(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
-            comp.VerifyDiagnostics(
-                // (6,35): error CS8176: Iterators cannot have by-reference locals
-                //         foreach (ref readonly int y in GetBuffer())
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "y").WithLocation(6, 35)
-                );
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -20154,7 +20154,7 @@ class Program
             CompileAndVerify(comp, expectedOutput: " 0 1 2 3", verify: Verification.Fails).VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void Foreach_InAsync_03()
         {
             var src = @"
@@ -20601,7 +20601,7 @@ class Program
             CompileAndVerify(comp, expectedOutput: " 0 1 2 3", verify: Verification.Fails).VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void Foreach_InAsync_07()
         {
             var src = @"
@@ -21042,7 +21042,7 @@ class Program
             CompileAndVerify(comp, expectedOutput: " 0 1 2 3", verify: Verification.Fails).VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void Foreach_InIterator_03()
         {
             var src = @"
@@ -21349,7 +21349,7 @@ class Program
             CompileAndVerify(comp, expectedOutput: " 0 1 2 3", verify: Verification.Fails).VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void Foreach_InIterator_07()
         {
             var src = @"

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -20160,20 +20160,27 @@ class Program
             var src = @"
 class Program
 {
-    static async void Test()
+    static Buffer4<int> s_buffer;
+
+    static async System.Threading.Tasks.Task Main()
     {
+        s_buffer[1] = 3;
+
         foreach (ref int y in GetBuffer())
         {
+            y *= y;
+            System.Console.Write(y);
         }
 
         await System.Threading.Tasks.Task.Yield();
     }
 
-    static ref Buffer4<int> GetBuffer() => throw null;
+    static ref Buffer4<int> GetBuffer() => ref s_buffer;
 }
 ";
-            var comp = CreateCompilation(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
-            comp.VerifyEmitDiagnostics();
+            var verifier = CompileAndVerify(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: "0900");
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -20600,20 +20607,26 @@ class Program
             var src = @"
 class Program
 {
-    static async void Test()
+    static Buffer4<int> s_buffer;
+
+    static async System.Threading.Tasks.Task Main()
     {
+        s_buffer[1] = 3;
+
         foreach (ref readonly int y in GetBuffer())
         {
+            System.Console.Write(y);
         }
 
         await System.Threading.Tasks.Task.Yield();
     }
 
-    static ref readonly Buffer4<int> GetBuffer() => throw null;
+    static ref readonly Buffer4<int> GetBuffer() => ref s_buffer;
 }
 ";
-            var comp = CreateCompilation(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
-            comp.VerifyEmitDiagnostics();
+            var verifier = CompileAndVerify(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: "0300");
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -21035,20 +21048,35 @@ class Program
             var src = @"
 class Program
 {
+    static Buffer4<int> s_buffer;
+
+    static void Main()
+    {
+        s_buffer[2] = 3;
+
+        foreach (int x in Test())
+        {
+            System.Console.Write(x);
+        }
+    }
+
     static System.Collections.Generic.IEnumerable<int> Test()
     {
         foreach (ref int y in GetBuffer())
         {
+            y *= y;
+            System.Console.Write(y);
         }
 
         yield return -1;
     }
 
-    static ref Buffer4<int> GetBuffer() => throw null;
+    static ref Buffer4<int> GetBuffer() => ref s_buffer;
 }
 ";
-            var comp = CreateCompilation(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
-            comp.VerifyEmitDiagnostics();
+            var verifier = CompileAndVerify(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: "0090-1");
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -21327,20 +21355,34 @@ class Program
             var src = @"
 class Program
 {
+    static Buffer4<int> s_buffer;
+
+    static void Main()
+    {
+        s_buffer[2] = 3;
+
+        foreach (int x in Test())
+        {
+            System.Console.Write(x);
+        }
+    }
+
     static System.Collections.Generic.IEnumerable<int> Test()
     {
         foreach (ref readonly int y in GetBuffer())
         {
+            System.Console.Write(y);
         }
 
         yield return -1;
     }
 
-    static ref readonly Buffer4<int> GetBuffer() => throw null;
+    static ref readonly Buffer4<int> GetBuffer() => ref s_buffer;
 }
 ";
-            var comp = CreateCompilation(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
-            comp.VerifyEmitDiagnostics();
+            var verifier = CompileAndVerify(src + Buffer4Definition, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe,
+                expectedOutput: "0030-1");
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/LockTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/LockTests.cs
@@ -2685,6 +2685,7 @@ public class LockTests : CSharpTestBase
             {
                 await Task.Yield();
                 lock (new Lock()) { System.Console.Write("L"); }
+                await Task.Yield();
             }
 
             await local();
@@ -2695,108 +2696,153 @@ public class LockTests : CSharpTestBase
         verifier.VerifyDiagnostics();
         verifier.VerifyIL("Program.<<<Main>$>g__local|0_0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", """
             {
-              // Code size      199 (0xc7)
+              // Code size      311 (0x137)
               .maxstack  3
               .locals init (int V_0,
                             System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
                             System.Runtime.CompilerServices.YieldAwaitable V_2,
                             Program.<<<Main>$>g__local|0_0>d V_3,
                             System.Threading.Lock.Scope V_4,
-                            System.Exception V_5)
+                            System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_5,
+                            System.Exception V_6)
               IL_0000:  ldarg.0
               IL_0001:  ldfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
               IL_0006:  stloc.0
               .try
               {
                 IL_0007:  ldloc.0
-                IL_0008:  brfalse.s  IL_000c
-                IL_000a:  br.s       IL_000e
-                IL_000c:  br.s       IL_004a
-                IL_000e:  nop
-                IL_000f:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
-                IL_0014:  stloc.2
-                IL_0015:  ldloca.s   V_2
-                IL_0017:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
-                IL_001c:  stloc.1
-                IL_001d:  ldloca.s   V_1
-                IL_001f:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
-                IL_0024:  brtrue.s   IL_0066
-                IL_0026:  ldarg.0
-                IL_0027:  ldc.i4.0
-                IL_0028:  dup
-                IL_0029:  stloc.0
-                IL_002a:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
-                IL_002f:  ldarg.0
-                IL_0030:  ldloc.1
-                IL_0031:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
-                IL_0036:  ldarg.0
-                IL_0037:  stloc.3
-                IL_0038:  ldarg.0
-                IL_0039:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
-                IL_003e:  ldloca.s   V_1
-                IL_0040:  ldloca.s   V_3
-                IL_0042:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<<<Main>$>g__local|0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<<<Main>$>g__local|0_0>d)"
-                IL_0047:  nop
-                IL_0048:  leave.s    IL_00c6
-                IL_004a:  ldarg.0
-                IL_004b:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
-                IL_0050:  stloc.1
-                IL_0051:  ldarg.0
-                IL_0052:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
-                IL_0057:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-                IL_005d:  ldarg.0
-                IL_005e:  ldc.i4.m1
-                IL_005f:  dup
-                IL_0060:  stloc.0
-                IL_0061:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
-                IL_0066:  ldloca.s   V_1
-                IL_0068:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
-                IL_006d:  nop
-                IL_006e:  newobj     "System.Threading.Lock..ctor()"
-                IL_0073:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
-                IL_0078:  stloc.s    V_4
+                IL_0008:  brfalse.s  IL_0012
+                IL_000a:  br.s       IL_000c
+                IL_000c:  ldloc.0
+                IL_000d:  ldc.i4.1
+                IL_000e:  beq.s      IL_0014
+                IL_0010:  br.s       IL_0019
+                IL_0012:  br.s       IL_0058
+                IL_0014:  br         IL_00e1
+                IL_0019:  nop
+                IL_001a:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_001f:  stloc.2
+                IL_0020:  ldloca.s   V_2
+                IL_0022:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_0027:  stloc.1
+                IL_0028:  ldloca.s   V_1
+                IL_002a:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_002f:  brtrue.s   IL_0074
+                IL_0031:  ldarg.0
+                IL_0032:  ldc.i4.0
+                IL_0033:  dup
+                IL_0034:  stloc.0
+                IL_0035:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_003a:  ldarg.0
+                IL_003b:  ldloc.1
+                IL_003c:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_0041:  ldarg.0
+                IL_0042:  stloc.3
+                IL_0043:  ldarg.0
+                IL_0044:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
+                IL_0049:  ldloca.s   V_1
+                IL_004b:  ldloca.s   V_3
+                IL_004d:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<<<Main>$>g__local|0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<<<Main>$>g__local|0_0>d)"
+                IL_0052:  nop
+                IL_0053:  leave      IL_0136
+                IL_0058:  ldarg.0
+                IL_0059:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_005e:  stloc.1
+                IL_005f:  ldarg.0
+                IL_0060:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_0065:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_006b:  ldarg.0
+                IL_006c:  ldc.i4.m1
+                IL_006d:  dup
+                IL_006e:  stloc.0
+                IL_006f:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_0074:  ldloca.s   V_1
+                IL_0076:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_007b:  nop
+                IL_007c:  newobj     "System.Threading.Lock..ctor()"
+                IL_0081:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
+                IL_0086:  stloc.s    V_4
                 .try
                 {
-                  IL_007a:  nop
-                  IL_007b:  ldstr      "L"
-                  IL_0080:  call       "void System.Console.Write(string)"
-                  IL_0085:  nop
-                  IL_0086:  nop
-                  IL_0087:  leave.s    IL_0096
+                  IL_0088:  nop
+                  IL_0089:  ldstr      "L"
+                  IL_008e:  call       "void System.Console.Write(string)"
+                  IL_0093:  nop
+                  IL_0094:  nop
+                  IL_0095:  leave.s    IL_00a4
                 }
                 finally
                 {
-                  IL_0089:  ldloc.0
-                  IL_008a:  ldc.i4.0
-                  IL_008b:  bge.s      IL_0095
-                  IL_008d:  ldloca.s   V_4
-                  IL_008f:  call       "void System.Threading.Lock.Scope.Dispose()"
-                  IL_0094:  nop
-                  IL_0095:  endfinally
+                  IL_0097:  ldloc.0
+                  IL_0098:  ldc.i4.0
+                  IL_0099:  bge.s      IL_00a3
+                  IL_009b:  ldloca.s   V_4
+                  IL_009d:  call       "void System.Threading.Lock.Scope.Dispose()"
+                  IL_00a2:  nop
+                  IL_00a3:  endfinally
                 }
-                IL_0096:  leave.s    IL_00b2
+                IL_00a4:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_00a9:  stloc.2
+                IL_00aa:  ldloca.s   V_2
+                IL_00ac:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_00b1:  stloc.s    V_5
+                IL_00b3:  ldloca.s   V_5
+                IL_00b5:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_00ba:  brtrue.s   IL_00fe
+                IL_00bc:  ldarg.0
+                IL_00bd:  ldc.i4.1
+                IL_00be:  dup
+                IL_00bf:  stloc.0
+                IL_00c0:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_00c5:  ldarg.0
+                IL_00c6:  ldloc.s    V_5
+                IL_00c8:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_00cd:  ldarg.0
+                IL_00ce:  stloc.3
+                IL_00cf:  ldarg.0
+                IL_00d0:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
+                IL_00d5:  ldloca.s   V_5
+                IL_00d7:  ldloca.s   V_3
+                IL_00d9:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<<<Main>$>g__local|0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<<<Main>$>g__local|0_0>d)"
+                IL_00de:  nop
+                IL_00df:  leave.s    IL_0136
+                IL_00e1:  ldarg.0
+                IL_00e2:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_00e7:  stloc.s    V_5
+                IL_00e9:  ldarg.0
+                IL_00ea:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_00ef:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_00f5:  ldarg.0
+                IL_00f6:  ldc.i4.m1
+                IL_00f7:  dup
+                IL_00f8:  stloc.0
+                IL_00f9:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_00fe:  ldloca.s   V_5
+                IL_0100:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_0105:  nop
+                IL_0106:  leave.s    IL_0122
               }
               catch System.Exception
               {
-                IL_0098:  stloc.s    V_5
-                IL_009a:  ldarg.0
-                IL_009b:  ldc.i4.s   -2
-                IL_009d:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
-                IL_00a2:  ldarg.0
-                IL_00a3:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
-                IL_00a8:  ldloc.s    V_5
-                IL_00aa:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
-                IL_00af:  nop
-                IL_00b0:  leave.s    IL_00c6
+                IL_0108:  stloc.s    V_6
+                IL_010a:  ldarg.0
+                IL_010b:  ldc.i4.s   -2
+                IL_010d:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_0112:  ldarg.0
+                IL_0113:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
+                IL_0118:  ldloc.s    V_6
+                IL_011a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+                IL_011f:  nop
+                IL_0120:  leave.s    IL_0136
               }
-              IL_00b2:  ldarg.0
-              IL_00b3:  ldc.i4.s   -2
-              IL_00b5:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
-              IL_00ba:  ldarg.0
-              IL_00bb:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
-              IL_00c0:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
-              IL_00c5:  nop
-              IL_00c6:  ret
+              IL_0122:  ldarg.0
+              IL_0123:  ldc.i4.s   -2
+              IL_0125:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+              IL_012a:  ldarg.0
+              IL_012b:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
+              IL_0130:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+              IL_0135:  nop
+              IL_0136:  ret
             }
             """);
 
@@ -2805,7 +2851,7 @@ public class LockTests : CSharpTestBase
         verifier.VerifyDiagnostics();
         verifier.VerifyIL("Program.<<<Main>$>g__local|0_0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", """
             {
-              // Code size      182 (0xb6)
+              // Code size      282 (0x11a)
               .maxstack  3
               .locals init (int V_0,
                             System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
@@ -2818,81 +2864,119 @@ public class LockTests : CSharpTestBase
               .try
               {
                 IL_0007:  ldloc.0
-                IL_0008:  brfalse.s  IL_0041
-                IL_000a:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
-                IL_000f:  stloc.2
-                IL_0010:  ldloca.s   V_2
-                IL_0012:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
-                IL_0017:  stloc.1
-                IL_0018:  ldloca.s   V_1
-                IL_001a:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
-                IL_001f:  brtrue.s   IL_005d
-                IL_0021:  ldarg.0
-                IL_0022:  ldc.i4.0
-                IL_0023:  dup
-                IL_0024:  stloc.0
-                IL_0025:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
-                IL_002a:  ldarg.0
-                IL_002b:  ldloc.1
-                IL_002c:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_0008:  brfalse.s  IL_004b
+                IL_000a:  ldloc.0
+                IL_000b:  ldc.i4.1
+                IL_000c:  beq        IL_00c8
+                IL_0011:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_0016:  stloc.2
+                IL_0017:  ldloca.s   V_2
+                IL_0019:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_001e:  stloc.1
+                IL_001f:  ldloca.s   V_1
+                IL_0021:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_0026:  brtrue.s   IL_0067
+                IL_0028:  ldarg.0
+                IL_0029:  ldc.i4.0
+                IL_002a:  dup
+                IL_002b:  stloc.0
+                IL_002c:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
                 IL_0031:  ldarg.0
-                IL_0032:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
-                IL_0037:  ldloca.s   V_1
-                IL_0039:  ldarg.0
-                IL_003a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<<<Main>$>g__local|0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<<<Main>$>g__local|0_0>d)"
-                IL_003f:  leave.s    IL_00b5
-                IL_0041:  ldarg.0
-                IL_0042:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
-                IL_0047:  stloc.1
-                IL_0048:  ldarg.0
-                IL_0049:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
-                IL_004e:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-                IL_0054:  ldarg.0
-                IL_0055:  ldc.i4.m1
-                IL_0056:  dup
-                IL_0057:  stloc.0
-                IL_0058:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
-                IL_005d:  ldloca.s   V_1
-                IL_005f:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
-                IL_0064:  newobj     "System.Threading.Lock..ctor()"
-                IL_0069:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
-                IL_006e:  stloc.3
+                IL_0032:  ldloc.1
+                IL_0033:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_0038:  ldarg.0
+                IL_0039:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
+                IL_003e:  ldloca.s   V_1
+                IL_0040:  ldarg.0
+                IL_0041:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<<<Main>$>g__local|0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<<<Main>$>g__local|0_0>d)"
+                IL_0046:  leave      IL_0119
+                IL_004b:  ldarg.0
+                IL_004c:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_0051:  stloc.1
+                IL_0052:  ldarg.0
+                IL_0053:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_0058:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_005e:  ldarg.0
+                IL_005f:  ldc.i4.m1
+                IL_0060:  dup
+                IL_0061:  stloc.0
+                IL_0062:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_0067:  ldloca.s   V_1
+                IL_0069:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_006e:  newobj     "System.Threading.Lock..ctor()"
+                IL_0073:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
+                IL_0078:  stloc.3
                 .try
                 {
-                  IL_006f:  ldstr      "L"
-                  IL_0074:  call       "void System.Console.Write(string)"
-                  IL_0079:  leave.s    IL_0087
+                  IL_0079:  ldstr      "L"
+                  IL_007e:  call       "void System.Console.Write(string)"
+                  IL_0083:  leave.s    IL_0091
                 }
                 finally
                 {
-                  IL_007b:  ldloc.0
-                  IL_007c:  ldc.i4.0
-                  IL_007d:  bge.s      IL_0086
-                  IL_007f:  ldloca.s   V_3
-                  IL_0081:  call       "void System.Threading.Lock.Scope.Dispose()"
-                  IL_0086:  endfinally
+                  IL_0085:  ldloc.0
+                  IL_0086:  ldc.i4.0
+                  IL_0087:  bge.s      IL_0090
+                  IL_0089:  ldloca.s   V_3
+                  IL_008b:  call       "void System.Threading.Lock.Scope.Dispose()"
+                  IL_0090:  endfinally
                 }
-                IL_0087:  leave.s    IL_00a2
+                IL_0091:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_0096:  stloc.2
+                IL_0097:  ldloca.s   V_2
+                IL_0099:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_009e:  stloc.1
+                IL_009f:  ldloca.s   V_1
+                IL_00a1:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_00a6:  brtrue.s   IL_00e4
+                IL_00a8:  ldarg.0
+                IL_00a9:  ldc.i4.1
+                IL_00aa:  dup
+                IL_00ab:  stloc.0
+                IL_00ac:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_00b1:  ldarg.0
+                IL_00b2:  ldloc.1
+                IL_00b3:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_00b8:  ldarg.0
+                IL_00b9:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
+                IL_00be:  ldloca.s   V_1
+                IL_00c0:  ldarg.0
+                IL_00c1:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<<<Main>$>g__local|0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<<<Main>$>g__local|0_0>d)"
+                IL_00c6:  leave.s    IL_0119
+                IL_00c8:  ldarg.0
+                IL_00c9:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_00ce:  stloc.1
+                IL_00cf:  ldarg.0
+                IL_00d0:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<<<Main>$>g__local|0_0>d.<>u__1"
+                IL_00d5:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_00db:  ldarg.0
+                IL_00dc:  ldc.i4.m1
+                IL_00dd:  dup
+                IL_00de:  stloc.0
+                IL_00df:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_00e4:  ldloca.s   V_1
+                IL_00e6:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_00eb:  leave.s    IL_0106
               }
               catch System.Exception
               {
-                IL_0089:  stloc.s    V_4
-                IL_008b:  ldarg.0
-                IL_008c:  ldc.i4.s   -2
-                IL_008e:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
-                IL_0093:  ldarg.0
-                IL_0094:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
-                IL_0099:  ldloc.s    V_4
-                IL_009b:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
-                IL_00a0:  leave.s    IL_00b5
+                IL_00ed:  stloc.s    V_4
+                IL_00ef:  ldarg.0
+                IL_00f0:  ldc.i4.s   -2
+                IL_00f2:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+                IL_00f7:  ldarg.0
+                IL_00f8:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
+                IL_00fd:  ldloc.s    V_4
+                IL_00ff:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+                IL_0104:  leave.s    IL_0119
               }
-              IL_00a2:  ldarg.0
-              IL_00a3:  ldc.i4.s   -2
-              IL_00a5:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
-              IL_00aa:  ldarg.0
-              IL_00ab:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
-              IL_00b0:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
-              IL_00b5:  ret
+              IL_0106:  ldarg.0
+              IL_0107:  ldc.i4.s   -2
+              IL_0109:  stfld      "int Program.<<<Main>$>g__local|0_0>d.<>1__state"
+              IL_010e:  ldarg.0
+              IL_010f:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<<Main>$>g__local|0_0>d.<>t__builder"
+              IL_0114:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+              IL_0119:  ret
             }
             """);
     }
@@ -3045,6 +3129,7 @@ public class LockTests : CSharpTestBase
             {
                 await Task.Yield();
                 lock (new Lock()) { System.Console.Write("L"); }
+                await Task.Yield();
             };
 
             await lam();
@@ -3055,108 +3140,153 @@ public class LockTests : CSharpTestBase
         verifier.VerifyDiagnostics();
         verifier.VerifyIL("Program.<>c.<<<Main>$>b__0_0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", """
             {
-              // Code size      199 (0xc7)
+              // Code size      311 (0x137)
               .maxstack  3
               .locals init (int V_0,
                             System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
                             System.Runtime.CompilerServices.YieldAwaitable V_2,
                             Program.<>c.<<<Main>$>b__0_0>d V_3,
                             System.Threading.Lock.Scope V_4,
-                            System.Exception V_5)
+                            System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_5,
+                            System.Exception V_6)
               IL_0000:  ldarg.0
               IL_0001:  ldfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
               IL_0006:  stloc.0
               .try
               {
                 IL_0007:  ldloc.0
-                IL_0008:  brfalse.s  IL_000c
-                IL_000a:  br.s       IL_000e
-                IL_000c:  br.s       IL_004a
-                IL_000e:  nop
-                IL_000f:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
-                IL_0014:  stloc.2
-                IL_0015:  ldloca.s   V_2
-                IL_0017:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
-                IL_001c:  stloc.1
-                IL_001d:  ldloca.s   V_1
-                IL_001f:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
-                IL_0024:  brtrue.s   IL_0066
-                IL_0026:  ldarg.0
-                IL_0027:  ldc.i4.0
-                IL_0028:  dup
-                IL_0029:  stloc.0
-                IL_002a:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
-                IL_002f:  ldarg.0
-                IL_0030:  ldloc.1
-                IL_0031:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
-                IL_0036:  ldarg.0
-                IL_0037:  stloc.3
-                IL_0038:  ldarg.0
-                IL_0039:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
-                IL_003e:  ldloca.s   V_1
-                IL_0040:  ldloca.s   V_3
-                IL_0042:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<>c.<<<Main>$>b__0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<>c.<<<Main>$>b__0_0>d)"
-                IL_0047:  nop
-                IL_0048:  leave.s    IL_00c6
-                IL_004a:  ldarg.0
-                IL_004b:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
-                IL_0050:  stloc.1
-                IL_0051:  ldarg.0
-                IL_0052:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
-                IL_0057:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-                IL_005d:  ldarg.0
-                IL_005e:  ldc.i4.m1
-                IL_005f:  dup
-                IL_0060:  stloc.0
-                IL_0061:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
-                IL_0066:  ldloca.s   V_1
-                IL_0068:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
-                IL_006d:  nop
-                IL_006e:  newobj     "System.Threading.Lock..ctor()"
-                IL_0073:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
-                IL_0078:  stloc.s    V_4
+                IL_0008:  brfalse.s  IL_0012
+                IL_000a:  br.s       IL_000c
+                IL_000c:  ldloc.0
+                IL_000d:  ldc.i4.1
+                IL_000e:  beq.s      IL_0014
+                IL_0010:  br.s       IL_0019
+                IL_0012:  br.s       IL_0058
+                IL_0014:  br         IL_00e1
+                IL_0019:  nop
+                IL_001a:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_001f:  stloc.2
+                IL_0020:  ldloca.s   V_2
+                IL_0022:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_0027:  stloc.1
+                IL_0028:  ldloca.s   V_1
+                IL_002a:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_002f:  brtrue.s   IL_0074
+                IL_0031:  ldarg.0
+                IL_0032:  ldc.i4.0
+                IL_0033:  dup
+                IL_0034:  stloc.0
+                IL_0035:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_003a:  ldarg.0
+                IL_003b:  ldloc.1
+                IL_003c:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_0041:  ldarg.0
+                IL_0042:  stloc.3
+                IL_0043:  ldarg.0
+                IL_0044:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
+                IL_0049:  ldloca.s   V_1
+                IL_004b:  ldloca.s   V_3
+                IL_004d:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<>c.<<<Main>$>b__0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<>c.<<<Main>$>b__0_0>d)"
+                IL_0052:  nop
+                IL_0053:  leave      IL_0136
+                IL_0058:  ldarg.0
+                IL_0059:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_005e:  stloc.1
+                IL_005f:  ldarg.0
+                IL_0060:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_0065:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_006b:  ldarg.0
+                IL_006c:  ldc.i4.m1
+                IL_006d:  dup
+                IL_006e:  stloc.0
+                IL_006f:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_0074:  ldloca.s   V_1
+                IL_0076:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_007b:  nop
+                IL_007c:  newobj     "System.Threading.Lock..ctor()"
+                IL_0081:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
+                IL_0086:  stloc.s    V_4
                 .try
                 {
-                  IL_007a:  nop
-                  IL_007b:  ldstr      "L"
-                  IL_0080:  call       "void System.Console.Write(string)"
-                  IL_0085:  nop
-                  IL_0086:  nop
-                  IL_0087:  leave.s    IL_0096
+                  IL_0088:  nop
+                  IL_0089:  ldstr      "L"
+                  IL_008e:  call       "void System.Console.Write(string)"
+                  IL_0093:  nop
+                  IL_0094:  nop
+                  IL_0095:  leave.s    IL_00a4
                 }
                 finally
                 {
-                  IL_0089:  ldloc.0
-                  IL_008a:  ldc.i4.0
-                  IL_008b:  bge.s      IL_0095
-                  IL_008d:  ldloca.s   V_4
-                  IL_008f:  call       "void System.Threading.Lock.Scope.Dispose()"
-                  IL_0094:  nop
-                  IL_0095:  endfinally
+                  IL_0097:  ldloc.0
+                  IL_0098:  ldc.i4.0
+                  IL_0099:  bge.s      IL_00a3
+                  IL_009b:  ldloca.s   V_4
+                  IL_009d:  call       "void System.Threading.Lock.Scope.Dispose()"
+                  IL_00a2:  nop
+                  IL_00a3:  endfinally
                 }
-                IL_0096:  leave.s    IL_00b2
+                IL_00a4:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_00a9:  stloc.2
+                IL_00aa:  ldloca.s   V_2
+                IL_00ac:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_00b1:  stloc.s    V_5
+                IL_00b3:  ldloca.s   V_5
+                IL_00b5:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_00ba:  brtrue.s   IL_00fe
+                IL_00bc:  ldarg.0
+                IL_00bd:  ldc.i4.1
+                IL_00be:  dup
+                IL_00bf:  stloc.0
+                IL_00c0:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_00c5:  ldarg.0
+                IL_00c6:  ldloc.s    V_5
+                IL_00c8:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_00cd:  ldarg.0
+                IL_00ce:  stloc.3
+                IL_00cf:  ldarg.0
+                IL_00d0:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
+                IL_00d5:  ldloca.s   V_5
+                IL_00d7:  ldloca.s   V_3
+                IL_00d9:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<>c.<<<Main>$>b__0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<>c.<<<Main>$>b__0_0>d)"
+                IL_00de:  nop
+                IL_00df:  leave.s    IL_0136
+                IL_00e1:  ldarg.0
+                IL_00e2:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_00e7:  stloc.s    V_5
+                IL_00e9:  ldarg.0
+                IL_00ea:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_00ef:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_00f5:  ldarg.0
+                IL_00f6:  ldc.i4.m1
+                IL_00f7:  dup
+                IL_00f8:  stloc.0
+                IL_00f9:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_00fe:  ldloca.s   V_5
+                IL_0100:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_0105:  nop
+                IL_0106:  leave.s    IL_0122
               }
               catch System.Exception
               {
-                IL_0098:  stloc.s    V_5
-                IL_009a:  ldarg.0
-                IL_009b:  ldc.i4.s   -2
-                IL_009d:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
-                IL_00a2:  ldarg.0
-                IL_00a3:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
-                IL_00a8:  ldloc.s    V_5
-                IL_00aa:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
-                IL_00af:  nop
-                IL_00b0:  leave.s    IL_00c6
+                IL_0108:  stloc.s    V_6
+                IL_010a:  ldarg.0
+                IL_010b:  ldc.i4.s   -2
+                IL_010d:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_0112:  ldarg.0
+                IL_0113:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
+                IL_0118:  ldloc.s    V_6
+                IL_011a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+                IL_011f:  nop
+                IL_0120:  leave.s    IL_0136
               }
-              IL_00b2:  ldarg.0
-              IL_00b3:  ldc.i4.s   -2
-              IL_00b5:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
-              IL_00ba:  ldarg.0
-              IL_00bb:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
-              IL_00c0:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
-              IL_00c5:  nop
-              IL_00c6:  ret
+              IL_0122:  ldarg.0
+              IL_0123:  ldc.i4.s   -2
+              IL_0125:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+              IL_012a:  ldarg.0
+              IL_012b:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
+              IL_0130:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+              IL_0135:  nop
+              IL_0136:  ret
             }
             """);
 
@@ -3165,7 +3295,7 @@ public class LockTests : CSharpTestBase
         verifier.VerifyDiagnostics();
         verifier.VerifyIL("Program.<>c.<<<Main>$>b__0_0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", """
             {
-              // Code size      182 (0xb6)
+              // Code size      282 (0x11a)
               .maxstack  3
               .locals init (int V_0,
                             System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
@@ -3178,81 +3308,119 @@ public class LockTests : CSharpTestBase
               .try
               {
                 IL_0007:  ldloc.0
-                IL_0008:  brfalse.s  IL_0041
-                IL_000a:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
-                IL_000f:  stloc.2
-                IL_0010:  ldloca.s   V_2
-                IL_0012:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
-                IL_0017:  stloc.1
-                IL_0018:  ldloca.s   V_1
-                IL_001a:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
-                IL_001f:  brtrue.s   IL_005d
-                IL_0021:  ldarg.0
-                IL_0022:  ldc.i4.0
-                IL_0023:  dup
-                IL_0024:  stloc.0
-                IL_0025:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
-                IL_002a:  ldarg.0
-                IL_002b:  ldloc.1
-                IL_002c:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_0008:  brfalse.s  IL_004b
+                IL_000a:  ldloc.0
+                IL_000b:  ldc.i4.1
+                IL_000c:  beq        IL_00c8
+                IL_0011:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_0016:  stloc.2
+                IL_0017:  ldloca.s   V_2
+                IL_0019:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_001e:  stloc.1
+                IL_001f:  ldloca.s   V_1
+                IL_0021:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_0026:  brtrue.s   IL_0067
+                IL_0028:  ldarg.0
+                IL_0029:  ldc.i4.0
+                IL_002a:  dup
+                IL_002b:  stloc.0
+                IL_002c:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
                 IL_0031:  ldarg.0
-                IL_0032:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
-                IL_0037:  ldloca.s   V_1
-                IL_0039:  ldarg.0
-                IL_003a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<>c.<<<Main>$>b__0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<>c.<<<Main>$>b__0_0>d)"
-                IL_003f:  leave.s    IL_00b5
-                IL_0041:  ldarg.0
-                IL_0042:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
-                IL_0047:  stloc.1
-                IL_0048:  ldarg.0
-                IL_0049:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
-                IL_004e:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-                IL_0054:  ldarg.0
-                IL_0055:  ldc.i4.m1
-                IL_0056:  dup
-                IL_0057:  stloc.0
-                IL_0058:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
-                IL_005d:  ldloca.s   V_1
-                IL_005f:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
-                IL_0064:  newobj     "System.Threading.Lock..ctor()"
-                IL_0069:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
-                IL_006e:  stloc.3
+                IL_0032:  ldloc.1
+                IL_0033:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_0038:  ldarg.0
+                IL_0039:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
+                IL_003e:  ldloca.s   V_1
+                IL_0040:  ldarg.0
+                IL_0041:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<>c.<<<Main>$>b__0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<>c.<<<Main>$>b__0_0>d)"
+                IL_0046:  leave      IL_0119
+                IL_004b:  ldarg.0
+                IL_004c:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_0051:  stloc.1
+                IL_0052:  ldarg.0
+                IL_0053:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_0058:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_005e:  ldarg.0
+                IL_005f:  ldc.i4.m1
+                IL_0060:  dup
+                IL_0061:  stloc.0
+                IL_0062:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_0067:  ldloca.s   V_1
+                IL_0069:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_006e:  newobj     "System.Threading.Lock..ctor()"
+                IL_0073:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
+                IL_0078:  stloc.3
                 .try
                 {
-                  IL_006f:  ldstr      "L"
-                  IL_0074:  call       "void System.Console.Write(string)"
-                  IL_0079:  leave.s    IL_0087
+                  IL_0079:  ldstr      "L"
+                  IL_007e:  call       "void System.Console.Write(string)"
+                  IL_0083:  leave.s    IL_0091
                 }
                 finally
                 {
-                  IL_007b:  ldloc.0
-                  IL_007c:  ldc.i4.0
-                  IL_007d:  bge.s      IL_0086
-                  IL_007f:  ldloca.s   V_3
-                  IL_0081:  call       "void System.Threading.Lock.Scope.Dispose()"
-                  IL_0086:  endfinally
+                  IL_0085:  ldloc.0
+                  IL_0086:  ldc.i4.0
+                  IL_0087:  bge.s      IL_0090
+                  IL_0089:  ldloca.s   V_3
+                  IL_008b:  call       "void System.Threading.Lock.Scope.Dispose()"
+                  IL_0090:  endfinally
                 }
-                IL_0087:  leave.s    IL_00a2
+                IL_0091:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_0096:  stloc.2
+                IL_0097:  ldloca.s   V_2
+                IL_0099:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_009e:  stloc.1
+                IL_009f:  ldloca.s   V_1
+                IL_00a1:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_00a6:  brtrue.s   IL_00e4
+                IL_00a8:  ldarg.0
+                IL_00a9:  ldc.i4.1
+                IL_00aa:  dup
+                IL_00ab:  stloc.0
+                IL_00ac:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_00b1:  ldarg.0
+                IL_00b2:  ldloc.1
+                IL_00b3:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_00b8:  ldarg.0
+                IL_00b9:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
+                IL_00be:  ldloca.s   V_1
+                IL_00c0:  ldarg.0
+                IL_00c1:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<>c.<<<Main>$>b__0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<>c.<<<Main>$>b__0_0>d)"
+                IL_00c6:  leave.s    IL_0119
+                IL_00c8:  ldarg.0
+                IL_00c9:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_00ce:  stloc.1
+                IL_00cf:  ldarg.0
+                IL_00d0:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<>c.<<<Main>$>b__0_0>d.<>u__1"
+                IL_00d5:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_00db:  ldarg.0
+                IL_00dc:  ldc.i4.m1
+                IL_00dd:  dup
+                IL_00de:  stloc.0
+                IL_00df:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_00e4:  ldloca.s   V_1
+                IL_00e6:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_00eb:  leave.s    IL_0106
               }
               catch System.Exception
               {
-                IL_0089:  stloc.s    V_4
-                IL_008b:  ldarg.0
-                IL_008c:  ldc.i4.s   -2
-                IL_008e:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
-                IL_0093:  ldarg.0
-                IL_0094:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
-                IL_0099:  ldloc.s    V_4
-                IL_009b:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
-                IL_00a0:  leave.s    IL_00b5
+                IL_00ed:  stloc.s    V_4
+                IL_00ef:  ldarg.0
+                IL_00f0:  ldc.i4.s   -2
+                IL_00f2:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+                IL_00f7:  ldarg.0
+                IL_00f8:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
+                IL_00fd:  ldloc.s    V_4
+                IL_00ff:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+                IL_0104:  leave.s    IL_0119
               }
-              IL_00a2:  ldarg.0
-              IL_00a3:  ldc.i4.s   -2
-              IL_00a5:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
-              IL_00aa:  ldarg.0
-              IL_00ab:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
-              IL_00b0:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
-              IL_00b5:  ret
+              IL_0106:  ldarg.0
+              IL_0107:  ldc.i4.s   -2
+              IL_0109:  stfld      "int Program.<>c.<<<Main>$>b__0_0>d.<>1__state"
+              IL_010e:  ldarg.0
+              IL_010f:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<>c.<<<Main>$>b__0_0>d.<>t__builder"
+              IL_0114:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+              IL_0119:  ret
             }
             """);
     }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/LockTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/LockTests.cs
@@ -3446,9 +3446,9 @@ public class LockTests : CSharpTestBase
             }
             """;
         CreateCompilation([source, LockTypeDefinition]).VerifyEmitDiagnostics(
-            // (9,15): error CS4013: Instance of type 'Lock.Scope' cannot be used inside a nested function, query expression, iterator block or async method
+            // (9,15): error CS4007: Instance of type 'System.Threading.Lock.Scope' cannot be preserved across 'await' or 'yield' boundary.
             //         lock (new Lock())
-            Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "new Lock()").WithArguments("", "System.Threading.Lock.Scope").WithLocation(9, 15));
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "new Lock()").WithArguments("System.Threading.Lock.Scope").WithLocation(9, 15));
     }
 
     [Fact]
@@ -3555,9 +3555,9 @@ public class LockTests : CSharpTestBase
             }
             """;
         CreateCompilationWithTasksExtensions([source, LockTypeDefinition, AsyncStreamsTypes]).VerifyEmitDiagnostics(
-            // (10,15): error CS4013: Instance of type 'Lock.Scope' cannot be used inside a nested function, query expression, iterator block or async method
+            // (10,15): error CS4007: Instance of type 'System.Threading.Lock.Scope' cannot be preserved across 'await' or 'yield' boundary.
             //         lock (new Lock())
-            Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "new Lock()").WithArguments("", "System.Threading.Lock.Scope").WithLocation(10, 15));
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "new Lock()").WithArguments("System.Threading.Lock.Scope").WithLocation(10, 15));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/LockTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/LockTests.cs
@@ -2018,6 +2018,7 @@ public class LockTests : CSharpTestBase
                 {
                     await Task.Yield();
                     lock (new Lock()) { System.Console.Write("L"); }
+                    await Task.Yield();
                 }
             }
             """;
@@ -2027,108 +2028,153 @@ public class LockTests : CSharpTestBase
         verifier.VerifyDiagnostics();
         verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", """
             {
-              // Code size      199 (0xc7)
+              // Code size      311 (0x137)
               .maxstack  3
               .locals init (int V_0,
                             System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
                             System.Runtime.CompilerServices.YieldAwaitable V_2,
                             C.<Main>d__0 V_3,
                             System.Threading.Lock.Scope V_4,
-                            System.Exception V_5)
+                            System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_5,
+                            System.Exception V_6)
               IL_0000:  ldarg.0
               IL_0001:  ldfld      "int C.<Main>d__0.<>1__state"
               IL_0006:  stloc.0
               .try
               {
                 IL_0007:  ldloc.0
-                IL_0008:  brfalse.s  IL_000c
-                IL_000a:  br.s       IL_000e
-                IL_000c:  br.s       IL_004a
-                IL_000e:  nop
-                IL_000f:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
-                IL_0014:  stloc.2
-                IL_0015:  ldloca.s   V_2
-                IL_0017:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
-                IL_001c:  stloc.1
-                IL_001d:  ldloca.s   V_1
-                IL_001f:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
-                IL_0024:  brtrue.s   IL_0066
-                IL_0026:  ldarg.0
-                IL_0027:  ldc.i4.0
-                IL_0028:  dup
-                IL_0029:  stloc.0
-                IL_002a:  stfld      "int C.<Main>d__0.<>1__state"
-                IL_002f:  ldarg.0
-                IL_0030:  ldloc.1
-                IL_0031:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
-                IL_0036:  ldarg.0
-                IL_0037:  stloc.3
-                IL_0038:  ldarg.0
-                IL_0039:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
-                IL_003e:  ldloca.s   V_1
-                IL_0040:  ldloca.s   V_3
-                IL_0042:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Main>d__0)"
-                IL_0047:  nop
-                IL_0048:  leave.s    IL_00c6
-                IL_004a:  ldarg.0
-                IL_004b:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
-                IL_0050:  stloc.1
-                IL_0051:  ldarg.0
-                IL_0052:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
-                IL_0057:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-                IL_005d:  ldarg.0
-                IL_005e:  ldc.i4.m1
-                IL_005f:  dup
-                IL_0060:  stloc.0
-                IL_0061:  stfld      "int C.<Main>d__0.<>1__state"
-                IL_0066:  ldloca.s   V_1
-                IL_0068:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
-                IL_006d:  nop
-                IL_006e:  newobj     "System.Threading.Lock..ctor()"
-                IL_0073:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
-                IL_0078:  stloc.s    V_4
+                IL_0008:  brfalse.s  IL_0012
+                IL_000a:  br.s       IL_000c
+                IL_000c:  ldloc.0
+                IL_000d:  ldc.i4.1
+                IL_000e:  beq.s      IL_0014
+                IL_0010:  br.s       IL_0019
+                IL_0012:  br.s       IL_0058
+                IL_0014:  br         IL_00e1
+                IL_0019:  nop
+                IL_001a:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_001f:  stloc.2
+                IL_0020:  ldloca.s   V_2
+                IL_0022:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_0027:  stloc.1
+                IL_0028:  ldloca.s   V_1
+                IL_002a:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_002f:  brtrue.s   IL_0074
+                IL_0031:  ldarg.0
+                IL_0032:  ldc.i4.0
+                IL_0033:  dup
+                IL_0034:  stloc.0
+                IL_0035:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_003a:  ldarg.0
+                IL_003b:  ldloc.1
+                IL_003c:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_0041:  ldarg.0
+                IL_0042:  stloc.3
+                IL_0043:  ldarg.0
+                IL_0044:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
+                IL_0049:  ldloca.s   V_1
+                IL_004b:  ldloca.s   V_3
+                IL_004d:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Main>d__0)"
+                IL_0052:  nop
+                IL_0053:  leave      IL_0136
+                IL_0058:  ldarg.0
+                IL_0059:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_005e:  stloc.1
+                IL_005f:  ldarg.0
+                IL_0060:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_0065:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_006b:  ldarg.0
+                IL_006c:  ldc.i4.m1
+                IL_006d:  dup
+                IL_006e:  stloc.0
+                IL_006f:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_0074:  ldloca.s   V_1
+                IL_0076:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_007b:  nop
+                IL_007c:  newobj     "System.Threading.Lock..ctor()"
+                IL_0081:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
+                IL_0086:  stloc.s    V_4
                 .try
                 {
-                  IL_007a:  nop
-                  IL_007b:  ldstr      "L"
-                  IL_0080:  call       "void System.Console.Write(string)"
-                  IL_0085:  nop
-                  IL_0086:  nop
-                  IL_0087:  leave.s    IL_0096
+                  IL_0088:  nop
+                  IL_0089:  ldstr      "L"
+                  IL_008e:  call       "void System.Console.Write(string)"
+                  IL_0093:  nop
+                  IL_0094:  nop
+                  IL_0095:  leave.s    IL_00a4
                 }
                 finally
                 {
-                  IL_0089:  ldloc.0
-                  IL_008a:  ldc.i4.0
-                  IL_008b:  bge.s      IL_0095
-                  IL_008d:  ldloca.s   V_4
-                  IL_008f:  call       "void System.Threading.Lock.Scope.Dispose()"
-                  IL_0094:  nop
-                  IL_0095:  endfinally
+                  IL_0097:  ldloc.0
+                  IL_0098:  ldc.i4.0
+                  IL_0099:  bge.s      IL_00a3
+                  IL_009b:  ldloca.s   V_4
+                  IL_009d:  call       "void System.Threading.Lock.Scope.Dispose()"
+                  IL_00a2:  nop
+                  IL_00a3:  endfinally
                 }
-                IL_0096:  leave.s    IL_00b2
+                IL_00a4:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_00a9:  stloc.2
+                IL_00aa:  ldloca.s   V_2
+                IL_00ac:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_00b1:  stloc.s    V_5
+                IL_00b3:  ldloca.s   V_5
+                IL_00b5:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_00ba:  brtrue.s   IL_00fe
+                IL_00bc:  ldarg.0
+                IL_00bd:  ldc.i4.1
+                IL_00be:  dup
+                IL_00bf:  stloc.0
+                IL_00c0:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_00c5:  ldarg.0
+                IL_00c6:  ldloc.s    V_5
+                IL_00c8:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_00cd:  ldarg.0
+                IL_00ce:  stloc.3
+                IL_00cf:  ldarg.0
+                IL_00d0:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
+                IL_00d5:  ldloca.s   V_5
+                IL_00d7:  ldloca.s   V_3
+                IL_00d9:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Main>d__0)"
+                IL_00de:  nop
+                IL_00df:  leave.s    IL_0136
+                IL_00e1:  ldarg.0
+                IL_00e2:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_00e7:  stloc.s    V_5
+                IL_00e9:  ldarg.0
+                IL_00ea:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_00ef:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_00f5:  ldarg.0
+                IL_00f6:  ldc.i4.m1
+                IL_00f7:  dup
+                IL_00f8:  stloc.0
+                IL_00f9:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_00fe:  ldloca.s   V_5
+                IL_0100:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_0105:  nop
+                IL_0106:  leave.s    IL_0122
               }
               catch System.Exception
               {
-                IL_0098:  stloc.s    V_5
-                IL_009a:  ldarg.0
-                IL_009b:  ldc.i4.s   -2
-                IL_009d:  stfld      "int C.<Main>d__0.<>1__state"
-                IL_00a2:  ldarg.0
-                IL_00a3:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
-                IL_00a8:  ldloc.s    V_5
-                IL_00aa:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
-                IL_00af:  nop
-                IL_00b0:  leave.s    IL_00c6
+                IL_0108:  stloc.s    V_6
+                IL_010a:  ldarg.0
+                IL_010b:  ldc.i4.s   -2
+                IL_010d:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_0112:  ldarg.0
+                IL_0113:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
+                IL_0118:  ldloc.s    V_6
+                IL_011a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+                IL_011f:  nop
+                IL_0120:  leave.s    IL_0136
               }
-              IL_00b2:  ldarg.0
-              IL_00b3:  ldc.i4.s   -2
-              IL_00b5:  stfld      "int C.<Main>d__0.<>1__state"
-              IL_00ba:  ldarg.0
-              IL_00bb:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
-              IL_00c0:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
-              IL_00c5:  nop
-              IL_00c6:  ret
+              IL_0122:  ldarg.0
+              IL_0123:  ldc.i4.s   -2
+              IL_0125:  stfld      "int C.<Main>d__0.<>1__state"
+              IL_012a:  ldarg.0
+              IL_012b:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
+              IL_0130:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+              IL_0135:  nop
+              IL_0136:  ret
             }
             """);
 
@@ -2137,7 +2183,7 @@ public class LockTests : CSharpTestBase
         verifier.VerifyDiagnostics();
         verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", """
             {
-              // Code size      182 (0xb6)
+              // Code size      282 (0x11a)
               .maxstack  3
               .locals init (int V_0,
                             System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
@@ -2150,81 +2196,119 @@ public class LockTests : CSharpTestBase
               .try
               {
                 IL_0007:  ldloc.0
-                IL_0008:  brfalse.s  IL_0041
-                IL_000a:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
-                IL_000f:  stloc.2
-                IL_0010:  ldloca.s   V_2
-                IL_0012:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
-                IL_0017:  stloc.1
-                IL_0018:  ldloca.s   V_1
-                IL_001a:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
-                IL_001f:  brtrue.s   IL_005d
-                IL_0021:  ldarg.0
-                IL_0022:  ldc.i4.0
-                IL_0023:  dup
-                IL_0024:  stloc.0
-                IL_0025:  stfld      "int C.<Main>d__0.<>1__state"
-                IL_002a:  ldarg.0
-                IL_002b:  ldloc.1
-                IL_002c:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_0008:  brfalse.s  IL_004b
+                IL_000a:  ldloc.0
+                IL_000b:  ldc.i4.1
+                IL_000c:  beq        IL_00c8
+                IL_0011:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_0016:  stloc.2
+                IL_0017:  ldloca.s   V_2
+                IL_0019:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_001e:  stloc.1
+                IL_001f:  ldloca.s   V_1
+                IL_0021:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_0026:  brtrue.s   IL_0067
+                IL_0028:  ldarg.0
+                IL_0029:  ldc.i4.0
+                IL_002a:  dup
+                IL_002b:  stloc.0
+                IL_002c:  stfld      "int C.<Main>d__0.<>1__state"
                 IL_0031:  ldarg.0
-                IL_0032:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
-                IL_0037:  ldloca.s   V_1
-                IL_0039:  ldarg.0
-                IL_003a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Main>d__0)"
-                IL_003f:  leave.s    IL_00b5
-                IL_0041:  ldarg.0
-                IL_0042:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
-                IL_0047:  stloc.1
-                IL_0048:  ldarg.0
-                IL_0049:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
-                IL_004e:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-                IL_0054:  ldarg.0
-                IL_0055:  ldc.i4.m1
-                IL_0056:  dup
-                IL_0057:  stloc.0
-                IL_0058:  stfld      "int C.<Main>d__0.<>1__state"
-                IL_005d:  ldloca.s   V_1
-                IL_005f:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
-                IL_0064:  newobj     "System.Threading.Lock..ctor()"
-                IL_0069:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
-                IL_006e:  stloc.3
+                IL_0032:  ldloc.1
+                IL_0033:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_0038:  ldarg.0
+                IL_0039:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
+                IL_003e:  ldloca.s   V_1
+                IL_0040:  ldarg.0
+                IL_0041:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Main>d__0)"
+                IL_0046:  leave      IL_0119
+                IL_004b:  ldarg.0
+                IL_004c:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_0051:  stloc.1
+                IL_0052:  ldarg.0
+                IL_0053:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_0058:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_005e:  ldarg.0
+                IL_005f:  ldc.i4.m1
+                IL_0060:  dup
+                IL_0061:  stloc.0
+                IL_0062:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_0067:  ldloca.s   V_1
+                IL_0069:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_006e:  newobj     "System.Threading.Lock..ctor()"
+                IL_0073:  call       "System.Threading.Lock.Scope System.Threading.Lock.EnterScope()"
+                IL_0078:  stloc.3
                 .try
                 {
-                  IL_006f:  ldstr      "L"
-                  IL_0074:  call       "void System.Console.Write(string)"
-                  IL_0079:  leave.s    IL_0087
+                  IL_0079:  ldstr      "L"
+                  IL_007e:  call       "void System.Console.Write(string)"
+                  IL_0083:  leave.s    IL_0091
                 }
                 finally
                 {
-                  IL_007b:  ldloc.0
-                  IL_007c:  ldc.i4.0
-                  IL_007d:  bge.s      IL_0086
-                  IL_007f:  ldloca.s   V_3
-                  IL_0081:  call       "void System.Threading.Lock.Scope.Dispose()"
-                  IL_0086:  endfinally
+                  IL_0085:  ldloc.0
+                  IL_0086:  ldc.i4.0
+                  IL_0087:  bge.s      IL_0090
+                  IL_0089:  ldloca.s   V_3
+                  IL_008b:  call       "void System.Threading.Lock.Scope.Dispose()"
+                  IL_0090:  endfinally
                 }
-                IL_0087:  leave.s    IL_00a2
+                IL_0091:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+                IL_0096:  stloc.2
+                IL_0097:  ldloca.s   V_2
+                IL_0099:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+                IL_009e:  stloc.1
+                IL_009f:  ldloca.s   V_1
+                IL_00a1:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+                IL_00a6:  brtrue.s   IL_00e4
+                IL_00a8:  ldarg.0
+                IL_00a9:  ldc.i4.1
+                IL_00aa:  dup
+                IL_00ab:  stloc.0
+                IL_00ac:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_00b1:  ldarg.0
+                IL_00b2:  ldloc.1
+                IL_00b3:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_00b8:  ldarg.0
+                IL_00b9:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
+                IL_00be:  ldloca.s   V_1
+                IL_00c0:  ldarg.0
+                IL_00c1:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Main>d__0)"
+                IL_00c6:  leave.s    IL_0119
+                IL_00c8:  ldarg.0
+                IL_00c9:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_00ce:  stloc.1
+                IL_00cf:  ldarg.0
+                IL_00d0:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Main>d__0.<>u__1"
+                IL_00d5:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+                IL_00db:  ldarg.0
+                IL_00dc:  ldc.i4.m1
+                IL_00dd:  dup
+                IL_00de:  stloc.0
+                IL_00df:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_00e4:  ldloca.s   V_1
+                IL_00e6:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+                IL_00eb:  leave.s    IL_0106
               }
               catch System.Exception
               {
-                IL_0089:  stloc.s    V_4
-                IL_008b:  ldarg.0
-                IL_008c:  ldc.i4.s   -2
-                IL_008e:  stfld      "int C.<Main>d__0.<>1__state"
-                IL_0093:  ldarg.0
-                IL_0094:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
-                IL_0099:  ldloc.s    V_4
-                IL_009b:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
-                IL_00a0:  leave.s    IL_00b5
+                IL_00ed:  stloc.s    V_4
+                IL_00ef:  ldarg.0
+                IL_00f0:  ldc.i4.s   -2
+                IL_00f2:  stfld      "int C.<Main>d__0.<>1__state"
+                IL_00f7:  ldarg.0
+                IL_00f8:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
+                IL_00fd:  ldloc.s    V_4
+                IL_00ff:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+                IL_0104:  leave.s    IL_0119
               }
-              IL_00a2:  ldarg.0
-              IL_00a3:  ldc.i4.s   -2
-              IL_00a5:  stfld      "int C.<Main>d__0.<>1__state"
-              IL_00aa:  ldarg.0
-              IL_00ab:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
-              IL_00b0:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
-              IL_00b5:  ret
+              IL_0106:  ldarg.0
+              IL_0107:  ldc.i4.s   -2
+              IL_0109:  stfld      "int C.<Main>d__0.<>1__state"
+              IL_010e:  ldarg.0
+              IL_010f:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder"
+              IL_0114:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+              IL_0119:  ret
             }
             """);
     }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/OutVarTests.cs
@@ -19581,9 +19581,9 @@ public class Cls
                 // (11,25): error CS1601: Cannot make reference to variable of type 'ArgIterator'
                 //     static object Test1(out System.ArgIterator x)
                 Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "out System.ArgIterator x").WithArguments("System.ArgIterator").WithLocation(11, 25),
-                // (8,25): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,25): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         Test2(Test1(out var x1), x1);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 25),
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 25),
                 // (6,16): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     async void Test()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "Test").WithLocation(6, 16)
@@ -19630,12 +19630,12 @@ public class Cls
                 // (12,25): error CS1601: Cannot make reference to variable of type 'ArgIterator'
                 //     static object Test1(out System.ArgIterator x)
                 Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "out System.ArgIterator x").WithArguments("System.ArgIterator").WithLocation(12, 25),
-                // (8,25): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,25): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         Test2(Test1(out System.ArgIterator x1), x1);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.ArgIterator").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 25),
-                // (9,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.ArgIterator").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 25),
+                // (9,9): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         var x = default(System.ArgIterator);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(9, 9),
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(9, 9),
                 // (9,13): warning CS0219: The variable 'x' is assigned but its value is never used
                 //         var x = default(System.ArgIterator);
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(9, 13),

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/OutVarTests.cs
@@ -19581,9 +19581,9 @@ public class Cls
                 // (11,25): error CS1601: Cannot make reference to variable of type 'ArgIterator'
                 //     static object Test1(out System.ArgIterator x)
                 Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "out System.ArgIterator x").WithArguments("System.ArgIterator").WithLocation(11, 25),
-                // (8,25): error CS4012: Parameters or locals of type 'ArgIterator' cannot be declared in async methods or async lambda expressions.
+                // (8,25): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         Test2(Test1(out var x1), x1);
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "var").WithArguments("System.ArgIterator").WithLocation(8, 25),
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 25),
                 // (6,16): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     async void Test()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "Test").WithLocation(6, 16)
@@ -19630,12 +19630,9 @@ public class Cls
                 // (12,25): error CS1601: Cannot make reference to variable of type 'ArgIterator'
                 //     static object Test1(out System.ArgIterator x)
                 Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "out System.ArgIterator x").WithArguments("System.ArgIterator").WithLocation(12, 25),
-                // (8,25): error CS4012: Parameters or locals of type 'ArgIterator' cannot be declared in async methods or async lambda expressions.
+                // (8,25): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         Test2(Test1(out System.ArgIterator x1), x1);
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "System.ArgIterator").WithArguments("System.ArgIterator").WithLocation(8, 25),
-                // (9,9): error CS4012: Parameters or locals of type 'ArgIterator' cannot be declared in async methods or async lambda expressions.
-                //         var x = default(System.ArgIterator);
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "var").WithArguments("System.ArgIterator").WithLocation(9, 9),
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.ArgIterator").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 25),
                 // (9,13): warning CS0219: The variable 'x' is assigned but its value is never used
                 //         var x = default(System.ArgIterator);
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(9, 13),

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/OutVarTests.cs
@@ -19633,6 +19633,9 @@ public class Cls
                 // (8,25): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         Test2(Test1(out System.ArgIterator x1), x1);
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.ArgIterator").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(8, 25),
+                // (9,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         var x = default(System.ArgIterator);
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(9, 9),
                 // (9,13): warning CS0219: The variable 'x' is assigned but its value is never used
                 //         var x = default(System.ArgIterator);
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(9, 13),

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PrimaryConstructorTests.cs
@@ -20414,10 +20414,10 @@ class C1(string p1)
                 Diagnostic(ErrorCode.ERR_UnsupportedPrimaryConstructorParameterCapturingRefAny, "a").WithArguments("System.ArgIterator").WithLocation(7, 13),
                 // (16,37): error CS4013: Instance of type 'ArgIterator' cannot be used inside a nested function, query expression, iterator block or async method
                 //         System.Action d = () => _ = b;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "b").WithArguments("", "System.ArgIterator").WithLocation(16, 37),
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "b").WithArguments("System.ArgIterator").WithLocation(16, 37),
                 // (23,33): error CS4013: Instance of type 'ArgIterator' cannot be used inside a nested function, query expression, iterator block or async method
                 //     System.Action d = () => _ = c;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "c").WithArguments("", "System.ArgIterator").WithLocation(23, 33)
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "c").WithArguments("System.ArgIterator").WithLocation(23, 33)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PrimaryConstructorTests.cs
@@ -20414,10 +20414,10 @@ class C1(string p1)
                 Diagnostic(ErrorCode.ERR_UnsupportedPrimaryConstructorParameterCapturingRefAny, "a").WithArguments("System.ArgIterator").WithLocation(7, 13),
                 // (16,37): error CS4013: Instance of type 'ArgIterator' cannot be used inside a nested function, query expression, iterator block or async method
                 //         System.Action d = () => _ = b;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "b").WithArguments("System.ArgIterator").WithLocation(16, 37),
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "b").WithArguments("", "System.ArgIterator").WithLocation(16, 37),
                 // (23,33): error CS4013: Instance of type 'ArgIterator' cannot be used inside a nested function, query expression, iterator block or async method
                 //     System.Action d = () => _ = c;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "c").WithArguments("System.ArgIterator").WithLocation(23, 33)
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "c").WithArguments("", "System.ArgIterator").WithLocation(23, 33)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
@@ -241,7 +241,7 @@ class C
 }";
             var comp = CreateCompilationWithMscorlib45(text, options: TestOptions.ReleaseDll);
             comp.VerifyEmitDiagnostics(
-                // (8,27): error CS4007: 'await' cannot be used in an expression containing the type 'System.TypedReference'
+                // (8,27): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
                 //         Console.WriteLine(new TypedReference().Equals(await Task.FromResult(0)));
                 Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await Task.FromResult(0)").WithArguments("System.TypedReference").WithLocation(8, 55));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
@@ -243,7 +243,7 @@ class C
             comp.VerifyEmitDiagnostics(
                 // (8,27): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
                 //         Console.WriteLine(new TypedReference().Equals(await Task.FromResult(0)));
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await Task.FromResult(0)").WithArguments("System.TypedReference").WithLocation(8, 55));
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "new TypedReference()").WithArguments("System.TypedReference").WithLocation(8, 27));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3261,9 +3261,9 @@ class Test
 
     async Task M2(bool truth)
     {
-        var tr = new TypedReference();
+        var tr = new TypedReference(); // 2
         await Task.Factory.StartNew(() => { });
-        var tr2 = tr; // 2
+        var tr2 = tr;
     }
 
     async Task M3()
@@ -3278,9 +3278,9 @@ class Test
                 // (9,13): warning CS0219: The variable 'tr' is assigned but its value is never used
                 //         var tr = new TypedReference(); // 1
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "tr").WithArguments("tr").WithLocation(9, 13),
-                // (17,19): error CS4013: Instance of type 'TypedReference' cannot be used inside a nested function, query expression, iterator block or async method
-                //         var tr2 = tr; // 2
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "tr").WithArguments("", "System.TypedReference").WithLocation(17, 19));
+                // (15,13): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
+                //         var tr = new TypedReference(); // 2
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "tr").WithArguments("System.TypedReference").WithLocation(15, 13));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3261,9 +3261,9 @@ class Test
 
     async Task M2(bool truth)
     {
-        var tr = new TypedReference(); // 2
+        var tr = new TypedReference();
         await Task.Factory.StartNew(() => { });
-        var tr2 = tr;
+        var tr2 = tr; // 2
     }
 
     async Task M3()
@@ -3278,9 +3278,9 @@ class Test
                 // (9,13): warning CS0219: The variable 'tr' is assigned but its value is never used
                 //         var tr = new TypedReference(); // 1
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "tr").WithArguments("tr").WithLocation(9, 13),
-                // (15,13): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
-                //         var tr = new TypedReference(); // 2
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "tr").WithArguments("System.TypedReference").WithLocation(15, 13));
+                // (17,19): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
+                //         var tr2 = tr; // 2
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "tr").WithArguments("System.TypedReference").WithLocation(17, 19));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3218,9 +3218,9 @@ class Test
     }
 }";
             CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
-                // (7,34): error CS4012: Parameters or locals of type 'System.TypedReference' cannot be declared in async methods or async lambda expressions
+                // (7,34): error CS4012: Parameters of type 'System.TypedReference' cannot be declared in async methods or async lambda expressions
                 //     async Task M1(TypedReference tr)
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "tr").WithArguments("System.TypedReference"));
+                Diagnostic(ErrorCode.ERR_BadSpecialByRefParameter, "tr").WithArguments("System.TypedReference"));
         }
 
         [Fact]
@@ -3238,10 +3238,7 @@ class Test
         await Task.Factory.StartNew(() => { });
     }
 }";
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
-                // (9,9): error CS4012: Parameters or locals of type 'System.TypedReference' cannot be declared in async methods or async lambda expressions
-                //         TypedReference tr;
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "TypedReference").WithArguments("System.TypedReference"),
+            CreateCompilationWithMscorlib45(source).VerifyEmitDiagnostics(
                 // (9,24): warning CS0168: The variable 'tr' is declared but never used
                 //         TypedReference tr;
                 Diagnostic(ErrorCode.WRN_UnreferencedVar, "tr").WithArguments("tr"));
@@ -3261,14 +3258,21 @@ class Test
         var tr = new TypedReference();
         await Task.Factory.StartNew(() => { });
     }
+
+    async Task M2(bool truth)
+    {
+        var tr = new TypedReference();
+        await Task.Factory.StartNew(() => { });
+        var tr2 = tr;
+    }
 }";
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
-                // (9,9): error CS4012: Parameters or locals of type 'TypedReference' cannot be declared in async methods or async lambda expressions.
-                //         var tr = new TypedReference();
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "var").WithArguments("System.TypedReference").WithLocation(9, 9),
+            CreateCompilationWithMscorlib45(source).VerifyEmitDiagnostics(
                 // (9,13): warning CS0219: The variable 'tr' is assigned but its value is never used
                 //         var tr = new TypedReference();
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "tr").WithArguments("tr").WithLocation(9, 13));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "tr").WithArguments("tr").WithLocation(9, 13),
+                // (17,19): error CS4013: Instance of type 'TypedReference' cannot be used inside a nested function, query expression, iterator block or async method
+                //         var tr2 = tr;
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "tr").WithArguments("", "System.TypedReference").WithLocation(17, 19));
         }
 
         [Fact]
@@ -3288,9 +3292,6 @@ public class MyClass
                 // (8,31): error CS0209: The type of a local declared in a fixed statement must be a pointer type
                 //         fixed (TypedReference tr) { }
                 Diagnostic(ErrorCode.ERR_BadFixedInitType, "tr"),
-                // (8,16): error CS4012: Parameters or locals of type 'System.TypedReference' cannot be declared in async methods or async lambda expressions.
-                //         fixed (TypedReference tr) { }
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "TypedReference").WithArguments("System.TypedReference"),
                 // (8,31): error CS0210: You must provide an initializer in a fixed or using statement declaration
                 //         fixed (TypedReference tr) { }
                 Diagnostic(ErrorCode.ERR_FixedMustInit, "tr"),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3255,7 +3255,7 @@ class Test
 {
     async Task M1(bool truth)
     {
-        var tr = new TypedReference();
+        var tr = new TypedReference(); // 1
         await Task.Factory.StartNew(() => { });
     }
 
@@ -3263,15 +3263,23 @@ class Test
     {
         var tr = new TypedReference();
         await Task.Factory.StartNew(() => { });
+        var tr2 = tr; // 2
+    }
+
+    async Task M3()
+    {
+        var tr = new TypedReference();
+        await Task.Factory.StartNew(() => { });
+        tr = default;
         var tr2 = tr;
     }
 }";
             CreateCompilationWithMscorlib45(source).VerifyEmitDiagnostics(
                 // (9,13): warning CS0219: The variable 'tr' is assigned but its value is never used
-                //         var tr = new TypedReference();
+                //         var tr = new TypedReference(); // 1
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "tr").WithArguments("tr").WithLocation(9, 13),
                 // (17,19): error CS4013: Instance of type 'TypedReference' cannot be used inside a nested function, query expression, iterator block or async method
-                //         var tr2 = tr;
+                //         var tr2 = tr; // 2
                 Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "tr").WithArguments("", "System.TypedReference").WithLocation(17, 19));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -3531,10 +3531,7 @@ class C
             System.Console.Write(x);
         }
     }
-}").VerifyDiagnostics(
-                // (20,26): error CS8177: Async methods cannot have by-reference locals
-                //         foreach (ref int x in new E())
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "x").WithLocation(20, 26));
+}").VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3565,10 +3562,7 @@ class C
             System.Console.Write(x);
         }
     }
-}").VerifyDiagnostics(
-                // (20,35): error CS8177: Async methods cannot have by-reference locals
-                //         foreach (ref readonly int x in new E())
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "x").WithLocation(20, 35));
+}").VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3597,10 +3591,7 @@ class C
             yield return x;
         }
     }
-}").VerifyDiagnostics(
-                // (18,26): error CS8176: Iterators cannot have by-reference locals
-                //         foreach (ref int x in new E())
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(18, 26));
+}").VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3629,10 +3620,7 @@ class C
             yield return x;
         }
     }
-}").VerifyDiagnostics(
-                // (18,35): error CS8176: Iterators cannot have by-reference locals
-                //         foreach (ref readonly int x in new E())
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(18, 35));
+}").VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -5981,15 +5981,15 @@ class Program
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics(
-                // (10,39): error CS4012: Parameters or locals of type 'TypedReference' cannot be declared in async methods or async lambda expressions.
+                // (10,39): error CS4012: Parameters of type 'TypedReference' cannot be declared in async methods or async lambda expressions.
                 //         D1 d1 = async (TypedReference r) => { await Task.Yield(); };
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "r").WithArguments("System.TypedReference").WithLocation(10, 39),
-                // (11,46): error CS4012: Parameters or locals of type 'RuntimeArgumentHandle' cannot be declared in async methods or async lambda expressions.
+                Diagnostic(ErrorCode.ERR_BadSpecialByRefParameter, "r").WithArguments("System.TypedReference").WithLocation(10, 39),
+                // (11,46): error CS4012: Parameters of type 'RuntimeArgumentHandle' cannot be declared in async methods or async lambda expressions.
                 //         D2 d2 = async (RuntimeArgumentHandle h) => { await Task.Yield(); };
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "h").WithArguments("System.RuntimeArgumentHandle").WithLocation(11, 46),
-                // (12,36): error CS4012: Parameters or locals of type 'ArgIterator' cannot be declared in async methods or async lambda expressions.
+                Diagnostic(ErrorCode.ERR_BadSpecialByRefParameter, "h").WithArguments("System.RuntimeArgumentHandle").WithLocation(11, 46),
+                // (12,36): error CS4012: Parameters of type 'ArgIterator' cannot be declared in async methods or async lambda expressions.
                 //         D3 d3 = async (ArgIterator i) => { await Task.Yield(); };
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "i").WithArguments("System.ArgIterator").WithLocation(12, 36));
+                Diagnostic(ErrorCode.ERR_BadSpecialByRefParameter, "i").WithArguments("System.ArgIterator").WithLocation(12, 36));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3516,9 +3516,9 @@ class Program
                 // (10,31): error CS0190: The __arglist construct is valid only within a variable argument method
                 //             Console.WriteLine(__arglist);
                 Diagnostic(ErrorCode.ERR_ArgsInvalid, "__arglist").WithLocation(10, 31),
-                // (18,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                // (18,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside a nested function, query expression, iterator block or async method
                 //             Console.WriteLine(__arglist);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle").WithLocation(18, 31),
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(18, 31),
                 // (24,20): error CS1669: __arglist is not valid in this context
                 //         void Local(__arglist)
                 Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(24, 20),
@@ -3528,9 +3528,9 @@ class Program
                 // (32,20): error CS1669: __arglist is not valid in this context
                 //         void Local(__arglist)
                 Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(32, 20),
-                // (34,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                // (34,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside a nested function, query expression, iterator block or async method
                 //             Console.WriteLine(__arglist);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle").WithLocation(34, 31)
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(34, 31)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3518,7 +3518,7 @@ class Program
                 Diagnostic(ErrorCode.ERR_ArgsInvalid, "__arglist").WithLocation(10, 31),
                 // (18,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //             Console.WriteLine(__arglist);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(18, 31),
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle").WithLocation(18, 31),
                 // (24,20): error CS1669: __arglist is not valid in this context
                 //         void Local(__arglist)
                 Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(24, 20),
@@ -3530,7 +3530,7 @@ class Program
                 Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(32, 20),
                 // (34,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //             Console.WriteLine(__arglist);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(34, 31)
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle").WithLocation(34, 31)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -5043,9 +5043,9 @@ class C
                 }
                 """;
             CreateCompilation(code).VerifyEmitDiagnostics(
-                // (7,17): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //         ref int y = ref x;
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(7, 17));
+                // (10,9): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         y.ToString(); // 1
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(10, 9));
         }
 
         [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
@@ -5388,7 +5388,7 @@ public static class Test
             compilation.VerifyEmitDiagnostics(
                 // (20,19): error CS4007: Instance of type 'PooledArrayHandle<int>' cannot be preserved across 'await' or 'yield' boundary.
                 //         using var handle = RentArray<int>(200, out var array);
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "handle").WithArguments("PooledArrayHandle<int>").WithLocation(20, 19));
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "handle = RentArray<int>(200, out var array)").WithArguments("PooledArrayHandle<int>").WithLocation(20, 19));
         }
 
         [Theory(Skip = "https://github.com/dotnet/roslyn/issues/40583")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -5043,9 +5043,9 @@ class C
                 }
                 """;
             CreateCompilation(code).VerifyEmitDiagnostics(
-                // (10,9): error CS4013: Instance of type 'ref int' cannot be used inside a nested function, query expression, iterator block or async method
-                //         y.ToString(); // 1
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "y").WithArguments("ref ", "int").WithLocation(10, 9));
+                // (7,17): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //         ref int y = ref x;
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(7, 17));
         }
 
         [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
@@ -5386,9 +5386,9 @@ public static class Test
 }
 """);
             compilation.VerifyEmitDiagnostics(
-                // (20,19): error CS4013: Instance of type 'PooledArrayHandle<int>' cannot be used inside a nested function, query expression, iterator block or async method
+                // (20,19): error CS4007: 'await' cannot be used in an expression containing the type 'PooledArrayHandle<int>'
                 //         using var handle = RentArray<int>(200, out var array);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "handle = RentArray<int>(200, out var array)").WithArguments("", "PooledArrayHandle<int>").WithLocation(20, 19));
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "handle").WithArguments("PooledArrayHandle<int>").WithLocation(20, 19));
         }
 
         [Theory(Skip = "https://github.com/dotnet/roslyn/issues/40583")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -4992,12 +4992,12 @@ class C
                     // (8,26): error CS0306: The type 'S' may not be used as a type argument
                     //     async Task M(Task<S> t)
                     Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("S").WithLocation(8, 26),
-                    // (12,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    // (12,9): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                     //         var a = await t;
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(12, 9),
-                    // (14,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(12, 9),
+                    // (14,9): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                     //         var r = t.Result;
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(14, 9),
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(14, 9),
                     // (15,9): error CS8350: This combination of arguments to 'C.M(S, ref S)' is disallowed because it may expose variables referenced by parameter 't' outside of their declaration scope
                     //         M(await t, ref r);
                     Diagnostic(ErrorCode.ERR_CallArgMixing, "M(await t, ref r)").WithArguments("C.M(S, ref S)", "t").WithLocation(15, 9)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -5386,7 +5386,7 @@ public static class Test
 }
 """);
             compilation.VerifyEmitDiagnostics(
-                // (20,19): error CS4007: 'await' cannot be used in an expression containing the type 'PooledArrayHandle<int>'
+                // (20,19): error CS4007: Instance of type 'PooledArrayHandle<int>' cannot be preserved across 'await' or 'yield' boundary.
                 //         using var handle = RentArray<int>(200, out var array);
                 Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "handle").WithArguments("PooledArrayHandle<int>").WithLocation(20, 19));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -4962,9 +4962,10 @@ public class C
         [Theory]
         [InlineData(LanguageVersion.CSharp10)]
         [InlineData(LanguageVersion.CSharp11)]
+        [InlineData(LanguageVersionFacts.CSharpNext)]
         public void AwaitRefStruct(LanguageVersion languageVersion)
         {
-            CreateCompilation(@"
+            var comp = CreateCompilation(@"
 using System.Threading.Tasks;
 
 ref struct S { }
@@ -4984,14 +4985,35 @@ class C
     void M(S t, ref S t1)
     {
     }
-}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics(
-                // (8,26): error CS0306: The type 'S' may not be used as a type argument
-                //     async Task M(Task<S> t)
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("S").WithLocation(8, 26),
-                // (15,9): error CS8350: This combination of arguments to 'C.M(S, ref S)' is disallowed because it may expose variables referenced by parameter 't' outside of their declaration scope
-                //         M(await t, ref r);
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "M(await t, ref r)").WithArguments("C.M(S, ref S)", "t").WithLocation(15, 9)
-                );
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll);
+            if (languageVersion < LanguageVersionFacts.CSharpNext)
+            {
+                comp.VerifyDiagnostics(
+                    // (8,26): error CS0306: The type 'S' may not be used as a type argument
+                    //     async Task M(Task<S> t)
+                    Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("S").WithLocation(8, 26),
+                    // (12,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         var a = await t;
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(12, 9),
+                    // (14,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         var r = t.Result;
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(14, 9),
+                    // (15,9): error CS8350: This combination of arguments to 'C.M(S, ref S)' is disallowed because it may expose variables referenced by parameter 't' outside of their declaration scope
+                    //         M(await t, ref r);
+                    Diagnostic(ErrorCode.ERR_CallArgMixing, "M(await t, ref r)").WithArguments("C.M(S, ref S)", "t").WithLocation(15, 9)
+                    );
+            }
+            else
+            {
+                comp.VerifyDiagnostics(
+                    // (8,26): error CS0306: The type 'S' may not be used as a type argument
+                    //     async Task M(Task<S> t)
+                    Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("S").WithLocation(8, 26),
+                    // (15,9): error CS8350: This combination of arguments to 'C.M(S, ref S)' is disallowed because it may expose variables referenced by parameter 't' outside of their declaration scope
+                    //         M(await t, ref r);
+                    Diagnostic(ErrorCode.ERR_CallArgMixing, "M(await t, ref r)").WithArguments("C.M(S, ref S)", "t").WithLocation(15, 9)
+                    );
+            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -1255,9 +1255,9 @@ class C
     }
 }");
             comp.VerifyEmitDiagnostics(
-                // (12,30): error CS4013: Instance of type 'ref readonly int' cannot be used inside a nested function, query expression, iterator block or async method
-                //                 yield return x;
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "x").WithArguments("ref readonly ", "int").WithLocation(12, 30));
+                // (10,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //                 ref readonly int x = ref (new int[1])[0];
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "x").WithLocation(10, 34));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -1255,9 +1255,9 @@ class C
     }
 }");
             comp.VerifyEmitDiagnostics(
-                // (10,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
-                //                 ref readonly int x = ref (new int[1])[0];
-                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "x").WithLocation(10, 34));
+                // (12,30): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+                //                 yield return x;
+                Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "x").WithLocation(12, 30));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -1209,10 +1209,7 @@ class C
         await Task.FromResult(false);
     }
 }");
-            comp.VerifyDiagnostics(
-                // (7,26): error CS8177: Async methods cannot have by-reference locals
-                //         ref readonly int x = ref (new int[1])[0];
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "x").WithLocation(7, 26));
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -1229,10 +1226,7 @@ class C
         yield return i;
     }
 }");
-            comp.VerifyDiagnostics(
-                // (7,26): error CS8176: Iterators cannot have by-reference locals
-                //         ref readonly int x = ref (new int[1])[0];
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(7, 26));
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -1247,7 +1241,7 @@ class C
         switch (this)
         {
             default:
-                ref readonly int x = ref (new int[1])[0]; // 1
+                ref readonly int x = ref (new int[1])[0];
                 yield return 1;
                 yield return x;
 
@@ -1260,10 +1254,10 @@ class C
         }
     }
 }");
-            comp.VerifyDiagnostics(
-                // (10,34): error CS8176: Iterators cannot have by-reference locals
-                //                 ref readonly int x = ref (new int[1])[0]; // 1
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(10, 34));
+            comp.VerifyEmitDiagnostics(
+                // (12,30): error CS4013: Instance of type 'ref readonly int' cannot be used inside a nested function, query expression, iterator block or async method
+                //                 yield return x;
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "x").WithArguments("ref readonly ", "int").WithLocation(12, 30));
         }
 
         [Fact]
@@ -1278,22 +1272,19 @@ class C
         switch (this)
         {
             default:
-                ref readonly int x; // 1, 2
+                ref readonly int x; // 1
                 yield return 1;
-                yield return x; // 3
+                yield return x; // 2
                 break;
         }
     }
 }");
             comp.VerifyDiagnostics(
-                // (10,34): error CS8176: Iterators cannot have by-reference locals
-                //                 ref readonly int x; // 1, 2
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(10, 34),
                 // (10,34): error CS8174: A declaration of a by-reference variable must have an initializer
-                //                 ref readonly int x; // 1, 2
+                //                 ref readonly int x; // 1
                 Diagnostic(ErrorCode.ERR_ByReferenceVariableMustBeInitialized, "x").WithLocation(10, 34),
                 // (12,30): error CS0165: Use of unassigned local variable 'x'
-                //                 yield return x; // 3
+                //                 yield return x; // 2
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(12, 30));
         }
 
@@ -1316,9 +1307,9 @@ class C
     }
 }");
             comp.VerifyDiagnostics(
-                // (10,43): error CS8176: Iterators cannot have by-reference locals
+                // (10,49): error CS1510: A ref or out value must be an assignable variable
                 //                 foreach (ref readonly int x in (new int[1]))
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(10, 43));
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "new int[1]").WithLocation(10, 49));
         }
 
         [Fact]
@@ -1331,18 +1322,15 @@ class C
     IEnumerable<int> M()
     {
         if (true)
-            ref int x = ref (new int[1])[0]; // 1, 2
+            ref int x = ref (new int[1])[0]; // 1
         
         yield return 1;
     }
 }");
             comp.VerifyDiagnostics(
                 // (8,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
-                //             ref int x = ref (new int[1])[0]; // 1, 2
-                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "ref int x = ref (new int[1])[0];").WithLocation(8, 13),
-                // (8,21): error CS8176: Iterators cannot have by-reference locals
-                //             ref int x = ref (new int[1])[0]; // 1, 2
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "x").WithLocation(8, 21));
+                //             ref int x = ref (new int[1])[0]; // 1
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "ref int x = ref (new int[1])[0];").WithLocation(8, 13));
         }
 
         [Fact]
@@ -1355,18 +1343,15 @@ class C
     async Task M()
     {
         if (true)
-            ref int x = ref (new int[1])[0]; // 1, 2
+            ref int x = ref (new int[1])[0]; // 1
         
         await Task.Yield();
     }
 }");
             comp.VerifyDiagnostics(
                 // (8,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
-                //             ref int x = ref (new int[1])[0]; // 1, 2
-                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "ref int x = ref (new int[1])[0];").WithLocation(8, 13),
-                // (8,21): error CS8177: Async methods cannot have by-reference locals
-                //             ref int x = ref (new int[1])[0]; // 1, 2
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "x").WithLocation(8, 21));
+                //             ref int x = ref (new int[1])[0]; // 1
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "ref int x = ref (new int[1])[0];").WithLocation(8, 13));
         }
 
         [Fact]
@@ -3088,13 +3073,7 @@ class TestClass
     }
 }";
 
-            CreateCompilation(code).VerifyDiagnostics(
-                // (13,21): error CS8176: Iterators cannot have by-reference locals
-                //             ref int z = ref x;
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "z").WithLocation(13, 21),
-                // (8,17): error CS8176: Iterators cannot have by-reference locals
-                //         ref int y = ref x;
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "y").WithLocation(8, 17));
+            CreateCompilation(code).VerifyEmitDiagnostics();
         }
 
         [Fact, WorkItem(13073, "https://github.com/dotnet/roslyn/issues/13073")]
@@ -3115,13 +3094,7 @@ class TestClass
         });
     }
 }";
-            CreateCompilationWithMscorlib45(code).VerifyDiagnostics(
-                // (8,17): error CS8177: Async methods cannot have by-reference locals
-                //         ref int y = ref x;
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "y").WithLocation(8, 17),
-                // (11,21): error CS8177: Async methods cannot have by-reference locals
-                //             ref int z = ref x;
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "z").WithLocation(11, 21));
+            CreateCompilationWithMscorlib45(code).VerifyEmitDiagnostics();
         }
 
         [Fact, WorkItem(13073, "https://github.com/dotnet/roslyn/issues/13073")]
@@ -3434,10 +3407,7 @@ class Program
 }
 ";
 
-            CreateCompilationWithMscorlib46(text).VerifyDiagnostics(
-                // (8,17): error CS8177: Async methods cannot have by-reference locals
-                //         ref int i = ref field;
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "i").WithLocation(8, 17),
+            CreateCompilationWithMscorlib46(text).VerifyEmitDiagnostics(
                 // (6,23): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     static async void Goo()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "Goo").WithLocation(6, 23));
@@ -3461,10 +3431,7 @@ class Program
 }
 ";
 
-            CreateCompilationWithMscorlib46(text).VerifyDiagnostics(
-                // (10,17): error CS8931: Iterators cannot have by-reference locals
-                //         ref int i = ref field;
-                Diagnostic(ErrorCode.ERR_BadIteratorLocalType, "i").WithLocation(10, 17));
+            CreateCompilationWithMscorlib46(text).VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7321,9 +7321,9 @@ using System.Collections.Generic;
 public class C
 {
   static void N(RuntimeArgumentHandle x) {}
-  static IEnumerable<int> M(RuntimeArgumentHandle h1) // Error: hoisted to field
+  static IEnumerable<int> M(RuntimeArgumentHandle h1)
   {
-    N(h1);
+    N(h1); // Error: hoisted to field
     yield return 1;
     RuntimeArgumentHandle h2 = default(RuntimeArgumentHandle);
     yield return 2;
@@ -7339,12 +7339,12 @@ public class C
 
             CreateCompilation(source).Emit(new System.IO.MemoryStream()).Diagnostics
                 .Verify(
-                // (7,51): error CS4007: Instance of type 'System.RuntimeArgumentHandle' cannot be preserved across 'await' or 'yield' boundary.
-                //   static IEnumerable<int> M(RuntimeArgumentHandle h1) // Error: hoisted to field
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "h1").WithArguments("System.RuntimeArgumentHandle").WithLocation(7, 51),
-                // (11,27): error CS4007: Instance of type 'System.RuntimeArgumentHandle' cannot be preserved across 'await' or 'yield' boundary.
-                //     RuntimeArgumentHandle h2 = default(RuntimeArgumentHandle);
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "h2").WithArguments("System.RuntimeArgumentHandle").WithLocation(11, 27)
+                // (9,7): error CS4007: Instance of type 'System.RuntimeArgumentHandle' cannot be preserved across 'await' or 'yield' boundary.
+                //     N(h1); // Error: hoisted to field
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "h1").WithArguments("System.RuntimeArgumentHandle").WithLocation(9, 7),
+                // (13,7): error CS4007: Instance of type 'System.RuntimeArgumentHandle' cannot be preserved across 'await' or 'yield' boundary.
+                //     N(h2); // Error: hoisted to field
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "h2").WithArguments("System.RuntimeArgumentHandle").WithLocation(13, 7)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7269,15 +7269,15 @@ public class C
 }";
             var comp = CreateCompilationWithMscorlib40AndSystemCore(source);
             comp.VerifyDiagnostics(
-                // (10,14): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                // (10,14): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside a nested function, query expression, iterator block or async method
                 //     f = x=>f(__arglist);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle"),
-                // (11,29): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(10, 14),
+                // (11,29): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside a nested function, query expression, iterator block or async method
                 //     f = delegate { return f(__arglist); };
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle"),
-                // (12,44): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(11, 29),
+                // (12,44): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside a nested function, query expression, iterator block or async method
                 //     var q = from x in new int[10] select f(__arglist);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle")
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(12, 44)
                 );
         }
 
@@ -7304,12 +7304,12 @@ public class C
   }
 }";
             CreateCompilationWithMscorlib45(source).VerifyEmitDiagnostics(
-                // (10,34): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                // (10,34): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside a nested function, query expression, iterator block or async method
                 //       RuntimeArgumentHandle h2 = h; // Bad use of h
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h").WithArguments("", "System.RuntimeArgumentHandle"),
-                // (11,43): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h").WithArguments("System.RuntimeArgumentHandle").WithLocation(10, 34),
+                // (11,43): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside a nested function, query expression, iterator block or async method
                 //       ArgIterator args1 = new ArgIterator(h); // Bad use of h
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h").WithArguments("", "System.RuntimeArgumentHandle"));
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h").WithArguments("System.RuntimeArgumentHandle").WithLocation(11, 43));
         }
 
         [Fact]
@@ -7339,12 +7339,12 @@ public class C
 
             CreateCompilation(source).Emit(new System.IO.MemoryStream()).Diagnostics
                 .Verify(
-                // (7,51): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                // (7,51): error CS4007: Instance of type 'System.RuntimeArgumentHandle' cannot be preserved across 'await' or 'yield' boundary.
                 //   static IEnumerable<int> M(RuntimeArgumentHandle h1) // Error: hoisted to field
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h1").WithArguments("", "System.RuntimeArgumentHandle"),
-                // (13,7): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
-                //     N(h2); // Error: hoisted to field
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h2").WithArguments("", "System.RuntimeArgumentHandle")
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "h1").WithArguments("System.RuntimeArgumentHandle").WithLocation(7, 51),
+                // (11,27): error CS4007: Instance of type 'System.RuntimeArgumentHandle' cannot be preserved across 'await' or 'yield' boundary.
+                //     RuntimeArgumentHandle h2 = default(RuntimeArgumentHandle);
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "h2").WithArguments("System.RuntimeArgumentHandle").WithLocation(11, 27)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7271,13 +7271,13 @@ public class C
             comp.VerifyDiagnostics(
                 // (10,14): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //     f = x=>f(__arglist);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle"),
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle"),
                 // (11,29): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //     f = delegate { return f(__arglist); };
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle"),
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle"),
                 // (12,44): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //     var q = from x in new int[10] select f(__arglist);
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle")
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("", "System.RuntimeArgumentHandle")
                 );
         }
 
@@ -7306,10 +7306,10 @@ public class C
             CreateCompilationWithMscorlib45(source).VerifyEmitDiagnostics(
                 // (10,34): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //       RuntimeArgumentHandle h2 = h; // Bad use of h
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h").WithArguments("System.RuntimeArgumentHandle"),
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h").WithArguments("", "System.RuntimeArgumentHandle"),
                 // (11,43): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //       ArgIterator args1 = new ArgIterator(h); // Bad use of h
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h").WithArguments("System.RuntimeArgumentHandle"));
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h").WithArguments("", "System.RuntimeArgumentHandle"));
         }
 
         [Fact]
@@ -7341,10 +7341,10 @@ public class C
                 .Verify(
                 // (7,51): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //   static IEnumerable<int> M(RuntimeArgumentHandle h1) // Error: hoisted to field
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h1").WithArguments("System.RuntimeArgumentHandle"),
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h1").WithArguments("", "System.RuntimeArgumentHandle"),
                 // (13,7): error CS4013: Instance of type 'System.RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
                 //     N(h2); // Error: hoisted to field
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h2").WithArguments("System.RuntimeArgumentHandle")
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "h2").WithArguments("", "System.RuntimeArgumentHandle")
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -1418,9 +1418,9 @@ public class Program
 
             var expectedDiagnostics = new[]
             {
-                // (17,39): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
+                // (17,19): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
                 //         TakesSpan(default(Span<int>), await I1());
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await I1()").WithArguments("System.Span<int>").WithLocation(17, 39)
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "default(Span<int>)").WithArguments("System.Span<int>").WithLocation(17, 19)
             };
 
             comp.VerifyEmitDiagnostics(expectedDiagnostics);
@@ -1468,9 +1468,9 @@ public class Program
 
             var expectedDiagnostics = new[]
             {
-                // (14,45): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
+                // (14,22): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
                 //         TakesSpan(s: default(Span<int>), i: await I1());
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await I1()").WithArguments("System.Span<int>").WithLocation(14, 45)
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "default(Span<int>)").WithArguments("System.Span<int>").WithLocation(14, 22)
             };
 
             comp.VerifyEmitDiagnostics(expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -1416,19 +1416,18 @@ public class Program
 
             CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text);
 
-            comp.VerifyEmitDiagnostics(
-                // (17,39): error CS4007: 'await' cannot be used in an expression containing the type 'System.Span<int>'
+            var expectedDiagnostics = new[]
+            {
+                // (17,39): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
                 //         TakesSpan(default(Span<int>), await I1());
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await I1()").WithArguments("System.Span<int>")
-            );
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await I1()").WithArguments("System.Span<int>").WithLocation(17, 39)
+            };
+
+            comp.VerifyEmitDiagnostics(expectedDiagnostics);
 
             comp = CreateCompilationWithMscorlibAndSpan(text, TestOptions.DebugExe);
 
-            comp.VerifyEmitDiagnostics(
-                // (17,39): error CS4007: 'await' cannot be used in an expression containing the type 'System.Span<int>'
-                //         TakesSpan(default(Span<int>), await I1());
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await I1()").WithArguments("System.Span<int>")
-            );
+            comp.VerifyEmitDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -1467,19 +1466,18 @@ public class Program
 
             CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text);
 
-            comp.VerifyEmitDiagnostics(
-                // (14,45): error CS4007: 'await' cannot be used in an expression containing the type 'Span<int>'
+            var expectedDiagnostics = new[]
+            {
+                // (14,45): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
                 //         TakesSpan(s: default(Span<int>), i: await I1());
                 Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await I1()").WithArguments("System.Span<int>").WithLocation(14, 45)
-            );
+            };
+
+            comp.VerifyEmitDiagnostics(expectedDiagnostics);
 
             comp = CreateCompilationWithMscorlibAndSpan(text, TestOptions.DebugExe);
 
-            comp.VerifyEmitDiagnostics(
-                // (14,45): error CS4007: 'await' cannot be used in an expression containing the type 'Span<int>'
-                //         TakesSpan(s: default(Span<int>), i: await I1());
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "await I1()").WithArguments("System.Span<int>").WithLocation(14, 45)
-            );
+            comp.VerifyEmitDiagnostics(expectedDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -851,7 +851,7 @@ class Program
 
         a();
 
-        // this is an error
+        // this is valid since C# 13
         foreach (var i in new C1())
         {
         }
@@ -879,8 +879,16 @@ class C1
 }
 ";
 
-            CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text);
+            CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular12);
+            comp.VerifyDiagnostics(
+                // (33,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         foreach (var i in new C1())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "foreach").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(33, 9));
 
+            comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.RegularNext);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilationWithMscorlibAndSpan(text);
             comp.VerifyEmitDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
@@ -764,18 +764,20 @@ class Test
         [Fact]
         public void TestAwait_Span_02()
         {
-            var comp = CreateCompilationWithMscorlibAndSpan(@"
-using System;
-using System.Threading.Tasks;
-class Test
-{
-    async void M()
-    {
-        Span<int> p = stackalloc int[1] { await Task.FromResult(2) };
-    }
-}", TestOptions.UnsafeReleaseDll);
+            var comp = CreateCompilationWithMscorlibAndSpan("""
+                using System;
+                using System.Threading.Tasks;
+                class Test
+                {
+                    static async Task Main()
+                    {
+                        Span<int> p = stackalloc int[1] { await Task.FromResult(2) };
+                        Console.WriteLine(p[0]);
+                    }
+                }
+                """, TestOptions.UnsafeReleaseExe);
 
-            comp.VerifyEmitDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "2", verify: Verification.Fails).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
@@ -757,11 +757,25 @@ class Test
             comp.VerifyDiagnostics(
                 // (8,38): error CS0150: A constant value is expected
                 //         Span<int> p = stackalloc int[await Task.FromResult(1)] { await Task.FromResult(2) };
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "await Task.FromResult(1)").WithLocation(8, 38),
-                // (8,9): error CS4012: Parameters or locals of type 'Span<int>' cannot be declared in async methods or async lambda expressions.
-                //         Span<int> p = stackalloc int[await Task.FromResult(1)] { await Task.FromResult(2) };
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "Span<int>").WithArguments("System.Span<int>").WithLocation(8, 9)
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "await Task.FromResult(1)").WithLocation(8, 38)
                 );
+        }
+
+        [Fact]
+        public void TestAwait_Span_02()
+        {
+            var comp = CreateCompilationWithMscorlibAndSpan(@"
+using System;
+using System.Threading.Tasks;
+class Test
+{
+    async void M()
+    {
+        Span<int> p = stackalloc int[1] { await Task.FromResult(2) };
+    }
+}", TestOptions.UnsafeReleaseDll);
+
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -1115,9 +1115,9 @@ await System.Threading.Tasks.Task.Yield();
 
             var expectedDiagnostics = new[]
             {
-                // (3,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (3,9): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // ref int d = ref c;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "d").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(3, 9)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "d").WithArguments("ref and unsafe in async and iterator methods").WithLocation(3, 9)
             };
 
             var comp = CreateCompilation(text, options: TestOptions.DebugExe, parseOptions: DefaultParseOptions);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -1113,13 +1113,24 @@ System.Console.Write(d);
 await System.Threading.Tasks.Task.Yield();
 ";
 
-            var comp = CreateCompilation(text, options: TestOptions.DebugExe, parseOptions: DefaultParseOptions);
-
-            comp.VerifyDiagnostics(
-                // (3,9): error CS8177: Async methods cannot have by-reference locals
+            var expectedDiagnostics = new[]
+            {
+                // (3,9): error CS8652: The feature 'Ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // ref int d = ref c;
-                Diagnostic(ErrorCode.ERR_BadAsyncLocalType, "d").WithLocation(3, 9)
-                );
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "d").WithArguments("Ref and unsafe in async and iterator methods").WithLocation(3, 9)
+            };
+
+            var comp = CreateCompilation(text, options: TestOptions.DebugExe, parseOptions: DefaultParseOptions);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+
+            comp = CreateCompilation(text, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular12);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+
+            comp = CreateCompilation(text, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularNext);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(text, options: TestOptions.DebugExe);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1159,7 +1159,7 @@ class C2
             compilation.VerifyEmitDiagnostics(
                 // 0.cs(14,25): error CS4007: Instance of type 'S1' cannot be preserved across 'await' or 'yield' boundary.
                 //         await using (S1 c = new S1())
-                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "c").WithArguments("S1").WithLocation(14, 25));
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "c = new S1()").WithArguments("S1").WithLocation(14, 25));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1127,8 +1127,67 @@ class C2
         }
     }
 }";
+            var compilation = CreateCompilationWithTasksExtensions(new[] { source, IAsyncDisposableDefinition }, options: TestOptions.ReleaseExe);
+            CompileAndVerify(compilation, expectedOutput: "Dispose async").VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void UsingPatternAsyncTest_02()
+        {
+            var source = """
+                using System.Threading.Tasks;
+                ref struct S1
+                {
+                    public ValueTask DisposeAsync() 
+                    { 
+                        System.Console.WriteLine("Dispose async");
+                        return new ValueTask(Task.CompletedTask);
+                    }
+                }
+                class C2
+                {
+                    static async Task Main()
+                    {
+                        await using (S1 c = new S1())
+                        {
+                            await Task.Yield();
+                        }
+                    }
+                }
+                """;
             var compilation = CreateCompilationWithTasksExtensions(new[] { source, IAsyncDisposableDefinition });
-            compilation.VerifyEmitDiagnostics();
+            compilation.VerifyEmitDiagnostics(
+                // 0.cs(14,25): error CS4013: Instance of type 'S1' cannot be used inside a nested function, query expression, iterator block or async method
+                //         await using (S1 c = new S1())
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "c = new S1()").WithArguments("", "S1").WithLocation(14, 25));
+        }
+
+        [Fact]
+        public void UsingPatternAsyncTest_03()
+        {
+            var source = """
+                using System.Threading.Tasks;
+                ref struct S1
+                {
+                    public S1(int x) { }
+                    public ValueTask DisposeAsync() 
+                    { 
+                        System.Console.WriteLine("Dispose async");
+                        return new ValueTask(Task.CompletedTask);
+                    }
+                }
+                class C2
+                {
+                    static async Task Main()
+                    {
+                        await using (S1 c = new S1(await Task.FromResult(1)))
+                        {
+                        }
+                    }
+                }
+                """;
+            var compilation = CreateCompilationWithTasksExtensions(new[] { source, IAsyncDisposableDefinition }, options: TestOptions.ReleaseExe);
+            CompileAndVerify(compilation, expectedOutput: "Dispose async").VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1157,9 +1157,9 @@ class C2
                 """;
             var compilation = CreateCompilationWithTasksExtensions(new[] { source, IAsyncDisposableDefinition });
             compilation.VerifyEmitDiagnostics(
-                // 0.cs(14,25): error CS4013: Instance of type 'S1' cannot be used inside a nested function, query expression, iterator block or async method
+                // 0.cs(14,25): error CS4007: Instance of type 'S1' cannot be preserved across 'await' or 'yield' boundary.
                 //         await using (S1 c = new S1())
-                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "c = new S1()").WithArguments("", "S1").WithLocation(14, 25));
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "c").WithArguments("S1").WithLocation(14, 25));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1127,12 +1127,8 @@ class C2
         }
     }
 }";
-            var compilation = CreateCompilationWithTasksExtensions(new[] { source, IAsyncDisposableDefinition }).VerifyDiagnostics(
-                // (16,22): error CS4012: Parameters or locals of type 'S1' cannot be declared in async methods or async lambda expressions.
-                //         await using (S1 c = new S1())
-                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "S1").WithArguments("S1").WithLocation(16, 22)
-                );
-
+            var compilation = CreateCompilationWithTasksExtensions(new[] { source, IAsyncDisposableDefinition });
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2978,6 +2978,7 @@ class Program
                     case ErrorCode.ERR_InterceptableMethodMustBeOrdinary:
                     case ErrorCode.ERR_PossibleAsyncIteratorWithoutYield:
                     case ErrorCode.ERR_PossibleAsyncIteratorWithoutYieldOrAwait:
+                    case ErrorCode.ERR_RefLocalAcrossAwait:
                         Assert.True(isBuildOnly, $"Check failed for ErrorCode.{errorCode}");
                         break;
 

--- a/src/Compilers/Core/Portable/Symbols/RefKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/RefKind.cs
@@ -85,17 +85,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal static string ToLocalPrefix(this RefKind kind)
-        {
-            return kind switch
-            {
-                RefKind.Ref => "ref ",
-                RefKind.RefReadOnly => "ref readonly ",
-                RefKind.None => string.Empty,
-                _ => throw ExceptionUtilities.UnexpectedValue(kind),
-            };
-        }
-
         // Used internally to track `In` arguments that were specified with `In` modifier
         // as opposed to those that were specified with no modifiers and matched `In` parameter.
         // There is at least one kind of analysis that cares about this distinction - hoisting

--- a/src/Compilers/Core/Portable/Symbols/RefKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/RefKind.cs
@@ -85,6 +85,17 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        internal static string ToLocalPrefix(this RefKind kind)
+        {
+            return kind switch
+            {
+                RefKind.Ref => "ref ",
+                RefKind.RefReadOnly => "ref readonly ",
+                RefKind.None => string.Empty,
+                _ => throw ExceptionUtilities.UnexpectedValue(kind),
+            };
+        }
+
         // Used internally to track `In` arguments that were specified with `In` modifier
         // as opposed to those that were specified with no modifiers and matched `In` parameter.
         // There is at least one kind of analysis that cares about this distinction - hoisting

--- a/src/Features/CSharp/Portable/Diagnostics/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
@@ -59,7 +59,8 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServer;
     "CS9178", // ErrorCode.ERR_InterceptorCannotBeGeneric
     "CS9207", // ErrorCode.ERR_InterceptableMethodMustBeOrdinary
     "CS8419", // ErrorCode.ERR_PossibleAsyncIteratorWithoutYield
-    "CS8420" // ErrorCode.ERR_PossibleAsyncIteratorWithoutYieldOrAwait
+    "CS8420", // ErrorCode.ERR_PossibleAsyncIteratorWithoutYieldOrAwait
+    "CS9217" // ErrorCode.ERR_RefLocalAcrossAwait
     )]
 [Shared]
 internal sealed class CSharpLspBuildOnlyDiagnostics : ILspBuildOnlyDiagnostics


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/72662
Speclet: https://github.com/dotnet/csharplang/blob/main/proposals/ref-unsafe-in-iterators-async.md