### PR TITLE
Create API docs feedback template

### DIFF
--- a/.github/ISSUE_TEMPLATE/z-apidocs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/z-apidocs-feedback.yml
@@ -1,0 +1,46 @@
+name: Learn feedback control.
+description: |
+  ⛔ This template is hooked into the feedback control on roslyn API documentation on docs.microsoft.com. It automatically fills in several fields for you. Don't use for other purposes. ⛔
+body:
+  - type: markdown
+    attributes:
+      value: "## Issue information"
+  - type: markdown
+    attributes:
+      value: Select the issue type, and describe the issue in the text box below. Add as much detail as needed to help us resolve the issue.
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of issue
+      options:
+        - Typo
+        - Code doesn't work
+        - Missing information
+        - Outdated article
+        - Other (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    validations:
+      required: true
+    attributes:
+      label: Description
+  - type: markdown
+    attributes:
+      value: "## 🚧 Article information 🚧"
+  - type: markdown
+    attributes:
+      value: "*Don't modify the following fields*. They are automatically filled in for you. Doing so will disconnect your issue from the affected article. *Don't edit them*."
+  - type: input
+    id: pageUrl
+    validations:
+      required: true
+    attributes:
+      label: Page URL
+  - type: input
+    id: contentSourceUrl
+    validations:
+      required: true
+    attributes:
+      label: Content source URL

--- a/.github/ISSUE_TEMPLATE/z-apidocs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/z-apidocs-feedback.yml
@@ -1,6 +1,6 @@
 name: Learn feedback control.
 description: |
-  ⛔ This template is hooked into the feedback control on roslyn API documentation on docs.microsoft.com. It automatically fills in several fields for you. Don't use for other purposes. ⛔
+  ⛔ This template is hooked into the feedback control on Roslyn API documentation on docs.microsoft.com. It automatically fills in several fields for you. Don't use for other purposes. ⛔
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This adds the issue template that will be configured for roslyn-api-docs feedback published on docs.microsoft.com. Many of the fields will be applied from the query string of the referrer URL.