### PR TITLE
Correct active statement span tracking

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
@@ -147,11 +147,24 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
             Func<int, bool> isOdd = x => x % 2 == 1;
 
-            // BUG:753260 Should this be ArgumentNullException for consistency?
             Assert.Throws<NullReferenceException>(() => default(ImmutableArray<int>).Single(isOdd));
             Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>().Single(isOdd));
             Assert.Equal(1, ImmutableArray.Create<int>(1, 2).Single(isOdd));
             Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>(1, 2, 3).Single(isOdd));
+        }
+
+        [Fact]
+        public void Single_Arg()
+        {
+            Assert.Throws<NullReferenceException>(() => default(ImmutableArray<int>).Single((_, _) => true, 1));
+            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>().Single((x, a) => x == a, 1));
+            Assert.Equal(1, ImmutableArray.Create<int>(1).Single((x, a) => x == a, 1));
+            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>(1, 1).Single((x, a) => x == a, 1));
+
+            Assert.Throws<NullReferenceException>(() => default(ImmutableArray<int>).Single((x, a) => x % a == 1, 2));
+            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>().Single((x, a) => x % a == 1, 2));
+            Assert.Equal(1, ImmutableArray.Create<int>(1, 2).Single((x, a) => x % a == 1, 2));
+            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>(1, 2, 3).Single((x, a) => x % a == 1, 2));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -636,6 +636,32 @@ namespace Microsoft.CodeAnalysis
             return default;
         }
 
+        public static TValue? Single<TValue, TArg>(this ImmutableArray<TValue> array, Func<TValue, TArg, bool> predicate, TArg arg)
+        {
+            var hasValue = false;
+            TValue? value = default;
+            foreach (var item in array)
+            {
+                if (predicate(item, arg))
+                {
+                    if (hasValue)
+                    {
+                        throw ExceptionUtilities.Unreachable();
+                    }
+
+                    value = item;
+                    hasValue = true;
+                }
+            }
+
+            if (!hasValue)
+            {
+                throw ExceptionUtilities.Unreachable();
+            }
+
+            return value;
+        }
+
         /// <summary>
         /// Casts the immutable array of a Type to an immutable array of its base type.
         /// </summary>

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTrackingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTrackingServiceTests.cs
@@ -40,15 +40,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 
             spanProvider.GetBaseActiveStatementSpansImpl = (_, documentIds) => ImmutableArray.Create(
                 ImmutableArray.Create(
-                    new ActiveStatementSpan(0, span11, ActiveStatementFlags.NonLeafFrame, unmappedDocumentId: null),
-                    new ActiveStatementSpan(1, span12, ActiveStatementFlags.LeafFrame, unmappedDocumentId: null)),
+                    new ActiveStatementSpan(new ActiveStatementId(0), span11, ActiveStatementFlags.NonLeafFrame),
+                    new ActiveStatementSpan(new ActiveStatementId(1), span12, ActiveStatementFlags.LeafFrame)),
                 ImmutableArray<ActiveStatementSpan>.Empty);
 
             spanProvider.GetAdjustedActiveStatementSpansImpl = (document, _) => document.Name switch
             {
                 "1.cs" => ImmutableArray.Create(
-                    new ActiveStatementSpan(0, span21, ActiveStatementFlags.NonLeafFrame, unmappedDocumentId: null),
-                    new ActiveStatementSpan(1, span22, ActiveStatementFlags.LeafFrame, unmappedDocumentId: null)),
+                    new ActiveStatementSpan(new ActiveStatementId(0), span21, ActiveStatementFlags.NonLeafFrame),
+                    new ActiveStatementSpan(new ActiveStatementId(1), span22, ActiveStatementFlags.LeafFrame)),
                 "2.cs" => ImmutableArray<ActiveStatementSpan>.Empty,
                 _ => throw ExceptionUtilities.Unreachable()
             };

--- a/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingService.cs
@@ -259,7 +259,7 @@ internal sealed class ActiveStatementTrackingService(Workspace workspace, IAsync
                 var newSpan = newSpans[i];
 
                 Contract.ThrowIfFalse(oldSpan.Flags == newSpan.Flags);
-                Contract.ThrowIfFalse(oldSpan.Ordinal == newSpan.Ordinal);
+                Contract.ThrowIfFalse(oldSpan.Id == newSpan.Id);
 
                 var newTextSpan = snapshot.GetTextSpan(newSpan.LineSpan).ToSpan();
                 if (oldSpan.Span.GetSpan(snapshot).Span != newTextSpan)
@@ -272,7 +272,7 @@ internal sealed class ActiveStatementTrackingService(Workspace workspace, IAsync
 
                     lazyBuilder[i] = new ActiveStatementTrackingSpan(
                         snapshot.CreateTrackingSpan(newTextSpan, SpanTrackingMode.EdgeExclusive),
-                        newSpan.Ordinal,
+                        newSpan.Id,
                         newSpan.Flags,
                         newSpan.UnmappedDocumentId);
                 }
@@ -316,7 +316,7 @@ internal sealed class ActiveStatementTrackingService(Workspace workspace, IAsync
                     var snapshot = sourceText.FindCorrespondingEditorTextSnapshot();
                     if (snapshot != null && snapshot.TextBuffer == documentSpans.First().Span.TextBuffer)
                     {
-                        return documentSpans.SelectAsArray(s => new ActiveStatementSpan(s.Ordinal, s.Span.GetSpan(snapshot).ToLinePositionSpan(), s.Flags, s.UnmappedDocumentId));
+                        return documentSpans.SelectAsArray(s => new ActiveStatementSpan(s.Id, s.Span.GetSpan(snapshot).ToLinePositionSpan(), s.Flags, s.UnmappedDocumentId));
                     }
                 }
             }

--- a/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingSpan.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingSpan.cs
@@ -8,10 +8,10 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
-internal readonly struct ActiveStatementTrackingSpan(ITrackingSpan trackingSpan, int ordinal, ActiveStatementFlags flags, DocumentId? unmappedDocumentId)
+internal readonly struct ActiveStatementTrackingSpan(ITrackingSpan trackingSpan, ActiveStatementId id, ActiveStatementFlags flags, DocumentId? unmappedDocumentId)
 {
     public readonly ITrackingSpan Span = trackingSpan;
-    public readonly int Ordinal = ordinal;
+    public readonly ActiveStatementId Id = id;
     public readonly ActiveStatementFlags Flags = flags;
     public readonly DocumentId? UnmappedDocumentId = unmappedDocumentId;
 
@@ -21,5 +21,5 @@ internal readonly struct ActiveStatementTrackingSpan(ITrackingSpan trackingSpan,
     public bool IsLeaf => (Flags & ActiveStatementFlags.LeafFrame) != 0;
 
     public static ActiveStatementTrackingSpan Create(ITextSnapshot snapshot, ActiveStatementSpan span)
-        => new(snapshot.CreateTrackingSpan(snapshot.GetTextSpan(span.LineSpan).ToSpan(), SpanTrackingMode.EdgeExclusive), span.Ordinal, span.Flags, span.UnmappedDocumentId);
+        => new(snapshot.CreateTrackingSpan(snapshot.GetTextSpan(span.LineSpan).ToSpan(), SpanTrackingMode.EdgeExclusive), span.Id, span.Flags, span.UnmappedDocumentId);
 }

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -2087,8 +2087,13 @@ class C { int Y => 2; }
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1371694")]
         public async Task Project_Add()
         {
+            // Project A:
             var sourceA1 = "class A { void M() { System.Console.WriteLine(1); } }";
+
+            // Project B (baseline, but not loaded into solution):
             var sourceB1 = "class B { int F() => 1; }";
+
+            // Additional documents added to B:
             var sourceB2 = "class B { int G() => 1; }";
             var sourceB3 = "class B { int F() => 2; }";
 
@@ -2141,7 +2146,7 @@ class C { int Y => 2; }
             }, baseSpans.Select(spans => spans.IsEmpty ? "<empty>" : string.Join(",", spans.Select(s => s.LineSpan.ToString()))));
 
             var trackedActiveSpans = ImmutableArray.Create(
-                new ActiveStatementSpan(1, activeLineSpanB1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, unmappedDocumentId: null));
+                new ActiveStatementSpan(new ActiveStatementId(0), activeLineSpanB1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame));
 
             var currentSpans = await debuggingSession.GetAdjustedActiveStatementSpansAsync(documentB2, (_, _, _) => new(trackedActiveSpans), CancellationToken.None);
             // TODO: https://github.com/dotnet/roslyn/issues/1204
@@ -3591,8 +3596,8 @@ class C { int Y => 1; }
 
             EnterBreakState(debuggingSession, activeStatements);
 
-            var activeStatementSpan11 = new ActiveStatementSpan(0, activeLineSpan11, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame, unmappedDocumentId: null);
-            var activeStatementSpan12 = new ActiveStatementSpan(1, activeLineSpan12, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, unmappedDocumentId: null);
+            var activeStatementSpan11 = new ActiveStatementSpan(new ActiveStatementId(0), activeLineSpan11, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame);
+            var activeStatementSpan12 = new ActiveStatementSpan(new ActiveStatementId(1), activeLineSpan12, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame);
 
             var baseSpans = await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(document1.Id), CancellationToken.None);
             AssertEx.Equal(new[]
@@ -3611,8 +3616,8 @@ class C { int Y => 1; }
             var document2 = solution.GetDocument(documentId);
 
             // tracking span update triggered by the edit:
-            var activeStatementSpan21 = new ActiveStatementSpan(0, activeLineSpan21, ActiveStatementFlags.NonLeafFrame, unmappedDocumentId: null);
-            var activeStatementSpan22 = new ActiveStatementSpan(1, activeLineSpan22, ActiveStatementFlags.LeafFrame, unmappedDocumentId: null);
+            var activeStatementSpan21 = new ActiveStatementSpan(new ActiveStatementId(0), activeLineSpan21, ActiveStatementFlags.NonLeafFrame);
+            var activeStatementSpan22 = new ActiveStatementSpan(new ActiveStatementId(1), activeLineSpan22, ActiveStatementFlags.LeafFrame);
             var trackedActiveSpans2 = ImmutableArray.Create(activeStatementSpan21, activeStatementSpan22);
 
             currentSpans = await debuggingSession.GetAdjustedActiveStatementSpansAsync(document2, (_, _, _) => new(trackedActiveSpans2), CancellationToken.None);
@@ -3671,8 +3676,8 @@ class C { int Y => 1; }
             var baseSpans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
             AssertEx.Equal(new[]
             {
-                new ActiveStatementSpan(0, activeLineSpan11, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame, unmappedDocumentId: null),
-                new ActiveStatementSpan(1, activeLineSpan12, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, unmappedDocumentId: null)
+                new ActiveStatementSpan(new ActiveStatementId(0), activeLineSpan11, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame),
+                new ActiveStatementSpan(new ActiveStatementId(1), activeLineSpan12, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame)
             }, baseSpans);
 
             // change the source (valid edit):
@@ -3801,7 +3806,7 @@ class C { int Y => 1; }
 
             Assert.Equal(3, baseActiveStatementsMap.InstructionMap.Count);
 
-            var statements = baseActiveStatementsMap.InstructionMap.Values.OrderBy(v => v.Ordinal).ToArray();
+            var statements = baseActiveStatementsMap.InstructionMap.Values.OrderBy(v => v.Id).ToArray();
             var s = statements[0];
             Assert.Equal(0x06000001, s.InstructionId.Method.Token);
             Assert.Equal(module4, s.InstructionId.Method.Module);
@@ -4197,7 +4202,7 @@ class C
             var spans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
             AssertEx.Equal(new[]
             {
-                new ActiveStatementSpan(0, new LinePositionSpan(new(4,41), new(4,42)), ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, unmappedDocumentId: null),
+                new ActiveStatementSpan(new ActiveStatementId(0), new LinePositionSpan(new(4,41), new(4,42)), ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame),
             }, spans);
 
             solution = solution.WithDocumentText(documentId, CreateText(SourceMarkers.Clear(markedSourceV4)));
@@ -4299,8 +4304,8 @@ class C
             var spans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
             AssertEx.Equal(new[]
             {
-                new ActiveStatementSpan(0, expectedSpanG1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, documentId),
-                new ActiveStatementSpan(1, expectedSpanF1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame, documentId)
+                new ActiveStatementSpan(new ActiveStatementId(0), expectedSpanG1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, documentId),
+                new ActiveStatementSpan(new ActiveStatementId(1), expectedSpanF1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame, documentId)
             }, spans);
 
             solution = solution.WithDocumentText(documentId, CreateText(SourceMarkers.Clear(markedSource3)));
@@ -4312,8 +4317,8 @@ class C
             spans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
             AssertEx.Equal(new[]
             {
-                new ActiveStatementSpan(0, expectedSpanG2, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, documentId),
-                new ActiveStatementSpan(1, expectedSpanF2, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame, documentId)
+                new ActiveStatementSpan(new ActiveStatementId(0), expectedSpanG2, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, documentId),
+                new ActiveStatementSpan(new ActiveStatementId(1), expectedSpanF2, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame, documentId)
             }, spans);
 
             // no rude edits:
@@ -4408,7 +4413,7 @@ class C
             var spans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
             AssertEx.Equal(new[]
             {
-                new ActiveStatementSpan(0, expectedSpanG1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, unmappedDocumentId: null)
+                new ActiveStatementSpan(new ActiveStatementId(0), expectedSpanG1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame)
                 // active statement in F has been deleted
             }, spans);
 

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -3806,7 +3806,7 @@ class C { int Y => 1; }
 
             Assert.Equal(3, baseActiveStatementsMap.InstructionMap.Count);
 
-            var statements = baseActiveStatementsMap.InstructionMap.Values.OrderBy(v => v.Id).ToArray();
+            var statements = baseActiveStatementsMap.InstructionMap.Values.OrderBy(v => v.Id.Ordinal).ToArray();
             var s = statements[0];
             Assert.Equal(0x06000001, s.InstructionId.Method.Token);
             Assert.Equal(module4, s.InstructionId.Method.Module);

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -10,14 +10,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
-using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.Testing;
@@ -129,7 +127,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
                 newSpan: new SourceSpan(1, 2, 1, 5));
 
             var activeSpans1 = ImmutableArray.Create(
-                new ActiveStatementSpan(0, new LinePositionSpan(new LinePosition(1, 2), new LinePosition(3, 4)), ActiveStatementFlags.NonLeafFrame, documentId));
+                new ActiveStatementSpan(new ActiveStatementId(0), new LinePositionSpan(new LinePosition(1, 2), new LinePosition(3, 4)), ActiveStatementFlags.NonLeafFrame, documentId));
 
             var activeStatementSpanProvider = new ActiveStatementSpanProvider((documentId, path, cancellationToken) =>
             {
@@ -292,7 +290,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
 
             // GetBaseActiveStatementSpans
 
-            var activeStatementSpan1 = new ActiveStatementSpan(0, span1, ActiveStatementFlags.NonLeafFrame | ActiveStatementFlags.PartiallyExecuted, unmappedDocumentId: documentId);
+            var activeStatementSpan1 = new ActiveStatementSpan(new ActiveStatementId(0), span1, ActiveStatementFlags.NonLeafFrame | ActiveStatementFlags.PartiallyExecuted, UnmappedDocumentId: documentId);
 
             mockEncService.GetBaseActiveStatementSpansImpl = (solution, documentIds) =>
             {

--- a/src/Features/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -119,12 +119,13 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             Project oldProject,
             Document newDocument,
             ActiveStatementsMap activeStatementMap = null,
-            EditAndContinueCapabilities capabilities = EditAndContinueTestHelpers.Net5RuntimeCapabilities)
+            EditAndContinueCapabilities capabilities = EditAndContinueTestHelpers.Net5RuntimeCapabilities,
+            ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans = default)
         {
             var analyzer = new CSharpEditAndContinueAnalyzer();
             var baseActiveStatements = AsyncLazy.Create(activeStatementMap ?? ActiveStatementsMap.Empty);
             var lazyCapabilities = AsyncLazy.Create(capabilities);
-            return await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, [], lazyCapabilities, CancellationToken.None);
+            return await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, newActiveStatementSpans.NullToEmpty(), lazyCapabilities, CancellationToken.None);
         }
 
         #endregion
@@ -319,7 +320,7 @@ class C
                 {
                     KeyValuePairUtil.Create(newDocument.FilePath, ImmutableArray.Create(
                         new ActiveStatement(
-                            ordinal: 0,
+                            new ActiveStatementId(0),
                             ActiveStatementFlags.LeafFrame,
                             new SourceFileSpan(newDocument.FilePath, oldStatementSpan),
                             instructionId: default)))

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -511,7 +511,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
         Project oldProject,
         AsyncLazy<ActiveStatementsMap> lazyOldActiveStatementMap,
         Document newDocument,
-        ImmutableArray<LinePositionSpan> newActiveStatementSpans,
+        ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans,
         AsyncLazy<EditAndContinueCapabilities> lazyCapabilities,
         CancellationToken cancellationToken)
     {
@@ -778,13 +778,12 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
         Match<SyntaxNode> topMatch,
         SourceText newText,
         ImmutableArray<UnmappedActiveStatement> oldActiveStatements,
-        ImmutableArray<LinePositionSpan> newActiveStatementSpans,
+        ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans,
         [In, Out] ImmutableArray<ActiveStatement>.Builder newActiveStatements,
         [In, Out] ImmutableArray<ImmutableArray<SourceFileSpan>>.Builder newExceptionRegions,
         CancellationToken cancellationToken)
     {
         Debug.Assert(!newActiveStatementSpans.IsDefault);
-        Debug.Assert(newActiveStatementSpans.IsEmpty || oldActiveStatements.Length == newActiveStatementSpans.Length);
         Debug.Assert(oldActiveStatements.Length == newActiveStatements.Count);
         Debug.Assert(oldActiveStatements.Length == newExceptionRegions.Count);
 
@@ -824,7 +823,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
 
                         // We seed the method body matching algorithm with tracking spans (unless they were deleted)
                         // to get precise matching.
-                        if (TryGetTrackedStatement(newActiveStatementSpans, i, newText, newBody, out var trackedStatement, out var trackedStatementPart))
+                        if (TryGetTrackedStatement(newActiveStatementSpans, oldActiveStatements[i].Statement.Id, newText, newBody, out var trackedStatement, out var trackedStatementPart))
                         {
                             // Adjust for active statements that cover more than the old member span.
                             // For example, C# variable declarators that represent field initializers:
@@ -833,7 +832,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
 
                             // The tracking span might have been moved outside of lambda.
                             // It is not an error to move the statement - we just ignore it.
-                            var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody.EncompassingAncestor, oldMember.FindToken(adjustedOldStatementStart).Parent!);
+                            var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody.EncompassingAncestor, oldBody.EncompassingAncestor.FindToken(adjustedOldStatementStart).Parent!);
                             var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody.EncompassingAncestor, trackedStatement);
                             if (oldEnclosingLambdaBody == newEnclosingLambdaBody)
                             {
@@ -932,7 +931,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
         bool isMemberReplaced,
         Match<SyntaxNode> topMatch,
         ImmutableArray<UnmappedActiveStatement> oldActiveStatements,
-        ImmutableArray<LinePositionSpan> newActiveStatementSpans,
+        ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans,
         EditAndContinueCapabilitiesGrantor capabilities,
         [Out] ImmutableArray<ActiveStatement>.Builder newActiveStatements,
         [Out] ImmutableArray<ImmutableArray<SourceFileSpan>>.Builder newExceptionRegions,
@@ -948,7 +947,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
 
         var diagnosticContext = CreateDiagnosticContext(diagnostics, oldMember, newMember, newDeclaration, newModel, topMatch);
 
-        var activeStatementIndices = oldMemberBody?.GetOverlappingActiveStatements(oldActiveStatements)?.ToArray() ?? [];
+        var activeStatementIndices = oldMemberBody?.GetOverlappingActiveStatementIndices(oldActiveStatements)?.ToArray() ?? [];
 
         if (isMemberReplaced && !activeStatementIndices.IsEmpty())
         {
@@ -1030,7 +1029,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
 
                     SyntaxNode? trackedNode = null;
 
-                    if (TryGetTrackedStatement(newActiveStatementSpans, activeStatementIndex, newText, newMemberBody, out var newStatementSyntax, out var _))
+                    if (TryGetTrackedStatement(newActiveStatementSpans, oldActiveStatements[activeStatementIndex].Statement.Id, newText, newMemberBody, out var newStatementSyntax, out var _))
                     {
                         var newEnclosingLambdaBody = FindEnclosingLambdaBody(newMemberBody.EncompassingAncestor, newStatementSyntax);
 
@@ -1282,18 +1281,13 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
         }
     }
 
-    private static bool TryGetTrackedStatement(ImmutableArray<LinePositionSpan> activeStatementSpans, int index, SourceText text, MemberBody body, [NotNullWhen(true)] out SyntaxNode? trackedStatement, out int trackedStatementPart)
+    private static bool TryGetTrackedStatement(ImmutableArray<ActiveStatementLineSpan> activeStatementSpans, ActiveStatementId id, SourceText text, MemberBody body, [NotNullWhen(true)] out SyntaxNode? trackedStatement, out int trackedStatementPart)
     {
         trackedStatement = null;
         trackedStatementPart = -1;
 
-        // Active statements are not tracked in this document (e.g. the file is closed).
-        if (activeStatementSpans.IsEmpty)
-        {
-            return false;
-        }
-
-        var trackedLineSpan = activeStatementSpans[index];
+        // Active statement span not tracked or tracking span has been lost.
+        var trackedLineSpan = activeStatementSpans.FirstOrDefault(static (s, id) => s.Id == id, id).LineSpan;
         if (trackedLineSpan == default)
         {
             return false;
@@ -2432,7 +2426,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
         EditScript<SyntaxNode> editScript,
         IReadOnlyDictionary<SyntaxNode, EditKind> editMap,
         ImmutableArray<UnmappedActiveStatement> oldActiveStatements,
-        ImmutableArray<LinePositionSpan> newActiveStatementSpans,
+        ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans,
         IReadOnlyList<(SyntaxNode OldNode, SyntaxNode NewNode, TextSpan DiagnosticSpan)> triviaEdits,
         Project oldProject,
         Document? oldDocument,
@@ -3016,7 +3010,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
                             return;
                         }
 
-                        var activeStatementIndices = oldBody.GetOverlappingActiveStatements(oldActiveStatements);
+                        var activeStatementIndices = oldBody.GetOverlappingActiveStatementIndices(oldActiveStatements);
                         if (!activeStatementIndices.Any())
                         {
                             return;
@@ -3253,7 +3247,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
 
                     // We need to provide syntax map to the compiler if the member is active (see member update above):
                     var isActiveMember =
-                        oldBody.GetOverlappingActiveStatements(oldActiveStatements).Any() ||
+                        oldBody.GetOverlappingActiveStatementIndices(oldActiveStatements).Any() ||
                         IsStateMachineMethod(oldDeclaration) ||
                         ContainsLambda(oldBody);
 

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatement.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatement.cs
@@ -18,7 +18,7 @@ internal sealed class ActiveStatement
     /// <summary>
     /// Ordinal of the active statement within the set of all active statements.
     /// </summary>
-    public readonly int Ordinal;
+    public readonly ActiveStatementId Id;
 
     /// <summary>
     /// The instruction of the active statement that is being executed.
@@ -37,11 +37,9 @@ internal sealed class ActiveStatement
     /// </summary>
     public readonly ActiveStatementFlags Flags;
 
-    public ActiveStatement(int ordinal, ActiveStatementFlags flags, SourceFileSpan span, ManagedInstructionId instructionId)
+    public ActiveStatement(ActiveStatementId id, ActiveStatementFlags flags, SourceFileSpan span, ManagedInstructionId instructionId)
     {
-        Debug.Assert(ordinal >= 0);
-
-        Ordinal = ordinal;
+        Id = id;
         Flags = flags;
         FileSpan = span;
         InstructionId = instructionId;
@@ -54,10 +52,10 @@ internal sealed class ActiveStatement
         => WithFileSpan(FileSpan.WithSpan(span));
 
     public ActiveStatement WithFileSpan(SourceFileSpan span)
-        => new(Ordinal, Flags, span, InstructionId);
+        => new(Id, Flags, span, InstructionId);
 
     public ActiveStatement WithFlags(ActiveStatementFlags flags)
-        => new(Ordinal, flags, FileSpan, InstructionId);
+        => new(Id, flags, FileSpan, InstructionId);
 
     public LinePositionSpan Span
         => FileSpan.Span;
@@ -90,5 +88,5 @@ internal sealed class ActiveStatement
         => (Flags & ActiveStatementFlags.Stale) != 0;
 
     private string GetDebuggerDisplay()
-        => $"{Ordinal}: {Span}";
+        => $"{Id}: {Span}";
 }

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementId.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementId.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+using System.Runtime.Serialization;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
-internal readonly struct ActiveStatementId(DocumentId documentId, int ordinal)
-{
-    public readonly DocumentId DocumentId = documentId;
-    public readonly int Ordinal = ordinal;
-}
+[DataContract]
+internal readonly record struct ActiveStatementId([property: DataMember(Order = 0)] int Ordinal);
+

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementLineSpan.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementLineSpan.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+/// <summary>
+/// Represents location of an active statement tracked by the client editor.
+/// </summary>
+/// <param name="Id">The corresponding <see cref="ActiveStatement.Id"/>.</param>
+/// <param name="LineSpan">Line span in the mapped document.</param>
+[DataContract]
+internal readonly record struct ActiveStatementLineSpan(
+    [property: DataMember(Order = 0)] ActiveStatementId Id,
+    [property: DataMember(Order = 1)] LinePositionSpan LineSpan);

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementSpan.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementSpan.cs
@@ -2,67 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
-using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
 /// <summary>
 /// Represents a span of an active statement tracked by the client editor.
 /// </summary>
+/// <param name="Id">The corresponding <see cref="ActiveStatement.Id"/>.</param>
+/// <param name="LineSpan">Line span in the mapped document.</param>
+/// <param name="Flags">Flags.</param>
+/// <param name="UnmappedDocumentId">
+/// The id of the unmapped document where the source of the active statement is and from where the statement might be mapped to <see cref="LineSpan"/> via <c>#line</c> directive.
+/// Null if unknown (not determined yet).
+/// </param>
 [DataContract]
-internal readonly struct ActiveStatementSpan : IEquatable<ActiveStatementSpan>
-{
-    /// <summary>
-    /// The corresponding <see cref="ActiveStatement.Ordinal"/>.
-    /// </summary>
-    [DataMember(Order = 0)]
-    public readonly int Ordinal;
-
-    /// <summary>
-    /// Line span in the mapped document.
-    /// </summary>
-    [DataMember(Order = 1)]
-    public readonly LinePositionSpan LineSpan;
-
-    /// <summary>
-    /// Flags.
-    /// </summary>
-    [DataMember(Order = 2)]
-    public readonly ActiveStatementFlags Flags;
-
-    /// <summary>
-    /// The id of the unmapped document where the source of the active statement is and from where the statement might be mapped to <see cref="LineSpan"/> via <c>#line</c> directive.
-    /// Null if unknown (not determined yet).
-    /// </summary>
-    [DataMember(Order = 3)]
-    public readonly DocumentId? UnmappedDocumentId;
-
-    public ActiveStatementSpan(int ordinal, LinePositionSpan lineSpan, ActiveStatementFlags flags, DocumentId? unmappedDocumentId)
-    {
-        Debug.Assert(ordinal >= 0);
-
-        Ordinal = ordinal;
-        LineSpan = lineSpan;
-        Flags = flags;
-        UnmappedDocumentId = unmappedDocumentId;
-    }
-
-    public override bool Equals(object? obj)
-        => obj is ActiveStatementSpan other && Equals(other);
-
-    public bool Equals(ActiveStatementSpan other)
-        => Ordinal.Equals(other.Ordinal) &&
-           LineSpan.Equals(other.LineSpan) &&
-           Flags == other.Flags &&
-           UnmappedDocumentId == other.UnmappedDocumentId;
-
-    public override int GetHashCode()
-        => Hash.Combine(Ordinal, Hash.Combine(LineSpan.GetHashCode(), Hash.Combine(UnmappedDocumentId, (int)Flags)));
-}
+internal readonly record struct ActiveStatementSpan(
+    [property: DataMember(Order = 0)] ActiveStatementId Id,
+    [property: DataMember(Order = 1)] LinePositionSpan LineSpan,
+    [property: DataMember(Order = 2)] ActiveStatementFlags Flags,
+    [property: DataMember(Order = 3)] DocumentId? UnmappedDocumentId = null);

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
@@ -25,8 +25,8 @@ internal sealed class ActiveStatementsMap
     public static readonly Comparer<ActiveStatement> Comparer =
         Comparer<ActiveStatement>.Create((x, y) => x.FileSpan.Start.CompareTo(y.FileSpan.Start));
 
-    private static readonly Comparer<(ManagedActiveStatementDebugInfo, SourceFileSpan, int)> s_infoSpanComparer =
-        Comparer<(ManagedActiveStatementDebugInfo, SourceFileSpan span, int)>.Create((x, y) => x.span.Start.CompareTo(y.span.Start));
+    private static readonly Comparer<(ManagedActiveStatementDebugInfo, SourceFileSpan, ActiveStatementId)> s_infoSpanComparer =
+        Comparer<(ManagedActiveStatementDebugInfo, SourceFileSpan span, ActiveStatementId)>.Create((x, y) => x.span.Start.CompareTo(y.span.Start));
 
     /// <summary>
     /// Groups active statements by document path as listed in the PDB.
@@ -60,7 +60,7 @@ internal sealed class ActiveStatementsMap
         ImmutableArray<ManagedActiveStatementDebugInfo> debugInfos,
         ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> remapping)
     {
-        using var _1 = PooledDictionary<string, ArrayBuilder<(ManagedActiveStatementDebugInfo info, SourceFileSpan span, int ordinal)>>.GetInstance(out var updatedSpansByDocumentPath);
+        using var _1 = PooledDictionary<string, ArrayBuilder<(ManagedActiveStatementDebugInfo info, SourceFileSpan span, ActiveStatementId id)>>.GetInstance(out var updatedSpansByDocumentPath);
 
         var ordinal = 0;
         foreach (var debugInfo in debugInfos)
@@ -79,10 +79,10 @@ internal sealed class ActiveStatementsMap
 
             if (!updatedSpansByDocumentPath.TryGetValue(documentName, out var documentInfos))
             {
-                updatedSpansByDocumentPath.Add(documentName, documentInfos = ArrayBuilder<(ManagedActiveStatementDebugInfo, SourceFileSpan, int)>.GetInstance());
+                updatedSpansByDocumentPath.Add(documentName, documentInfos = ArrayBuilder<(ManagedActiveStatementDebugInfo, SourceFileSpan, ActiveStatementId)>.GetInstance());
             }
 
-            documentInfos.Add((debugInfo, new SourceFileSpan(documentName, baseSpan), ordinal++));
+            documentInfos.Add((debugInfo, new SourceFileSpan(documentName, baseSpan), new ActiveStatementId(ordinal++)));
         }
 
         foreach (var (_, infos) in updatedSpansByDocumentPath)
@@ -93,7 +93,7 @@ internal sealed class ActiveStatementsMap
         var byDocumentPath = updatedSpansByDocumentPath.ToImmutableDictionary(
             keySelector: entry => entry.Key,
             elementSelector: entry => entry.Value.SelectAsArray(item => new ActiveStatement(
-                ordinal: item.ordinal,
+                id: item.id,
                 flags: item.info.Flags,
                 span: item.span,
                 instructionId: item.info.ActiveInstruction)));

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveStatementsMap> baseActiveStatements, AsyncLazy<EditAndContinueCapabilities> capabilities)
 {
     private readonly object _guard = new();
-    private readonly Dictionary<DocumentId, (AsyncLazy<DocumentAnalysisResults> results, Project baseProject, Document document, ImmutableArray<LinePositionSpan> activeStatementSpans)> _analyses = [];
+    private readonly Dictionary<DocumentId, (AsyncLazy<DocumentAnalysisResults> results, Project baseProject, Document document, ImmutableArray<ActiveStatementLineSpan> activeStatementSpans)> _analyses = [];
     private readonly AsyncLazy<ActiveStatementsMap> _baseActiveStatements = baseActiveStatements;
     private readonly AsyncLazy<EditAndContinueCapabilities> _capabilities = capabilities;
 
@@ -97,7 +97,7 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
     /// <summary>
     /// Calculates unmapped active statement spans in the <paramref name="newDocument"/> from spans provided by <paramref name="newActiveStatementSpanProvider"/>.
     /// </summary>
-    private async Task<ImmutableArray<LinePositionSpan>> GetLatestUnmappedActiveStatementSpansAsync(Document? oldDocument, Document newDocument, ActiveStatementSpanProvider newActiveStatementSpanProvider, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<ActiveStatementLineSpan>> GetLatestUnmappedActiveStatementSpansAsync(Document? oldDocument, Document newDocument, ActiveStatementSpanProvider newActiveStatementSpanProvider, CancellationToken cancellationToken)
     {
         if (oldDocument == null)
         {
@@ -118,7 +118,7 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
         if (!newLineMappings.Any())
         {
             var newMappedDocumentSpans = await newActiveStatementSpanProvider(newDocument.Id, newDocument.FilePath, cancellationToken).ConfigureAwait(false);
-            return newMappedDocumentSpans.SelectAsArray(s => s.LineSpan);
+            return newMappedDocumentSpans.SelectAsArray(static s => new ActiveStatementLineSpan(s.Id, s.LineSpan));
         }
 
         // The document has #line directives. In order to determine all active statement spans in the document
@@ -126,7 +126,7 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
         // We retrieve the tracking spans for all such documents and then map them back to this document.
 
         using var _1 = PooledDictionary<string, ImmutableArray<ActiveStatementSpan>>.GetInstance(out var mappedSpansByDocumentPath);
-        using var _2 = ArrayBuilder<LinePositionSpan>.GetInstance(out var activeStatementSpansBuilder);
+        using var _2 = ArrayBuilder<ActiveStatementLineSpan>.GetInstance(out var activeStatementSpansBuilder);
 
         var baseActiveStatements = await _baseActiveStatements.GetValueAsync(cancellationToken).ConfigureAwait(false);
         var analyzer = newDocument.Project.Services.GetRequiredService<IEditAndContinueAnalyzer>();
@@ -148,20 +148,20 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
             }
 
             // all baseline spans are being tracked in their corresponding mapped documents (if a span is deleted it's still tracked as empty):
-            var newMappedDocumentActiveSpan = newMappedDocumentSpans.GetStatement(oldActiveStatement.Statement.Ordinal);
+            var newMappedDocumentActiveSpan = newMappedDocumentSpans.Single(static (s, id) => s.Id == id, oldActiveStatement.Statement.Id);
             Debug.Assert(newMappedDocumentActiveSpan.UnmappedDocumentId == null || newMappedDocumentActiveSpan.UnmappedDocumentId == newDocument.Id);
 
             // TODO: optimize
             var newLineMappingContainingActiveSpan = newLineMappings.FirstOrDefault(mapping => mapping.MappedSpan.Span.Contains(newMappedDocumentActiveSpan.LineSpan));
 
             var unmappedSpan = newLineMappingContainingActiveSpan.MappedSpan.IsValid ? newLineMappingContainingActiveSpan.Span : default;
-            activeStatementSpansBuilder.Add(unmappedSpan);
+            activeStatementSpansBuilder.Add(new ActiveStatementLineSpan(newMappedDocumentActiveSpan.Id, unmappedSpan));
         }
 
         return activeStatementSpansBuilder.ToImmutable();
     }
 
-    private AsyncLazy<DocumentAnalysisResults> GetDocumentAnalysisNoLock(Project baseProject, Document document, ImmutableArray<LinePositionSpan> activeStatementSpans)
+    private AsyncLazy<DocumentAnalysisResults> GetDocumentAnalysisNoLock(Project baseProject, Document document, ImmutableArray<ActiveStatementLineSpan> activeStatementSpans)
     {
         // Do not reuse an analysis of the document unless its snasphot is exactly the same as was used to calculate the results.
         // Note that comparing document snapshots in effect compares the entire solution snapshots (when another document is changed a new solution snapshot is created

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueAnalyzer.cs
@@ -17,7 +17,7 @@ internal interface IEditAndContinueAnalyzer : ILanguageService
         Project baseProject,
         AsyncLazy<ActiveStatementsMap> lazyBaseActiveStatements,
         Document document,
-        ImmutableArray<LinePositionSpan> newActiveStatementSpans,
+        ImmutableArray<ActiveStatementLineSpan> newActiveStatementSpans,
         AsyncLazy<EditAndContinueCapabilities> lazyCapabilities,
         CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/EditAndContinue/MemberBody.cs
+++ b/src/Features/Core/Portable/EditAndContinue/MemberBody.cs
@@ -42,7 +42,7 @@ internal abstract class MemberBody : DeclarationBody
     public SyntaxNode FindStatement(TextSpan span, out int statementPart)
         => FindStatementAndPartner(span, partnerDeclarationBody: null, out _, out statementPart);
 
-    public IEnumerable<int> GetOverlappingActiveStatements(ImmutableArray<UnmappedActiveStatement> statements)
+    public IEnumerable<int> GetOverlappingActiveStatementIndices(ImmutableArray<UnmappedActiveStatement> statements)
     {
         var envelope = Envelope;
 

--- a/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
@@ -35,45 +35,6 @@ internal static partial class Extensions
     public static SourceSpan ToSourceSpan(this LinePositionSpan span)
         => new(span.Start.Line, span.Start.Character, span.End.Line, span.End.Character);
 
-    public static ActiveStatement GetStatement(this ImmutableArray<ActiveStatement> statements, int ordinal)
-    {
-        foreach (var item in statements)
-        {
-            if (item.Ordinal == ordinal)
-            {
-                return item;
-            }
-        }
-
-        throw ExceptionUtilities.UnexpectedValue(ordinal);
-    }
-
-    public static ActiveStatementSpan GetStatement(this ImmutableArray<ActiveStatementSpan> statements, int ordinal)
-    {
-        foreach (var item in statements)
-        {
-            if (item.Ordinal == ordinal)
-            {
-                return item;
-            }
-        }
-
-        throw ExceptionUtilities.UnexpectedValue(ordinal);
-    }
-
-    public static UnmappedActiveStatement GetStatement(this ImmutableArray<UnmappedActiveStatement> statements, int ordinal)
-    {
-        foreach (var item in statements)
-        {
-            if (item.Statement.Ordinal == ordinal)
-            {
-                return item;
-            }
-        }
-
-        throw ExceptionUtilities.UnexpectedValue(ordinal);
-    }
-
     /// <summary>
     /// True if the project supports Edit and Continue.
     /// Only depends on the language of the project and never changes.

--- a/src/Features/Test/EditAndContinue/ActiveStatementsMapTests.cs
+++ b/src/Features/Test/EditAndContinue/ActiveStatementsMapTests.cs
@@ -151,7 +151,7 @@ S5();
                 "[120..124) -> (4,0)-(4,4) #2",
                 "[127..131) -> (5,0)-(5,4) #4",
                 "[134..138) -> (6,0)-(6,4) #1"
-            }, oldSpans.Select(s => $"{s.UnmappedSpan} -> {s.Statement.Span} #{s.Statement.Ordinal}"));
+            }, oldSpans.Select(s => $"{s.UnmappedSpan} -> {s.Statement.Span} #{s.Statement.Id}"));
         }
 
         [Fact]

--- a/src/Features/Test/EditAndContinue/ActiveStatementsMapTests.cs
+++ b/src/Features/Test/EditAndContinue/ActiveStatementsMapTests.cs
@@ -151,7 +151,7 @@ S5();
                 "[120..124) -> (4,0)-(4,4) #2",
                 "[127..131) -> (5,0)-(5,4) #4",
                 "[134..138) -> (6,0)-(6,4) #1"
-            }, oldSpans.Select(s => $"{s.UnmappedSpan} -> {s.Statement.Span} #{s.Statement.Id}"));
+            }, oldSpans.Select(s => $"{s.UnmappedSpan} -> {s.Statement.Span} #{s.Statement.Id.Ordinal}"));
         }
 
         [Fact]

--- a/src/Features/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/Features/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -7,22 +7,19 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.EditAndContinue;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
-using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests;
-using Moq;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using System.Text;
-using System.IO;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 {
@@ -186,7 +183,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             // Active Statements
 
-            var statements = baseActiveStatementsMap.InstructionMap.Values.OrderBy(v => v.Id).ToArray();
+            var statements = baseActiveStatementsMap.InstructionMap.Values.OrderBy(v => v.Id.Ordinal).ToArray();
             AssertEx.Equal(new[]
             {
                 $"0: {document1.FilePath}: (9,14)-(9,35) flags=[LeafFrame, MethodUpToDate] mvid=11111111-1111-1111-1111-111111111111 0x06000001 v1 IL_0001",
@@ -344,7 +341,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             // Active Statements
 
-            var baseActiveStatements = baseActiveStatementMap.InstructionMap.Values.OrderBy(v => v.Id).ToArray();
+            var baseActiveStatements = baseActiveStatementMap.InstructionMap.Values.OrderBy(v => v.Id.Ordinal).ToArray();
 
             AssertEx.Equal(new[]
             {
@@ -526,7 +523,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             // Active Statements
 
-            var baseActiveStatements = baseActiveStatementMap.InstructionMap.Values.OrderBy(v => v.Id).ToArray();
+            var baseActiveStatements = baseActiveStatementMap.InstructionMap.Values.OrderBy(v => v.Id.Ordinal).ToArray();
 
             // Note that the spans of AS:2 and AS:3 correspond to the base snapshot (V2).
             AssertEx.Equal(new[]

--- a/src/Features/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/Features/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             // Active Statements
 
-            var statements = baseActiveStatementsMap.InstructionMap.Values.OrderBy(v => v.Ordinal).ToArray();
+            var statements = baseActiveStatementsMap.InstructionMap.Values.OrderBy(v => v.Id).ToArray();
             AssertEx.Equal(new[]
             {
                 $"0: {document1.FilePath}: (9,14)-(9,35) flags=[LeafFrame, MethodUpToDate] mvid=11111111-1111-1111-1111-111111111111 0x06000001 v1 IL_0001",
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             // Active Statements
 
-            var baseActiveStatements = baseActiveStatementMap.InstructionMap.Values.OrderBy(v => v.Ordinal).ToArray();
+            var baseActiveStatements = baseActiveStatementMap.InstructionMap.Values.OrderBy(v => v.Id).ToArray();
 
             AssertEx.Equal(new[]
             {
@@ -526,7 +526,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             // Active Statements
 
-            var baseActiveStatements = baseActiveStatementMap.InstructionMap.Values.OrderBy(v => v.Ordinal).ToArray();
+            var baseActiveStatements = baseActiveStatementMap.InstructionMap.Values.OrderBy(v => v.Id).ToArray();
 
             // Note that the spans of AS:2 and AS:3 correspond to the base snapshot (V2).
             AssertEx.Equal(new[]

--- a/src/Features/TestUtilities/EditAndContinue/ActiveStatementTestHelpers.cs
+++ b/src/Features/TestUtilities/EditAndContinue/ActiveStatementTestHelpers.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             => InsertNewLines(Delete(src, marker), marker);
 
         public static string InspectActiveStatement(ActiveStatement statement)
-            => $"{statement.Id}: {statement.FileSpan} flags=[{statement.Flags}]";
+            => $"{statement.Id.Ordinal}: {statement.FileSpan} flags=[{statement.Flags}]";
 
         public static string InspectActiveStatementAndInstruction(ActiveStatement statement)
             => InspectActiveStatement(statement) + " " + statement.InstructionId.GetDebuggerDisplay();

--- a/src/Features/TestUtilities/EditAndContinue/ActiveStatementTestHelpers.cs
+++ b/src/Features/TestUtilities/EditAndContinue/ActiveStatementTestHelpers.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             => InsertNewLines(Delete(src, marker), marker);
 
         public static string InspectActiveStatement(ActiveStatement statement)
-            => $"{statement.Ordinal}: {statement.FileSpan} flags=[{statement.Flags}]";
+            => $"{statement.Id}: {statement.FileSpan} flags=[{statement.Flags}]";
 
         public static string InspectActiveStatementAndInstruction(ActiveStatement statement)
             => InspectActiveStatement(statement) + " " + statement.InstructionId.GetDebuggerDisplay();

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             ImmutableArray<ImmutableArray<SourceFileSpan>> actualNewExceptionRegions)
         {
             // check active statements:
-            AssertSpansEqual(description.NewMappedSpans, actualNewActiveStatements.OrderBy(x => x.Ordinal).Select(s => s.FileSpan), newTree);
+            AssertSpansEqual(description.NewMappedSpans, actualNewActiveStatements.OrderBy(x => x.Id.Ordinal).Select(s => s.FileSpan), newTree);
 
             var oldRoot = oldTree.GetRoot();
 
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 for (var i = 0; i < actualNewActiveStatements.Length; i++)
                 {
                     var activeStatement = actualNewActiveStatements[i];
-                    AssertSpansEqual(description.NewMappedRegions[activeStatement.Ordinal], actualNewExceptionRegions[i], newTree);
+                    AssertSpansEqual(description.NewMappedRegions[activeStatement.Id.Ordinal], actualNewExceptionRegions[i], newTree);
                 }
             }
         }

--- a/src/Features/TestUtilities/EditAndContinue/SourceMarkers.cs
+++ b/src/Features/TestUtilities/EditAndContinue/SourceMarkers.cs
@@ -85,7 +85,7 @@ internal static class SourceMarkers
     public static IEnumerable<(TextSpan Span, int Id)> GetActiveSpans(string markedSource)
         => GetSpans(markedSource, tagName: "AS").Select(s => (s.span, s.id.major));
 
-    public static TextSpan[] GetTrackingSpans(string src, int count)
+    public static (int id, TextSpan span)[] GetTrackingSpans(string src)
     {
         var matches = s_trackingStatementPattern.Matches(src);
         if (matches.Count == 0)
@@ -93,20 +93,20 @@ internal static class SourceMarkers
             return [];
         }
 
-        var result = new TextSpan[count];
+        var result = new List<(int id, TextSpan span)>();
 
         for (var i = 0; i < matches.Count; i++)
         {
             var span = matches[i].Groups["TrackingStatement"];
             foreach (var (id, _) in ParseIds(matches[i]))
             {
-                result[id] = new TextSpan(span.Index, span.Length);
+                result.Add((id, new TextSpan(span.Index, span.Length)));
             }
         }
 
         Contract.ThrowIfTrue(result.Any(span => span == default));
 
-        return result;
+        return result.ToArray();
     }
 
     public static ImmutableArray<ImmutableArray<TextSpan>> GetExceptionRegions(string markedSource)

--- a/src/Features/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -123,7 +123,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
             Dim baseActiveStatements = AsyncLazy.Create(If(activeStatementMap, ActiveStatementsMap.Empty))
             Dim capabilities = AsyncLazy.Create(EditAndContinueTestHelpers.Net5RuntimeCapabilities)
-            Return Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray(Of LinePositionSpan).Empty, capabilities, CancellationToken.None)
+            Return Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray(Of ActiveStatementLineSpan).Empty, capabilities, CancellationToken.None)
         End Function
 #End Region
 
@@ -485,7 +485,7 @@ End Class
                     {
                         KeyValuePairUtil.Create(newDocument.FilePath, ImmutableArray.Create(
                             New ActiveStatement(
-                                ordinal:=0,
+                                New ActiveStatementId(0),
                                 ActiveStatementFlags.LeafFrame,
                                 New SourceFileSpan(newDocument.FilePath, oldStatementSpan),
                                 instructionId:=Nothing)))


### PR DESCRIPTION
Represent id of an active statement by `ActiveStatementId` struct instead of an `int` and use it to link tracking spans with corresponding active statements. Also correct FindToken call in EnC analyzer to avoid out of range lookup.

Fixes IndexOutOfRangeException reported in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1913237