### PR TITLE
Provide all possible keywords in xml doc comment `langword` tag

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
@@ -8,8 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Roslyn.Test.Utilities;
@@ -872,7 +872,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/11490")]
         public async Task SeeLangwordAttributeValue()
         {
-            await VerifyItemsExistAsync("""
+            var source = """
                 class C
                 {
                     /// <summary>
@@ -882,7 +882,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                     {
                     }
                 }
-                """, "null", "true", "false", "await");
+                """;
+
+            foreach (var keywordKind in SyntaxFacts.GetKeywordKinds())
+            {
+                var keywordText = SyntaxFacts.GetText(keywordKind);
+
+                if (keywordText[0] == '_')
+                {
+                    await VerifyItemIsAbsentAsync(source, keywordText);
+                }
+                else
+                {
+                    await VerifyItemExistsAsync(source, keywordText, glyph: (int)Glyph.Keyword);
+                }
+            }
         }
 
         [Fact]

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_XmlDoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_XmlDoc.vb
@@ -712,7 +712,7 @@ class c
 
         <WpfTheory, CombinatorialData>
         Public Function InvokeWithTrueKeywordCommitSeeLangword(showCompletionInArgumentLists As Boolean) As Task
-            Return InvokeWithKeywordCommitSeeLangword("true", showCompletionInArgumentLists)
+            Return InvokeWithKeywordCommitSeeLangword("true", showCompletionInArgumentLists, unique:=False)
         End Function
 
         <WpfTheory, CombinatorialData>
@@ -740,7 +740,7 @@ class c
             Return InvokeWithKeywordCommitSeeLangword("await", showCompletionInArgumentLists)
         End Function
 
-        Private Shared Async Function InvokeWithKeywordCommitSeeLangword(keyword As String, showCompletionInArgumentLists As Boolean) As Task
+        Private Shared Async Function InvokeWithKeywordCommitSeeLangword(keyword As String, showCompletionInArgumentLists As Boolean, Optional unique As Boolean = True) As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document><![CDATA[
 class c
@@ -756,7 +756,13 @@ class c
                 ' or did not insert text at all).
                 state.SendTypeChars(keyword.Substring(0, keyword.Length - 1))
                 state.SendInvokeCompletionList()
-                Await state.SendCommitUniqueCompletionListItemAsync()
+                If unique Then
+                    Await state.SendCommitUniqueCompletionListItemAsync()
+                Else
+                    Await state.AssertSelectedCompletionItem(displayText:=keyword)
+                    state.SendTab()
+                End If
+
                 Await state.AssertNoCompletionSession()
 
                 ' /// <see langword="keyword"/>$$

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb
@@ -637,12 +637,12 @@ End Class
 
         <WpfFact>
         Public Function InvokeWithTrueKeywordCommitSeeLangword() As Task
-            Return InvokeWithKeywordCommitSeeLangword("True")
+            Return InvokeWithKeywordCommitSeeLangword("True", unique:=False)
         End Function
 
         <WpfFact>
         Public Function InvokeWithFalseKeywordCommitSeeLangword() As Task
-            Return InvokeWithKeywordCommitSeeLangword("False")
+            Return InvokeWithKeywordCommitSeeLangword("False", unique:=False)
         End Function
 
         <WpfFact>
@@ -687,8 +687,6 @@ End Class
                     Await state.AssertSelectedCompletionItem(displayText:=keyword)
                     state.SendTab()
                 End If
-
-                Await state.AssertNoCompletionSession()
 
                 ' ''' <see langword="keyword"/>$$
                 Await state.AssertLineTextAroundCaret("    ''' <see langword=""" + keyword + """/>", "")

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb
@@ -688,6 +688,8 @@ End Class
                     state.SendTab()
                 End If
 
+                Await state.AssertNoCompletionSession()
+
                 ' ''' <see langword="keyword"/>$$
                 Await state.AssertLineTextAroundCaret("    ''' <see langword=""" + keyword + """/>", "")
             End Using

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -847,7 +847,9 @@ Class C
     End Sub
 End Class
 "
-            Await VerifyItemsExistAsync(text, "Nothing", "True", "False", "Await")
+            For Each keywordKind In SyntaxFacts.GetKeywordKinds()
+                Await VerifyItemExistsAsync(text, SyntaxFacts.GetText(keywordKind), glyph:=Glyph.Keyword)
+            Next
         End Function
 
         <Fact>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -17,7 +16,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -35,6 +34,27 @@ internal partial class XmlDocCommentCompletionProvider : AbstractDocCommentCompl
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public XmlDocCommentCompletionProvider() : base(s_defaultRules)
     {
+    }
+
+    private static readonly ImmutableArray<string> s_keywordNames;
+
+    static XmlDocCommentCompletionProvider()
+    {
+        using var _ = ArrayBuilder<string>.GetInstance(out var keywordsBuilder);
+
+        foreach (var keywordKind in SyntaxFacts.GetKeywordKinds())
+        {
+            var keywordText = SyntaxFacts.GetText(keywordKind);
+
+            // There are several very special keywords like `__makeref`, which are not intended for pubic use.
+            // They all start with `_`, so we are filtering them here
+            if (keywordText[0] != '_')
+            {
+                keywordsBuilder.Add(keywordText);
+            }
+        }
+
+        s_keywordNames = keywordsBuilder.ToImmutable();
     }
 
     internal override string Language => LanguageNames.CSharp;
@@ -313,18 +333,8 @@ internal partial class XmlDocCommentCompletionProvider : AbstractDocCommentCompl
         return false;
     }
 
-    protected override IEnumerable<string> GetKeywordNames()
-    {
-        yield return SyntaxFacts.GetText(SyntaxKind.NullKeyword);
-        yield return SyntaxFacts.GetText(SyntaxKind.StaticKeyword);
-        yield return SyntaxFacts.GetText(SyntaxKind.VirtualKeyword);
-        yield return SyntaxFacts.GetText(SyntaxKind.TrueKeyword);
-        yield return SyntaxFacts.GetText(SyntaxKind.FalseKeyword);
-        yield return SyntaxFacts.GetText(SyntaxKind.AbstractKeyword);
-        yield return SyntaxFacts.GetText(SyntaxKind.SealedKeyword);
-        yield return SyntaxFacts.GetText(SyntaxKind.AsyncKeyword);
-        yield return SyntaxFacts.GetText(SyntaxKind.AwaitKeyword);
-    }
+    protected override ImmutableArray<string> GetKeywordNames()
+        => s_keywordNames;
 
     protected override IEnumerable<string> GetExistingTopLevelElementNames(DocumentationCommentTriviaSyntax syntax)
         => syntax.Content.Select(GetElementName).WhereNotNull();

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -94,7 +94,7 @@ internal abstract class AbstractDocCommentCompletionProvider<TSyntax> : LSPCompl
 
     protected abstract IEnumerable<string?> GetExistingTopLevelAttributeValues(TSyntax syntax, string tagName, string attributeName);
 
-    protected abstract IEnumerable<string> GetKeywordNames();
+    protected abstract ImmutableArray<string> GetKeywordNames();
 
     /// <summary>
     /// A temporarily hack that should be removed once/if https://github.com/dotnet/roslyn/issues/53092 is fixed.

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -9,7 +9,6 @@ Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.Host.Mef
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Utilities.DocumentationCommentXmlNames
@@ -25,6 +24,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
             MyBase.New(s_defaultRules)
+        End Sub
+
+        Private Shared ReadOnly s_keywordNames As ImmutableArray(Of String)
+
+        Shared Sub New()
+            Dim keywordsBuilder As New List(Of String)
+
+            For Each keywordKind In SyntaxFacts.GetKeywordKinds()
+                keywordsBuilder.Add(SyntaxFacts.GetText(keywordKind))
+            Next
+
+            s_keywordNames = keywordsBuilder.ToImmutableArray()
         End Sub
 
         Friend Overrides ReadOnly Property Language As String
@@ -270,16 +281,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             End If
         End Sub
 
-        Protected Overrides Iterator Function GetKeywordNames() As IEnumerable(Of String)
-            Yield SyntaxFacts.GetText(SyntaxKind.NothingKeyword)
-            Yield SyntaxFacts.GetText(SyntaxKind.SharedKeyword)
-            Yield SyntaxFacts.GetText(SyntaxKind.OverridableKeyword)
-            Yield SyntaxFacts.GetText(SyntaxKind.TrueKeyword)
-            Yield SyntaxFacts.GetText(SyntaxKind.FalseKeyword)
-            Yield SyntaxFacts.GetText(SyntaxKind.MustInheritKeyword)
-            Yield SyntaxFacts.GetText(SyntaxKind.NotOverridableKeyword)
-            Yield SyntaxFacts.GetText(SyntaxKind.AsyncKeyword)
-            Yield SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)
+        Protected Overrides Function GetKeywordNames() As ImmutableArray(Of String)
+            Return s_keywordNames
         End Function
 
         Protected Overrides Function GetExistingTopLevelElementNames(parentTrivia As DocumentationCommentTriviaSyntax) As IEnumerable(Of String)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/72258