### PR TITLE
Speed up go-to-def by utilizing frozen snapshots

### DIFF
--- a/src/Features/Core/Portable/Navigation/AbstractNavigableItemsService.cs
+++ b/src/Features/Core/Portable/Navigation/AbstractNavigableItemsService.cs
@@ -12,21 +12,40 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Navigation;
 
-internal class AbstractNavigableItemsService : INavigableItemsService
+internal abstract class AbstractNavigableItemsService : INavigableItemsService
 {
     public async Task<ImmutableArray<INavigableItem>> GetNavigableItemsAsync(
         Document document, int position, CancellationToken cancellationToken)
     {
         var symbolService = document.GetRequiredLanguageService<IGoToDefinitionSymbolService>();
-        var (symbol, project, _) = await symbolService.GetSymbolProjectAndBoundSpanAsync(document, position, cancellationToken).ConfigureAwait(false);
 
-        var solution = project.Solution;
-        symbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false) ?? symbol;
-        symbol = await GoToDefinitionFeatureHelpers.TryGetPreferredSymbolAsync(solution, symbol, cancellationToken).ConfigureAwait(false);
+        // First try with frozen partial semantics.  For the common case where no symbols referenced though skeleton
+        // references are involved, this can be much faster.  If that fails, try again, this time allowing skeletons to
+        // be built.
+        var symbolAndSolution =
+            await GetSymbolAsync(document.WithFrozenPartialSemantics(cancellationToken)).ConfigureAwait(false) ??
+            await GetSymbolAsync(document).ConfigureAwait(false);
+
+        if (symbolAndSolution is null)
+            return [];
+
+        var (symbol, solution) = symbolAndSolution.Value;
 
         // Try to compute source definitions from symbol.
-        return symbol != null
-            ? NavigableItemFactory.GetItemsFromPreferredSourceLocations(solution, symbol, displayTaggedParts: FindUsagesHelpers.GetDisplayParts(symbol), cancellationToken: cancellationToken)
-            : [];
+        return NavigableItemFactory.GetItemsFromPreferredSourceLocations(solution, symbol, FindUsagesHelpers.GetDisplayParts(symbol), cancellationToken);
+
+        async Task<(ISymbol symbol, Solution solution)?> GetSymbolAsync(Document document)
+        {
+            var (symbol, project, _) = await symbolService.GetSymbolProjectAndBoundSpanAsync(document, position, cancellationToken).ConfigureAwait(false);
+
+            var solution = project.Solution;
+            symbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false) ?? symbol;
+            symbol = await GoToDefinitionFeatureHelpers.TryGetPreferredSymbolAsync(solution, symbol, cancellationToken).ConfigureAwait(false);
+
+            if (symbol is null or IErrorTypeSymbol)
+                return null;
+
+            return (symbol, solution);
+        }
     }
 }

--- a/src/Features/Core/Portable/Navigation/AbstractNavigableItemsService.cs
+++ b/src/Features/Core/Portable/Navigation/AbstractNavigableItemsService.cs
@@ -39,6 +39,7 @@ internal abstract class AbstractNavigableItemsService : INavigableItemsService
             var (symbol, project, _) = await symbolService.GetSymbolProjectAndBoundSpanAsync(document, position, cancellationToken).ConfigureAwait(false);
 
             var solution = project.Solution;
+
             symbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false) ?? symbol;
             symbol = await GoToDefinitionFeatureHelpers.TryGetPreferredSymbolAsync(solution, symbol, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
When tracing local goto-defs that were slow, i could see a lot of the time was spent in building up to date skeleton references (despite me not referencing symbols that were cross language in the first place). 