### PR TITLE
Compiler server fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -423,7 +423,7 @@ stages:
     steps:
       - template: eng/pipelines/checkout-windows-task.yml
 
-      - powershell: eng/make-bootstrap.ps1 -output $(bootstrapDir)
+      - powershell: eng/make-bootstrap.ps1 -output $(bootstrapDir) -ci
         displayName: Build Bootstrap Compiler
 
       - powershell: eng/test-determinism.ps1 -configuration Debug -bootstrapDir $(bootstrapDir) -ci

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -132,16 +132,8 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 throw new ArgumentException($"Request is over {MaximumRequestSize >> 20}MB in length");
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Read the full request
-            var requestBuffer = new byte[length];
-            await ReadAllAsync(inStream, requestBuffer, length, cancellationToken).ConfigureAwait(false);
-
-            cancellationToken.ThrowIfCancellationRequested();
-
             // Parse the request into the Request data structure.
-            using var reader = new BinaryReader(new MemoryStream(requestBuffer), Encoding.Unicode);
+            using var reader = new BinaryReader(inStream, Encoding.Unicode);
             var requestId = reader.ReadString();
             var language = (RequestLanguage)reader.ReadUInt32();
             var compilerHash = reader.ReadString();

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             }
 
             // Parse the request into the Request data structure.
-            using var reader = new BinaryReader(inStream, Encoding.Unicode);
+            using var reader = new BinaryReader(inStream, Encoding.Unicode, leaveOpen: true);
             var requestId = reader.ReadString();
             var language = (RequestLanguage)reader.ReadUInt32();
             var compilerHash = reader.ReadString();

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -753,7 +753,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     Log.LogError($"Critical error {responseType} when building");
                     return false;
                 case BuildResponse.ResponseType.Rejected:
-                    Log.LogError($"Compiler request rejected");
+                    Log.LogError($"Compiler request rejected: {((RejectedBuildResponse)response).Reason}");
                     return false;
                 case BuildResponse.ResponseType.CannotConnect:
                     if (Interlocked.Increment(ref s_connectFailedCount) > maxCannotConnectCount)

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -753,7 +753,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     Log.LogError($"Critical error {responseType} when building");
                     return false;
                 case BuildResponse.ResponseType.Rejected:
-                    Log.LogError($"Compiler request rejected: {((RejectedBuildResponse)response).Reason}");
+                    Log.LogError($"Compiler request rejected: {((RejectedBuildResponse)response!).Reason}");
                     return false;
                 case BuildResponse.ResponseType.CannotConnect:
                     if (Interlocked.Increment(ref s_connectFailedCount) > maxCannotConnectCount)


### PR DESCRIPTION
Couple quick fixes:

1. Include the rejected reason in bootstrap build failure messages.
2. Don't read entire request into memory, do it incrementally from the original `Stream`. This saves ~4MB of LOH allocations.