### PR TITLE
Remove serialization of SourceTexts

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -535,7 +535,8 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var document = CreateWorkspace().CurrentSolution.AddProject("empty", "empty", LanguageNames.CSharp).AddDocument("empty", SourceText.From(""));
             var serializer = document.Project.Solution.Services.GetService<ISerializerService>();
 
-            var source = serializer.CreateChecksum(await document.GetTextAsync().ConfigureAwait(false), CancellationToken.None);
+            var text = await document.GetTextAsync().ConfigureAwait(false);
+            var source = serializer.CreateChecksum(new SerializableSourceText(text, text.GetContentHash()), CancellationToken.None);
             var metadata = serializer.CreateChecksum(new MissingMetadataReference(), CancellationToken.None);
             var analyzer = serializer.CreateChecksum(new AnalyzerFileReference(Path.Combine(TempRoot.Root, "missing"), new MissingAnalyzerLoader()), CancellationToken.None);
 
@@ -607,21 +608,22 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             // test with right serializable encoding
             var sourceText = SourceText.From("Hello", Encoding.UTF8);
+            var serializableSourceText = new SerializableSourceText(sourceText, sourceText.GetContentHash());
             using (var stream = SerializableBytes.CreateWritableStream())
             {
                 using var context = new SolutionReplicationContext();
 
                 using (var objectWriter = new ObjectWriter(stream, leaveOpen: true))
                 {
-                    serializer.Serialize(sourceText, objectWriter, context, CancellationToken.None);
+                    serializer.Serialize(serializableSourceText, objectWriter, context, CancellationToken.None);
                 }
 
                 stream.Position = 0;
 
                 using var objectReader = ObjectReader.TryGetReader(stream);
 
-                var newText = (SourceText)serializer.Deserialize(sourceText.GetWellKnownSynchronizationKind(), objectReader, CancellationToken.None);
-                Assert.Equal(sourceText.ToString(), newText.ToString());
+                var newText = (SerializableSourceText)serializer.Deserialize(serializableSourceText.GetWellKnownSynchronizationKind(), objectReader, CancellationToken.None);
+                Assert.Equal(sourceText.ToString(), newText.GetText(CancellationToken.None).ToString());
             }
 
             // test with wrong encoding that doesn't support serialization

--- a/src/VisualStudio/Core/Test.Next/Remote/SolutionAsset.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SolutionAsset.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Serialization;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote;
 
@@ -30,11 +29,6 @@ internal readonly struct SolutionAsset
     public SolutionAsset(Checksum checksum, object value)
     {
         var kind = value.GetWellKnownSynchronizationKind();
-        // SolutionAsset is not allowed to hold strong references to SourceText. SerializableSourceText is used
-        // instead to allow data to be released from process address space when it is also held in temporary
-        // storage.
-        // https://github.com/dotnet/roslyn/issues/43802
-        Contract.ThrowIfTrue(kind is WellKnownSynchronizationKind.SourceText);
 
         Checksum = checksum;
         Kind = kind;

--- a/src/Workspaces/Core/Portable/Remote/WellKnownSynchronizationKind.cs
+++ b/src/Workspaces/Core/Portable/Remote/WellKnownSynchronizationKind.cs
@@ -28,7 +28,6 @@ internal enum WellKnownSynchronizationKind
     ProjectReference,
     MetadataReference,
     AnalyzerReference,
-    SourceText,
 
     SerializableSourceText,
 }

--- a/src/Workspaces/Core/Portable/Serialization/SerializationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializationExtensions.cs
@@ -30,7 +30,6 @@ internal static class SerializationExtensions
             MetadataReference => WellKnownSynchronizationKind.MetadataReference,
             AnalyzerReference => WellKnownSynchronizationKind.AnalyzerReference,
             SerializableSourceText => WellKnownSynchronizationKind.SerializableSourceText,
-            SourceText => WellKnownSynchronizationKind.SourceText,
             SourceGeneratedDocumentIdentity => WellKnownSynchronizationKind.SourceGeneratedDocumentIdentity,
             _ => throw ExceptionUtilities.UnexpectedValue(value),
         };

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -86,9 +86,6 @@ internal partial class SerializerService : ISerializerService
                 case WellKnownSynchronizationKind.SerializableSourceText:
                     return Checksum.Create(((SerializableSourceText)value).ContentHash);
 
-                case WellKnownSynchronizationKind.SourceText:
-                    return Checksum.Create(((SourceText)value).GetContentHash());
-
                 default:
                     // object that is not part of solution is not supported since we don't know what inputs are required to
                     // serialize it
@@ -148,11 +145,6 @@ internal partial class SerializerService : ISerializerService
                     SerializeSourceText((SerializableSourceText)value, writer, context, cancellationToken);
                     return;
 
-                case WellKnownSynchronizationKind.SourceText:
-                    var sourceText = (SourceText)value;
-                    SerializeSourceText(new SerializableSourceText(sourceText, sourceText.GetContentHash()), writer, context, cancellationToken);
-                    return;
-
                 case WellKnownSynchronizationKind.SolutionCompilationState:
                     ((SolutionCompilationStateChecksums)value).Serialize(writer);
                     return;
@@ -204,7 +196,6 @@ internal partial class SerializerService : ISerializerService
                 WellKnownSynchronizationKind.MetadataReference => DeserializeMetadataReference(reader, cancellationToken),
                 WellKnownSynchronizationKind.AnalyzerReference => DeserializeAnalyzerReference(reader, cancellationToken),
                 WellKnownSynchronizationKind.SerializableSourceText => SerializableSourceText.Deserialize(reader, _storageService, _textService, cancellationToken),
-                WellKnownSynchronizationKind.SourceText => DeserializeSourceText(reader, cancellationToken),
                 _ => throw ExceptionUtilities.UnexpectedValue(kind),
             };
         }

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
@@ -22,12 +22,6 @@ internal partial class SerializerService
         text.Serialize(writer, context, cancellationToken);
     }
 
-    private SourceText DeserializeSourceText(ObjectReader reader, CancellationToken cancellationToken)
-    {
-        var serializableSourceText = SerializableSourceText.Deserialize(reader, _storageService, _textService, cancellationToken);
-        return serializableSourceText.GetText(cancellationToken);
-    }
-
     private void SerializeCompilationOptions(CompilationOptions options, ObjectWriter writer, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/72705

All non-test code already is properly only dealing with a SerializableSoruceText.  Fixed up the tests to do the same, and now we can remove these extra cases from teh product code.