### PR TITLE
Revert "Simplify updating the primary workspace without passing in a version"

### DIFF
--- a/src/EditorFeatures/Core/Remote/SolutionChecksumUpdater.cs
+++ b/src/EditorFeatures/Core/Remote/SolutionChecksumUpdater.cs
@@ -60,6 +60,9 @@ internal sealed class SolutionChecksumUpdater
             listener,
             shutdownToken);
 
+        // Use an equality comparer here as we will commonly get lots of change notifications that will all be
+        // associated with the same cancellation token controlling that batch of work.  No need to enqueue the same
+        // token a huge number of times when we only need the single value of it when doing the work.
         _synchronizeWorkspaceQueue = new AsyncBatchingWorkQueue(
             DelayTimeSpan.NearImmediate,
             SynchronizePrimaryWorkspaceAsync,
@@ -139,15 +142,17 @@ internal sealed class SolutionChecksumUpdater
 
     private async ValueTask SynchronizePrimaryWorkspaceAsync(CancellationToken cancellationToken)
     {
+        var solution = _workspace.CurrentSolution;
         var client = await RemoteHostClient.TryGetClientAsync(_workspace, cancellationToken).ConfigureAwait(false);
         if (client == null)
             return;
 
         using (Logger.LogBlock(FunctionId.SolutionChecksumUpdater_SynchronizePrimaryWorkspace, cancellationToken))
         {
+            var workspaceVersion = solution.WorkspaceVersion;
             await client.TryInvokeAsync<IRemoteAssetSynchronizationService>(
-                _workspace.CurrentSolution,
-                (service, solution, cancellationToken) => service.SynchronizePrimaryWorkspaceAsync(solution, cancellationToken),
+                solution,
+                (service, solution, cancellationToken) => service.SynchronizePrimaryWorkspaceAsync(solution, workspaceVersion, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/Workspaces/Remote/Core/IRemoteAssetSynchronizationService.cs
+++ b/src/Workspaces/Remote/Core/IRemoteAssetSynchronizationService.cs
@@ -7,14 +7,15 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.Remote;
-
-internal interface IRemoteAssetSynchronizationService
+namespace Microsoft.CodeAnalysis.Remote
 {
-    /// <summary>
-    /// Synchronize data to OOP proactively so that the corresponding solution is often already available when features
-    /// call into it.
-    /// </summary>
-    ValueTask SynchronizePrimaryWorkspaceAsync(Checksum solutionChecksum, CancellationToken cancellationToken);
-    ValueTask SynchronizeTextAsync(DocumentId documentId, Checksum baseTextChecksum, IEnumerable<TextChange> textChanges, CancellationToken cancellationToken);
+    internal interface IRemoteAssetSynchronizationService
+    {
+        /// <summary>
+        /// Synchronize data to OOP proactively so that the corresponding solution is often already available when
+        /// features call into it.
+        /// </summary>
+        ValueTask SynchronizePrimaryWorkspaceAsync(Checksum solutionChecksum, int workspaceVersion, CancellationToken cancellationToken);
+        ValueTask SynchronizeTextAsync(DocumentId documentId, Checksum baseTextChecksum, IEnumerable<TextChange> textChanges, CancellationToken cancellationToken);
+    }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
+
     internal sealed partial class RemoteWorkspace
     {
         /// <summary>
@@ -38,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private InFlightSolution GetOrCreateSolutionAndAddInFlightCount_NoLock(
             AssetProvider assetProvider,
             Checksum solutionChecksum,
+            int workspaceVersion,
             bool updatePrimaryBranch)
         {
             Contract.ThrowIfFalse(_gate.CurrentCount == 0);
@@ -53,7 +56,8 @@ namespace Microsoft.CodeAnalysis.Remote
             // to compute the primary branch as well, let it know so it can start that now.
             if (updatePrimaryBranch)
             {
-                solution.TryKickOffPrimaryBranchWork_NoLock(this.UpdateWorkspaceCurrentSolutionAsync);
+                solution.TryKickOffPrimaryBranchWork_NoLock((disconnectedSolution, cancellationToken) =>
+                    this.TryUpdateWorkspaceCurrentSolutionAsync(workspaceVersion, disconnectedSolution, cancellationToken));
             }
 
             CheckCacheInvariants_NoLock();

--- a/src/Workspaces/Remote/ServiceHub/Services/AssetSynchronization/RemoteAssetSynchronizationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/AssetSynchronization/RemoteAssetSynchronizationService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Remote
         {
         }
 
-        public ValueTask SynchronizePrimaryWorkspaceAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
+        public ValueTask SynchronizePrimaryWorkspaceAsync(Checksum solutionChecksum, int workspaceVersion, CancellationToken cancellationToken)
         {
             return RunServiceAsync(async cancellationToken =>
             {
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     var workspace = GetWorkspace();
                     var assetProvider = workspace.CreateAssetProvider(solutionChecksum, WorkspaceManager.SolutionAssetCache, SolutionAssetSource);
-                    await workspace.UpdatePrimaryBranchSolutionAsync(assetProvider, solutionChecksum, cancellationToken).ConfigureAwait(false);
+                    await workspace.UpdatePrimaryBranchSolutionAsync(assetProvider, solutionChecksum, workspaceVersion, cancellationToken).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }


### PR DESCRIPTION
Reverts dotnet/roslyn#72688

for Perf tests [validation](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=9303048&view=results)