### PR TITLE
Modify BinderFactory to use a shared pool instead of one per BinderFactory instance.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -34,6 +34,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _memberOpt = memberOpt;
             }
 
+            internal void Clear()
+            {
+                _factory = null;
+                _position = 0;
+                _memberDeclarationOpt = null;
+                _memberOpt = null;
+            }
+
             private CSharpCompilation compilation
             {
                 get

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed partial class BinderFactory
     {
-        private sealed class BinderFactoryVisitor : CSharpSyntaxVisitor<Binder>
+        internal sealed class BinderFactoryVisitor : CSharpSyntaxVisitor<Binder>
         {
             private int _position;
             private CSharpSyntaxNode _memberDeclarationOpt;

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -22,17 +22,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             private int _position;
             private CSharpSyntaxNode _memberDeclarationOpt;
             private Symbol _memberOpt;
-            private readonly BinderFactory _factory;
+            private BinderFactory _factory;
 
-            internal BinderFactoryVisitor(BinderFactory factory)
-            {
-                _factory = factory;
-            }
-
-            internal void Initialize(int position, CSharpSyntaxNode memberDeclarationOpt, Symbol memberOpt)
+            internal void Initialize(BinderFactory factory, int position, CSharpSyntaxNode memberDeclarationOpt, Symbol memberOpt)
             {
                 Debug.Assert((memberDeclarationOpt == null) == (memberOpt == null));
 
+                _factory = factory;
                 _position = position;
                 _memberDeclarationOpt = memberDeclarationOpt;
                 _memberOpt = memberOpt;

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // This results in a lot of allocations of BinderFactoryVisitors. Pooling them
         // reduces this churn to almost nothing.
         private static readonly ObjectPool<BinderFactoryVisitor> s_binderFactoryVisitorPool
-            = new ObjectPool<BinderFactoryVisitor>(() => new BinderFactoryVisitor(), 64);
+            = new ObjectPool<BinderFactoryVisitor>(static () => new BinderFactoryVisitor(), 64);
 
         internal BinderFactory(CSharpCompilation compilation, SyntaxTree syntaxTree, bool ignoreAccessibility)
         {

--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.BinderFactoryVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.BinderFactoryVisitor.vb
@@ -2,13 +2,12 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend Class BinderFactory
 
-        Private NotInheritable Class BinderFactoryVisitor
+        Friend NotInheritable Class BinderFactoryVisitor
             Inherits VisualBasicSyntaxVisitor(Of Binder)
 
             Private _position As Integer

--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.BinderFactoryVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.BinderFactoryVisitor.vb
@@ -19,6 +19,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Me._position = position
             End Sub
 
+            Public Sub Clear()
+                _factory = Nothing
+                _position = 0
+            End Sub
+
             Public Overrides Function VisitXmlCrefAttribute(node As XmlCrefAttributeSyntax) As Binder
                 Dim trivia As StructuredTriviaSyntax = node.EnclosingStructuredTrivia
 

--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.BinderFactoryVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.BinderFactoryVisitor.vb
@@ -12,17 +12,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Inherits VisualBasicSyntaxVisitor(Of Binder)
 
             Private _position As Integer
-            Private ReadOnly _factory As BinderFactory
+            Private _factory As BinderFactory
 
-            Public Sub New(factory As BinderFactory)
+            Public Sub Initialize(factory As BinderFactory, position As Integer)
                 Me._factory = factory
+                Me._position = position
             End Sub
-
-            Friend WriteOnly Property Position As Integer
-                Set(value As Integer)
-                    Me._position = value
-                End Set
-            End Property
 
             Public Overrides Function VisitXmlCrefAttribute(node As XmlCrefAttributeSyntax) As Binder
                 Dim trivia As StructuredTriviaSyntax = node.EnclosingStructuredTrivia

--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
@@ -48,15 +48,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If SyntaxFacts.InSpanOrEffectiveTrailingOfNode(node, position) OrElse
                node.Kind = SyntaxKind.CompilationUnit Then
 
-                Dim visitor = s_binderFactoryVisitorPool.Allocate()
-                visitor.Initialize(Me, position)
+                Dim visitor = GetBinderFactoryVisitor(position)
                 Dim result = visitor.Visit(node)
-                s_binderFactoryVisitorPool.Free(visitor)
+                ClearBinderFactoryVisitor(visitor)
                 Return result
             End If
 
             Return Nothing
         End Function
+
+        Private Function GetBinderFactoryVisitor(position As Integer) As BinderFactoryVisitor
+            Dim visitor = s_binderFactoryVisitorPool.Allocate()
+            visitor.Initialize(Me, position)
+
+            Return visitor
+        End Function
+
+        Private Sub ClearBinderFactoryVisitor(visitor As BinderFactoryVisitor)
+            visitor.Clear()
+            s_binderFactoryVisitorPool.Free(visitor)
+        End Sub
 
         ' Get binder for interior of a namespace block
         Public Function GetNamespaceBinder(node As NamespaceBlockSyntax) As Binder


### PR DESCRIPTION
This showed up as abou 0.7% of allocations on a profile I took on my machine where I typed about 20 characters in a large file.

![image](https://github.com/dotnet/roslyn/assets/6785178/eda98cd6-0df1-4d9f-86a0-cd26812b7936)