### PR TITLE
Always run OOP process on .net core (part 2)

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/UnitTesting/Api/UnitTestingGlobalOptions.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/UnitTesting/Api/UnitTestingGlobalOptions.cs
@@ -5,18 +5,15 @@
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api;
 
 [Export(typeof(UnitTestingGlobalOptions)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class UnitTestingGlobalOptions(IGlobalOptionService globalOptions)
+internal sealed class UnitTestingGlobalOptions()
 {
-    private readonly IGlobalOptionService _globalOptions = globalOptions;
-
-    public bool IsServiceHubProcessCoreClr
-        => _globalOptions.GetOption(RemoteHostOptionsStorage.OOPCoreClr);
+#pragma warning disable CA1822 // Mark members as static
+    public bool IsServiceHubProcessCoreClr => true;
+#pragma warning restore CA1822 // Mark members as static
 }

--- a/src/EditorFeatures/Core/Remote/RemoteHostOptionsStorage.cs
+++ b/src/EditorFeatures/Core/Remote/RemoteHostOptionsStorage.cs
@@ -11,8 +11,5 @@ internal sealed class RemoteHostOptionsStorage
     // use 64bit OOP
     public static readonly Option2<bool> OOP64Bit = new("dotnet_code_analysis_in_separate_process", defaultValue: true);
 
-    // use coreclr host for OOP
-    public static readonly Option2<bool> OOPCoreClr = new("dotnet_enable_core_clr_in_code_analysis_process", defaultValue: true);
-
     public static readonly Option2<bool> OOPServerGCFeatureFlag = new("dotnet_enable_server_garbage_collection_in_code_analysis_process", defaultValue: false);
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -53,14 +53,8 @@
                     </StackPanel>
 
                     <CheckBox x:Name="Run_code_analysis_in_separate_process"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_in_separate_process}"
-                              Checked="Run_code_analysis_in_separate_process_Checked"
-                              Unchecked="Run_code_analysis_in_separate_process_Unchecked"/>
-                    <StackPanel Margin="15, 0, 0, 0">
-                        <CheckBox x:Name="Run_code_analysis_on_dotnet"
-                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_on_dotnet}" />
-                    </StackPanel>
-                    
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_in_separate_process}" />
+
                     <CheckBox x:Name="Analyze_source_generated_files"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_analyze_source_generated_files}" />
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -67,7 +67,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(on_the_right_edge_of_the_editor_window, InlineDiagnosticsOptionsStorage.Location, InlineDiagnosticsLocations.PlacedAtEndOfEditor, LanguageNames.CSharp);
 
             BindToOption(Run_code_analysis_in_separate_process, RemoteHostOptionsStorage.OOP64Bit);
-            BindToOption(Run_code_analysis_on_dotnet, RemoteHostOptionsStorage.OOPCoreClr);
 
             BindToOption(Analyze_source_generated_files, SolutionCrawlerOptionsStorage.EnableDiagnosticsInSourceGeneratedFiles, () =>
             {
@@ -277,16 +276,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             Collapse_usings_on_file_open.IsEnabled = false;
             Collapse_metadata_signature_files_on_open.IsEnabled = false;
             Collapse_sourcelink_embedded_decompiled_files_on_open.IsEnabled = false;
-        }
-
-        private void Run_code_analysis_in_separate_process_Checked(object sender, RoutedEventArgs e)
-        {
-            Run_code_analysis_on_dotnet.IsEnabled = true;
-        }
-
-        private void Run_code_analysis_in_separate_process_Unchecked(object sender, RoutedEventArgs e)
-        {
-            Run_code_analysis_on_dotnet.IsEnabled = false;
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -78,9 +78,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_run_code_analysis_in_separate_process
             => ServicesVSResources.Run_code_analysis_in_separate_process_requires_restart;
 
-        public static string Option_run_code_analysis_on_dotnet
-            => ServicesVSResources.Run_code_analysis_on_latest_dotnet_requires_restart;
-
         public static string Option_analyze_source_generated_files
             => ServicesVSResources.Analyze_source_generated_files;
 

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -364,7 +364,6 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_format_on_save", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "FormatOnSave")},
         {"dotnet_enable_full_solution_analysis_memory_monitor", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "Full Solution Analysis Memory Monitor")},
         {"dotnet_code_analysis_in_separate_process", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "OOP64Bit")},
-        {"dotnet_enable_core_clr_in_code_analysis_process", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "OOPCoreClr")},
         {"dotnet_enable_server_garbage_collection_in_code_analysis_process", new FeatureFlagStorage(@"Roslyn.OOPServerGC")},
         {"dotnet_remove_intellicode_recommendation_limit", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "RemoveRecommendationLimit")},
         {"dotnet_enable_rename_tracking", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "Rename Tracking")},

--- a/src/VisualStudio/Core/Def/Remote/VisualStudioRemoteHostClientProvider.cs
+++ b/src/VisualStudio/Core/Def/Remote/VisualStudioRemoteHostClientProvider.cs
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var serviceBroker = brokeredServiceContainer.GetFullAccessServiceBroker();
 
                 var configuration =
-                    (_globalOptions.GetOption(RemoteHostOptionsStorage.OOPCoreClr) ? RemoteProcessConfiguration.Core : 0) |
+                    RemoteProcessConfiguration.Core |
                     (_globalOptions.GetOption(RemoteHostOptionsStorage.OOPServerGCFeatureFlag) ? RemoteProcessConfiguration.ServerGC : 0);
 
                 // VS AsyncLazy does not currently support cancellation:

--- a/src/VisualStudio/Core/Def/Remote/VisualStudioRemoteHostClientProvider.cs
+++ b/src/VisualStudio/Core/Def/Remote/VisualStudioRemoteHostClientProvider.cs
@@ -120,8 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var serviceBroker = brokeredServiceContainer.GetFullAccessServiceBroker();
 
                 var configuration =
-                    RemoteProcessConfiguration.Core |
-                    (_globalOptions.GetOption(RemoteHostOptionsStorage.OOPServerGCFeatureFlag) ? RemoteProcessConfiguration.ServerGC : 0);
+                    _globalOptions.GetOption(RemoteHostOptionsStorage.OOPServerGCFeatureFlag) ? RemoteProcessConfiguration.ServerGC : 0;
 
                 // VS AsyncLazy does not currently support cancellation:
                 var client = await ServiceHubRemoteHostClient.CreateAsync(Services, configuration, _listenerProvider, serviceBroker, _callbackDispatchers, CancellationToken.None).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1672,9 +1672,6 @@ Additional information: {1}</value>
   <data name="Run_code_analysis_in_separate_process_requires_restart" xml:space="preserve">
     <value>Run code analysis in separate process (requires restart)</value>
   </data>
-  <data name="Run_code_analysis_on_latest_dotnet_requires_restart" xml:space="preserve">
-    <value>Run code analysis on latest .NET (requires restart)</value>
-  </data>
   <data name="Quick_Actions" xml:space="preserve">
     <value>Quick Actions</value>
   </data>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Spustit analýzu kódu v samostatném procesu (vyžaduje restartování)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">Spustit analýzu kódu na nejnovějším rozhraní .NET (vyžaduje restartování)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Spouští se analýza kódu pro {0}...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Codeanalyse in separatem Prozess ausführen (Neustart erforderlich)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">Codeanalyse für die neueste .NET-Version ausführen (Neustart erforderlich)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Die Codeanalyse für "{0}" wird ausgeführt...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Ejecutar el análisis de código en un proceso independiente (requiere reiniciar)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">Ejecutar análisis de código en la versión más reciente de .NET (requiere reiniciar)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Ejecutando el análisis de código para "{0}"...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Exécuter l’analyse du code dans un processus séparé (requiert un redémarrage)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">Exécutez l'analyse de code sur le dernier .NET (nécessite un redémarrage)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Exécution de l'analyse du code pour '{0}'...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Esegui analisi codice in un processo separato (richiede il riavvio)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">Esegui Code Analysis nella versione più recente di .NET (richiede il riavvio)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Esecuzione di Code Analysis per '{0}'...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">別のプロセスでコード分析を実行する (再起動が必要)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">最新の .NET でコード分析を実行する (再起動が必要)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">'{0}' のコード分析を実行しています...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">별도의 프로세스에서 코드 분석 실행(다시 시작해야 함)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">최신 .NET에서 코드 분석 실행(다시 시작 필요)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">'{0}'에 대한 코드 분석을 실행하는 중...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Uruchom analizę kodu w oddzielnym procesie (wymaga ponownego uruchomienia)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">Uruchamianie analizy kodu na najnowszej platformie .NET (wymaga ponownego uruchomienia)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Trwa analizowanie kodu dla elementu „{0}”...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Execute a análise de código em um processo separado (requer reinicialização)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">Executar análise de código no .NET mais recente (requer reinicialização)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Executando a análise de código para '{0}'...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Запуск анализа кода в отдельном процессе (требуется перезапуск)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">Выполнить анализ кода на последней версии .NET (требуется перезапуск)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Выполняется анализ кода для "{0}"…</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">Kod analizini ayrı bir işlemde çalıştır (yeniden başlatma gerektirir)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">En son .NET'te kod analizi çalıştırın (yeniden başlatma gerektirir)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">'{0}' için kod analizi çalıştırılıyor...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">在单独的进程中运行代码分析(需要重启)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">在最新 .NET 上运行代码分析(需要重启)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">正在为“{0}”运行代码分析…</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1227,11 +1227,6 @@
         <target state="translated">在獨立的流程中執行程式碼分析 (需要重新開機)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
-        <source>Run code analysis on latest .NET (requires restart)</source>
-        <target state="translated">針對最新的 .NET 執行程式碼分析 (需要重新啟動)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">正在執行 '{0}' 的程式碼分析...</target>

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -53,13 +53,7 @@
                     </StackPanel>
 
                     <CheckBox x:Name="Run_code_analysis_in_separate_process"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_in_separate_process}"
-                              Checked="Run_code_analysis_in_separate_process_Checked"
-                              Unchecked="Run_code_analysis_in_separate_process_Unchecked"/>
-                    <StackPanel Margin="15, 0, 0, 0">
-                        <CheckBox x:Name="Run_code_analysis_on_dotnet"
-                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_on_dotnet}" />
-                    </StackPanel>
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_in_separate_process}" />
 
                     <CheckBox x:Name="Analyze_source_generated_files"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_analyze_source_generated_files}" />

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -71,7 +71,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(at_the_end_of_the_line_of_code, InlineDiagnosticsOptionsStorage.Location, InlineDiagnosticsLocations.PlacedAtEndOfCode, LanguageNames.VisualBasic)
             BindToOption(on_the_right_edge_of_the_editor_window, InlineDiagnosticsOptionsStorage.Location, InlineDiagnosticsLocations.PlacedAtEndOfEditor, LanguageNames.VisualBasic)
             BindToOption(Run_code_analysis_in_separate_process, RemoteHostOptionsStorage.OOP64Bit)
-            BindToOption(Run_code_analysis_on_dotnet, RemoteHostOptionsStorage.OOPCoreClr)
 
             BindToOption(Enable_file_logging_for_diagnostics, VisualStudioLoggingOptionsStorage.EnableFileLoggingForDiagnostics)
             BindToOption(Skip_analyzers_for_implicitly_triggered_builds, FeatureOnOffOptions.SkipAnalyzersForImplicitlyTriggeredBuilds)
@@ -241,14 +240,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             Collapse_imports_on_file_open.IsEnabled = False
             Collapse_sourcelink_embedded_decompiled_files_on_open.IsEnabled = False
             Collapse_metadata_signature_files_on_open.IsEnabled = False
-        End Sub
-
-        Private Sub Run_code_analysis_in_separate_process_Checked(sender As Object, e As RoutedEventArgs)
-            Run_code_analysis_on_dotnet.IsEnabled = True
-        End Sub
-
-        Private Sub Run_code_analysis_in_separate_process_Unchecked(sender As Object, e As RoutedEventArgs)
-            Run_code_analysis_on_dotnet.IsEnabled = False
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -76,9 +76,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_run_code_analysis_in_separate_process As String =
             ServicesVSResources.Run_code_analysis_in_separate_process_requires_restart
 
-        Public ReadOnly Property Option_run_code_analysis_on_dotnet As String =
-            ServicesVSResources.Run_code_analysis_on_latest_dotnet_requires_restart
-
         Public ReadOnly Property Option_DisplayLineSeparators As String =
             BasicVSResources.Show_procedure_line_separators
 

--- a/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
+++ b/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
@@ -363,20 +363,16 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
         [MemberData(nameof(AllServiceDescriptors))]
         internal void GetFeatureDisplayName(
             Type serviceInterface,
-            ServiceDescriptor descriptor64,
-            ServiceDescriptor descriptor64ServerGC,
             ServiceDescriptor descriptorCoreClr64,
             ServiceDescriptor descriptorCoreClr64ServerGC)
         {
             Assert.NotNull(serviceInterface);
 
-            var expectedName = descriptor64.GetFeatureDisplayName();
+            var expectedName = descriptorCoreClr64.GetFeatureDisplayName();
 
             // The service name couldn't be found. It may need to be added to RemoteWorkspacesResources.resx as FeatureName_{name}
             Assert.False(string.IsNullOrEmpty(expectedName), $"Service name for '{serviceInterface.GetType()}' not available.");
 
-            Assert.Equal(expectedName, descriptor64ServerGC.GetFeatureDisplayName());
-            Assert.Equal(expectedName, descriptorCoreClr64.GetFeatureDisplayName());
             Assert.Equal(expectedName, descriptorCoreClr64ServerGC.GetFeatureDisplayName());
         }
 

--- a/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
+++ b/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
@@ -53,13 +53,13 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
     {
         public static IEnumerable<object[]> AllServiceDescriptors
             => ServiceDescriptors.Instance.GetTestAccessor().Descriptors
-                .Select(descriptor => new object[] { descriptor.Key, descriptor.Value.descriptor64, descriptor.Value.descriptor64ServerGC, descriptor.Value.descriptorCoreClr64, descriptor.Value.descriptorCoreClr64ServerGC });
+                .Select(descriptor => new object[] { descriptor.Key, descriptor.Value.descriptorCoreClr64, descriptor.Value.descriptorCoreClr64ServerGC });
 
         private static Dictionary<Type, MemberInfo> GetAllParameterTypesOfRemoteApis()
         {
             var interfaces = new List<Type>();
 
-            foreach (var (serviceType, (descriptor, _, _, _)) in ServiceDescriptors.Instance.GetTestAccessor().Descriptors)
+            foreach (var (serviceType, (descriptor, _)) in ServiceDescriptors.Instance.GetTestAccessor().Descriptors)
             {
                 interfaces.Add(serviceType);
                 if (descriptor.ClientInterface != null)
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var callbackDispatchers = ((IMefHostExportProvider)hostServices).GetExports<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatcherRegistry.ExportMetadata>();
 
             var descriptorsWithCallbackServiceTypes = ServiceDescriptors.Instance.GetTestAccessor().Descriptors
-                .Where(d => d.Value.descriptor64.ClientInterface != null).Select(d => d.Key);
+                .Where(d => d.Value.descriptorCoreClr64.ClientInterface != null).Select(d => d.Key);
 
             var callbackDispatcherServiceTypes = callbackDispatchers.Select(d => d.Metadata.ServiceInterface);
             AssertEx.SetEqual(descriptorsWithCallbackServiceTypes, callbackDispatcherServiceTypes);

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
         public override RemoteServiceConnection<T> CreateConnection<T>(object? callbackTarget) where T : class
         {
-            var descriptor = ServiceDescriptors.Instance.GetServiceDescriptor(typeof(T), RemoteProcessConfiguration.ServerGC | (ServiceDescriptors.IsCurrentProcessRunningOnCoreClr() ? RemoteProcessConfiguration.Core : 0));
+            var descriptor = ServiceDescriptors.Instance.GetServiceDescriptor(typeof(T), RemoteProcessConfiguration.ServerGC);
             var callbackDispatcher = (descriptor.ClientInterface != null) ? _callbackDispatchers.GetDispatcher(typeof(T)) : null;
 
             return new BrokeredServiceConnection<T>(

--- a/src/Workspaces/Remote/Core/RemoteProcessConfiguration.cs
+++ b/src/Workspaces/Remote/Core/RemoteProcessConfiguration.cs
@@ -4,19 +4,13 @@
 
 using System;
 
-namespace Microsoft.CodeAnalysis.Remote
-{
-    [Flags]
-    internal enum RemoteProcessConfiguration
-    {
-        /// <summary>
-        /// Remote host runs on .NET 6+.
-        /// </summary>
-        Core = 1,
+namespace Microsoft.CodeAnalysis.Remote;
 
-        /// <summary>
-        /// Remote host uses server GC.
-        /// </summary>
-        ServerGC = 1 << 1,
-    }
+[Flags]
+internal enum RemoteProcessConfiguration
+{
+    /// <summary>
+    /// Remote host uses server GC.
+    /// </summary>
+    ServerGC = 1,
 }


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/72772.  Removes non-core descriptors as well.  Not sure if this will succeed though given that some of our tests may run on netfx.   