### PR TITLE
Experimental idea: Remove the global file-path-to-document-ids map at the solution level.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -14,11 +15,11 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
-using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -64,6 +65,8 @@ internal partial class ProjectState
     /// The list of source generators and the analyzer reference they came from.
     /// </summary>
     private ImmutableDictionary<ISourceGenerator, AnalyzerReference>? _lazySourceGenerators;
+
+    private FrozenDictionary<string, OneOrMany<DocumentId>>? _filePathToDocumentIds;
 
     private ProjectState(
         ProjectInfo projectInfo,
@@ -975,5 +978,40 @@ internal partial class ProjectState
             : contentChanged
                 ? CreateLazyLatestDocumentTopLevelChangeVersion(newDocument, newDocumentStates, newAdditionalDocumentStates)
                 : _lazyLatestDocumentTopLevelChangeVersion;
+    }
+
+    public void AddDocumentIdsWithFilePath(ref TemporaryArray<DocumentId> temporaryArray, string filePath)
+    {
+        var filePathToDocumentIds = _filePathToDocumentIds ??= CreateFilePathToDocumentIds();
+        if (filePathToDocumentIds.TryGetValue(filePath, out var oneOrMany))
+        {
+            foreach (var value in oneOrMany)
+                temporaryArray.Add(value);
+        }
+    }
+
+    private FrozenDictionary<string, OneOrMany<DocumentId>> CreateFilePathToDocumentIds()
+    {
+        using var _ = PooledDictionary<string, OneOrMany<DocumentId>>.GetInstance(out var map);
+
+        AddStates(this.DocumentStates);
+        AddStates(this.AdditionalDocumentStates);
+        AddStates(this.AnalyzerConfigDocumentStates);
+
+        return map.ToFrozenDictionary();
+
+        void AddStates<TState>(TextDocumentStates<TState> states) where TState : TextDocumentState
+        {
+            foreach (var (documentId, state) in states.States)
+            {
+                var filePath = state.FilePath;
+                if (filePath is null)
+                    continue;
+
+                map[filePath] = map.TryGetValue(filePath, out var existingValue)
+                    ? existingValue.Add(documentId)
+                    : OneOrMany.Create(documentId);
+            }
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -1144,19 +1144,6 @@ internal sealed partial class SolutionCompilationState
         var newIdToProjectStateMapBuilder = this.SolutionState.ProjectStates.ToBuilder();
         var newIdToTrackerMapBuilder = _projectIdToTrackerMap.ToBuilder();
 
-        // Keep track of the files that were potentially added between the last frozen snapshot point we have for a
-        // project and now.  Specifically, if a file was removed in reality, it may show us as an add as we are
-        // effectively jumping back to a prior point in time for a particular project.  We want all those files (and
-        // related doc ids) to be present in the frozen solution we hand back.
-        //
-        // Note: we only keep track of added files.  We do not keep track of removed files.  This is intentionally done
-        // for performance reasons.  Specifically, it is quite normal for a project to drop all documents when frozen
-        // (for example, when no documents have been parsed in it).  Actually dropping all these files from this map is
-        // very expensive.  This does mean that the FilePathToDocumentIdsMap will be a superset of all files.  That's
-        // ok.  We'll mark this map as being frozen (and thus potentially containing a superset of legal ids), and later
-        // on our helpers will check for that and filter down to the set that is in a solution when queried.
-        var filePathToDocumentIdsMapBuilder = this.SolutionState.FilePathToDocumentIdsMap.ToFrozen().ToBuilder();
-
         foreach (var projectId in this.SolutionState.ProjectIds)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -1177,39 +1164,15 @@ internal sealed partial class SolutionCompilationState
 
             newIdToProjectStateMapBuilder[projectId] = newProjectState;
             newIdToTrackerMapBuilder[projectId] = newTracker;
-
-            // Freezing projects can cause them to have an entirely different set of documents (since it effectively
-            // rewinds the project back to the last time it produced a compilation).  Ensure we keep track of the docs
-            // added or removed from the project states to keep the final filepath-to-documentid map accurate.
-            //
-            // Note: we only have to do this if the actual project-state changed.  If we were able to use the same
-            // instance (common if we already got the compilation for a project), then nothing changes with the set
-            // of documents.
-            //
-            // Examples of where the documents may absolutely change though are when we haven't even gotten a
-            // compilation yet.  In that case, the project transitions to an empty state, which means we should remove
-            // all its documents from the filePathToDocumentIdsMap.  Similarly, if we were at some in-progress-state we
-            // might reset the project back to a prior state from when the last compilation was requested, losing
-            // information about documents recently added or removed.
-
-            if (oldProjectState != newProjectState)
-            {
-                AddMissingOrChangedFilePathMappings(filePathToDocumentIdsMapBuilder, oldProjectState.DocumentStates, newProjectState.DocumentStates);
-                AddMissingOrChangedFilePathMappings(filePathToDocumentIdsMapBuilder, oldProjectState.AdditionalDocumentStates, newProjectState.AdditionalDocumentStates);
-                AddMissingOrChangedFilePathMappings(filePathToDocumentIdsMapBuilder, oldProjectState.AnalyzerConfigDocumentStates, newProjectState.AnalyzerConfigDocumentStates);
-            }
         }
 
         var newIdToProjectStateMap = newIdToProjectStateMapBuilder.ToImmutable();
         var newIdToTrackerMap = newIdToTrackerMapBuilder.ToImmutable();
 
-        var filePathToDocumentIdsMap = filePathToDocumentIdsMapBuilder.ToImmutable();
-
         var dependencyGraph = SolutionState.CreateDependencyGraph(this.SolutionState.ProjectIds, newIdToProjectStateMap);
 
         var newState = this.SolutionState.Branch(
             idToProjectStateMap: newIdToProjectStateMap,
-            filePathToDocumentIdsMap: filePathToDocumentIdsMap,
             dependencyGraph: dependencyGraph);
 
         var newCompilationState = this.Branch(
@@ -1219,41 +1182,6 @@ internal sealed partial class SolutionCompilationState
             cachedFrozenSnapshot: _cachedFrozenSnapshot);
 
         return newCompilationState;
-
-        static void AddMissingOrChangedFilePathMappings<TDocumentState>(
-            FilePathToDocumentIdsMap.Builder filePathToDocumentIdsMapBuilder,
-            TextDocumentStates<TDocumentState> oldStates,
-            TextDocumentStates<TDocumentState> newStates) where TDocumentState : TextDocumentState
-        {
-            if (oldStates.Equals(newStates))
-                return;
-
-            // We want to make sure that all the documents in the new-state are properly represented in the file map.
-            // It's ok if old-state documents are still in the map as GetDocumentIdsWithFilePath will filter them out
-            // later since we're producing a frozen-partial map.
-            // 
-            // Iterating over the new-states has an additional benefit.  For projects that haven't ever been looked at
-            // (so they haven't really parsed any documents), this will results in empty new-states.  So this loop will
-            // be almost a no-op for most non-relevant projects.
-            foreach (var (documentId, newDocumentState) in newStates.States)
-            {
-                if (!oldStates.TryGetState(documentId, out var oldDocumentState))
-                {
-                    // Keep track of files that are definitely added.  Make sure the added doc is in the file path map.
-                    filePathToDocumentIdsMapBuilder.Add(newDocumentState.FilePath, documentId);
-
-                }
-                else if (oldDocumentState != newDocumentState &&
-                         oldDocumentState.FilePath != newDocumentState.FilePath)
-                {
-                    // Otherwise, if the document is in both, but the file name changed, then remove the old mapping
-                    // and add the new mapping.  Importantly, we don't want other linked files with the *old* path
-                    // to consider this document one of their linked brethren.
-                    filePathToDocumentIdsMapBuilder.Remove(oldDocumentState.FilePath, oldDocumentState.Id);
-                    filePathToDocumentIdsMapBuilder.Add(newDocumentState.FilePath, newDocumentState.Id);
-                }
-            }
-        }
     }
 
     /// <summary>
@@ -1469,9 +1397,7 @@ internal sealed partial class SolutionCompilationState
 
             var stateChange = newCompilationState.SolutionState.ForkProject(
                 oldProjectState,
-                newProjectState,
-                // intentionally accessing this.Solution here not newSolutionState
-                newFilePathToDocumentIdsMap: this.SolutionState.CreateFilePathToDocumentIdsMapWithAddedDocuments(newDocumentStates));
+                newProjectState);
 
             newCompilationState = newCompilationState.ForkProject(
                 stateChange,
@@ -1523,9 +1449,7 @@ internal sealed partial class SolutionCompilationState
 
             var stateChange = newCompilationState.SolutionState.ForkProject(
                 oldProjectState,
-                newProjectState,
-                // Intentionally using this.Solution here and not newSolutionState
-                newFilePathToDocumentIdsMap: this.SolutionState.CreateFilePathToDocumentIdsMapWithRemovedDocuments(removedDocumentStatesForProject));
+                newProjectState);
 
             newCompilationState = newCompilationState.ForkProject(
                 stateChange,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -42,11 +42,12 @@ internal sealed partial class SolutionState
 
     private readonly SolutionInfo.SolutionAttributes _solutionAttributes;
     private readonly ImmutableDictionary<ProjectId, ProjectState> _projectIdToProjectStateMap;
-    private readonly FilePathToDocumentIdsMap _filePathToDocumentIdsMap;
     private readonly ProjectDependencyGraph _dependencyGraph;
 
     // holds on data calculated based on the AnalyzerReferences list
     private readonly Lazy<HostDiagnosticAnalyzers> _lazyAnalyzers;
+
+    private ImmutableDictionary<string, ImmutableArray<DocumentId>> _lazyFilePathToRelatedDocumentIds = ImmutableDictionary<string, ImmutableArray<DocumentId>>.Empty;
 
     private SolutionState(
         string? workspaceKind,
@@ -57,7 +58,6 @@ internal sealed partial class SolutionState
         SolutionOptionSet options,
         IReadOnlyList<AnalyzerReference> analyzerReferences,
         ImmutableDictionary<ProjectId, ProjectState> idToProjectStateMap,
-        FilePathToDocumentIdsMap filePathToDocumentIdsMap,
         ProjectDependencyGraph dependencyGraph,
         Lazy<HostDiagnosticAnalyzers>? lazyAnalyzers)
     {
@@ -69,7 +69,6 @@ internal sealed partial class SolutionState
         Options = options;
         AnalyzerReferences = analyzerReferences;
         _projectIdToProjectStateMap = idToProjectStateMap;
-        _filePathToDocumentIdsMap = filePathToDocumentIdsMap;
         _dependencyGraph = dependencyGraph;
         _lazyAnalyzers = lazyAnalyzers ?? CreateLazyHostDiagnosticAnalyzers(analyzerReferences);
 
@@ -100,7 +99,6 @@ internal sealed partial class SolutionState
             options,
             analyzerReferences,
             idToProjectStateMap: ImmutableDictionary<ProjectId, ProjectState>.Empty,
-            filePathToDocumentIdsMap: FilePathToDocumentIdsMap.Empty,
             dependencyGraph: ProjectDependencyGraph.Empty,
             lazyAnalyzers: null)
     {
@@ -152,7 +150,6 @@ internal sealed partial class SolutionState
         SolutionOptionSet? options = null,
         IReadOnlyList<AnalyzerReference>? analyzerReferences = null,
         ImmutableDictionary<ProjectId, ProjectState>? idToProjectStateMap = null,
-        FilePathToDocumentIdsMap? filePathToDocumentIdsMap = null,
         ProjectDependencyGraph? dependencyGraph = null)
     {
         solutionAttributes ??= _solutionAttributes;
@@ -160,7 +157,6 @@ internal sealed partial class SolutionState
         idToProjectStateMap ??= _projectIdToProjectStateMap;
         options ??= Options;
         analyzerReferences ??= AnalyzerReferences;
-        filePathToDocumentIdsMap ??= _filePathToDocumentIdsMap;
         dependencyGraph ??= _dependencyGraph;
 
         var analyzerReferencesEqual = AnalyzerReferences.SequenceEqual(analyzerReferences);
@@ -170,7 +166,6 @@ internal sealed partial class SolutionState
             options == Options &&
             analyzerReferencesEqual &&
             idToProjectStateMap == _projectIdToProjectStateMap &&
-            filePathToDocumentIdsMap == _filePathToDocumentIdsMap &&
             dependencyGraph == _dependencyGraph)
         {
             return this;
@@ -185,7 +180,6 @@ internal sealed partial class SolutionState
             options,
             analyzerReferences,
             idToProjectStateMap,
-            filePathToDocumentIdsMap.Value,
             dependencyGraph,
             analyzerReferencesEqual ? _lazyAnalyzers : null);
     }
@@ -218,12 +212,9 @@ internal sealed partial class SolutionState
             Options,
             AnalyzerReferences,
             _projectIdToProjectStateMap,
-            _filePathToDocumentIdsMap,
             _dependencyGraph,
             _lazyAnalyzers);
     }
-
-    public FilePathToDocumentIdsMap FilePathToDocumentIdsMap => _filePathToDocumentIdsMap;
 
     /// <summary>
     /// The version of the most recently modified project.
@@ -329,13 +320,10 @@ internal sealed partial class SolutionState
             }
         }
 
-        var newFilePathToDocumentIdsMap = CreateFilePathToDocumentIdsMapWithAddedDocuments(GetDocumentStates(newStateMap[projectId]));
-
         return Branch(
             solutionAttributes: newSolutionAttributes,
             projectIds: newProjectIds,
             idToProjectStateMap: newStateMap,
-            filePathToDocumentIdsMap: newFilePathToDocumentIdsMap,
             dependencyGraph: newDependencyGraph);
     }
 
@@ -399,55 +387,12 @@ internal sealed partial class SolutionState
         var newProjectIds = ProjectIds.ToImmutableArray().Remove(projectId);
         var newStateMap = _projectIdToProjectStateMap.Remove(projectId);
         var newDependencyGraph = _dependencyGraph.WithProjectRemoved(projectId);
-        var newFilePathToDocumentIdsMap = CreateFilePathToDocumentIdsMapWithRemovedDocuments(GetDocumentStates(_projectIdToProjectStateMap[projectId]));
 
         return this.Branch(
             solutionAttributes: newSolutionAttributes,
             projectIds: newProjectIds,
             idToProjectStateMap: newStateMap,
-            filePathToDocumentIdsMap: newFilePathToDocumentIdsMap,
             dependencyGraph: newDependencyGraph);
-    }
-
-    public FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithAddedDocuments(IEnumerable<TextDocumentState> documentStates)
-    {
-        var builder = _filePathToDocumentIdsMap.ToBuilder();
-        AddDocumentFilePaths(documentStates, builder);
-        return builder.ToImmutable();
-    }
-
-    private static void AddDocumentFilePaths(IEnumerable<TextDocumentState> documentStates, FilePathToDocumentIdsMap.Builder builder)
-    {
-        foreach (var documentState in documentStates)
-            builder.Add(documentState.FilePath, documentState.Id);
-    }
-
-    public FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithRemovedDocuments(IEnumerable<TextDocumentState> documentStates)
-    {
-        var builder = _filePathToDocumentIdsMap.ToBuilder();
-        RemoveDocumentFilePaths(documentStates, builder);
-        return builder.ToImmutable();
-    }
-
-    private static void RemoveDocumentFilePaths(IEnumerable<TextDocumentState> documentStates, FilePathToDocumentIdsMap.Builder builder)
-    {
-        foreach (var documentState in documentStates)
-            builder.Remove(documentState.FilePath, documentState.Id);
-    }
-
-    private FilePathToDocumentIdsMap CreateFilePathToDocumentIdsMapWithFilePath(DocumentId documentId, string? oldFilePath, string? newFilePath)
-    {
-        if (oldFilePath == newFilePath)
-        {
-            return _filePathToDocumentIdsMap;
-        }
-
-        var builder = _filePathToDocumentIdsMap.ToBuilder();
-
-        builder.Remove(oldFilePath, documentId);
-        builder.Add(newFilePath, documentId);
-
-        return builder.ToImmutable();
     }
 
     /// <summary>
@@ -1118,13 +1063,9 @@ internal sealed partial class SolutionState
         // This method shouldn't have been called if the document has not changed.
         Debug.Assert(oldProject != newProject);
 
-        var oldDocument = oldProject.DocumentStates.GetRequiredState(newDocument.Id);
-        var newFilePathToDocumentIdsMap = CreateFilePathToDocumentIdsMapWithFilePath(newDocument.Id, oldDocument.FilePath, newDocument.FilePath);
-
         return ForkProject(
             oldProject,
-            newProject,
-            newFilePathToDocumentIdsMap: newFilePathToDocumentIdsMap);
+            newProject);
     }
 
     private StateChange UpdateAdditionalDocumentState(AdditionalDocumentState newDocument, bool contentChanged)
@@ -1158,8 +1099,7 @@ internal sealed partial class SolutionState
     public StateChange ForkProject(
         ProjectState oldProjectState,
         ProjectState newProjectState,
-        ProjectDependencyGraph? newDependencyGraph = null,
-        FilePathToDocumentIdsMap? newFilePathToDocumentIdsMap = null)
+        ProjectDependencyGraph? newDependencyGraph = null)
     {
         var projectId = newProjectState.Id;
 
@@ -1170,8 +1110,7 @@ internal sealed partial class SolutionState
 
         var newSolutionState = this.Branch(
             idToProjectStateMap: newStateMap,
-            dependencyGraph: newDependencyGraph,
-            filePathToDocumentIdsMap: newFilePathToDocumentIdsMap ?? _filePathToDocumentIdsMap);
+            dependencyGraph: newDependencyGraph);
 
         return new(newSolutionState, oldProjectState, newProjectState);
     }
@@ -1185,38 +1124,19 @@ internal sealed partial class SolutionState
         if (string.IsNullOrEmpty(filePath))
             return [];
 
-        if (!_filePathToDocumentIdsMap.TryGetValue(filePath, out var documentIds))
-            return [];
+        return ImmutableInterlocked.GetOrAdd(
+            ref _lazyFilePathToRelatedDocumentIds,
+            filePath,
+            static (filePath, @this) => ComputeDocumentIdsWithFilePath(@this, filePath),
+            this);
 
-        // If this wasn't the result of a freeze, then we can return the document ids as is.  They should be accurate.
-        if (!_filePathToDocumentIdsMap.IsFrozen)
+        static ImmutableArray<DocumentId> ComputeDocumentIdsWithFilePath(SolutionState @this, string filePath)
         {
-            Debug.Assert(documentIds.All(ContainsAnyDocument));
-            return documentIds;
-        }
+            using var result = TemporaryArray<DocumentId>.Empty;
+            foreach (var (projectId, projectState) in @this.ProjectStates)
+                projectState.AddDocumentIdsWithFilePath(ref result.AsRef(), filePath);
 
-        // We were frozen.  So we may be seeing document ids that no longer exist within this snapshot.  If so,
-        // filter them out.
-        using var _ = ArrayBuilder<DocumentId>.GetInstance(documentIds.Length, out var result);
-
-        foreach (var documentId in documentIds)
-        {
-            if (ContainsAnyDocument(documentId))
-                result.Add(documentId);
-        }
-
-        result.RemoveDuplicates();
-        return result.ToImmutableAndClear();
-
-        bool ContainsAnyDocument(DocumentId documentId)
-        {
-            var project = this.GetProjectState(documentId.ProjectId);
-            if (project is null)
-                return false;
-
-            return project.DocumentStates.Contains(documentId)
-                || project.AdditionalDocumentStates.Contains(documentId)
-                || project.AnalyzerConfigDocumentStates.Contains(documentId);
+            return result.ToImmutableAndClear();
         }
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -364,11 +364,6 @@ internal sealed partial class SolutionState
         return this.AddProject(newProject);
     }
 
-    private static IEnumerable<TextDocumentState> GetDocumentStates(ProjectState projectState)
-        => projectState.DocumentStates.States.Values
-               .Concat<TextDocumentState>(projectState.AdditionalDocumentStates.States.Values)
-               .Concat(projectState.AnalyzerConfigDocumentStates.States.Values);
-
     /// <summary>
     /// Create a new solution instance without the project specified.
     /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
@@ -269,5 +270,10 @@ internal readonly struct TextDocumentStates<TState>
         var documentChecksumTasks = SelectAsArray(static (state, token) => state.GetChecksumAsync(token), cancellationToken);
         var documentChecksums = new ChecksumCollection(await documentChecksumTasks.WhenAll().ConfigureAwait(false));
         return new(documentChecksums, SelectAsArray(static s => s.Id));
+    }
+
+    public void AddDocumentIdsWithFilePath(ref TemporaryArray<DocumentId> temporaryArray, string filePath)
+    {
+
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -312,9 +312,12 @@ public abstract partial class Workspace : IDisposable
             var relatedDocumentIds = solution.GetRelatedDocumentIds(addedDocumentId);
             foreach (var relatedDocumentId in relatedDocumentIds)
             {
+                // GetRelatedDocumentIds includes the document id passed in.  Skip that if it's the first id we get back.
                 if (relatedDocumentId == addedDocumentId)
                     continue;
 
+                // Copy over the contents of our linked file over to the added file.  Immediately return at that point,
+                // there's no point looking at any further related documents.
                 var relatedDocument = solution.GetRequiredDocument(relatedDocumentId);
                 return solution.WithDocumentContentsFrom(addedDocumentId, relatedDocument.DocumentState, forceEvenIfTreesWouldDiffer: false);
             }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -312,6 +312,9 @@ public abstract partial class Workspace : IDisposable
             var relatedDocumentIds = solution.GetRelatedDocumentIds(addedDocumentId);
             foreach (var relatedDocumentId in relatedDocumentIds)
             {
+                if (relatedDocumentId == addedDocumentId)
+                    continue;
+
                 var relatedDocument = solution.GetRequiredDocument(relatedDocumentId);
                 return solution.WithDocumentContentsFrom(addedDocumentId, relatedDocument.DocumentState, forceEvenIfTreesWouldDiffer: false);
             }


### PR DESCRIPTION
Instead, keep maps at the project level and search those when needed.  This needs to do a perf run to make sure there are no problems with this. 

The benefits of this system are that it's extremely simple.  We now only keep small maps at the TextDocumentStates level, and it's exceedingly easy to keep that map up to date.  The cons are that finding the related documents for a particular file-path now involves a linear walk of all the projects.  However, per project it is O(1).  My hope is that that fine from a perf perspective.

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=9328057&view=results