### PR TITLE
Update Rename UI to accommodate for getting suggestions automatically

### DIFF
--- a/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
+++ b/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
@@ -159,4 +159,7 @@
   <data name="Toggle_AI_suggestions" xml:space="preserve">
     <value>Toggle rename suggestions (Ctrl+Space)</value>
   </data>
+  <data name="Generating_suggestions" xml:space="preserve">
+    <value>Generating suggestions...</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
+++ b/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
@@ -156,4 +156,7 @@
   <data name="Get_AI_suggestions" xml:space="preserve">
     <value>Get AI-powered rename suggestions (Ctrl+Space)</value>
   </data>
+  <data name="Toggle_AI_suggestions" xml:space="preserve">
+    <value>Toggle rename suggestions (Ctrl+Space)</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -52,6 +52,9 @@
                     x:Name="ToggleExpandButton"
                     Grid.Column="1"
                     Click="ToggleExpand"
+                    Height="22"
+                    VerticalAlignment="Top"
+                    Margin="0 4 0 0"
                     Background="Transparent"
                     platformimaging:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Background, ElementName=Outline, Converter={StaticResource BrushToColorConverter}}" >
                     <Button.Style>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -53,7 +53,6 @@
                     Grid.Column="1"
                     Click="ToggleExpand"
                     VerticalAlignment="Top"
-                    Height="22"
                     Margin="0 2 0 0"
                     Background="Transparent"
                     platformimaging:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Background, ElementName=Outline, Converter={StaticResource BrushToColorConverter}}" >

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -52,9 +52,9 @@
                     x:Name="ToggleExpandButton"
                     Grid.Column="1"
                     Click="ToggleExpand"
-                    Height="22"
                     VerticalAlignment="Top"
-                    Margin="0 4 0 0"
+                    Height="22"
+                    Margin="0 2 0 0"
                     Background="Transparent"
                     platformimaging:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Background, ElementName=Outline, Converter={StaticResource BrushToColorConverter}}" >
                     <Button.Style>
@@ -104,6 +104,7 @@
                 Text="{Binding SearchText}"
                 Visibility="{Binding ShowSearchText, Converter={StaticResource BooleanToVisibilityConverter}}"
                 FontWeight="Light"
+                VerticalAlignment="Center"
                 Margin="0,0,0,5" />
 
             <StackPanel Orientation="Vertical" Visibility="{Binding IsExpanded, Converter={StaticResource BooleanToVisibilityConverter}}">

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -209,9 +209,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                         if (_viewModel.SmartRenameViewModel is not null && _viewModel.SmartRenameViewModel.GetSuggestionsCommand.CanExecute(null))
                         {
                             // If smart rename can use automatic behavior, enable it
-                            if (!_viewModel.SmartRenameViewModel.IsUsingDropdown && _viewModel.SmartRenameViewModel.IsSuggestionsPanelCollapsed)
+                            if (!_viewModel.SmartRenameViewModel.IsUsingDropdown)
                             {
-                                _viewModel.SmartRenameViewModel.IsSuggestionsPanelCollapsed = false;
+                                _viewModel.SmartRenameViewModel.IsSuggestionsPanelCollapsed = !_viewModel.SmartRenameViewModel.IsSuggestionsPanelCollapsed;
                             }
                             _viewModel.SmartRenameViewModel.GetSuggestionsCommand.Execute(null);
                         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -208,6 +208,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                         // If smart rename is available, trigger it.
                         if (_viewModel.SmartRenameViewModel is not null && _viewModel.SmartRenameViewModel.GetSuggestionsCommand.CanExecute(null))
                         {
+                            // If smart rename can use automatic behavior, enable it
+                            if (!_viewModel.SmartRenameViewModel.IsUsingDropdown && _viewModel.SmartRenameViewModel.IsSuggestionsPanelCollapsed)
+                            {
+                                _viewModel.SmartRenameViewModel.IsSuggestionsPanelCollapsed = false;
+                            }
                             _viewModel.SmartRenameViewModel.GetSuggestionsCommand.Execute(null);
                         }
                     }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public string PreviewChanges => EditorFeaturesResources.Preview_changes1;
         public string SubmitText
             => _viewModel.SmartRenameViewModel is not null
-            ? EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion
+            ? _viewModel.SmartRenameViewModel.SubmitTextOverride
             : EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
 #pragma warning restore CA1822 // Mark members as static
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             var smartRenameSession = smartRenameSessionFactory?.Value.CreateSmartRenameSession(_session.TriggerSpan);
             if (smartRenameSession is not null)
             {
-                SmartRenameViewModel = new SmartRenameViewModel(threadingContext, listenerProvider, smartRenameSession.Value, this);
+                SmartRenameViewModel = new SmartRenameViewModel(globalOptionService, threadingContext, listenerProvider, smartRenameSession.Value, this);
             }
 
             RegisterOleComponent();

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -10,7 +10,6 @@
           mc:Ignorable="d"
           GotKeyboardFocus="ComboBox_GotKeyboardFocus"
           LostKeyboardFocus="ComboBox_LostKeyboardFocus"
-          LostFocus="ComboBox_LostFocus"
           Unloaded="ComboBox_Unloaded"
           PreviewKeyUp="ComboBox_PreviewKeyUp"
           SelectionChanged="ComboBox_SelectionChanged"

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -210,7 +210,7 @@
                         x:Uid="ProgressBarHost"
                         Grid.Row="1"
                         Grid.Column="0"
-                        BorderThickness="0" 
+                        BorderThickness="0"
                         Visibility="{Binding IsUsingDropdown, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}">
                     <ProgressBar x:Name="ProgressBar"
                                  x:Uid="ProgressBar"
@@ -224,7 +224,7 @@
                         x:Uid="panelBorder"
                         Grid.Row="2"
                         Grid.Column="0"
-                        Height="60"
+                        Height="62"
                         Visibility="{Binding IsUsingResultPanel, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}"
                         BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBorderBrushKey}}"
                         BorderThickness="1">
@@ -240,15 +240,16 @@
                                         Orientation="Vertical"
                                         Visibility="{Binding IsInProgress, Converter={StaticResource BooleanToHiddenVisibilityConverter}, Mode=OneWay}"
                                         >
-                                <ProgressBar x:Name="PanelProgressBar"
-                                             x:Uid="PanelProgressBar"
-                                             Margin="{TemplateBinding BorderThickness}"
-                                             IsIndeterminate="{Binding IsInProgress}"
-                                             Foreground="{StaticResource copilotBranding}"
-                                             Background="{DynamicResource {x:Static vsfx:VsBrushes.CommandBarMenuBackgroundGradientBeginKey}}" />
                                 <TextBlock x:Name="PanelLabel"
                                            x:Uid="PanelLabel"
-                                        Text="Generating suggestions..." />
+                                           Padding="2"
+                                           Text="Generating suggestions..." />
+                                <ProgressBar x:Name="PanelProgressBar"
+                                     x:Uid="PanelProgressBar"
+                                     Margin="{TemplateBinding BorderThickness}"
+                                     IsIndeterminate="{Binding IsInProgress}"
+                                     Foreground="{StaticResource copilotBranding}"
+                                     Background="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBackgroundGradientBrushKey}}" />
                             </StackPanel>
                             <ItemsPresenter x:Name="AltItemsPresenter"
                                     x:Uid="AltItemsPresenter"

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -169,7 +169,7 @@
                                 Grid.Row="0"
                                 Grid.Column="1"
                                 Style="{StaticResource GetSuggestionButtonStyle}"
-                                ToolTip="{x:Static sr:SmartRenameViewModel.GetSuggestionsTooltip}"
+                                ToolTip="{Binding GetSuggestionsTooltip}"
                                 Click="GetSuggestionsButtonClick"
                                 Command="{Binding GetSuggestionsCommand}">
                     <Button.Content>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -10,6 +10,7 @@
           mc:Ignorable="d"
           GotKeyboardFocus="ComboBox_GotKeyboardFocus"
           LostKeyboardFocus="ComboBox_LostKeyboardFocus"
+          LostFocus="ComboBox_LostFocus"
           Unloaded="ComboBox_Unloaded"
           PreviewKeyUp="ComboBox_PreviewKeyUp"
           SelectionChanged="ComboBox_SelectionChanged"
@@ -23,6 +24,7 @@
     <ComboBox.Resources>
         <ResourceDictionary>
             <vsui:BooleanToHiddenVisibilityConverter x:Key="BooleanToHiddenVisibilityConverter"/>
+            <vsui:BooleanToCustomVisibilityConverter x:Key="BooleanToCollapsedVisibilityConverter"/>
             <SolidColorBrush x:Key="copilotBranding" Color="#6F66E3"/>
 
             <ControlTemplate x:Key="ComboBoxItemTemplate" TargetType="{x:Type ComboBoxItem}">
@@ -95,6 +97,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -102,6 +105,7 @@
                 </Grid.ColumnDefinitions>
                 <Popup x:Name="PART_Popup"
                                x:Uid="PART_Popup"
+                               Visibility="{Binding IsUsingDropdown, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}"
                                AllowsTransparency="true"
                                Grid.ColumnSpan="2"
                                Placement="Bottom"
@@ -202,15 +206,60 @@
                         </Canvas>
                     </Button.Content>
                 </Button>
-                <ProgressBar x:Name="ProgressBar"
-                             x:Uid="ProgressBar"
-                             Grid.Row="1"
-                             Grid.Column="0"
-                             Margin="{TemplateBinding BorderThickness}"
-                             IsIndeterminate="{Binding IsInProgress}"
-                             Visibility="{Binding IsInProgress, Converter={StaticResource BooleanToHiddenVisibilityConverter}, Mode=OneWay}"
-                             Foreground="{StaticResource copilotBranding}"
-                             Background="{DynamicResource {x:Static vsfx:VsBrushes.CommandBarMenuBackgroundGradientBeginKey}}" />
+                <Border x:Name="ProgressBarHost"
+                        x:Uid="ProgressBarHost"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        BorderThickness="0" 
+                        Visibility="{Binding IsUsingDropdown, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}">
+                    <ProgressBar x:Name="ProgressBar"
+                                 x:Uid="ProgressBar"
+                                 Margin="{TemplateBinding BorderThickness}"
+                                 IsIndeterminate="{Binding IsInProgress}"
+                                 Visibility="{Binding IsInProgress, Converter={StaticResource BooleanToHiddenVisibilityConverter}, Mode=OneWay}"
+                                 Foreground="{StaticResource copilotBranding}"
+                                 Background="{DynamicResource {x:Static vsfx:VsBrushes.CommandBarMenuBackgroundGradientBeginKey}}" />
+                </Border>
+                <Border x:Name="panelBorder"
+                        x:Uid="panelBorder"
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Height="60"
+                        Visibility="{Binding IsUsingResultPanel, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}"
+                        BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBorderBrushKey}}"
+                        BorderThickness="1">
+                    <ScrollViewer x:Name="PanelScrollViewer"
+                        x:Uid="PanelScrollViewer">
+                        <Grid x:Name="panelGrid"
+                            x:Uid="panelGrid"
+                            RenderOptions.ClearTypeHint="Enabled"
+                            RenderOptions.BitmapScalingMode="{x:Static vsui:DpiHelper.BitmapScalingMode}"
+                            Background="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBackgroundGradientBrushKey}}">
+                            <StackPanel x:Name="PanelProgressBarHost"
+                                        x:Uid="PanelProgressBarHost"
+                                        Orientation="Vertical"
+                                        Visibility="{Binding IsInProgress, Converter={StaticResource BooleanToHiddenVisibilityConverter}, Mode=OneWay}"
+                                        >
+                                <ProgressBar x:Name="PanelProgressBar"
+                                             x:Uid="PanelProgressBar"
+                                             Margin="{TemplateBinding BorderThickness}"
+                                             IsIndeterminate="{Binding IsInProgress}"
+                                             Foreground="{StaticResource copilotBranding}"
+                                             Background="{DynamicResource {x:Static vsfx:VsBrushes.CommandBarMenuBackgroundGradientBeginKey}}" />
+                                <TextBlock x:Name="PanelLabel"
+                                           x:Uid="PanelLabel"
+                                        Text="Generating suggestions..." />
+                            </StackPanel>
+                            <ItemsPresenter x:Name="AltItemsPresenter"
+                                    x:Uid="AltItemsPresenter"
+                                    VirtualizingStackPanel.IsVirtualizing="True"
+                                    KeyboardNavigation.DirectionalNavigation="Contained"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                    PreviewMouseUp="ItemsPresenter_PreviewMouseUp">
+                            </ItemsPresenter>
+                        </Grid>
+                    </ScrollViewer>
+                </Border>
             </Grid>
             <ControlTemplate.Triggers>
                 <Trigger SourceName="PART_EditableTextBox" Property="IsEnabled" Value="false">

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -251,7 +251,7 @@
                                 <TextBlock x:Name="PanelLabel"
                                            x:Uid="PanelLabel"
                                            Padding="2"
-                                           Text="Generating suggestions..." />
+                                           Text="{Binding GeneratingSuggestionsLabel}" />
                                 <ProgressBar x:Name="PanelProgressBar"
                                      x:Uid="PanelProgressBar"
                                      Margin="{TemplateBinding BorderThickness}"

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -230,6 +230,7 @@
                         x:Uid="SuggestionsPanel"
                         Grid.Row="2"
                         Grid.Column="0"
+                        Margin="1 0"
                         Height="62"
                         Visibility="{Binding IsSuggestionsPanelExpanded, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}"
                         BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBorderBrushKey}}"

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -80,12 +80,15 @@
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="true">
                         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderHoverBrushKey}}"/>
-                        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonHoverBrushKey}}"/>
+                        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonFocusedBrushKey}}"/>
                     </Trigger>
                     <Trigger Property="IsKeyboardFocused" Value="true">
                         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderFocusedBrushKey}}"/>
                         <Setter Property="Background" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonFocusedBrushKey}}"/>
                     </Trigger>
+                    <DataTrigger Binding="{Binding IsSuggestionsPanelExpanded}" Value="True">
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderPressedBrushKey}}"/>
+                    </DataTrigger>
                 </Style.Triggers>
             </Style>
         </ResourceDictionary>
@@ -166,6 +169,7 @@
                                 Grid.Column="1"
                                 Style="{StaticResource GetSuggestionButtonStyle}"
                                 ToolTip="{x:Static sr:SmartRenameViewModel.GetSuggestionsTooltip}"
+                                Click="GetSuggestionsButtonClick"
                                 Command="{Binding GetSuggestionsCommand}">
                     <Button.Content>
                         <Canvas Width="16" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center">
@@ -213,24 +217,26 @@
                         Visibility="{Binding IsUsingDropdown, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}">
                     <ProgressBar x:Name="ProgressBar"
                                  x:Uid="ProgressBar"
+                                 Height="2"
                                  Margin="{TemplateBinding BorderThickness}"
                                  IsIndeterminate="{Binding IsInProgress}"
                                  Visibility="{Binding IsInProgress, Converter={StaticResource BooleanToHiddenVisibilityConverter}, Mode=OneWay}"
+                                 Template="{DynamicResource {x:Static vsfx:VsResourceKeys.ProgressBarTemplateKey}}"
                                  Foreground="{StaticResource copilotBranding}"
                                  Background="{DynamicResource {x:Static vsfx:VsBrushes.CommandBarMenuBackgroundGradientBeginKey}}" />
                 </Border>
-                <Border x:Name="panelBorder"
-                        x:Uid="panelBorder"
+                <Border x:Name="SuggestionsPanel"
+                        x:Uid="SuggestionsPanel"
                         Grid.Row="2"
                         Grid.Column="0"
                         Height="62"
-                        Visibility="{Binding IsUsingResultPanel, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}"
+                        Visibility="{Binding IsSuggestionsPanelExpanded, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}"
                         BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBorderBrushKey}}"
                         BorderThickness="1">
-                    <ScrollViewer x:Name="PanelScrollViewer"
-                        x:Uid="PanelScrollViewer">
-                        <Grid x:Name="panelGrid"
-                            x:Uid="panelGrid"
+                    <ScrollViewer x:Name="SuggestionsPanelScrollViewer"
+                        x:Uid="SuggestionsPanelScrollViewer">
+                        <Grid x:Name="SuggestionsPanelGrid"
+                            x:Uid="SuggestionsPanelGrid"
                             RenderOptions.ClearTypeHint="Enabled"
                             RenderOptions.BitmapScalingMode="{x:Static vsui:DpiHelper.BitmapScalingMode}"
                             Background="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBackgroundGradientBrushKey}}">
@@ -247,6 +253,8 @@
                                      x:Uid="PanelProgressBar"
                                      Margin="{TemplateBinding BorderThickness}"
                                      IsIndeterminate="{Binding IsInProgress}"
+                                     Height="2"
+                                     Template="{DynamicResource {x:Static vsfx:VsResourceKeys.ProgressBarTemplateKey}}"
                                      Foreground="{StaticResource copilotBranding}"
                                      Background="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBackgroundGradientBrushKey}}" />
                             </StackPanel>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -69,8 +69,8 @@
             </Style>
 
             <Style x:Key="GetSuggestionButtonStyle" BasedOn="{StaticResource {x:Static vsfx:VsResourceKeys.ButtonStyleKey}}" TargetType="Button">
-                <Setter Property="Padding" Value="5,5,2,1"/>
-                <Setter Property="Margin" Value="3,1,1,1"/>
+                <Setter Property="Padding" Value="5,4,2,0"/>
+                <Setter Property="Margin" Value="3,0,1,0"/>
                 <Setter Property="MinHeight" Value="0"/>
                 <Setter Property="MinWidth" Value="0"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"/>
@@ -230,6 +230,7 @@
                         x:Uid="SuggestionsPanel"
                         Grid.Row="2"
                         Grid.Column="0"
+                        Grid.ColumnSpan="2"
                         Margin="1 0"
                         Height="62"
                         Visibility="{Binding IsSuggestionsPanelExpanded, Converter={StaticResource BooleanToCollapsedVisibilityConverter}, Mode=OneWay}"

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -69,8 +69,8 @@
             </Style>
 
             <Style x:Key="GetSuggestionButtonStyle" BasedOn="{StaticResource {x:Static vsfx:VsResourceKeys.ButtonStyleKey}}" TargetType="Button">
-                <Setter Property="Padding" Value="5,4,2,0"/>
-                <Setter Property="Margin" Value="3,0,1,0"/>
+                <Setter Property="Padding" Value="4,4,1,0"/>
+                <Setter Property="Margin" Value="3,0,1,1"/>
                 <Setter Property="MinHeight" Value="0"/>
                 <Setter Property="MinWidth" Value="0"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"/>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml
@@ -73,22 +73,23 @@
                 <Setter Property="Margin" Value="3,1,1,1"/>
                 <Setter Property="MinHeight" Value="0"/>
                 <Setter Property="MinWidth" Value="0"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderDefaultBrushKey}}"/>
-                <Setter Property="Background" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonDefaultBrushKey}}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderBrushKey}}"/>
+                <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="Cursor" Value="Arrow"/>
                 <Setter Property="ForceCursor" Value="True"/>
                 <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsSuggestionsPanelExpanded}" Value="True">
+                        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonDefaultBrushKey}}"/>
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderPressedBrushKey}}"/>
+                    </DataTrigger>
                     <Trigger Property="IsMouseOver" Value="true">
                         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderHoverBrushKey}}"/>
-                        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonFocusedBrushKey}}"/>
+                        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonHoverBrushKey}}"/>
                     </Trigger>
                     <Trigger Property="IsKeyboardFocused" Value="true">
                         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderFocusedBrushKey}}"/>
                         <Setter Property="Background" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonFocusedBrushKey}}"/>
                     </Trigger>
-                    <DataTrigger Binding="{Binding IsSuggestionsPanelExpanded}" Value="True">
-                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:CommonControlsColors.ButtonBorderPressedBrushKey}}"/>
-                    </DataTrigger>
                 </Style.Triggers>
             </Style>
         </ResourceDictionary>
@@ -223,7 +224,7 @@
                                  Visibility="{Binding IsInProgress, Converter={StaticResource BooleanToHiddenVisibilityConverter}, Mode=OneWay}"
                                  Template="{DynamicResource {x:Static vsfx:VsResourceKeys.ProgressBarTemplateKey}}"
                                  Foreground="{StaticResource copilotBranding}"
-                                 Background="{DynamicResource {x:Static vsfx:VsBrushes.CommandBarMenuBackgroundGradientBeginKey}}" />
+                                 Background="Transparent" />
                 </Border>
                 <Border x:Name="SuggestionsPanel"
                         x:Uid="SuggestionsPanel"
@@ -256,7 +257,7 @@
                                      Height="2"
                                      Template="{DynamicResource {x:Static vsfx:VsResourceKeys.ProgressBarTemplateKey}}"
                                      Foreground="{StaticResource copilotBranding}"
-                                     Background="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxPopupBackgroundGradientBrushKey}}" />
+                                     Background="Transparent" />
                             </StackPanel>
                             <ItemsPresenter x:Name="AltItemsPresenter"
                                     x:Uid="AltItemsPresenter"

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -118,8 +118,18 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
         _dropDownPopup.IsOpen = false;
     }
 
+    private void ComboBox_LostFocus(object sender, RoutedEventArgs e)
+    {
+        Assumes.NotNull(_dropDownPopup);
+        _dropDownPopup.IsOpen = false;
+    }
+
     private void ComboBox_PreviewKeyUp(object sender, KeyEventArgs e)
     {
+        if (!_smartRenameViewModel.IsUsingDropdown)
+        {
+            return;
+        }
         if ((e.Key is Key.Up or Key.Down) && Items.Count > 0)
         {
             Assumes.NotNull(_dropDownPopup);
@@ -144,6 +154,10 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
 
     private void InnerTextBox_GotFocus(object sender, RoutedEventArgs e)
     {
+        if (!_smartRenameViewModel.IsUsingDropdown)
+        {
+            return;
+        }
         if (Items.Count > 0)
         {
             Assumes.NotNull(_dropDownPopup);

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -118,12 +118,6 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
         _dropDownPopup.IsOpen = false;
     }
 
-    private void ComboBox_LostFocus(object sender, RoutedEventArgs e)
-    {
-        Assumes.NotNull(_dropDownPopup);
-        _dropDownPopup.IsOpen = false;
-    }
-
     private void ComboBox_PreviewKeyUp(object sender, KeyEventArgs e)
     {
         if (!_smartRenameViewModel.IsUsingDropdown)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -102,6 +102,22 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
         _dropDownPopup = (Popup)GetTemplateChild(DropDownPopup)!;
     }
 
+    private void GetSuggestionsButtonClick(object sender, RoutedEventArgs e)
+    {
+        if (_smartRenameViewModel.IsUsingResultPanel)
+        {
+            _smartRenameViewModel.IsSuggestionsPanelExpanded = !_smartRenameViewModel.IsSuggestionsPanelExpanded;
+            if (_smartRenameViewModel.IsSuggestionsPanelExpanded)
+            {
+                _smartRenameViewModel.GetSuggestionsCommand.Execute(null);
+            }
+        }
+        else
+        {
+            _smartRenameViewModel.GetSuggestionsCommand.Execute(null);
+        }
+    }
+
     private void ComboBox_Unloaded(object sender, RoutedEventArgs e)
     {
         _smartRenameViewModel.SuggestedNames.CollectionChanged -= SuggestedNames_CollectionChanged;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -106,7 +106,7 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
     {
         if (_smartRenameViewModel.IsUsingResultPanel)
         {
-            _smartRenameViewModel.IsSuggestionsPanelExpanded = !_smartRenameViewModel.IsSuggestionsPanelExpanded;
+            _smartRenameViewModel.IsSuggestionsPanelCollapsed = !_smartRenameViewModel.IsSuggestionsPanelCollapsed;
             if (_smartRenameViewModel.IsSuggestionsPanelExpanded)
             {
                 _smartRenameViewModel.GetSuggestionsCommand.Execute(null);

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -184,7 +184,9 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
     private void InnerTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
     {
         Assumes.NotNull(_dropDownPopup);
-        if ((e.Key is Key.Escape or Key.Space or Key.Enter) && _dropDownPopup.IsOpen)
+        if ((e.Key is Key.Escape or Key.Space or Key.Enter)
+            && (_dropDownPopup.IsOpen // Handle these keystrokes when dropdown is present
+            || _smartRenameViewModel.IsUsingResultPanel && this.TextSelectionLength < this.Text.Length)) // Or when panel is present and text is not yet selected
         {
             _dropDownPopup.IsOpen = false;
             SelectAllText();

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -96,7 +96,7 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
         }
     }
 
-    private static bool toggleEveryInvocation; // Temporary flag for prototyping
+    private static bool toggleEveryInvocation; // Temporary flag for prototyping. This will be replaced by a read of a feature flag
 
     private void OnGetSuggestionsCommandExecute()
     {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.EditorFeatures.Lightup;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.VisualStudio.PlatformUI;
 
 namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -100,6 +100,8 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         ? EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion
         : EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
 
+    public string GeneratingSuggestionsLabel => EditorFeaturesWpfResources.Generating_suggestions;
+
     public ICommand GetSuggestionsCommand { get; }
 
     public SmartRenameViewModel(

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -89,7 +89,15 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
         get => IsUsingResultPanel && !IsSuggestionsPanelCollapsed;
     }
 
-    public static string GetSuggestionsTooltip => EditorFeaturesWpfResources.Get_AI_suggestions;
+    public string GetSuggestionsTooltip
+        => IsUsingDropdown
+        ? EditorFeaturesWpfResources.Get_AI_suggestions
+        : EditorFeaturesWpfResources.Toggle_AI_suggestions;
+
+    public string SubmitTextOverride
+        => IsUsingDropdown
+        ? EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion
+        : EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
 
     public ICommand GetSuggestionsCommand { get; }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -122,13 +122,12 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
         }
     }
 
-    private static bool toggleEveryInvocation; // Temporary flag for prototyping. This will be replaced by a read of a feature flag
-
     private void OnGetSuggestionsCommandExecute()
     {
         _threadingContext.ThrowIfNotOnUIThread();
         if (IsUsingResultPanel && SuggestedNames.Count > 0)
         {
+            // Don't get suggestions again in the automatic scenario
             return;
         }
         if (_getSuggestionsTask.Status is TaskStatus.RanToCompletion or TaskStatus.Faulted or TaskStatus.Canceled)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -72,7 +72,7 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
 
     public bool IsSuggestionsPanelCollapsed
     {
-        get => !IsUsingDropdown && _globalOptionService.GetOption(InlineRenameUIOptionsStorage.CollapseSuggestionsPanel);
+        get => IsUsingDropdown || _globalOptionService.GetOption(InlineRenameUIOptionsStorage.CollapseSuggestionsPanel);
         set
         {
             if (value != IsSuggestionsPanelCollapsed)
@@ -86,8 +86,7 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
 
     public bool IsSuggestionsPanelExpanded
     {
-        get => !IsSuggestionsPanelCollapsed;
-        set => IsSuggestionsPanelCollapsed = !value;
+        get => IsUsingResultPanel && !IsSuggestionsPanelCollapsed;
     }
 
     public static string GetSuggestionsTooltip => EditorFeaturesWpfResources.Get_AI_suggestions;
@@ -128,7 +127,7 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
     private void OnGetSuggestionsCommandExecute()
     {
         _threadingContext.ThrowIfNotOnUIThread();
-        if (SuggestedNames.Count > 0)
+        if (IsUsingResultPanel && SuggestedNames.Count > 0)
         {
             return;
         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -44,6 +44,8 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
     public string StatusMessage => _smartRenameSession.StatusMessage;
 
     public bool StatusMessageVisibility => _smartRenameSession.StatusMessageVisibility;
+    public bool IsUsingResultPanel { get; set; }
+    public bool IsUsingDropdown { get; set; }
 
     private string? _selectedSuggestedName;
 
@@ -85,7 +87,16 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
         this.BaseViewModel.IdentifierText = baseViewModel.IdentifierText;
 
         GetSuggestionsCommand = new DelegateCommand(OnGetSuggestionsCommandExecute, null, threadingContext.JoinableTaskFactory);
+        toggleEveryInvocation = !toggleEveryInvocation;
+        IsUsingResultPanel = toggleEveryInvocation;
+        IsUsingDropdown = !IsUsingResultPanel;
+        if (IsUsingResultPanel)
+        {
+            OnGetSuggestionsCommandExecute();
+        }
     }
+
+    private static bool toggleEveryInvocation; // Temporary flag for prototyping
 
     private void OnGetSuggestionsCommandExecute()
     {
@@ -107,8 +118,14 @@ internal sealed class SmartRenameViewModel : INotifyPropertyChanged, IDisposable
             var textInputBackup = BaseViewModel.IdentifierText;
 
             SuggestedNames.Clear();
+            var count = 0;
             foreach (var name in _smartRenameSession.SuggestedNames)
             {
+                if (++count > 3 && IsUsingResultPanel)
+                {
+                    // Set limit of 3 results when using the result panel
+                    break;
+                }
                 SuggestedNames.Add(name);
             }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -99,7 +99,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         ? EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview_ctrl_space_for_ai_suggestion
         : EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
 
-    public string GeneratingSuggestionsLabel => EditorFeaturesWpfResources.Generating_suggestions;
+    public static string GeneratingSuggestionsLabel => EditorFeaturesWpfResources.Generating_suggestions;
 
     public ICommand GetSuggestionsCommand { get; }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.CodeAnalysis.Editor.InlineRename;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Telemetry;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
@@ -1,0 +1,65 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.InlineRename;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Telemetry;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
+{
+    internal partial class SmartRenameViewModel
+    {
+        private SuggestionsPanelTelemetry? _suggestionsPanelTelemetry;
+        private SuggestionsDropdownTelemetry? _suggestionsDropdownTelemetry;
+
+        private sealed class SuggestionsPanelTelemetry
+        {
+            public bool CollapseSuggestionsPanelWhenRenameStarts { get; set; }
+        }
+
+        private sealed class SuggestionsDropdownTelemetry
+        {
+            public int DropdownButtonClickTimes { get; set; }
+        }
+
+        private void SetupTelemetry()
+        {
+            var getSuggestionsAutomatically = _globalOptionService.GetOption(InlineRenameUIOptionsStorage.GetSuggestionsAutomatically);
+            if (getSuggestionsAutomatically)
+            {
+                _suggestionsPanelTelemetry = new SuggestionsPanelTelemetry
+                {
+                    CollapseSuggestionsPanelWhenRenameStarts = _globalOptionService.GetOption(InlineRenameUIOptionsStorage.CollapseSuggestionsPanel)
+                };
+            }
+            else
+            {
+                _suggestionsDropdownTelemetry = new SuggestionsDropdownTelemetry();
+            }
+        }
+
+        private void PostTelemetry(bool isCommit)
+        {
+            if (_suggestionsPanelTelemetry is not null)
+            {
+                RoslynDebug.Assert(_suggestionsDropdownTelemetry is null);
+                TelemetryLogging.Log(FunctionId.Copilot_Rename, KeyValueLogMessage.Create(m =>
+                {
+                    m[nameof(isCommit)] = isCommit;
+                    m["UseSuggestionsPanel"] = true;
+                    m[nameof(SuggestionsPanelTelemetry.CollapseSuggestionsPanelWhenRenameStarts)] = _suggestionsPanelTelemetry.CollapseSuggestionsPanelWhenRenameStarts;
+                    m["CollapseSuggestionsPanelWhenRenameEnds"] = _globalOptionService.GetOption(InlineRenameUIOptionsStorage.CollapseSuggestionsPanel);
+                }));
+            }
+            else
+            {
+                RoslynDebug.Assert(_suggestionsDropdownTelemetry is not null);
+                TelemetryLogging.Log(FunctionId.Copilot_Rename, KeyValueLogMessage.Create(m =>
+                {
+                    m[nameof(isCommit)] = isCommit;
+                    m["UseDropDown"] = true;
+                    m[nameof(SuggestionsDropdownTelemetry.DropdownButtonClickTimes)] = _suggestionsDropdownTelemetry.DropdownButtonClickTimes;
+                }));
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel_Telemetry.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Editor.InlineRename;
+using Microsoft.CodeAnalysis.EditorFeatures.Lightup;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Telemetry;
 using Roslyn.Utilities;
@@ -51,6 +52,7 @@ namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
                     m["UseSuggestionsPanel"] = true;
                     m[nameof(SuggestionsPanelTelemetry.CollapseSuggestionsPanelWhenRenameStarts)] = _suggestionsPanelTelemetry.CollapseSuggestionsPanelWhenRenameStarts;
                     m["CollapseSuggestionsPanelWhenRenameEnds"] = _globalOptionService.GetOption(InlineRenameUIOptionsStorage.CollapseSuggestionsPanel);
+                    m["smartRenameSessionInProgress"] = _smartRenameSession.IsInProgress;
                 }));
             }
             else
@@ -61,6 +63,7 @@ namespace Microsoft.CodeAnalysis.InlineRename.UI.SmartRename
                     m[nameof(isCommit)] = isCommit;
                     m["UseDropDown"] = true;
                     m[nameof(SuggestionsDropdownTelemetry.DropdownButtonClickTimes)] = _suggestionsDropdownTelemetry.DropdownButtonClickTimes;
+                    m["smartRenameSessionInProgress"] = _smartRenameSession.IsInProgress;
                 }));
             }
         }

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Výběr se spouští v okně Interactive.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">Získejte návrhy přejmenování využívající umělou inteligenci (Ctrl+Mezerník)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Vlastnost CurrentWindow se dá přiřadit jenom jednou.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Die Eigenschaft "CurrentWindow" kann nur ein Mal zugewiesen werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Die Auswahl wird im Interactive-Fenster ausgeführt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">KI-gestützte Umbenennungsvorschläge abrufen (STRG+LEERTASTE)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Ejecutando selección en ventana interactiva.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">Obtener sugerencias de cambio de nombre con tecnología de inteligencia artificial (Ctrl+Espacio)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">La propiedad CurrentWindow solo se puede asignar una vez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">La propriété CurrentWindow ne peut être assignée qu'une seule fois.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Exécution de la sélection dans la fenêtre interactive.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">Obtenir des suggestions de renommage basées sur l’intelligence artificielle (Ctrl+Espace)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Esecuzione della selezione nella finestra interattiva.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">Ottieni suggerimenti di ridenominazione basati sull'intelligenza artificiale (CTRL+BARRA SPAZIATRICE)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">La proprietà CurrentWindow può essere assegnata una sola volta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">インタラクティブ ウィンドウで選択を実行します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">AI を利用した名前変更の提示を取得する (Ctrl + Space)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">CurrentWindow プロパティは 1 回のみ割り当てることができます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">CurrentWindow 속성은 한 번만 할당될 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">선택 영역을 대화형 창에서 실행하는 중입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">AI 기반 이름 바꾸기 제안 보기(Ctrl+스페이스바)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Wykonywanie zaznaczenia w oknie Interactive.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">Uzyskaj funkcję Zmień nazwy sugestii obsługiwane przez sztuczną inteligencję (Ctrl+Spacja)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Właściwość CurrentWindow można przypisać tylko raz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Executando seleção na Janela Interativa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">Obter sugestões de renomeação com tecnologia de IA (Ctrl+Espaço)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="translated">A propriedade CurrentWindow deve ser atribuído apenas uma vez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Свойство CurrentWindow может быть назначено только один раз.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Выполнение выделенного фрагмента в Интерактивном окне.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">Подбор имени на базе искусственного интеллекта (CTRL+ПРОБЕЛ)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">CurrentWindow özelliği yalnızca bir kez atanabilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Seçim, Etkileşimli Pencere'de yürütülüyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">Yapay zeka destekli yeniden adlandırma önerileri alın (Ctrl+Space)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">只能对 CurrentWindow 属性进行一次赋值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">在交互窗口中执行所选内容。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">获取 AI 支持的重命名建议(Ctrl+空格键)</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">CurrentWindow 屬性只能受指派一次。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Toggle_AI_suggestions">
+        <source>Toggle rename suggestions (Ctrl+Space)</source>
+        <target state="new">Toggle rename suggestions (Ctrl+Space)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">正在於互動視窗中執行選取範圍。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generating_suggestions">
+        <source>Generating suggestions...</source>
+        <target state="new">Generating suggestions...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Get_AI_suggestions">
         <source>Get AI-powered rename suggestions (Ctrl+Space)</source>
         <target state="translated">取得 AI 支援的重新命名建議 (Ctrl+Space)</target>

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameUIOptionsStorage.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameUIOptionsStorage.cs
@@ -10,4 +10,6 @@ internal sealed class InlineRenameUIOptionsStorage
 {
     public static readonly Option2<bool> UseInlineAdornment = new("dotnet_rename_use_inline_adornment", defaultValue: true);
     public static readonly Option2<bool> CollapseUI = new("dotnet_collapse_inline_rename_ui", defaultValue: false);
+    public static readonly Option2<bool> CollapseSuggestionsPanel = new("dotnet_collapse_suggestions_in_inline_rename_ui", defaultValue: false);
+    public static readonly Option2<bool> GetSuggestionsAutomatically = new("dotnet_rename_get_suggestions_automatically", defaultValue: false);
 }

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -350,6 +350,8 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_collapse_inline_rename_ui", new RoamingProfileStorage("TextEditor.CollapseRenameUI")},
         {"dotnet_rename_use_inline_adornment", new RoamingProfileStorage("TextEditor.RenameUseInlineAdornment")},
         {"dotnet_preview_inline_rename_changes", new RoamingProfileStorage("TextEditor.Specific.PreviewRename")},
+        {"dotnet_collapse_suggestions_in_inline_rename_ui", new RoamingProfileStorage("TextEditor.CollapseRenameSuggestionsUI")},
+        {"dotnet_rename_get_suggestions_automatically", new FeatureFlagStorage(@"Editor.AutoSmartRenameSuggestions")},
         {"dotnet_rename_asynchronously", new RoamingProfileStorage("TextEditor.Specific.RenameAsynchronously")},
         {"dotnet_rename_file", new RoamingProfileStorage("TextEditor.Specific.RenameFile")},
         {"dotnet_rename_in_comments", new RoamingProfileStorage("TextEditor.Specific.RenameInComments")},

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -624,4 +624,5 @@ internal enum FunctionId
 
     // 800-850 for Copilot performance logging.
     Copilot_Suggestion_Dismissed = 800,
+    Copilot_Rename = 851
 }


### PR DESCRIPTION
We're introducing an experiment to automatically request Rename suggestions.
We don't want to automatically obstruct the Rename options with suggested names, so we've worked with PMs and designers to come up with a UI that always accommodates for 3 results, and gets them automatically.
User may opt out of this behavior by toggling the Copilot button (via mouse or hitting Ctrl+Space), which would restore the default UI.

## Screenshots and Gifs
### Inline rename with Copilot, suggestions are obtained automatically
_✨ this is the new scenario_
![roslyn NEW behavior](https://github.com/dotnet/roslyn/assets/1673956/2fb0165f-8fbd-4b22-a0c1-934384d2d41d)

Ctrl+Space works to toggle whether suggestions are obtained automatically. If they were off, hitting Ctrl+Space will request suggestions. This state is saved for next time when the rename dialog opens.
![roslyn NEW persistence](https://github.com/dotnet/roslyn/assets/1673956/a98c99f1-998b-4f62-8f5e-f2af3f3df262)

String changes:
- Removed the Shift+Space comment, which drastically narrowed the window back to its original size
- Adjusted the tooltip (this is a new string and may need to be localized)
![image](https://github.com/dotnet/roslyn/assets/1673956/7b9f0448-d925-4aa7-9740-81ae45447676)

### For reference: Inline rename with Copilot, existing behavior 
where Ctrl+Space or button press gets suggestions
Here, the copilot button is a bit smaller (and chevron is larger) so that buttons line up. Additionally, the progress bar does not have a light gray background that it had before.
![roslyn NEW manual smart rename](https://github.com/dotnet/roslyn/assets/1673956/00243ed6-964a-491e-a734-752d1dbf9f0b)

### For reference: Inline rename without Copilot 
Here, the chevron button is a bit larger. I had to make this change so that the buttons line up in all 3 scenarios. This increased height of the textbox by 2px, which I believe looks better.
![roslyn NEW no smart rename2](https://github.com/dotnet/roslyn/assets/1673956/e0355eef-8f82-46b3-bf41-c0777c858600)