### PR TITLE
WIP: Improve batching for document add / removes for reduced allocations

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -752,6 +752,21 @@ namespace Roslyn.Utilities
             return dictionary;
         }
 
+        internal static Dictionary<TKey, ImmutableArray<TValue>> ToMultiDictionary<TKey, TValue, TData>(this IEnumerable<TData> data, Func<TData, TKey> keySelector, Func<TData, TValue> valueSelector, IEqualityComparer<TKey>? comparer = null)
+            where TKey : notnull
+            where TValue : notnull
+        {
+            var dictionary = new Dictionary<TKey, ImmutableArray<TValue>>(comparer);
+            var groups = data.GroupBy(keySelector, comparer);
+            foreach (var grouping in groups)
+            {
+                var items = grouping.SelectAsArray(data => valueSelector(data));
+                dictionary.Add(grouping.Key, items);
+            }
+
+            return dictionary;
+        }
+
         /// <summary>
         /// Returns the only element of specified sequence if it has exactly one, and default(TSource) otherwise.
         /// Unlike <see cref="Enumerable.SingleOrDefault{TSource}(IEnumerable{TSource})"/> doesn't throw if there is more than one element in the sequence.

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -752,21 +752,6 @@ namespace Roslyn.Utilities
             return dictionary;
         }
 
-        internal static Dictionary<TKey, ImmutableArray<TValue>> ToMultiDictionary<TKey, TValue, TData>(this IEnumerable<TData> data, Func<TData, TKey> keySelector, Func<TData, TValue> valueSelector, IEqualityComparer<TKey>? comparer = null)
-            where TKey : notnull
-            where TValue : notnull
-        {
-            var dictionary = new Dictionary<TKey, ImmutableArray<TValue>>(comparer);
-            var groups = data.GroupBy(keySelector, comparer);
-            foreach (var grouping in groups)
-            {
-                var items = grouping.SelectAsArray(data => valueSelector(data));
-                dictionary.Add(grouping.Key, items);
-            }
-
-            return dictionary;
-        }
-
         /// <summary>
         /// Returns the only element of specified sequence if it has exactly one, and default(TSource) otherwise.
         /// Unlike <see cref="Enumerable.SingleOrDefault{TSource}(IEnumerable{TSource})"/> doesn't throw if there is more than one element in the sequence.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1176,6 +1176,30 @@ internal sealed partial class SolutionState
         return new(newSolutionState, oldProjectState, newProjectState);
     }
 
+    public SolutionState ForkProjects(
+        IEnumerable<ProjectState> newProjectStates,
+        ProjectDependencyGraph? newDependencyGraph = null,
+        FilePathToDocumentIdsMap? newFilePathToDocumentIdsMap = null)
+    {
+        var newStateMap = _projectIdToProjectStateMap;
+        foreach (var newProjectState in newProjectStates)
+        {
+            var projectId = newProjectState.Id;
+
+            Contract.ThrowIfFalse(_projectIdToProjectStateMap.ContainsKey(projectId));
+            newStateMap = newStateMap.SetItem(projectId, newProjectState);
+        }
+
+        newDependencyGraph ??= _dependencyGraph;
+
+        var newSolutionState = this.Branch(
+            idToProjectStateMap: newStateMap,
+            dependencyGraph: newDependencyGraph,
+            filePathToDocumentIdsMap: newFilePathToDocumentIdsMap ?? _filePathToDocumentIdsMap);
+
+        return newSolutionState;
+    }
+
     /// <summary>
     /// Gets the set of <see cref="DocumentId"/>s in this <see cref="Solution"/> with a
     /// <see cref="TextDocument.FilePath"/> that matches the given file path.


### PR DESCRIPTION
The modified entry points now only fork the solutionstate and project once when batched add/remove document calls are made.

Locally, I saw about a 3.5% allocation reduction when bringing up completion 20 times (half from ^j, half from typing a '.')