### PR TITLE
Add support for nullable enum options

### DIFF
--- a/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
@@ -109,7 +109,20 @@ internal sealed class VisualStudioSettingsOptionPersister
 
         var underlyingType = Nullable.GetUnderlyingType(storageType);
         if (underlyingType?.IsEnum == true)
-            return manager.TryGetValue(storageKey, out int? value) == GetValueResult.Success ? (value.HasValue ? Enum.ToObject(underlyingType, value.Value) : null) : default(Optional<object?>);
+        {
+            if (manager.TryGetValue(storageKey, out int? nullableValue) == GetValueResult.Success)
+            {
+                return nullableValue.HasValue ? Enum.ToObject(underlyingType, nullableValue.Value) : null;
+            }
+            else if (manager.TryGetValue(storageKey, out int value) == GetValueResult.Success)
+            {
+                return Enum.ToObject(underlyingType, value);
+            }
+            else
+            {
+                return default;
+            }
+        }
 
         if (storageType == typeof(NamingStylePreferences))
         {

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -191,6 +191,40 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             _bindingExpressions.Add(bindingExpression);
         }
 
+        private protected void BindToOption<T>(RadioButton radiobutton, Option2<T> optionKey, T optionValue)
+        {
+            var binding = new Binding()
+            {
+                Source = new OptionBinding<T>(OptionStore, optionKey),
+                Path = new PropertyPath("Value"),
+                UpdateSourceTrigger = UpdateSourceTrigger.Default,
+                Converter = new RadioButtonCheckedConverter(),
+                ConverterParameter = optionValue
+            };
+
+            AddSearchHandler(radiobutton);
+
+            var bindingExpression = radiobutton.SetBinding(RadioButton.IsCheckedProperty, binding);
+            _bindingExpressions.Add(bindingExpression);
+        }
+
+        private protected void BindToOption<T>(RadioButton radioButton, Option2<T?> nullableOptionKey, T optionValue, Func<bool> onNullValue) where T : struct
+        {
+            var binding = new Binding()
+            {
+                Source = new OptionBinding<T?>(OptionStore, nullableOptionKey),
+                Path = new PropertyPath("Value"),
+                UpdateSourceTrigger = UpdateSourceTrigger.Default,
+                Converter = new RadioButtonCheckedConverter<T>(onNullValue),
+                ConverterParameter = optionValue,
+            };
+
+            AddSearchHandler(radioButton);
+
+            var bindingExpression = radioButton.SetBinding(RadioButton.IsCheckedProperty, binding);
+            _bindingExpressions.Add(bindingExpression);
+        }
+
         private protected void BindToOption<T>(RadioButton radiobutton, PerLanguageOption2<T> optionKey, T optionValue, string languageName)
         {
             var binding = new Binding()
@@ -255,19 +289,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         }
     }
 
-    public class RadioButtonCheckedConverter : IValueConverter
+    public sealed class RadioButtonCheckedConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter,
-            System.Globalization.CultureInfo culture)
-        {
-            return value.Equals(parameter);
-        }
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value.Equals(parameter);
 
-        public object ConvertBack(object value, Type targetType, object parameter,
-            System.Globalization.CultureInfo culture)
-        {
-            return value.Equals(true) ? parameter : Binding.DoNothing;
-        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => value.Equals(true) ? parameter : Binding.DoNothing;
+    }
+
+    public sealed class RadioButtonCheckedConverter<T>(Func<bool> onNullValue) : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value switch
+            {
+                null => onNullValue(),
+                _ => value.Equals(parameter),
+            };
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => value.Equals(true) ? parameter : Binding.DoNothing;
     }
 
     public class ComboBoxItemTagToIndexConverter : IValueConverter

--- a/src/VisualStudio/Core/Impl/Options/Converters/NullableBoolOptionConverter.cs
+++ b/src/VisualStudio/Core/Impl/Options/Converters/NullableBoolOptionConverter.cs
@@ -7,25 +7,18 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Converters
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Converters;
+
+internal sealed class NullableBoolOptionConverter(Func<bool> onNullValue) : IValueConverter
 {
-    internal class NullableBoolOptionConverter : IValueConverter
-    {
-        private readonly Func<bool> _onNullValue;
-        public NullableBoolOptionConverter(Func<bool> onNullValue)
+    public object Convert(object? value, Type targetType, object parameter, CultureInfo culture)
+        => value switch
         {
-            _onNullValue = onNullValue;
-        }
+            null => onNullValue(),
+            bool b => b,
+            _ => DependencyProperty.UnsetValue
+        };
 
-        public object Convert(object? value, Type targetType, object parameter, CultureInfo culture)
-            => value switch
-            {
-                null => _onNullValue(),
-                bool b => b,
-                _ => DependencyProperty.UnsetValue
-            };
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => value;
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => value;
 }

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioSettingsOptionPersisterTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioSettingsOptionPersisterTests.cs
@@ -100,17 +100,6 @@ public class VisualStudioSettingsOptionPersisterTests
            optionType == typeof(ImmutableArray<string>) ? (ImmutableArray.Create("a", "b"), new[] { "a", "b" }) :
            throw ExceptionUtilities.UnexpectedValue(optionType);
 
-    private static Type GetStorageType(Type optionType)
-        => optionType.IsEnum ? typeof(int) :
-           (Nullable.GetUnderlyingType(optionType)?.IsEnum == true) ? typeof(int?) :
-           optionType == typeof(NamingStylePreferences) ? typeof(string) :
-           typeof(ICodeStyleOption2).IsAssignableFrom(optionType) ? typeof(string) :
-           optionType == typeof(ImmutableArray<string>) ? typeof(string[]) :
-           optionType == typeof(ImmutableArray<bool>) ? typeof(bool[]) :
-           optionType == typeof(ImmutableArray<int>) ? typeof(int[]) :
-           optionType == typeof(ImmutableArray<long>) ? typeof(long[]) :
-           optionType;
-
     private static bool IsDefaultImmutableArray(object array)
         => (bool)array.GetType().GetMethod("get_IsDefault").Invoke(array, [])!;
 
@@ -229,11 +218,10 @@ public class VisualStudioSettingsOptionPersisterTests
         Type optionType)
     {
         var (optionValue, storageValue) = GetSomeOptionValue(optionType);
-        var storageType = GetStorageType(optionType);
 
         var mockManager = new MockSettingsManager()
         {
-            GetValueImpl = (_, type) => (type == storageType ? specializedTypeResult : GetValueResult.Success, storageValue)
+            GetValueImpl = (_, type) => (specializedTypeResult, storageValue)
         };
 
         var result = VisualStudioSettingsOptionPersister.TryReadOptionValue(mockManager, "key", optionType, optionValue);


### PR DESCRIPTION
Extracted from https://github.com/dotnet/roslyn/pull/72494 to make that PR easier to review.

Currently, we support enum options, and we support nullable options in a few cases (like nullable-bool options).  This adds support so we can have `nullable enum` options.  In particular, for "Run SG on build" we want an enum controlling the behavior, but we want `null` to mean `can be controlled with a feature flag`.  