### PR TITLE
Print diagnostics in invariant culture (English error messages) in assert text

### DIFF
--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
@@ -6,17 +6,18 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using Roslyn.Test.Utilities;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
@@ -518,7 +519,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             for (i = 0; e.MoveNext(); i++)
             {
                 Diagnostic d = e.Current;
-                string message = d.ToString();
+                string message = d.ToString(CultureInfo.InvariantCulture);
                 if (Regex.Match(message, @"{\d+}").Success)
                 {
                     Assert.True(false, "Diagnostic messages should never contain unsubstituted placeholders.\n    " + message);
@@ -533,7 +534,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 {
                     Indent(assertText, indentDepth);
                     assertText.Append("// ");
-                    assertText.AppendLine(d.ToString());
+                    assertText.AppendLine(message);
                     var l = d.Location;
                     if (l.IsInSource)
                     {


### PR DESCRIPTION
Assert text is only used when test fails to show expected vs actual diagnostics. Printing them with English messages won't break any culture-specific tests, but bring 2 positive changes:
- If test fails in CI, diagnostic messages will be in English even in non-English pipelines
- Folks with non-English language on their PC (for instance me) can copy-paste diagnostics from "Actual" section to the test without need to find original error messages in English