### PR TITLE
Move code that retrieves source generators to running in OOP only

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.cs
@@ -569,16 +569,13 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     // We will finalize the compilation by adding full contents here.
-                    var (compilationWithGeneratedDocuments, generatedDocuments, generatorDriver) = await AddExistingOrComputeNewGeneratorInfoAsync(
+                    var (compilationWithGeneratedDocuments, nextGeneratorInfo) = await AddExistingOrComputeNewGeneratorInfoAsync(
                         creationPolicy,
                         compilationState,
                         compilationWithoutGeneratedDocuments,
                         generatorInfo,
                         staleCompilationWithGeneratedDocuments,
                         cancellationToken).ConfigureAwait(false);
-
-                    // After producing the sg documents, we must always be in the final state for the generator data.
-                    var nextGeneratorInfo = new CompilationTrackerGeneratorInfo(generatedDocuments, generatorDriver);
 
                     var finalState = FinalCompilationTrackerState.Create(
                         creationPolicy,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker_Generators.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker_Generators.cs
@@ -241,7 +241,10 @@ internal partial class SolutionCompilationState
             Compilation? compilationWithStaleGeneratedTrees,
             CancellationToken cancellationToken)
         {
-            // If we don't have any source generators.  Trivially bail out.
+            // If we don't have any source generators.  Trivially bail out.  Note: this check is intentionally don't in
+            // the "InCurrentProcess" call so that it will normally run only in the OOP process, thus ensuring that we
+            // get accurate information about what SourceGenerators we actually have (say, in case they they are rebuilt
+            // by the user while VS is running).
             if (!this.ProjectState.SourceGenerators.Any())
                 return (compilationWithoutGeneratedFiles, TextDocumentStates<SourceGeneratedDocumentState>.Empty, generatorDriver);
 


### PR DESCRIPTION
This will be part of a series of PRs.  The main purpose here is to get all calls to ProjectState.SourceGenerators and AnalyzerReference.GetGenerators to run in OOP only.  By doing that, we don't even have to load it in VS and we don't have to worry about the .net fx loading semantics for generators (versus the .net core semantics, which can reload generators).

Example of where this matters.  Imagine if a user starts with an AnalyzerReference with no source generators in it, but then replaces those (while VS is running) with references that *do* have source-generators in them.  With teh current code, because we loaded the generators *within* VS, and then checked if we had any, we'll always stay in teh state where we think we have none.  However, by moving these loads/checks to OOP, we can realistically reload the reference/generators and then now know that we *should* be running generators on a particular project.