### PR TITLE
Add method name to TimeInQueue telemetry

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -66,6 +66,7 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
             m[TelemetryLogging.KeyValue] = queuedDuration.Milliseconds;
             m[TelemetryLogging.KeyMetricName] = "TimeInQueue";
             m["server"] = _serverTypeName;
+            m["method"] = methodName;
         }));
 
         TelemetryLogging.LogAggregated(FunctionId.LSP_RequestDuration, KeyValueLogMessage.Create(m =>


### PR DESCRIPTION
Was trying to create a dashboard to use the TimeInQueue telemetry and noticed that the method name wasn't present.