### PR TITLE
Fix a couple of issues with extension lookup/binding

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1453,9 +1453,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return false;
                     }
                 }
-            }
 
-            return true;
+                return true;
+            }
         }
 
         private bool CheckIsValidReceiverForVariable(SyntaxNode node, BoundExpression receiver, BindValueKind kind, BindingDiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1211,7 +1211,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case RefKind.Ref:
                         return true;
                     case RefKind.RefReadOnly:
-                        ReportReadOnlyError(fieldSymbol, node, valueKind, checkingReceiver, diagnostics); // TODO2 test
+                        ReportReadOnlyError(fieldSymbol, node, valueKind, checkingReceiver, diagnostics);
                         return false;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(fieldSymbol.RefKind);

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1408,6 +1408,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // (since we don't know which is being used).
                     return false;
                 }
+
+                if (RequiresVariableReceiver(receiver, eventSymbol) && !CheckIsValidReceiverForVariable(eventSyntax, receiver, valueKind, diagnostics))
+                {
+                    return false;
+                }
+
+                return true;
             }
             else
             {
@@ -1446,12 +1453,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return false;
                     }
                 }
-
-            }
-
-            if (RequiresVariableReceiver(receiver, eventSymbol) && !CheckIsValidReceiverForVariable(eventSyntax, receiver, valueKind, diagnostics))
-            {
-                return false;
             }
 
             return true;

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1476,7 +1476,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return symbol.RequiresInstanceReceiver()
                 && symbol.Kind != SymbolKind.Event
-                && symbol.ContainingType.IsStructType();
+                && symbol.ContainingType.IsValueType;
         }
 
         protected bool CheckMethodReturnValueKind(

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1476,7 +1476,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return symbol.RequiresInstanceReceiver()
                 && symbol.Kind != SymbolKind.Event
-                && receiver?.Type?.IsValueType == true;
+                && receiver?.Type?.IsValueType == true
+                && !symbol.ContainingType.IsExtension;
         }
 
         protected bool CheckMethodReturnValueKind(

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1476,8 +1476,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return symbol.RequiresInstanceReceiver()
                 && symbol.Kind != SymbolKind.Event
-                && receiver?.Type?.IsValueType == true
-                && !symbol.ContainingType.IsExtension;
+                && symbol.ContainingType.IsStructType();
         }
 
         protected bool CheckMethodReturnValueKind(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -505,6 +505,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression GetExtensionMemberAccess(SyntaxNode syntax, BoundExpression? receiver, Symbol extensionMember, BindingDiagnosticBag diagnostics)
         {
+            Debug.Assert(extensionMember.Kind != SymbolKind.Method);
+            receiver = ReplaceTypeOrValueReceiver(receiver, useType: extensionMember.IsStatic || extensionMember.Kind == SymbolKind.NamedType, diagnostics);
+
+            // Events are handled later.
+            // Properties are handled in BindPropertyAccess
+            Debug.Assert(receiver?.Kind != BoundKind.BaseReference);
+            if (extensionMember.Kind is not (SymbolKind.Event or SymbolKind.Property))
+            {
+                ReportDiagnosticsIfObsolete(diagnostics, extensionMember, syntax, hasBaseReceiver: false);
+            }
+
             switch (extensionMember)
             {
                 case PropertySymbol propertySymbol:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -1959,6 +1960,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return expression.GetLocation();
         }
 
+#nullable enable
         /// <summary>
         /// Replace a BoundTypeOrValueExpression with a BoundExpression for either a type (if useType is true)
         /// or a value (if useType is false).  Any other node is bound to its natural type.
@@ -1967,9 +1969,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Call this once overload resolution has succeeded on the method group of which the BoundTypeOrValueExpression
         /// is the receiver.  Generally, useType will be true if the chosen method is static and false otherwise.
         /// </remarks>
-        private BoundExpression ReplaceTypeOrValueReceiver(BoundExpression receiver, bool useType, BindingDiagnosticBag diagnostics)
+        [return: NotNullIfNotNull(nameof(receiver))]
+        private BoundExpression? ReplaceTypeOrValueReceiver(BoundExpression? receiver, bool useType, BindingDiagnosticBag diagnostics)
         {
-            if ((object)receiver == null)
+            if (receiver is null)
             {
                 return null;
             }
@@ -2013,6 +2016,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return BindToNaturalType(receiver, diagnostics);
             }
         }
+#nullable disable
 
         private static BoundExpression GetValueExpressionIfTypeOrValueReceiver(BoundExpression receiver)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodGroup.cs
@@ -52,7 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var member in members)
             {
                 this.Methods.Add((MethodSymbol)member);
-                Debug.Assert(((MethodSymbol)member).IsExtensionMethod == isExtensionMethodGroup);
+                Debug.Assert(((MethodSymbol)member).IsExtensionMethod == isExtensionMethodGroup
+                    || (member.ContainingType.IsExtension && !isExtensionMethodGroup));
             }
 
             if (!typeArguments.IsDefault)

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -1504,7 +1504,7 @@ implicit extension E for object
             Diagnostic(ErrorCode.ERR_ObjectProhibited, "new object().M").WithArguments("E.M(object)").WithLocation(4, 1),
             // (9,26): error CS9321: Extension methods are not allowed in extension types.
             //     public static string M(this object o) => throw null;
-            Diagnostic(ErrorCode.ERR_ExtensionMethodInExtension, "M").WithLocation(9, 26) );
+            Diagnostic(ErrorCode.ERR_ExtensionMethodInExtension, "M").WithLocation(9, 26));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -33182,8 +33182,8 @@ static class D
 """);
     }
 
-    [Fact]
-    public void PropertyAccess_CanModifyStructReceiver()
+    [ConditionalFact(typeof(NoUsedAssembliesValidation))] // PROTOTYPE(instance) enable and execute once we can lower/emit for non-static scenarios
+    public void PropertyAccess_Instance_CanModifyStructReceiver()
     {
         var src = """
 S s = default;

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -33098,7 +33098,6 @@ implicit extension E for object
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70, options: TestOptions.UnsafeDebugExe);
         comp.VerifyEmitDiagnostics();
-        // TODO2
         var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("42"), verify: Verification.Fails).VerifyDiagnostics();
         verifier.VerifyIL("C.Main", """
 {

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -33204,7 +33204,7 @@ implicit extension E for S
         // PROTOTYPE(instance) update CheckValue logic
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoUsedAssembliesValidation))] // PROTOTYPE(instance) enable once we can lower/emit for non-static scenarios
     public void PropertyAccess_Instance_CanModifyStructReceiver_StructTypeParameterReceiver()
     {
         var src = """
@@ -33244,7 +33244,7 @@ implicit extension E for I
             Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Property").WithArguments("T", "Property").WithLocation(7, 7));
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoUsedAssembliesValidation))] // PROTOTYPE(instance) enable once we can lower/emit for non-static scenarios
     public void PropertyAccess_Instance_CanModifyStructReceiver_UnconstrainedTypeParameterReceiver()
     {
         var src = """

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -1488,7 +1488,7 @@ object.M(null);
 
 implicit extension E for object
 {
-    public static string M(this object o) => throw null;
+    public static string M(this object o) => throw null;
 }
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
@@ -1503,8 +1503,8 @@ implicit extension E for object
             // new object().M(null);
             Diagnostic(ErrorCode.ERR_ObjectProhibited, "new object().M").WithArguments("E.M(object)").WithLocation(4, 1),
             // (9,26): error CS9321: Extension methods are not allowed in extension types.
-            //     public static string M(this object o) => throw null;
-            Diagnostic(ErrorCode.ERR_ExtensionMethodInExtension, "M").WithLocation(9, 26));
+            //     public static string M(this object o) => throw null;
+            Diagnostic(ErrorCode.ERR_ExtensionMethodInExtension, "M").WithLocation(9, 26) );
     }
 
     [Fact]
@@ -1515,13 +1515,13 @@ var x = object.M;
 
 implicit extension E for object
 {
-    public static string M(this object o) => throw null;
+    public static string M(this object o) => throw null;
 }
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyEmitDiagnostics(
             // (5,26): error CS9321: Extension methods are not allowed in extension types.
-            //     public static string M(this object o) => throw null;
+            //     public static string M(this object o) => throw null;
             Diagnostic(ErrorCode.ERR_ExtensionMethodInExtension, "M").WithLocation(5, 26));
 
         var tree = comp.SyntaxTrees.Single();
@@ -1541,7 +1541,7 @@ var x = new object().M;
 
 implicit extension E for object
 {
-    public static string M(this object o) => throw null;
+    public static string M(this object o) => throw null;
 }
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
@@ -1550,7 +1550,7 @@ implicit extension E for object
             // var x = new object().M;
             Diagnostic(ErrorCode.ERR_ObjectProhibited, "new object().M").WithArguments("E.M(object)").WithLocation(1, 9),
             // (5,26): error CS9321: Extension methods are not allowed in extension types.
-            //     public static string M(this object o) => throw null;
+            //     public static string M(this object o) => throw null;
             Diagnostic(ErrorCode.ERR_ExtensionMethodInExtension, "M").WithLocation(5, 26));
 
         var tree = comp.SyntaxTrees.Single();

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -33200,8 +33200,11 @@ implicit extension E for S
     public int Property { set => this.field = value; }
 }
 """;
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
-        // PROTOTYPE(instance) update CheckValue logic
+        if (!CompilationExtensions.EnableVerifyIOperation)
+        {
+            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+            // PROTOTYPE(instance) update CheckValue logic
+        }
     }
 
     [ConditionalFact(typeof(NoUsedAssembliesValidation))] // PROTOTYPE(instance) enable once we can lower/emit for non-static scenarios

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -33205,7 +33205,7 @@ implicit extension E for S
     }
 
     [Fact]
-    public void PropertyAccess_CanModifyStructReceiver_StructTypeParameterReceiver()
+    public void PropertyAccess_Instance_CanModifyStructReceiver_StructTypeParameterReceiver()
     {
         var src = """
 S s = default;
@@ -33245,7 +33245,7 @@ implicit extension E for I
     }
 
     [Fact]
-    public void PropertyAccess_CanModifyStructReceiver_UnconstrainedTypeParameterReceiver()
+    public void PropertyAccess_Instance_CanModifyStructReceiver_UnconstrainedTypeParameterReceiver()
     {
         var src = """
 S s = default;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -3802,13 +3802,43 @@ class C
 }";
             CreateCompilation(source).VerifyDiagnostics(
                 // (16,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         default(S).P = null;
                 Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "default(S).P").WithLocation(16, 9),
-                // (16,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                // (17,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         default(T).P = null; // Dev10: no error
                 Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "default(T).P").WithLocation(17, 9),
                 // (18,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         default(S)[0] = null;
                 Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "default(S)[0]").WithLocation(18, 9),
-                // (18,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                // (19,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         default(T)[0] = null; // Dev10: no error
                 Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "default(T)[0]").WithLocation(19, 9));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73003")]
+        public void CS0131ERR_AssgLvalueExpected03_UnconstrainedTypeParameter()
+        {
+            var source = """
+struct S
+{
+    public object P { get; set; }
+    public object this[object index] { get { return null; } set { } }
+}
+interface I
+{
+    object P { get; set; }
+    object this[object index] { get; set; }
+}
+class C
+{
+    static void M<T>() where T : I
+    {
+        default(T).P = null;
+        default(T)[0] = null;
+    }
+}
+""";
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [WorkItem(538077, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538077")]
@@ -14955,8 +14985,10 @@ class C<T, U, V>
 }";
             CreateCompilation(source).VerifyDiagnostics(
                 // (20,9): error CS1612: Cannot modify the return value of 'C<T, U, V>.F1' because it is not a variable
+                //         F1.P = null;
                 Diagnostic(ErrorCode.ERR_ReturnNotLValue, "F1").WithArguments("C<T, U, V>.F1").WithLocation(20, 9),
-                // (20,9): error CS1612: Cannot modify the return value of 'C<T, U, V>.F2' because it is not a variable
+                // (21,9): error CS1612: Cannot modify the return value of 'C<T, U, V>.F2' because it is not a variable
+                //         F2.P = null;
                 Diagnostic(ErrorCode.ERR_ReturnNotLValue, "F2").WithArguments("C<T, U, V>.F2").WithLocation(21, 9));
         }
 


### PR DESCRIPTION
This PR addresses two issues:
- I noticed that binding for extension members (`GetExtensionMemberAccess`) lacked some logic compared to `BindMemberOfType`.
- I ran into an assertion (illustrated by test `Members_ExtensionMethod_DisallowedInExtensionTypes_Invocation`)

Relates to test plan https://github.com/dotnet/roslyn/issues/66722