### PR TITLE
Make snippet generation strongly typed.

### DIFF
--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -66,18 +66,18 @@ internal abstract class AbstractCSharpAutoPropertySnippetProvider : AbstractProp
             accessorList: SyntaxFactory.AccessorList([.. accessors.Where(a => a is not null)!]));
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, PropertyDeclarationSyntax caretTarget, SourceText sourceText)
-        => caretTarget.AccessorList!.CloseBraceToken.Span.End;
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, PropertyDeclarationSyntax propertyDeclaration, SourceText sourceText)
+        => propertyDeclaration.AccessorList!.CloseBraceToken.Span.End;
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(PropertyDeclarationSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(PropertyDeclarationSyntax propertyDeclaration, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
         using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);
-        var identifier = node.Identifier;
-        var type = node.Type;
+        var identifier = propertyDeclaration.Identifier;
+        var type = propertyDeclaration.Type;
 
         arrayBuilder.Add(new SnippetPlaceholder(type.ToString(), type.SpanStart));
         arrayBuilder.Add(new SnippetPlaceholder(identifier.ValueText, identifier.SpanStart));
-        return arrayBuilder.ToImmutableArray();
+        return arrayBuilder.ToImmutable();
     }
 
     protected override PropertyDeclarationSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position)

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -71,13 +71,14 @@ internal abstract class AbstractCSharpAutoPropertySnippetProvider : AbstractProp
 
     protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(PropertyDeclarationSyntax propertyDeclaration, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
-        using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);
         var identifier = propertyDeclaration.Identifier;
         var type = propertyDeclaration.Type;
 
-        arrayBuilder.Add(new SnippetPlaceholder(type.ToString(), type.SpanStart));
-        arrayBuilder.Add(new SnippetPlaceholder(identifier.ValueText, identifier.SpanStart));
-        return arrayBuilder.ToImmutable();
+        return
+        [
+            new SnippetPlaceholder(type.ToString(), type.SpanStart),
+            new SnippetPlaceholder(identifier.ValueText, identifier.SpanStart),
+        ];
     }
 
     protected override PropertyDeclarationSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position)

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -66,11 +66,8 @@ internal abstract class AbstractCSharpAutoPropertySnippetProvider : AbstractProp
             accessorList: SyntaxFactory.AccessorList([.. accessors.Where(a => a is not null)!]));
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        var propertyDeclaration = (PropertyDeclarationSyntax)caretTarget;
-        return propertyDeclaration.AccessorList!.CloseBraceToken.Span.End;
-    }
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, PropertyDeclarationSyntax caretTarget, SourceText sourceText)
+        => caretTarget.AccessorList!.CloseBraceToken.Span.End;
 
     protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(PropertyDeclarationSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -84,7 +83,7 @@ internal abstract class AbstractCSharpAutoPropertySnippetProvider : AbstractProp
         return arrayBuilder.ToImmutableArray();
     }
 
-    protected override PropertyDeclarationSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
+    protected override PropertyDeclarationSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position)
     {
         var node = root.FindNode(TextSpan.FromBounds(position, position));
         return node.GetAncestorOrThis<PropertyDeclarationSyntax>();

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -108,8 +108,8 @@ internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSn
         return result.ToImmutableAndClear();
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock<ForStatementSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ForStatementSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static s => (BlockSyntax)s.Statement,
             sourceText);

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -81,15 +81,15 @@ internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSn
         }
     }
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(ForStatementSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(ForStatementSyntax forStatement, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
         using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var result);
         var placeholderBuilder = new MultiDictionary<string, int>();
-        var declaration = node.Declaration;
-        var condition = node.Condition;
-        var incrementor = node.Incrementors.Single();
+        var declaration = forStatement.Declaration;
+        var condition = forStatement.Condition;
+        var incrementor = forStatement.Incrementors.Single();
 
-        var variableDeclarator = ((VariableDeclarationSyntax)declaration!).Variables.Single();
+        var variableDeclarator = declaration!.Variables.Single();
         var declaratorIdentifier = variableDeclarator.Identifier;
         placeholderBuilder.Add(declaratorIdentifier.ValueText, declaratorIdentifier.SpanStart);
 
@@ -108,9 +108,9 @@ internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSn
         return result.ToImmutableAndClear();
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ForStatementSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ForStatementSyntax forStatement, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            forStatement,
             static s => (BlockSyntax)s.Statement,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -114,10 +114,10 @@ internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSn
             static s => (BlockSyntax)s.Statement,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<ForStatementSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, ForStatementSyntax forStatement, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            forStatement,
             static s => (BlockSyntax)s.Statement,
             cancellationToken);
 }

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
 using static SyntaxFactory;
 
-internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSnippetProvider
+internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSnippetProvider<ForStatementSyntax>
 {
     private static readonly string[] s_iteratorBaseNames = ["i", "j", "k"];
 
@@ -38,7 +38,7 @@ internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSn
 
     protected abstract void AddSpecificPlaceholders(MultiDictionary<string, int> placeholderBuilder, ExpressionSyntax initializer, ExpressionSyntax rightOfCondition);
 
-    protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
+    protected override ForStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
     {
         var semanticModel = syntaxContext.SemanticModel;
         var compilation = semanticModel.Compilation;
@@ -81,11 +81,13 @@ internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSn
         }
     }
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(ForStatementSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
         using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var result);
         var placeholderBuilder = new MultiDictionary<string, int>();
-        GetPartsOfForStatement(node, out var declaration, out var condition, out var incrementor, out var _);
+        var declaration = node.Declaration;
+        var condition = node.Condition;
+        var incrementor = node.Incrementors.Single();
 
         var variableDeclarator = ((VariableDeclarationSyntax)declaration!).Variables.Single();
         var declaratorIdentifier = variableDeclarator.Identifier;
@@ -118,13 +120,4 @@ internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSn
             FindSnippetAnnotation,
             static s => (BlockSyntax)s.Statement,
             cancellationToken);
-
-    private static void GetPartsOfForStatement(SyntaxNode node, out SyntaxNode? declaration, out SyntaxNode? condition, out SyntaxNode? incrementor, out SyntaxNode? statement)
-    {
-        var forStatement = (ForStatementSyntax)node;
-        declaration = forStatement.Declaration;
-        condition = forStatement.Condition;
-        incrementor = forStatement.Incrementors.Single();
-        statement = forStatement.Statement;
-    }
 }

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Snippets;
@@ -11,7 +12,7 @@ using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
-internal abstract class AbstractCSharpMainMethodSnippetProvider : AbstractMainMethodSnippetProvider
+internal abstract class AbstractCSharpMainMethodSnippetProvider : AbstractMainMethodSnippetProvider<MethodDeclarationSyntax>
 {
     protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
@@ -12,7 +12,8 @@ using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
-internal abstract class AbstractCSharpMainMethodSnippetProvider : AbstractMainMethodSnippetProvider<MethodDeclarationSyntax>
+internal abstract class AbstractCSharpMainMethodSnippetProvider
+    : AbstractMainMethodSnippetProvider<MethodDeclarationSyntax, StatementSyntax, TypeSyntax>
 {
     protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -24,7 +24,8 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
-internal abstract class AbstractCSharpTypeSnippetProvider : AbstractTypeSnippetProvider
+internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax> : AbstractTypeSnippetProvider<TTypeDeclarationSyntax>
+    where TTypeDeclarationSyntax : BaseTypeDeclarationSyntax
 {
     protected abstract ISet<SyntaxKind> ValidModifiers { get; }
 
@@ -87,10 +88,10 @@ internal abstract class AbstractCSharpTypeSnippetProvider : AbstractTypeSnippetP
         return line.Span.End;
     }
 
-    protected override SyntaxNode? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
+    protected override TTypeDeclarationSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
     {
         var node = root.FindNode(TextSpan.FromBounds(position, position));
-        return node.GetAncestorOrThis<BaseTypeDeclarationSyntax>();
+        return node.GetAncestorOrThis<TTypeDeclarationSyntax>();
     }
 
     protected override async Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -88,7 +87,7 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
         return line.Span.End;
     }
 
-    protected override TTypeDeclarationSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
+    protected override TTypeDeclarationSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position)
     {
         var node = root.FindNode(TextSpan.FromBounds(position, position));
         return node.GetAncestorOrThis<TTypeDeclarationSyntax>();

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -78,10 +78,9 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
         return new TextChange(TextSpan.FromBounds(targetPosition, targetPosition), SyntaxFacts.GetText(SyntaxKind.PublicKeyword) + " ");
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, TTypeDeclarationSyntax caretTarget, SourceText sourceText)
     {
-        var typeDeclaration = (BaseTypeDeclarationSyntax)caretTarget;
-        var triviaSpan = typeDeclaration.CloseBraceToken.LeadingTrivia.Span;
+        var triviaSpan = caretTarget.CloseBraceToken.LeadingTrivia.Span;
         var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
         // Getting the location at the end of the line before the newline.
         return line.Span.End;

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -106,9 +106,6 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
         return document.WithSyntaxRoot(newRoot);
     }
 
-    protected override void GetTypeDeclarationIdentifier(SyntaxNode node, out SyntaxToken identifier)
-    {
-        var typeDeclaration = (BaseTypeDeclarationSyntax)node;
-        identifier = typeDeclaration.Identifier;
-    }
+    protected sealed override SyntaxToken GetTypeDeclarationIdentifier(TTypeDeclarationSyntax baseTypeDeclaration)
+        => baseTypeDeclaration.Identifier;
 }

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -78,9 +78,9 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
         return new TextChange(TextSpan.FromBounds(targetPosition, targetPosition), SyntaxFacts.GetText(SyntaxKind.PublicKeyword) + " ");
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, TTypeDeclarationSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, TTypeDeclarationSyntax typeDeclaration, SourceText sourceText)
     {
-        var triviaSpan = caretTarget.CloseBraceToken.LeadingTrivia.Span;
+        var triviaSpan = typeDeclaration.CloseBraceToken.LeadingTrivia.Span;
         var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
         // Getting the location at the end of the line before the newline.
         return line.Span.End;
@@ -92,17 +92,17 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
         return node.GetAncestorOrThis<TTypeDeclarationSyntax>();
     }
 
-    protected override async Task<Document> AddIndentationToDocumentAsync(Document document, TTypeDeclarationSyntax originalTypeDeclaration, CancellationToken cancellationToken)
+    protected override async Task<Document> AddIndentationToDocumentAsync(Document document, TTypeDeclarationSyntax typeDeclaration, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
         var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
-        var indentationString = CSharpSnippetHelpers.GetBlockLikeIndentationString(document, originalTypeDeclaration.OpenBraceToken.SpanStart, syntaxFormattingOptions, cancellationToken);
+        var indentationString = CSharpSnippetHelpers.GetBlockLikeIndentationString(document, typeDeclaration.OpenBraceToken.SpanStart, syntaxFormattingOptions, cancellationToken);
 
-        var newTypeDeclaration = originalTypeDeclaration.WithCloseBraceToken(
-            originalTypeDeclaration.CloseBraceToken.WithPrependedLeadingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, indentationString)));
+        var newTypeDeclaration = typeDeclaration.WithCloseBraceToken(
+            typeDeclaration.CloseBraceToken.WithPrependedLeadingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, indentationString)));
 
-        var newRoot = root.ReplaceNode(originalTypeDeclaration, newTypeDeclaration.WithAdditionalAnnotations(FindSnippetAnnotation));
+        var newRoot = root.ReplaceNode(typeDeclaration, newTypeDeclaration.WithAdditionalAnnotations(FindSnippetAnnotation));
         return document.WithSyntaxRoot(newRoot);
     }
 

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -106,7 +106,7 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
         var newTypeDeclaration = originalTypeDeclaration.WithCloseBraceToken(
             originalTypeDeclaration.CloseBraceToken.WithPrependedLeadingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, indentationString)));
 
-        var newRoot = root.ReplaceNode(originalTypeDeclaration, newTypeDeclaration.WithAdditionalAnnotations(CursorAnnotation, FindSnippetAnnotation));
+        var newRoot = root.ReplaceNode(originalTypeDeclaration, newTypeDeclaration.WithAdditionalAnnotations(FindSnippetAnnotation));
         return document.WithSyntaxRoot(newRoot);
     }
 

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -92,13 +92,9 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
         return node.GetAncestorOrThis<TTypeDeclarationSyntax>();
     }
 
-    protected override async Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
+    protected override async Task<Document> AddIndentationToDocumentAsync(Document document, TTypeDeclarationSyntax originalTypeDeclaration, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var snippet = root.GetAnnotatedNodes(FindSnippetAnnotation).FirstOrDefault();
-
-        if (snippet is not BaseTypeDeclarationSyntax originalTypeDeclaration)
-            return document;
 
         var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
         var indentationString = CSharpSnippetHelpers.GetBlockLikeIndentationString(document, originalTypeDeclaration.OpenBraceToken.SpanStart, syntaxFormattingOptions, cancellationToken);

--- a/src/Features/CSharp/Portable/Snippets/CSharpClassSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpClassSnippetProvider.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Snippets;
@@ -51,7 +50,4 @@ internal sealed class CSharpClassSnippetProvider() : AbstractCSharpTypeSnippetPr
         var name = NameGenerator.GenerateUniqueName("MyClass", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
         return (ClassDeclarationSyntax)generator.ClassDeclaration(name);
     }
-
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => syntaxFacts.IsClassDeclaration;
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpClassSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpClassSnippetProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpClassSnippetProvider() : AbstractCSharpTypeSnippetProvider
+internal sealed class CSharpClassSnippetProvider() : AbstractCSharpTypeSnippetProvider<ClassDeclarationSyntax>
 {
     private static readonly ISet<SyntaxKind> s_validModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
     {
@@ -42,17 +43,15 @@ internal sealed class CSharpClassSnippetProvider() : AbstractCSharpTypeSnippetPr
 
     protected override ISet<SyntaxKind> ValidModifiers => s_validModifiers;
 
-    protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
+    protected override async Task<ClassDeclarationSyntax> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var generator = SyntaxGenerator.GetGenerator(document);
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
         var name = NameGenerator.GenerateUniqueName("MyClass", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
-        return generator.ClassDeclaration(name);
+        return (ClassDeclarationSyntax)generator.ClassDeclaration(name);
     }
 
     protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-    {
-        return syntaxFacts.IsClassDeclaration;
-    }
+        => syntaxFacts.IsClassDeclaration;
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpConsoleSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConsoleSnippetProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Composition;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
@@ -13,6 +14,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpConsoleSnippetProvider() : AbstractConsoleSnippetProvider
+internal sealed class CSharpConsoleSnippetProvider() : AbstractConsoleSnippetProvider<ExpressionStatementSyntax>
 {
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
@@ -76,9 +76,9 @@ internal sealed class CSharpConstructorSnippetProvider() : AbstractConstructorSn
         return new TextChange(TextSpan.FromBounds(position, position), constructorDeclaration.NormalizeWhitespace().ToFullString());
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ConstructorDeclarationSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ConstructorDeclarationSyntax constructorDeclaration, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            constructorDeclaration,
             static d => d.Body!,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
@@ -82,12 +82,10 @@ internal sealed class CSharpConstructorSnippetProvider() : AbstractConstructorSn
             static d => d.Body!,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-    {
-        return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<ConstructorDeclarationSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, ConstructorDeclarationSyntax constructorDeclaration, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            constructorDeclaration,
             static d => d.Body!,
             cancellationToken);
-    }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
@@ -76,13 +76,11 @@ internal sealed class CSharpConstructorSnippetProvider() : AbstractConstructorSn
         return new TextChange(TextSpan.FromBounds(position, position), constructorDeclaration.NormalizeWhitespace().ToFullString());
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<ConstructorDeclarationSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ConstructorDeclarationSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static d => d.Body!,
             sourceText);
-    }
 
     protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpConstructorSnippetProvider() : AbstractConstructorSnippetProvider
+internal sealed class CSharpConstructorSnippetProvider() : AbstractConstructorSnippetProvider<ConstructorDeclarationSyntax>
 {
     private static readonly ISet<SyntaxKind> s_validModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
@@ -37,9 +37,6 @@ internal sealed class CSharpDoWhileLoopStatementProvider()
     protected override ExpressionSyntax GetCondition(DoStatementSyntax node)
         => node.Condition;
 
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => static node => node is DoStatementSyntax;
-
     protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
     {
         return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<DoStatementSyntax>(

--- a/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
@@ -43,12 +43,10 @@ internal sealed class CSharpDoWhileLoopStatementProvider()
             static s => (BlockSyntax)s.Statement,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-    {
-        return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<DoStatementSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, DoStatementSyntax doStatement, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            doStatement,
             static s => (BlockSyntax)s.Statement,
             cancellationToken);
-    }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
@@ -20,24 +20,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpDoWhileLoopStatementProvider() : AbstractConditionalBlockSnippetProvider
+internal sealed class CSharpDoWhileLoopStatementProvider()
+    : AbstractConditionalBlockSnippetProvider<DoStatementSyntax, ExpressionSyntax>
 {
     public override string Identifier => CSharpSnippetIdentifiers.Do;
 
     public override string Description => CSharpFeaturesResources.do_while_loop;
 
-    protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
+    protected override DoStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
     {
         return SyntaxFactory.DoStatement(
             SyntaxFactory.Block(),
             (ExpressionSyntax)(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression()));
     }
 
-    protected override SyntaxNode GetCondition(SyntaxNode node)
-    {
-        var doStatement = (DoStatementSyntax)node;
-        return doStatement.Condition;
-    }
+    protected override ExpressionSyntax GetCondition(DoStatementSyntax node)
+        => node.Condition;
 
     protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
         => static node => node is DoStatementSyntax;

--- a/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
@@ -37,9 +37,9 @@ internal sealed class CSharpDoWhileLoopStatementProvider()
     protected override ExpressionSyntax GetCondition(DoStatementSyntax node)
         => node.Condition;
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, DoStatementSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, DoStatementSyntax doStatement, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            doStatement,
             static s => (BlockSyntax)s.Statement,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopStatementProvider.cs
@@ -37,13 +37,11 @@ internal sealed class CSharpDoWhileLoopStatementProvider()
     protected override ExpressionSyntax GetCondition(DoStatementSyntax node)
         => node.Condition;
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<DoStatementSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, DoStatementSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static s => (BlockSyntax)s.Statement,
             sourceText);
-    }
 
     protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -67,12 +67,10 @@ internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider<
             static c => (BlockSyntax)c.Statement,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-    {
-        return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<ElseClauseSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, ElseClauseSyntax elseClause, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            elseClause,
             static c => (BlockSyntax)c.Statement,
             cancellationToken);
-    }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider
+internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider<ElseClauseSyntax>
 {
     public override string Identifier => CSharpSnippetIdentifiers.Else;
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -61,13 +61,11 @@ internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider<
         return Task.FromResult(new TextChange(TextSpan.FromBounds(position, position), elseClause.ToFullString()));
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<ElseClauseSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ElseClauseSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static c => (BlockSyntax)c.Statement,
             sourceText);
-    }
 
     protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -61,9 +61,9 @@ internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider<
         return Task.FromResult(new TextChange(TextSpan.FromBounds(position, position), elseClause.ToFullString()));
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ElseClauseSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ElseClauseSyntax elseClause, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            elseClause,
             static c => (BlockSyntax)c.Statement,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpEnumSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpEnumSnippetProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpEnumSnippetProvider() : AbstractCSharpTypeSnippetProvider
+internal sealed class CSharpEnumSnippetProvider() : AbstractCSharpTypeSnippetProvider<EnumDeclarationSyntax>
 {
     private static readonly ISet<SyntaxKind> s_validModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
     {
@@ -37,17 +38,15 @@ internal sealed class CSharpEnumSnippetProvider() : AbstractCSharpTypeSnippetPro
 
     protected override ISet<SyntaxKind> ValidModifiers => s_validModifiers;
 
-    protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
+    protected override async Task<EnumDeclarationSyntax> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var generator = SyntaxGenerator.GetGenerator(document);
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
         var name = NameGenerator.GenerateUniqueName("MyEnum", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
-        return generator.EnumDeclaration(name);
+        return (EnumDeclarationSyntax)generator.EnumDeclaration(name);
     }
 
     protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-    {
-        return syntaxFacts.IsEnumDeclaration;
-    }
+        => syntaxFacts.IsEnumDeclaration;
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpEnumSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpEnumSnippetProvider.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Snippets;
@@ -46,7 +45,4 @@ internal sealed class CSharpEnumSnippetProvider() : AbstractCSharpTypeSnippetPro
         var name = NameGenerator.GenerateUniqueName("MyEnum", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
         return (EnumDeclarationSyntax)generator.EnumDeclaration(name);
     }
-
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => syntaxFacts.IsEnumDeclaration;
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -113,13 +113,11 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
         return arrayBuilder.ToImmutableArray();
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<ForEachStatementSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ForEachStatementSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static s => (BlockSyntax)s.Statement,
             sourceText);
-    }
 
     protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -119,12 +119,10 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
             static s => (BlockSyntax)s.Statement,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-    {
-        return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<ForEachStatementSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, ForEachStatementSyntax forEachStatement, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            forEachStatement,
             static s => (BlockSyntax)s.Statement,
             cancellationToken);
-    }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -110,12 +110,12 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
         if (!ConstructedFromInlineExpression)
             arrayBuilder.Add(new SnippetPlaceholder(node.Expression.ToString(), node.Expression.SpanStart));
 
-        return arrayBuilder.ToImmutableArray();
+        return arrayBuilder.ToImmutable();
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ForEachStatementSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, ForEachStatementSyntax forEachStatement, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            forEachStatement,
             static s => (BlockSyntax)s.Statement,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSnippetProvider
+internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSnippetProvider<ForEachStatementSyntax>
 {
     public override string Identifier => CSharpSnippetIdentifiers.ForEach;
 
@@ -48,7 +48,7 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
         return base.IsValidSnippetLocation(in context, cancellationToken);
     }
 
-    protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
+    protected override ForEachStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
     {
         var semanticModel = syntaxContext.SemanticModel;
         var position = syntaxContext.Position;
@@ -102,14 +102,13 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
     /// Goes through each piece of the foreach statement and extracts the identifiers
     /// as well as their locations to create SnippetPlaceholder's of each.
     /// </summary>
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(ForEachStatementSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
         using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);
-        GetPartsOfForEachStatement(node, out var identifier, out var expression, out var _1);
-        arrayBuilder.Add(new SnippetPlaceholder(identifier.ToString(), identifier.SpanStart));
+        arrayBuilder.Add(new SnippetPlaceholder(node.Identifier.ToString(), node.Identifier.SpanStart));
 
         if (!ConstructedFromInlineExpression)
-            arrayBuilder.Add(new SnippetPlaceholder(expression.ToString(), expression.SpanStart));
+            arrayBuilder.Add(new SnippetPlaceholder(node.Expression.ToString(), node.Expression.SpanStart));
 
         return arrayBuilder.ToImmutableArray();
     }
@@ -129,13 +128,5 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
             FindSnippetAnnotation,
             static s => (BlockSyntax)s.Statement,
             cancellationToken);
-    }
-
-    private static void GetPartsOfForEachStatement(SyntaxNode node, out SyntaxToken identifier, out SyntaxNode expression, out SyntaxNode statement)
-    {
-        var forEachStatement = (ForEachStatementSyntax)node;
-        identifier = forEachStatement.Identifier;
-        expression = forEachStatement.Expression;
-        statement = forEachStatement.Statement;
     }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -33,12 +33,10 @@ internal sealed class CSharpIfSnippetProvider() : AbstractIfSnippetProvider<IfSt
             static s => (BlockSyntax)s.Statement,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-    {
-        return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<IfStatementSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, IfStatementSyntax ifStatement, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            ifStatement,
             static s => (BlockSyntax)s.Statement,
             cancellationToken);
-    }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -27,13 +27,11 @@ internal sealed class CSharpIfSnippetProvider() : AbstractIfSnippetProvider<IfSt
     protected override ExpressionSyntax GetCondition(IfStatementSyntax node)
         => node.Condition;
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<IfStatementSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, IfStatementSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static s => (BlockSyntax)s.Statement,
             sourceText);
-    }
 
     protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -18,17 +18,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpIfSnippetProvider() : AbstractIfSnippetProvider
+internal sealed class CSharpIfSnippetProvider() : AbstractIfSnippetProvider<IfStatementSyntax, ExpressionSyntax>
 {
     public override string Identifier => CSharpSnippetIdentifiers.If;
 
     public override string Description => FeaturesResources.if_statement;
 
-    protected override SyntaxNode GetCondition(SyntaxNode node)
-    {
-        var ifStatement = (IfStatementSyntax)node;
-        return ifStatement.Condition;
-    }
+    protected override ExpressionSyntax GetCondition(IfStatementSyntax node)
+        => node.Condition;
 
     protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -27,9 +27,9 @@ internal sealed class CSharpIfSnippetProvider() : AbstractIfSnippetProvider<IfSt
     protected override ExpressionSyntax GetCondition(IfStatementSyntax node)
         => node.Condition;
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, IfStatementSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, IfStatementSyntax ifStatement, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            ifStatement,
             static s => (BlockSyntax)s.Statement,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
@@ -39,10 +39,9 @@ internal sealed class CSharpIntMainSnippetProvider() : AbstractCSharpMainMethodS
         return SpecializedCollections.SingletonEnumerable(returnStatement);
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, MethodDeclarationSyntax caretTarget, SourceText sourceText)
     {
-        var methodDeclaration = (MethodDeclarationSyntax)caretTarget;
-        var body = methodDeclaration.Body!;
+        var body = caretTarget.Body!;
         var returnStatement = body.Statements.First();
 
         var triviaSpan = returnStatement.GetLeadingTrivia().Span;

--- a/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
@@ -29,13 +29,13 @@ internal sealed class CSharpIntMainSnippetProvider() : AbstractCSharpMainMethodS
 
     public override string Description => CSharpFeaturesResources.static_int_Main;
 
-    protected override SyntaxNode GenerateReturnType(SyntaxGenerator generator)
-        => generator.TypeExpression(SpecialType.System_Int32);
+    protected override TypeSyntax GenerateReturnType(SyntaxGenerator generator)
+        => (TypeSyntax)generator.TypeExpression(SpecialType.System_Int32);
 
-    protected override IEnumerable<SyntaxNode> GenerateInnerStatements(SyntaxGenerator generator)
+    protected override IEnumerable<StatementSyntax> GenerateInnerStatements(SyntaxGenerator generator)
     {
-        var returnStatement = generator.ReturnStatement(generator.LiteralExpression(0));
-        return SpecializedCollections.SingletonEnumerable(returnStatement);
+        var returnStatement = (StatementSyntax)generator.ReturnStatement(generator.LiteralExpression(0));
+        return [returnStatement];
     }
 
     protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, MethodDeclarationSyntax methodDeclaration, SourceText sourceText)

--- a/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
@@ -50,13 +50,9 @@ internal sealed class CSharpIntMainSnippetProvider() : AbstractCSharpMainMethodS
         return line.Span.End;
     }
 
-    protected override async Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
+    protected override async Task<Document> AddIndentationToDocumentAsync(Document document, MethodDeclarationSyntax methodDeclaration, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var snippetNode = root.GetAnnotatedNodes(FindSnippetAnnotation).FirstOrDefault();
-
-        if (snippetNode is not MethodDeclarationSyntax methodDeclaration)
-            return document;
 
         var body = methodDeclaration.Body!;
         var returnStatement = body.Statements.First();

--- a/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -39,9 +38,9 @@ internal sealed class CSharpIntMainSnippetProvider() : AbstractCSharpMainMethodS
         return SpecializedCollections.SingletonEnumerable(returnStatement);
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, MethodDeclarationSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, MethodDeclarationSyntax methodDeclaration, SourceText sourceText)
     {
-        var body = caretTarget.Body!;
+        var body = methodDeclaration.Body!;
         var returnStatement = body.Statements.First();
 
         var triviaSpan = returnStatement.GetLeadingTrivia().Span;

--- a/src/Features/CSharp/Portable/Snippets/CSharpInterfaceSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpInterfaceSnippetProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpInterfaceSnippetProvider() : AbstractCSharpTypeSnippetProvider
+internal sealed class CSharpInterfaceSnippetProvider() : AbstractCSharpTypeSnippetProvider<InterfaceDeclarationSyntax>
 {
     private static readonly ISet<SyntaxKind> s_validModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
     {
@@ -38,17 +39,15 @@ internal sealed class CSharpInterfaceSnippetProvider() : AbstractCSharpTypeSnipp
 
     protected override ISet<SyntaxKind> ValidModifiers => s_validModifiers;
 
-    protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
+    protected override async Task<InterfaceDeclarationSyntax> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var generator = SyntaxGenerator.GetGenerator(document);
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
         var name = NameGenerator.GenerateUniqueName("MyInterface", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
-        return generator.InterfaceDeclaration(name);
+        return (InterfaceDeclarationSyntax)generator.InterfaceDeclaration(name);
     }
 
     protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-    {
-        return syntaxFacts.IsInterfaceDeclaration;
-    }
+        => syntaxFacts.IsInterfaceDeclaration;
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpInterfaceSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpInterfaceSnippetProvider.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Snippets;
@@ -47,7 +46,4 @@ internal sealed class CSharpInterfaceSnippetProvider() : AbstractCSharpTypeSnipp
         var name = NameGenerator.GenerateUniqueName("MyInterface", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
         return (InterfaceDeclarationSyntax)generator.InterfaceDeclaration(name);
     }
-
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => syntaxFacts.IsInterfaceDeclaration;
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
@@ -19,16 +19,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpLockSnippetProvider() : AbstractLockSnippetProvider
+internal sealed class CSharpLockSnippetProvider() : AbstractLockSnippetProvider<LockStatementSyntax>
 {
     public override string Identifier => CSharpSnippetIdentifiers.Lock;
 
     public override string Description => CSharpFeaturesResources.lock_statement;
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(LockStatementSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
-        var lockStatement = (LockStatementSyntax)node;
-        var expression = lockStatement.Expression;
+        var expression = node.Expression;
         return [new SnippetPlaceholder(expression.ToString(), expression.SpanStart)];
     }
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
@@ -37,12 +37,10 @@ internal sealed class CSharpLockSnippetProvider() : AbstractLockSnippetProvider<
             static s => (BlockSyntax)s.Statement,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-    {
-        return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<LockStatementSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, LockStatementSyntax lockStatement, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            lockStatement,
             static s => (BlockSyntax)s.Statement,
             cancellationToken);
-    }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
@@ -31,13 +31,11 @@ internal sealed class CSharpLockSnippetProvider() : AbstractLockSnippetProvider<
         return [new SnippetPlaceholder(expression.ToString(), expression.SpanStart)];
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<LockStatementSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, LockStatementSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static s => (BlockSyntax)s.Statement,
             sourceText);
-    }
 
     protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
@@ -31,9 +31,9 @@ internal sealed class CSharpLockSnippetProvider() : AbstractLockSnippetProvider<
         return [new SnippetPlaceholder(expression.ToString(), expression.SpanStart)];
     }
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, LockStatementSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, LockStatementSyntax lockStatement, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            lockStatement,
             static s => (BlockSyntax)s.Statement,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpSnippetHelpers.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpSnippetHelpers.cs
@@ -16,11 +16,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
 internal static class CSharpSnippetHelpers
 {
-    public static int GetTargetCaretPositionInBlock<TTargetNode>(SyntaxNode caretTarget, Func<TTargetNode, BlockSyntax> getBlock, SourceText sourceText)
+    public static int GetTargetCaretPositionInBlock<TTargetNode>(TTargetNode caretTarget, Func<TTargetNode, BlockSyntax> getBlock, SourceText sourceText)
         where TTargetNode : SyntaxNode
     {
-        var targetNode = (TTargetNode)caretTarget;
-        var block = getBlock(targetNode);
+        var block = getBlock(caretTarget);
 
         var triviaSpan = block.CloseBraceToken.LeadingTrivia.Span;
         var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);

--- a/src/Features/CSharp/Portable/Snippets/CSharpStructSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpStructSnippetProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpStructSnippetProvider() : AbstractCSharpTypeSnippetProvider
+internal sealed class CSharpStructSnippetProvider() : AbstractCSharpTypeSnippetProvider<StructDeclarationSyntax>
 {
     private static readonly ISet<SyntaxKind> s_validModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
     {
@@ -40,17 +41,15 @@ internal sealed class CSharpStructSnippetProvider() : AbstractCSharpTypeSnippetP
 
     protected override ISet<SyntaxKind> ValidModifiers => s_validModifiers;
 
-    protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
+    protected override async Task<StructDeclarationSyntax> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var generator = SyntaxGenerator.GetGenerator(document);
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
         var name = NameGenerator.GenerateUniqueName("MyStruct", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
-        return generator.StructDeclaration(name);
+        return (StructDeclarationSyntax)generator.StructDeclaration(name);
     }
 
     protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-    {
-        return syntaxFacts.IsStructDeclaration;
-    }
+        => syntaxFacts.IsStructDeclaration;
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpStructSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpStructSnippetProvider.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Snippets;
@@ -49,7 +48,4 @@ internal sealed class CSharpStructSnippetProvider() : AbstractCSharpTypeSnippetP
         var name = NameGenerator.GenerateUniqueName("MyStruct", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
         return (StructDeclarationSyntax)generator.StructDeclaration(name);
     }
-
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => syntaxFacts.IsStructDeclaration;
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
@@ -33,13 +33,11 @@ internal sealed class CSharpVoidMainSnippetProvider() : AbstractCSharpMainMethod
     protected override IEnumerable<SyntaxNode> GenerateInnerStatements(SyntaxGenerator generator)
         => SpecializedCollections.EmptyEnumerable<SyntaxNode>();
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<MethodDeclarationSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, MethodDeclarationSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static d => d.Body!,
             sourceText);
-    }
 
     protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
@@ -39,12 +39,10 @@ internal sealed class CSharpVoidMainSnippetProvider() : AbstractCSharpMainMethod
             static d => d.Body!,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-    {
-        return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<MethodDeclarationSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, MethodDeclarationSyntax methodDeclaration, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            methodDeclaration,
             static m => m.Body!,
             cancellationToken);
-    }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
@@ -27,15 +26,15 @@ internal sealed class CSharpVoidMainSnippetProvider() : AbstractCSharpMainMethod
 
     public override string Description => CSharpFeaturesResources.static_void_Main;
 
-    protected override SyntaxNode GenerateReturnType(SyntaxGenerator generator)
+    protected override TypeSyntax GenerateReturnType(SyntaxGenerator generator)
         => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword));
 
-    protected override IEnumerable<SyntaxNode> GenerateInnerStatements(SyntaxGenerator generator)
-        => SpecializedCollections.EmptyEnumerable<SyntaxNode>();
+    protected override IEnumerable<StatementSyntax> GenerateInnerStatements(SyntaxGenerator generator)
+        => [];
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, MethodDeclarationSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, MethodDeclarationSyntax methodDeclaration, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            methodDeclaration,
             static d => d.Body!,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Composition;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -28,13 +27,11 @@ internal sealed class CSharpWhileLoopSnippetProvider() : AbstractWhileLoopSnippe
     protected override ExpressionSyntax GetCondition(WhileStatementSyntax node)
         => node.Condition;
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-    {
-        return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<WhileStatementSyntax>(
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, WhileStatementSyntax caretTarget, SourceText sourceText)
+        => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
             caretTarget,
             static s => (BlockSyntax)s.Statement,
             sourceText);
-    }
 
     protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
@@ -27,9 +27,9 @@ internal sealed class CSharpWhileLoopSnippetProvider() : AbstractWhileLoopSnippe
     protected override ExpressionSyntax GetCondition(WhileStatementSyntax node)
         => node.Condition;
 
-    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, WhileStatementSyntax caretTarget, SourceText sourceText)
+    protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, WhileStatementSyntax whileStatement, SourceText sourceText)
         => CSharpSnippetHelpers.GetTargetCaretPositionInBlock(
-            caretTarget,
+            whileStatement,
             static s => (BlockSyntax)s.Statement,
             sourceText);
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Composition;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -18,17 +19,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpWhileLoopSnippetProvider() : AbstractWhileLoopSnippetProvider
+internal sealed class CSharpWhileLoopSnippetProvider() : AbstractWhileLoopSnippetProvider<WhileStatementSyntax, ExpressionSyntax>
 {
     public override string Identifier => CSharpSnippetIdentifiers.While;
 
     public override string Description => FeaturesResources.while_loop;
 
-    protected override SyntaxNode GetCondition(SyntaxNode node)
-    {
-        var whileStatement = (WhileStatementSyntax)node;
-        return whileStatement.Condition;
-    }
+    protected override ExpressionSyntax GetCondition(WhileStatementSyntax node)
+        => node.Condition;
 
     protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
@@ -33,12 +33,10 @@ internal sealed class CSharpWhileLoopSnippetProvider() : AbstractWhileLoopSnippe
             static s => (BlockSyntax)s.Statement,
             sourceText);
 
-    protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
-    {
-        return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<WhileStatementSyntax>(
+    protected override Task<Document> AddIndentationToDocumentAsync(Document document, WhileStatementSyntax whileStatement, CancellationToken cancellationToken)
+        => CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync(
             document,
-            FindSnippetAnnotation,
+            whileStatement,
             static s => (BlockSyntax)s.Statement,
             cancellationToken);
-    }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConditionalBlockSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConditionalBlockSnippetProvider.cs
@@ -11,14 +11,16 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 /// <summary>
 /// Base class for "if" and "while" snippet providers
 /// </summary>
-internal abstract class AbstractConditionalBlockSnippetProvider : AbstractInlineStatementSnippetProvider
+internal abstract class AbstractConditionalBlockSnippetProvider<TStatementSyntax, TExpressionSyntax> : AbstractInlineStatementSnippetProvider<TStatementSyntax>
+    where TStatementSyntax : SyntaxNode
+    where TExpressionSyntax : SyntaxNode
 {
-    protected abstract SyntaxNode GetCondition(SyntaxNode node);
+    protected abstract TExpressionSyntax GetCondition(TStatementSyntax node);
 
-    protected override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
+    protected sealed override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
         => type.SpecialType == SpecialType.System_Boolean;
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TStatementSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
         if (ConstructedFromInlineExpression)
             return [];

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConditionalBlockSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConditionalBlockSnippetProvider.cs
@@ -26,8 +26,6 @@ internal abstract class AbstractConditionalBlockSnippetProvider<TStatementSyntax
             return [];
 
         var condition = GetCondition(node);
-        var placeholder = new SnippetPlaceholder(condition.ToString(), condition.SpanStart);
-
-        return [placeholder];
+        return [new SnippetPlaceholder(condition.ToString(), condition.SpanStart)];
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -36,11 +36,6 @@ internal abstract class AbstractConsoleSnippetProvider<TExpressionStatementSynta
         return base.IsValidSnippetLocation(in context, cancellationToken);
     }
 
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-    {
-        return syntaxFacts.IsExpressionStatement;
-    }
-
     protected sealed override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var generator = SyntaxGenerator.GetGenerator(document);
@@ -79,7 +74,7 @@ internal abstract class AbstractConsoleSnippetProvider<TExpressionStatementSynta
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-        var snippetExpressionNode = FindAddedSnippetSyntaxNode(root, position, syntaxFacts.IsExpressionStatement);
+        var snippetExpressionNode = FindAddedSnippetSyntaxNode(root, position);
         Contract.ThrowIfNull(snippetExpressionNode);
 
         var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
@@ -113,10 +108,10 @@ internal abstract class AbstractConsoleSnippetProvider<TExpressionStatementSynta
     private static INamedTypeSymbol? GetConsoleSymbolFromMetaDataName(Compilation compilation)
         => compilation.GetBestTypeByMetadataName(typeof(Console).FullName!);
 
-    protected sealed override TExpressionStatementSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
+    protected sealed override TExpressionStatementSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position)
     {
         var closestNode = root.FindNode(TextSpan.FromBounds(position, position));
-        var nearestExpressionStatement = closestNode.FirstAncestorOrSelf<TExpressionStatementSyntax>(isCorrectContainer);
+        var nearestExpressionStatement = closestNode.FirstAncestorOrSelf<TExpressionStatementSyntax>();
         if (nearestExpressionStatement is null)
             return null;
 

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -73,7 +73,6 @@ internal abstract class AbstractConsoleSnippetProvider<TExpressionStatementSynta
         SyntaxAnnotation findSnippetAnnotation, SyntaxAnnotation cursorAnnotation, int position, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
         var snippetExpressionNode = FindAddedSnippetSyntaxNode(root, position);
         Contract.ThrowIfNull(snippetExpressionNode);
 

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -51,19 +51,15 @@ internal abstract class AbstractConsoleSnippetProvider<TExpressionStatementSynta
     /// Tries to get the location after the open parentheses in the argument list.
     /// If it can't, then we default to the end of the snippet's span.
     /// </summary>
-    protected sealed override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
+    protected sealed override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, TExpressionStatementSyntax caretTarget, SourceText sourceText)
     {
         var invocationExpression = caretTarget.DescendantNodes().Where(syntaxFacts.IsInvocationExpression).FirstOrDefault();
         if (invocationExpression is null)
-        {
             return caretTarget.Span.End;
-        }
 
         var argumentListNode = syntaxFacts.GetArgumentListOfInvocationExpression(invocationExpression);
         if (argumentListNode is null)
-        {
             return caretTarget.Span.End;
-        }
 
         syntaxFacts.GetPartsOfArgumentList(argumentListNode, out var openParenToken, out _, out _);
         return openParenToken.Span.End;

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -65,8 +65,8 @@ internal abstract class AbstractConsoleSnippetProvider<TExpressionStatementSynta
         return openParenToken.Span.End;
     }
 
-    protected sealed override async Task<SyntaxNode> AnnotateNodesToReformatAsync(Document document,
-        SyntaxAnnotation findSnippetAnnotation, SyntaxAnnotation cursorAnnotation, int position, CancellationToken cancellationToken)
+    protected sealed override async Task<SyntaxNode> AnnotateNodesToReformatAsync(
+        Document document, int position, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var snippetExpressionNode = FindAddedSnippetSyntaxNode(root, position);
@@ -74,7 +74,7 @@ internal abstract class AbstractConsoleSnippetProvider<TExpressionStatementSynta
 
         var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
         var consoleSymbol = GetConsoleSymbolFromMetaDataName(compilation);
-        var reformatSnippetNode = snippetExpressionNode.WithAdditionalAnnotations(findSnippetAnnotation, cursorAnnotation, Simplifier.Annotation, SymbolAnnotation.Create(consoleSymbol!), Formatter.Annotation);
+        var reformatSnippetNode = snippetExpressionNode.WithAdditionalAnnotations(FindSnippetAnnotation, Simplifier.Annotation, SymbolAnnotation.Create(consoleSymbol!), Formatter.Annotation);
         return root.ReplaceNode(snippetExpressionNode, reformatSnippetNode);
     }
 

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConstructorSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConstructorSnippetProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -17,8 +16,6 @@ internal abstract class AbstractConstructorSnippetProvider<TConstructorDeclarati
     public sealed override string Description => FeaturesResources.constructor;
 
     public sealed override ImmutableArray<string> AdditionalFilterTexts { get; } = ["constructor"];
-
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsConstructorDeclaration;
 
     protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TConstructorDeclarationSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         => [];

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConstructorSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConstructorSnippetProvider.cs
@@ -9,16 +9,17 @@ using Microsoft.CodeAnalysis.LanguageService;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractConstructorSnippetProvider : AbstractSingleChangeSnippetProvider
+internal abstract class AbstractConstructorSnippetProvider<TConstructorDeclarationSyntax> : AbstractSingleChangeSnippetProvider<TConstructorDeclarationSyntax>
+    where TConstructorDeclarationSyntax : SyntaxNode
 {
-    public override string Identifier => CommonSnippetIdentifiers.Constructor;
+    public sealed override string Identifier => CommonSnippetIdentifiers.Constructor;
 
-    public override string Description => FeaturesResources.constructor;
+    public sealed override string Description => FeaturesResources.constructor;
 
-    public override ImmutableArray<string> AdditionalFilterTexts { get; } = ["constructor"];
+    public sealed override ImmutableArray<string> AdditionalFilterTexts { get; } = ["constructor"];
 
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsConstructorDeclaration;
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsConstructorDeclaration;
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TConstructorDeclarationSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         => [];
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractElseSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractElseSnippetProvider.cs
@@ -9,10 +9,11 @@ using Microsoft.CodeAnalysis.LanguageService;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractElseSnippetProvider : AbstractStatementSnippetProvider
+internal abstract class AbstractElseSnippetProvider<TElseClauseSyntax> : AbstractStatementSnippetProvider<TElseClauseSyntax>
+    where TElseClauseSyntax : SyntaxNode
 {
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsElseClause;
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsElseClause;
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TElseClauseSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         => [];
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractElseSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractElseSnippetProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -12,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 internal abstract class AbstractElseSnippetProvider<TElseClauseSyntax> : AbstractStatementSnippetProvider<TElseClauseSyntax>
     where TElseClauseSyntax : SyntaxNode
 {
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsElseClause;
-
     protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TElseClauseSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         => [];
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
@@ -14,7 +12,4 @@ internal abstract class AbstractForEachLoopSnippetProvider<TStatementSyntax> : A
 {
     protected sealed override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
         => type.CanBeEnumerated() || type.CanBeAsynchronouslyEnumerated(compilation);
-
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => syntaxFacts.IsForEachStatement;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
@@ -9,13 +9,12 @@ using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
 namespace Microsoft.CodeAnalysis.Snippets;
 
-internal abstract class AbstractForEachLoopSnippetProvider : AbstractInlineStatementSnippetProvider
+internal abstract class AbstractForEachLoopSnippetProvider<TStatementSyntax> : AbstractInlineStatementSnippetProvider<TStatementSyntax>
+    where TStatementSyntax : SyntaxNode
 {
-    protected override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
+    protected sealed override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
         => type.CanBeEnumerated() || type.CanBeAsynchronouslyEnumerated(compilation);
 
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-    {
-        return syntaxFacts.IsForEachStatement;
-    }
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
+        => syntaxFacts.IsForEachStatement;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForLoopSnippetProvider.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
@@ -25,9 +23,6 @@ internal abstract class AbstractForLoopSnippetProvider<TStatementSyntax> : Abstr
         // We want to allow types, which have either `Length` or `Count` property, but not both to avoid ambiguity
         return hasLengthProperty ^ hasCountProperty;
     }
-
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => syntaxFacts.IsForStatement;
 
     protected static bool IsSuitableIntegerType(ITypeSymbol type)
         => type.IsIntegralType() || type.IsNativeIntegerType;

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForLoopSnippetProvider.cs
@@ -9,9 +9,10 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractForLoopSnippetProvider : AbstractInlineStatementSnippetProvider
+internal abstract class AbstractForLoopSnippetProvider<TStatementSyntax> : AbstractInlineStatementSnippetProvider<TStatementSyntax>
+    where TStatementSyntax : SyntaxNode
 {
-    protected override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
+    protected sealed override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
     {
         if (IsSuitableIntegerType(type))
         {
@@ -25,7 +26,7 @@ internal abstract class AbstractForLoopSnippetProvider : AbstractInlineStatement
         return hasLengthProperty ^ hasCountProperty;
     }
 
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
         => syntaxFacts.IsForStatement;
 
     protected static bool IsSuitableIntegerType(ITypeSymbol type)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
@@ -16,8 +14,6 @@ internal abstract class AbstractIfSnippetProvider<TIfStatementSyntax, TExpressio
     where TExpressionSyntax : SyntaxNode
 {
     public sealed override ImmutableArray<string> AdditionalFilterTexts { get; } = ["statement"];
-
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsIfStatement;
 
     protected sealed override TIfStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
         => (TIfStatementSyntax)generator.IfStatement(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), []);

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
@@ -11,12 +11,14 @@ using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
 namespace Microsoft.CodeAnalysis.Snippets;
 
-internal abstract class AbstractIfSnippetProvider : AbstractConditionalBlockSnippetProvider
+internal abstract class AbstractIfSnippetProvider<TIfStatementSyntax, TExpressionSyntax> : AbstractConditionalBlockSnippetProvider<TIfStatementSyntax, TExpressionSyntax>
+    where TIfStatementSyntax : SyntaxNode
+    where TExpressionSyntax : SyntaxNode
 {
-    public override ImmutableArray<string> AdditionalFilterTexts { get; } = ["statement"];
+    public sealed override ImmutableArray<string> AdditionalFilterTexts { get; } = ["statement"];
 
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsIfStatement;
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsIfStatement;
 
-    protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
-        => generator.IfStatement(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), []);
+    protected sealed override TIfStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
+        => (TIfStatementSyntax)generator.IfStatement(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), []);
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -18,7 +18,8 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 /// Base class for snippets, that can be both executed as normal statement snippets
 /// or constructed from a member access expression when accessing members of a specific type
 /// </summary>
-internal abstract class AbstractInlineStatementSnippetProvider : AbstractStatementSnippetProvider
+internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax> : AbstractStatementSnippetProvider<TStatementSyntax>
+    where TStatementSyntax : SyntaxNode
 {
     /// <summary>
     /// Tells if accessing type of a member access expression is valid for that snippet
@@ -31,7 +32,7 @@ internal abstract class AbstractInlineStatementSnippetProvider : AbstractStateme
     /// Generate statement node
     /// </summary>
     /// <param name="inlineExpressionInfo">Information about inline expression or <see langword="null"/> if snippet is executed in normal statement context</param>
-    protected abstract SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo);
+    protected abstract TStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo);
 
     /// <summary>
     /// Tells whether the original snippet was constructed from member access expression.
@@ -69,10 +70,10 @@ internal abstract class AbstractInlineStatementSnippetProvider : AbstractStateme
         return new TextChange(TextSpan.FromBounds(inlineExpressionInfo?.Node.SpanStart ?? position, position), statement.ToFullString());
     }
 
-    protected sealed override SyntaxNode? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
+    protected sealed override TStatementSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
     {
         var closestNode = root.FindNode(TextSpan.FromBounds(position, position), getInnermostNodeForTie: true);
-        return closestNode.FirstAncestorOrSelf<SyntaxNode>(isCorrectContainer);
+        return closestNode.FirstAncestorOrSelf<TStatementSyntax>(isCorrectContainer);
     }
 
     private static bool TryGetInlineExpressionInfo(SyntaxToken targetToken, ISyntaxFactsService syntaxFacts, SemanticModel semanticModel, [NotNullWhen(true)] out InlineExpressionInfo? expressionInfo, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -70,10 +69,10 @@ internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax>
         return new TextChange(TextSpan.FromBounds(inlineExpressionInfo?.Node.SpanStart ?? position, position), statement.ToFullString());
     }
 
-    protected sealed override TStatementSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
+    protected sealed override TStatementSyntax? FindAddedSnippetSyntaxNode(SyntaxNode root, int position)
     {
         var closestNode = root.FindNode(TextSpan.FromBounds(position, position), getInnermostNodeForTie: true);
-        return closestNode.FirstAncestorOrSelf<TStatementSyntax>(isCorrectContainer);
+        return closestNode.FirstAncestorOrSelf<TStatementSyntax>();
     }
 
     private static bool TryGetInlineExpressionInfo(SyntaxToken targetToken, ISyntaxFactsService syntaxFacts, SemanticModel semanticModel, [NotNullWhen(true)] out InlineExpressionInfo? expressionInfo, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractLockSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractLockSnippetProvider.cs
@@ -12,15 +12,16 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractLockSnippetProvider : AbstractStatementSnippetProvider
+internal abstract class AbstractLockSnippetProvider<TLockStatementSyntax> : AbstractStatementSnippetProvider<TLockStatementSyntax>
+    where TLockStatementSyntax : SyntaxNode
 {
-    protected override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
+    protected sealed override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var generator = SyntaxGenerator.GetGenerator(document);
         var statement = generator.LockStatement(generator.ThisExpression(), SpecializedCollections.EmptyEnumerable<SyntaxNode>());
         return Task.FromResult(new TextChange(TextSpan.FromBounds(position, position), statement.NormalizeWhitespace().ToFullString()));
     }
 
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
         => syntaxFacts.IsLockStatement;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractLockSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractLockSnippetProvider.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -21,7 +19,4 @@ internal abstract class AbstractLockSnippetProvider<TLockStatementSyntax> : Abst
         var statement = generator.LockStatement(generator.ThisExpression(), SpecializedCollections.EmptyEnumerable<SyntaxNode>());
         return Task.FromResult(new TextChange(TextSpan.FromBounds(position, position), statement.NormalizeWhitespace().ToFullString()));
     }
-
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => syntaxFacts.IsLockStatement;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -38,7 +37,4 @@ internal abstract class AbstractMainMethodSnippetProvider<TMethodDeclarationSynt
 
     protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TMethodDeclarationSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         => [];
-
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-        => syntaxFacts.IsMethodDeclaration;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
@@ -14,13 +14,14 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractMainMethodSnippetProvider : AbstractSingleChangeSnippetProvider
+internal abstract class AbstractMainMethodSnippetProvider<TMethodDeclarationSyntax> : AbstractSingleChangeSnippetProvider<TMethodDeclarationSyntax>
+    where TMethodDeclarationSyntax : SyntaxNode
 {
     protected abstract SyntaxNode GenerateReturnType(SyntaxGenerator generator);
 
     protected abstract IEnumerable<SyntaxNode> GenerateInnerStatements(SyntaxGenerator generator);
 
-    protected override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
+    protected sealed override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var generator = SyntaxGenerator.GetGenerator(document);
         var method = generator.MethodDeclaration(
@@ -35,9 +36,9 @@ internal abstract class AbstractMainMethodSnippetProvider : AbstractSingleChange
         return Task.FromResult(new TextChange(TextSpan.FromBounds(position, position), method.NormalizeWhitespace().ToFullString()));
     }
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TMethodDeclarationSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         => [];
 
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
         => syntaxFacts.IsMethodDeclaration;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
@@ -13,12 +13,14 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractMainMethodSnippetProvider<TMethodDeclarationSyntax> : AbstractSingleChangeSnippetProvider<TMethodDeclarationSyntax>
+internal abstract class AbstractMainMethodSnippetProvider<TMethodDeclarationSyntax, TStatementSyntax, TTypeSyntax> : AbstractSingleChangeSnippetProvider<TMethodDeclarationSyntax>
     where TMethodDeclarationSyntax : SyntaxNode
+    where TStatementSyntax : SyntaxNode
+    where TTypeSyntax : SyntaxNode
 {
-    protected abstract SyntaxNode GenerateReturnType(SyntaxGenerator generator);
+    protected abstract TTypeSyntax GenerateReturnType(SyntaxGenerator generator);
 
-    protected abstract IEnumerable<SyntaxNode> GenerateInnerStatements(SyntaxGenerator generator);
+    protected abstract IEnumerable<TStatementSyntax> GenerateInnerStatements(SyntaxGenerator generator);
 
     protected sealed override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
     {

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractPropertySnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractPropertySnippetProvider.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
@@ -24,10 +22,5 @@ internal abstract class AbstractPropertySnippetProvider<TPropertyDeclarationSynt
     {
         var propertyDeclaration = await GenerateSnippetSyntaxAsync(document, position, cancellationToken).ConfigureAwait(false);
         return new TextChange(TextSpan.FromBounds(position, position), propertyDeclaration.NormalizeWhitespace().ToFullString());
-    }
-
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
-    {
-        return syntaxFacts.IsPropertyDeclaration;
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractPropertySnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractPropertySnippetProvider.cs
@@ -10,22 +10,23 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractPropertySnippetProvider : AbstractSingleChangeSnippetProvider
+internal abstract class AbstractPropertySnippetProvider<TPropertyDeclarationSyntax> : AbstractSingleChangeSnippetProvider<TPropertyDeclarationSyntax>
+    where TPropertyDeclarationSyntax : SyntaxNode
 {
     /// <summary>
     /// Generates the property syntax.
     /// Requires language specificity for the TypeSyntax as well as the
     /// type of the PropertySyntax.
     /// </summary>
-    protected abstract Task<SyntaxNode> GenerateSnippetSyntaxAsync(Document document, int position, CancellationToken cancellationToken);
+    protected abstract Task<TPropertyDeclarationSyntax> GenerateSnippetSyntaxAsync(Document document, int position, CancellationToken cancellationToken);
 
-    protected override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
+    protected sealed override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var propertyDeclaration = await GenerateSnippetSyntaxAsync(document, position, cancellationToken).ConfigureAwait(false);
         return new TextChange(TextSpan.FromBounds(position, position), propertyDeclaration.NormalizeWhitespace().ToFullString());
     }
 
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
     {
         return syntaxFacts.IsPropertyDeclaration;
     }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSingleChangeSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSingleChangeSnippetProvider.cs
@@ -9,7 +9,8 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractSingleChangeSnippetProvider : AbstractSnippetProvider
+internal abstract class AbstractSingleChangeSnippetProvider<TSnippetSyntax> : AbstractSnippetProvider<TSnippetSyntax>
+    where TSnippetSyntax : SyntaxNode
 {
     protected abstract Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -233,8 +233,17 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
     /// The SyntaxGenerator does not insert this space for us nor does the LSP Snippet Expander.
     /// We need to manually add that spacing to snippets containing blocks.
     /// </summary>
-    protected virtual async Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
+    private async Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
     {
-        return await Task.FromResult(document).ConfigureAwait(false);
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var snippetNode = root.GetAnnotatedNodes(FindSnippetAnnotation).FirstOrDefault();
+
+        if (snippetNode is not TSnippetSyntax snippet)
+            return document;
+
+        return await AddIndentationToDocumentAsync(document, snippet, cancellationToken).ConfigureAwait(false);
     }
+
+    protected virtual Task<Document> AddIndentationToDocumentAsync(Document document, TSnippetSyntax snippet, CancellationToken cancellationToken)
+        => Task.FromResult(document);
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -44,7 +44,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
     /// <summary>
     /// Gets the position that we want the caret to be at after all of the indentation/formatting has been done.
     /// </summary>
-    protected abstract int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText);
+    protected abstract int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, TSnippetSyntax caretTarget, SourceText sourceText);
 
     /// <summary>
     /// Method to find the locations that must be renamed and where tab stops must be inserted into the snippet.
@@ -101,10 +101,8 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
         var documentWithIndentation = await AddIndentationToDocumentAsync(reformattedDocument, cancellationToken).ConfigureAwait(false);
 
         var reformattedRoot = await documentWithIndentation.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var caretTarget = reformattedRoot.GetAnnotatedNodes(CursorAnnotation).FirstOrDefault();
+        var caretTarget = (TSnippetSyntax)reformattedRoot.GetAnnotatedNodes(CursorAnnotation).First();
         var mainChangeNode = (TSnippetSyntax)reformattedRoot.GetAnnotatedNodes(FindSnippetAnnotation).First();
-
-        Contract.ThrowIfNull(caretTarget);
 
         var annotatedReformattedDocument = documentWithIndentation.WithSyntaxRoot(reformattedRoot);
 

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractStatementSnippetProvider.cs
@@ -6,7 +6,8 @@ using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractStatementSnippetProvider : AbstractSingleChangeSnippetProvider
+internal abstract class AbstractStatementSnippetProvider<TStatementSyntax> : AbstractSingleChangeSnippetProvider<TStatementSyntax>
+    where TStatementSyntax : SyntaxNode
 {
     protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
         => context.SyntaxContext.IsStatementContext || context.SyntaxContext.IsGlobalStatementContext;

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 internal abstract class AbstractTypeSnippetProvider<TTypeDeclarationSyntax> : AbstractSnippetProvider<TTypeDeclarationSyntax>
     where TTypeDeclarationSyntax : SyntaxNode
 {
-    protected abstract void GetTypeDeclarationIdentifier(SyntaxNode node, out SyntaxToken identifier);
+    protected abstract SyntaxToken GetTypeDeclarationIdentifier(TTypeDeclarationSyntax node);
     protected abstract Task<TTypeDeclarationSyntax> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken);
     protected abstract Task<TextChange?> GetAccessibilityModifiersChangeAsync(Document document, int position, CancellationToken cancellationToken);
 
@@ -36,11 +36,8 @@ internal abstract class AbstractTypeSnippetProvider<TTypeDeclarationSyntax> : Ab
 
     protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TTypeDeclarationSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
-        using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);
-        GetTypeDeclarationIdentifier(node, out var identifier);
-        arrayBuilder.Add(new SnippetPlaceholder(identifier.ValueText, identifier.SpanStart));
-
-        return arrayBuilder.ToImmutableArray();
+        var identifier = GetTypeDeclarationIdentifier(node);
+        return [new SnippetPlaceholder(identifier.ValueText, identifier.SpanStart)];
     }
 
     protected static async Task<bool> AreAccessibilityModifiersRequiredAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
@@ -12,13 +12,14 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractTypeSnippetProvider : AbstractSnippetProvider
+internal abstract class AbstractTypeSnippetProvider<TTypeDeclarationSyntax> : AbstractSnippetProvider<TTypeDeclarationSyntax>
+    where TTypeDeclarationSyntax : SyntaxNode
 {
     protected abstract void GetTypeDeclarationIdentifier(SyntaxNode node, out SyntaxToken identifier);
-    protected abstract Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken);
+    protected abstract Task<TTypeDeclarationSyntax> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken);
     protected abstract Task<TextChange?> GetAccessibilityModifiersChangeAsync(Document document, int position, CancellationToken cancellationToken);
 
-    protected override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+    protected sealed override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var typeDeclaration = await GenerateTypeDeclarationAsync(document, position, cancellationToken).ConfigureAwait(false);
 
@@ -33,7 +34,7 @@ internal abstract class AbstractTypeSnippetProvider : AbstractSnippetProvider
         return [mainChange];
     }
 
-    protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+    protected sealed override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TTypeDeclarationSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
     {
         using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);
         GetTypeDeclarationIdentifier(node, out var identifier);

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
@@ -14,8 +12,6 @@ internal abstract class AbstractWhileLoopSnippetProvider<TWhileStatementSyntax, 
     where TWhileStatementSyntax : SyntaxNode
     where TExpressionSyntax : SyntaxNode
 {
-    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsWhileStatement;
-
     protected sealed override TWhileStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
         => (TWhileStatementSyntax)generator.WhileStatement(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), []);
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
@@ -9,10 +9,13 @@ using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
-internal abstract class AbstractWhileLoopSnippetProvider : AbstractConditionalBlockSnippetProvider
+internal abstract class AbstractWhileLoopSnippetProvider<TWhileStatementSyntax, TExpressionSyntax>
+    : AbstractConditionalBlockSnippetProvider<TWhileStatementSyntax, TExpressionSyntax>
+    where TWhileStatementSyntax : SyntaxNode
+    where TExpressionSyntax : SyntaxNode
 {
-    protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsWhileStatement;
+    protected sealed override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsWhileStatement;
 
-    protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
-        => generator.WhileStatement(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), []);
+    protected sealed override TWhileStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
+        => (TWhileStatementSyntax)generator.WhileStatement(inlineExpressionInfo?.Node.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), []);
 }


### PR DESCRIPTION
* Use generics to more clearly articulate the type of syntax various snippets create
* Simplify code by using language-specific syntax APIs where available (instead of relying on generic `ISyntaxFacts` helpers)
* Remove `CursorAnnotation` since it was functioning as an exact duplicate of `FindSnippetAnnotation`

This change does not alter the root `ISnippetProvider` interface or otherwise change the path we would need to take to make these APIs public.