### PR TITLE
Use semantics to check for readonly struct

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpAutoPropertyCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpAutoPropertyCompletionProviderTests.cs
@@ -80,6 +80,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public abstract Task InsertSnippetInReadonlyStruct();
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public abstract Task InsertSnippetInReadonlyStruct_ReadonlyModifierInOtherPartialDeclaration();
+
         // This case might produce non-default results for different snippets (e.g. no `set` accessor in 'propg' snippet),
         // so it is tested separately for all of them
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropSnippetCompletionProviderTests.cs
@@ -24,6 +24,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 """, "public int MyProperty { get; }");
         }
 
+        public override async Task InsertSnippetInReadonlyStruct_ReadonlyModifierInOtherPartialDeclaration()
+        {
+            // Ensure we don't generate redundant `set` accessor when executed in readonly struct
+            await VerifyPropertyAsync("""
+                partial struct MyStruct
+                {
+                    $$
+                }
+
+                readonly partial struct MyStruct
+                {
+                }
+                """, "public int MyProperty { get; }");
+        }
+
         public override async Task InsertSnippetInInterface()
         {
             await VerifyDefaultPropertyAsync("""

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropgSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropgSnippetCompletionProviderTests.cs
@@ -24,6 +24,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 """, "public int MyProperty { get; }");
         }
 
+        public override async Task InsertSnippetInReadonlyStruct_ReadonlyModifierInOtherPartialDeclaration()
+        {
+            // Ensure we don't generate redundant `set` accessor when executed in readonly struct
+            await VerifyPropertyAsync("""
+                partial struct MyStruct
+                {
+                    $$
+                }
+
+                readonly partial struct MyStruct
+                {
+                }
+                """, "public int MyProperty { get; }");
+        }
+
         public override async Task InsertSnippetInInterface()
         {
             // Ensure we don't generate redundant `set` accessor when executed in interface

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropiSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropiSnippetCompletionProviderTests.cs
@@ -23,6 +23,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 """);
         }
 
+        public override async Task InsertSnippetInReadonlyStruct_ReadonlyModifierInOtherPartialDeclaration()
+        {
+            await VerifyDefaultPropertyAsync("""
+                partial struct MyStruct
+                {
+                    $$
+                }
+
+                readonly partial struct MyStruct
+                {
+                }
+                """);
+        }
+
         public override async Task InsertSnippetInInterface()
         {
             await VerifyDefaultPropertyAsync("""

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -24,10 +24,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
 internal abstract class AbstractCSharpAutoPropertySnippetProvider : AbstractPropertySnippetProvider
 {
-    protected virtual AccessorDeclarationSyntax? GenerateGetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator)
+    protected virtual AccessorDeclarationSyntax? GenerateGetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator, CancellationToken cancellationToken)
         => (AccessorDeclarationSyntax)generator.GetAccessorDeclaration();
 
-    protected virtual AccessorDeclarationSyntax? GenerateSetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator)
+    protected virtual AccessorDeclarationSyntax? GenerateSetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator, CancellationToken cancellationToken)
         => (AccessorDeclarationSyntax)generator.SetAccessorDeclaration();
 
     protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
@@ -46,8 +46,8 @@ internal abstract class AbstractCSharpAutoPropertySnippetProvider : AbstractProp
         var syntaxContext = CSharpSyntaxContext.CreateContext(document, semanticModel, position, cancellationToken);
         var accessors = new AccessorDeclarationSyntax?[]
         {
-            GenerateGetAccessorDeclaration(syntaxContext, generator),
-            GenerateSetAccessorDeclaration(syntaxContext, generator),
+            GenerateGetAccessorDeclaration(syntaxContext, generator, cancellationToken),
+            GenerateSetAccessorDeclaration(syntaxContext, generator, cancellationToken),
         };
 
         SyntaxTokenList modifiers = default;

--- a/src/Features/CSharp/Portable/Snippets/CSharpPropiSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpPropiSnippetProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -22,6 +23,6 @@ internal sealed class CSharpPropiSnippetProvider() : AbstractCSharpAutoPropertyS
 
     public override string Description => CSharpFeaturesResources.init_only_property;
 
-    protected override AccessorDeclarationSyntax? GenerateSetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator)
+    protected override AccessorDeclarationSyntax? GenerateSetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator, CancellationToken cancellationToken)
         => SyntaxFactory.AccessorDeclaration(SyntaxKind.InitAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 }


### PR DESCRIPTION
Not sure why I didn't do this in the first place. Added tests clearly show that the syntax-only way isn't sufficient in some scenarios