### PR TITLE
Move IDE off of SpecializedCollections.Singleton to using collectoin exprs

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUpdateExpressionSyntaxHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUpdateExpressionSyntaxHelper.cs
@@ -40,5 +40,5 @@ internal sealed class CSharpUpdateExpressionSyntaxHelper : IUpdateExpressionSynt
     }
 
     private static IEnumerable<StatementSyntax> ExtractEmbeddedStatements(StatementSyntax embeddedStatement)
-        => embeddedStatement is BlockSyntax block ? block.Statements : SpecializedCollections.SingletonEnumerable(embeddedStatement);
+        => embeddedStatement is BlockSyntax block ? block.Statements : [embeddedStatement];
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUpdateExpressionSyntaxHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUpdateExpressionSyntaxHelper.cs
@@ -40,5 +40,5 @@ internal sealed class CSharpUpdateExpressionSyntaxHelper : IUpdateExpressionSynt
     }
 
     private static IEnumerable<StatementSyntax> ExtractEmbeddedStatements(StatementSyntax embeddedStatement)
-        => embeddedStatement is BlockSyntax block ? block.Statements : [embeddedStatement];
+        => embeddedStatement is BlockSyntax block ? block.Statements : SpecializedCollections.SingletonEnumerable(embeddedStatement);
 }

--- a/src/Analyzers/Core/Analyzers/Formatting/FormatterHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Formatting/FormatterHelper.cs
@@ -30,10 +30,10 @@ internal static class FormatterHelper
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, SpecializedCollections.SingletonEnumerable(node.FullSpan), syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, [node.FullSpan], syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
 
     public static SyntaxNode Format(SyntaxNode node, TextSpan spanToFormat, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, SpecializedCollections.SingletonEnumerable(spanToFormat), syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, [spanToFormat], syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
 
     /// <summary>
     /// Formats the whitespace of a syntax tree.
@@ -63,5 +63,5 @@ internal static class FormatterHelper
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The changes necessary to format the tree.</returns>
     public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => GetFormattedTextChanges(node, SpecializedCollections.SingletonEnumerable(node.FullSpan), syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
+        => GetFormattedTextChanges(node, [node.FullSpan], syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
 }

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -35,7 +35,7 @@ internal static class PopulateSwitchExpressionHelpers
             }
         }
 
-        return SpecializedCollections.EmptyCollection<ISymbol>();
+        return [];
     }
 
     public static bool HasNullSwitchArm(ISwitchExpressionOperation operation)

--- a/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleCodeFixProvider.cs
@@ -148,10 +148,7 @@ internal sealed class NamingStyleCodeFixProvider() : CodeFixProvider
         }
 
         protected override async Task<IEnumerable<CodeActionOperation>> ComputePreviewOperationsAsync(CancellationToken cancellationToken)
-        {
-            return SpecializedCollections.SingletonEnumerable(
-                new ApplyChangesOperation(await _createChangedSolutionAsync(cancellationToken).ConfigureAwait(false)));
-        }
+            => [new ApplyChangesOperation(await _createChangedSolutionAsync(cancellationToken).ConfigureAwait(false))];
 
         protected override async Task<ImmutableArray<CodeActionOperation>> ComputeOperationsAsync(IProgress<CodeAnalysisProgress> progress, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -105,7 +105,7 @@ internal partial class AutomaticLineEnderCommandHandler(
         var formatter = document.LanguageServices.GetRequiredService<ISyntaxFormattingService>();
         return formatter.GetFormattingResult(
             root,
-            SpecializedCollections.SingletonCollection(CommonFormattingHelpers.GetFormattingSpan(root, span.Value)),
+            [CommonFormattingHelpers.GetFormattingSpan(root, span.Value)],
             options,
             rules: null,
             cancellationToken).GetTextChanges(cancellationToken);

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
@@ -390,9 +390,9 @@ internal partial class AutomaticLineEnderCommandHandler
             // =>
             // var l = new Bar() {}; // I am some comments
             var replacementContainerNode = objectCreationNodeContainer.ReplaceSyntax(
-                nodes: SpecializedCollections.SingletonCollection(baseObjectCreationExpressionNode),
+                nodes: [baseObjectCreationExpressionNode],
                 (_, _) => objectCreationNodeWithCorrectInitializer.WithoutTrailingTrivia(),
-                tokens: SpecializedCollections.SingletonCollection(nextToken),
+                tokens: [nextToken],
                 computeReplacementToken: (_, _) =>
                     SyntaxFactory.Token(SyntaxKind.SemicolonToken).WithTrailingTrivia(objectCreationNodeWithCorrectInitializer.GetTrailingTrivia()),
                 trivia: [],

--- a/src/EditorFeatures/CSharp/Formatting/CSharpFormattingInteractionService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpFormattingInteractionService.cs
@@ -92,7 +92,7 @@ internal partial class CSharpFormattingInteractionService(EditorOptionsService e
         var span = textSpan ?? new TextSpan(0, parsedDocument.Root.FullSpan.Length);
         var formattingSpan = CommonFormattingHelpers.GetFormattingSpan(parsedDocument.Root, span);
 
-        return Task.FromResult(Formatter.GetFormattedTextChanges(parsedDocument.Root, SpecializedCollections.SingletonEnumerable(formattingSpan), document.Project.Solution.Services, options, cancellationToken).ToImmutableArray());
+        return Task.FromResult(Formatter.GetFormattedTextChanges(parsedDocument.Root, [formattingSpan], document.Project.Solution.Services, options, cancellationToken).ToImmutableArray());
     }
 
     public Task<ImmutableArray<TextChange>> GetFormattingChangesOnPasteAsync(Document document, ITextBuffer textBuffer, TextSpan textSpan, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveWindowResetCommand.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveWindowResetCommand.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             => null;
 
         public IEnumerable<string> Names
-            => SpecializedCollections.SingletonEnumerable(CommandName);
+            => [CommandName];
 
         public string CommandLine
             => "[" + NoConfigParameterName + "] [" + PlatformNames + "]";

--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
             public SnapshotSpan SymbolSpan { get; }
 
             public IEnumerable<INavigableRelationship> Relationships
-                => SpecializedCollections.SingletonEnumerable(PredefinedNavigableRelationships.Definition);
+                => [PredefinedNavigableRelationships.Definition];
 
             public void Navigate(INavigableRelationship relationship)
             {

--- a/src/EditorFeatures/Core.Wpf/Peek/DefinitionPeekableItem.cs
+++ b/src/EditorFeatures/Core.Wpf/Peek/DefinitionPeekableItem.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
         }
 
         public override IEnumerable<IPeekRelationship> Relationships
-            => SpecializedCollections.SingletonEnumerable(PredefinedPeekRelationships.Definitions);
+            => [PredefinedPeekRelationships.Definitions];
 
         public override IPeekResultSource GetOrCreateResultSource(string relationshipName)
             => new ResultSource(this);

--- a/src/EditorFeatures/Core.Wpf/Peek/ExternalFilePeekableItem.cs
+++ b/src/EditorFeatures/Core.Wpf/Peek/ExternalFilePeekableItem.cs
@@ -27,9 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
         }
 
         public override IEnumerable<IPeekRelationship> Relationships
-        {
-            get { return SpecializedCollections.SingletonEnumerable(_relationship); }
-        }
+            => [_relationship];
 
         public override IPeekResultSource GetOrCreateResultSource(string relationshipName)
             => new ResultSource(this);

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
@@ -91,7 +91,7 @@ internal partial class InlineHintsDataTaggerProvider(
             return base.GetSpansToTag(textView, subjectBuffer);
         }
 
-        return SpecializedCollections.SingletonEnumerable(visibleSpanOpt.Value);
+        return [visibleSpanOpt.Value];
     }
 
     protected override async Task ProduceTagsAsync(

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -247,7 +247,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         }
 
         this.UndoManager.CreateInitialState(this.ReplacementText, _triggerView.Selection, new SnapshotSpan(triggerSpan.Snapshot, startingSpan));
-        _openTextBuffers[triggerSpan.Snapshot.TextBuffer].SetReferenceSpans(SpecializedCollections.SingletonEnumerable(startingSpan.ToTextSpan()));
+        _openTextBuffers[triggerSpan.Snapshot.TextBuffer].SetReferenceSpans([startingSpan.ToTextSpan()]);
 
         UpdateReferenceLocationsTask();
 

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
@@ -81,8 +81,7 @@ internal sealed partial class RenameTrackingTaggerProvider
 
             var solutionSet = await _renameTrackingCommitter.RenameSymbolAsync(cancellationToken).ConfigureAwait(false);
 
-            return SpecializedCollections.SingletonEnumerable(
-                (CodeActionOperation)new ApplyChangesOperation(solutionSet.RenamedSolution));
+            return [new ApplyChangesOperation(solutionSet.RenamedSolution)];
         }
 
         private bool TryInitializeRenameTrackingCommitter(CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextSnapshotExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextSnapshotExtensions.cs
@@ -44,7 +44,7 @@ internal static partial class ITextSnapshotExtensions
         var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();
 
         var options = textBuffer.GetSyntaxFormattingOptions(editorOptionsService, document.Project.Services, explicitFormat: false);
-        var result = formatter.GetFormattingResult(documentSyntax.Root, SpecializedCollections.SingletonEnumerable(span), options, rules, cancellationToken);
+        var result = formatter.GetFormattingResult(documentSyntax.Root, [span], options, rules, cancellationToken);
         var changes = result.GetTextChanges(cancellationToken);
 
         using (Logger.LogBlock(FunctionId.Formatting_ApplyResultToBuffer, cancellationToken))

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -390,8 +390,8 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                 return;
             }
 
-            OnTagsChangedForBuffer(SpecializedCollections.SingletonCollection(
-                new KeyValuePair<ITextBuffer, DiffResult>(buffer, difference)),
+            OnTagsChangedForBuffer(
+                [new KeyValuePair<ITextBuffer, DiffResult>(buffer, difference)],
                 highPriority: false);
         }
     }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -90,7 +90,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                         var textChangeRange = new TextChangeRange(new TextSpan(c.OldSpan.Start, c.OldSpan.Length), c.NewLength);
                         this.AccumulatedTextChanges = this.AccumulatedTextChanges == null
                             ? textChangeRange
-                            : this.AccumulatedTextChanges.Accumulate(SpecializedCollections.SingletonEnumerable(textChangeRange));
+                            : this.AccumulatedTextChanges.Accumulate([textChangeRange]);
                     }
 
                     break;

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -222,7 +222,7 @@ internal abstract partial class AbstractAsynchronousTaggerProvider<TTag> where T
     protected virtual IEnumerable<SnapshotSpan> GetSpansToTag(ITextView? textView, ITextBuffer subjectBuffer)
     {
         // For a standard tagger, the spans to tag is the span of the entire snapshot.
-        return SpecializedCollections.SingletonEnumerable(subjectBuffer.CurrentSnapshot.GetFullSpan());
+        return [subjectBuffer.CurrentSnapshot.GetFullSpan()];
     }
 
     /// <summary>

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.SingleViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.SingleViewportTaggerProvider.cs
@@ -80,7 +80,7 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> where T
 
             // If we're the 'InView' tagger, tag what was visible. 
             if (_viewPortToTag is ViewPortToTag.InView)
-                return SpecializedCollections.SingletonEnumerable(visibleSpan);
+                return [visibleSpan];
 
             // For the above/below tagger, broaden the span to to the requested portion above/below what's visible, then
             // subtract out the visible range.

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             if (scope == FixAllScope.Custom)
             {
                 // Bulk fixing diagnostics in selected scope.                    
-                var diagnosticsToFix = ImmutableDictionary.CreateRange(SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(document, diagnostics.ToImmutableArray())));
+                var diagnosticsToFix = ImmutableDictionary.CreateRange([KeyValuePairUtil.Create(document, diagnostics.ToImmutableArray())]);
                 return FixAllState.Create(fixAllProvider, diagnosticsToFix, fixer, equivalenceKey, optionsProvider);
             }
 

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -411,10 +411,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
         }
 
         private static IEnumerable<Lazy<CodeFixProvider, CodeChangeProviderMetadata>> CreateFixers()
-        {
-            return SpecializedCollections.SingletonEnumerable(
-                new Lazy<CodeFixProvider, CodeChangeProviderMetadata>(() => new MockFixer(), new CodeChangeProviderMetadata("Test", languages: LanguageNames.CSharp)));
-        }
+            => [new Lazy<CodeFixProvider, CodeChangeProviderMetadata>(() => new MockFixer(), new CodeChangeProviderMetadata("Test", languages: LanguageNames.CSharp))];
 
         internal class MockFixer : CodeFixProvider
         {

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
         internal static async Task GenerateAndVerifySourceAsync(
             string metadataSource, string symbolName, string projectLanguage, string expected, bool signaturesOnly = true, bool includeXmlDocComments = false, string languageVersion = null, string metadataLanguageVersion = null, string metadataCommonReferences = null)
         {
-            using var context = TestContext.Create(projectLanguage, SpecializedCollections.SingletonEnumerable(metadataSource), includeXmlDocComments, languageVersion: languageVersion, metadataLanguageVersion: metadataLanguageVersion, metadataCommonReferences: metadataCommonReferences);
+            using var context = TestContext.Create(projectLanguage, [metadataSource], includeXmlDocComments, languageVersion: languageVersion, metadataLanguageVersion: metadataLanguageVersion, metadataCommonReferences: metadataCommonReferences);
             await context.GenerateAndVerifySourceAsync(symbolName, expected, signaturesOnly: signaturesOnly);
         }
 
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
             var metadataSource = @"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C { }";
             var symbolName = "C";
 
-            using var context = TestContext.Create(projectLanguage, SpecializedCollections.SingletonEnumerable(metadataSource));
+            using var context = TestContext.Create(projectLanguage, [metadataSource]);
             var metadataSymbol = await context.ResolveSymbolAsync(symbolName);
             var metadataSymbolId = metadataSymbol.GetSymbolKey();
             var generatedFile = await context.GenerateSourceAsync(symbolName);

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -2693,7 +2693,7 @@ public static class ObjectExtensions
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 sourceWithSymbolReference: sourceWithSymbolReference);
             var navigationSymbol = await context.GetNavigationSymbolAsync();
@@ -2735,7 +2735,7 @@ End Namespace";
 
             using var context = TestContext.Create(
                 LanguageNames.VisualBasic,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 sourceWithSymbolReference: sourceWithSymbolReference);
             var navigationSymbol = await context.GetNavigationSymbolAsync();
@@ -3199,7 +3199,7 @@ public class [|TestType|]<T> where T : unmanaged
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "7.3",
                 sourceWithSymbolReference: sourceWithSymbolReference);
@@ -3239,7 +3239,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "7.3",
                 sourceWithSymbolReference: sourceWithSymbolReference);
@@ -3268,7 +3268,7 @@ public delegate void [|D|]<T>() where T : unmanaged;";
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "7.3",
                 sourceWithSymbolReference: sourceWithSymbolReference);
@@ -4746,7 +4746,7 @@ public class [|TestType|]<T> where T : notnull
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -4788,7 +4788,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -4819,7 +4819,7 @@ public delegate void [|D|]<T>() where T : notnull;";
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -4877,7 +4877,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -4932,7 +4932,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -4995,7 +4995,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5045,7 +5045,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5096,7 +5096,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5144,7 +5144,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5192,7 +5192,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5238,7 +5238,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5284,7 +5284,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5330,7 +5330,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5374,7 +5374,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5438,7 +5438,7 @@ namespace N
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5512,7 +5512,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,
@@ -5556,7 +5556,7 @@ public class TestType
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,
-                SpecializedCollections.SingletonEnumerable(metadata),
+                [metadata],
                 includeXmlDocComments: false,
                 languageVersion: "8",
                 sourceWithSymbolReference: sourceWithSymbolReference,

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -976,7 +976,7 @@ public class [|C|]
             var metadataSource = "namespace N { public class C {} }";
 
             using var context = TestContext.Create(
-                LanguageNames.CSharp, SpecializedCollections.SingletonEnumerable(metadataSource), languageVersion: "10");
+                LanguageNames.CSharp, [metadataSource], languageVersion: "10");
 
             await context.GenerateAndVerifySourceAsync("N.C",
                 $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -998,7 +998,7 @@ public class [|C|]
             var metadataSource = "namespace N { public class C {} }";
 
             using var context = TestContext.Create(
-                LanguageNames.CSharp, SpecializedCollections.SingletonEnumerable(metadataSource), languageVersion: "9");
+                LanguageNames.CSharp, [metadataSource], languageVersion: "9");
 
             await context.GenerateAndVerifySourceAsync("N.C",
                 $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
@@ -1020,7 +1020,7 @@ namespace N
             var metadataSource = "namespace N { public class C {} }";
 
             using var context = TestContext.Create(
-                LanguageNames.CSharp, SpecializedCollections.SingletonEnumerable(metadataSource), languageVersion: "10");
+                LanguageNames.CSharp, [metadataSource], languageVersion: "10");
 
             await context.GenerateAndVerifySourceAsync("N.C",
                 $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
@@ -1699,7 +1699,7 @@ public class [|C|]
         {
             var metadataSource = "public class C { public bool Is; }";
 
-            using var context = TestContext.Create(LanguageNames.CSharp, SpecializedCollections.SingletonEnumerable(metadataSource));
+            using var context = TestContext.Create(LanguageNames.CSharp, [metadataSource]);
             var a = await context.GenerateSourceAsync("C");
             var b = await context.GenerateSourceAsync("C.Is");
             TestContext.VerifyDocumentReused(a, b);

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
             {
                 _codeRefactoringProvider = new RenameTrackingCodeRefactoringProvider(
                     _historyRegistry,
-                    SpecializedCollections.SingletonEnumerable(_mockRefactorNotifyService));
+                    [_mockRefactorNotifyService]);
             }
             else
             {

--- a/src/EditorFeatures/TestUtilities/GoToAdjacentMember/AbstractGoToAdjacentMemberTests.cs
+++ b/src/EditorFeatures/TestUtilities/GoToAdjacentMember/AbstractGoToAdjacentMemberTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToAdjacentMember
         {
             var kinds = sourceCodeKind != null
                 ? SpecializedCollections.SingletonEnumerable(sourceCodeKind.Value)
-                : new[] { SourceCodeKind.Regular, SourceCodeKind.Script };
+                : [SourceCodeKind.Regular, SourceCodeKind.Script];
 
             foreach (var kind in kinds)
             {

--- a/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
@@ -32,13 +32,13 @@ namespace Roslyn.Test.Utilities
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
         {
             var testCase = new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow);
-            return SpecializedCollections.SingletonEnumerable(testCase);
+            return [testCase];
         }
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
             var testCase = new WpfTheoryTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
-            return SpecializedCollections.SingletonEnumerable(testCase);
+            return [testCase];
         }
     }
 }

--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -117,7 +117,7 @@ internal abstract class AbstractCurlyBraceOrBracketCompletionService : AbstractC
             // Handling syntax tree directly to avoid parsing in potentially UI blocking code-path
             var closingToken = FindClosingBraceToken(document.Root, closingPoint);
             var annotatedNewline = SyntaxFactory.EndOfLine(options.FormattingOptions.NewLine).WithAdditionalAnnotations(s_closingBraceNewlineAnnotation);
-            var newClosingToken = closingToken.WithPrependedLeadingTrivia(SpecializedCollections.SingletonEnumerable(annotatedNewline));
+            var newClosingToken = closingToken.WithPrependedLeadingTrivia(annotatedNewline);
 
             var rootToFormat = document.Root.ReplaceToken(closingToken, newClosingToken);
             annotatedNewline = rootToFormat.GetAnnotatedTrivia(s_closingBraceNewlineAnnotation).Single();

--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -245,7 +245,7 @@ internal abstract class AbstractCurlyBraceOrBracketCompletionService : AbstractC
         var annotatedRoot = GetSyntaxRootWithAnnotatedClosingBrace(document.Root, closingPoint);
 
         var result = Formatter.GetFormattingResult(
-            annotatedRoot, SpecializedCollections.SingletonEnumerable(spanToFormat), document.SolutionServices, options.FormattingOptions, rules, cancellationToken);
+            annotatedRoot, [spanToFormat], document.SolutionServices, options.FormattingOptions, rules, cancellationToken);
 
         if (result == null)
         {

--- a/src/Features/CSharp/Portable/BraceCompletion/BracketBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/BracketBraceCompletionService.cs
@@ -74,7 +74,7 @@ internal class BracketBraceCompletionService : AbstractCurlyBraceOrBracketComple
                 // For list patterns we format brackets as though they are a block, so ensure the close bracket
                 // is aligned with the open bracket
                 AddAlignIndentationOfTokensToBaseTokenOperation(list, node, bracketPair.openBracket,
-                    SpecializedCollections.SingletonEnumerable(bracketPair.closeBracket), AlignTokensOption.AlignIndentationOfTokensToFirstTokenOfBaseTokenLine);
+                    [bracketPair.closeBracket], AlignTokensOption.AlignIndentationOfTokensToFirstTokenOfBaseTokenLine);
             }
         }
     }

--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -260,7 +260,7 @@ internal class CurlyBraceCompletionService : AbstractCurlyBraceOrBracketCompleti
                     // If the user has set block style indentation and we're in a valid brace pair
                     // then make sure we align the close brace to the open brace.
                     AddAlignIndentationOfTokensToBaseTokenOperation(list, node, bracePair.openBrace,
-                        SpecializedCollections.SingletonEnumerable(bracePair.closeBrace), AlignTokensOption.AlignIndentationOfTokensToFirstTokenOfBaseTokenLine);
+                        [bracePair.closeBrace], AlignTokensOption.AlignIndentationOfTokensToFirstTokenOfBaseTokenLine);
                 }
             }
         }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -265,8 +265,7 @@ internal partial class NamedParameterCompletionProvider : LSPCompletionProvider,
             }
             else if (expressionType.IsDelegateType())
             {
-                var delegateType = expressionType;
-                return SpecializedCollections.SingletonEnumerable(delegateType.DelegateInvokeMethod!.Parameters);
+                return [expressionType.DelegateInvokeMethod!.Parameters];
             }
         }
 

--- a/src/Features/CSharp/Portable/ConvertForEachToFor/CSharpConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertForEachToFor/CSharpConvertForEachToForCodeRefactoringProvider.cs
@@ -144,7 +144,7 @@ internal sealed class CSharpConvertForEachToForCodeRefactoringProvider :
 
             return bodyBlock.InsertNodesBefore(
                 bodyBlock.Statements[0],
-                SpecializedCollections.SingletonEnumerable(variableStatement));
+                [variableStatement]);
         }
     }
 

--- a/src/Features/CSharp/Portable/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/Features/CSharp/Portable/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -61,7 +61,7 @@ internal class CSharpDecompiledSourceService : IDecompiledSourceService
         // Apply formatting rules
         var formattedDoc = await Formatter.FormatAsync(
              document,
-             SpecializedCollections.SingletonEnumerable(node.FullSpan),
+             [node.FullSpan],
              options,
              CSharpDecompiledSourceFormattingRule.Instance.Concat(Formatter.GetDefaultFormattingRules(document)),
              cancellationToken).ConfigureAwait(false);

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -472,7 +472,7 @@ internal static class BreakpointSpans
         => CreateSpan(constructor.Modifiers, constructor.Identifier, constructor.ParameterList.CloseParenToken);
 
     internal static IEnumerable<SyntaxToken> GetActiveTokensForImplicitConstructorInitializer(ConstructorDeclarationSyntax constructor)
-        => constructor.Modifiers.Concat(SpecializedCollections.SingletonEnumerable(constructor.Identifier)).Concat(constructor.ParameterList.DescendantTokens());
+        => constructor.Modifiers.Concat([constructor.Identifier]).Concat(constructor.ParameterList.DescendantTokens());
 
     internal static TextSpan CreateSpanForExplicitConstructorInitializer(ConstructorInitializerSyntax constructorInitializer)
         => CreateSpan(constructorInitializer.ThisOrBaseKeyword, constructorInitializer.ArgumentList.CloseParenToken);

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/CSharpLambdaBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/CSharpLambdaBody.cs
@@ -55,7 +55,7 @@ internal sealed class CSharpLambdaBody(SyntaxNode node) : LambdaBody
         => LambdaUtilities.TryGetCorrespondingLambdaBody(node, newLambda) is { } newNode ? new CSharpLambdaBody(newNode) : null;
 
     public override IEnumerable<SyntaxNode> GetExpressionsAndStatements()
-        => SpecializedCollections.SingletonEnumerable(node);
+        => [node];
 
     public override SyntaxNode GetLambda()
         => LambdaUtilities.GetLambda(node);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -673,14 +673,14 @@ internal partial class CSharpMethodExtractor
                 return method.ReplaceToken(
                         body.OpenBraceToken,
                         body.OpenBraceToken.WithAppendedTrailingTrivia(
-                            SpecializedCollections.SingletonEnumerable(SyntaxFactory.ElasticCarriageReturnLineFeed)));
+                            SyntaxFactory.ElasticCarriageReturnLineFeed));
             }
             else if (expressionBody != null)
             {
                 return method.ReplaceToken(
                         expressionBody.ArrowToken,
                         expressionBody.ArrowToken.WithPrependedLeadingTrivia(
-                            SpecializedCollections.SingletonEnumerable(SyntaxFactory.ElasticCarriageReturnLineFeed)));
+                            SyntaxFactory.ElasticCarriageReturnLineFeed));
             }
             else
             {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.TriviaResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.TriviaResult.cs
@@ -102,9 +102,7 @@ internal partial class CSharpMethodExtractor
                 if (tokenPair.PreviousToken == body.OpenBraceToken &&
                     tokenPair.NextToken == body.CloseBraceToken)
                 {
-                    return (location == TriviaLocation.AfterBeginningOfSpan)
-                        ? SpecializedCollections.SingletonEnumerable(SyntaxFactory.ElasticMarker)
-                        : [];
+                    return location == TriviaLocation.AfterBeginningOfSpan ? [SyntaxFactory.ElasticMarker] : [];
                 }
             }
             else
@@ -112,9 +110,7 @@ internal partial class CSharpMethodExtractor
                 if (tokenPair.PreviousToken == expressionBody.ArrowToken &&
                     tokenPair.NextToken.GetPreviousToken() == semicolonToken)
                 {
-                    return (location == TriviaLocation.AfterBeginningOfSpan)
-                        ? SpecializedCollections.SingletonEnumerable(SyntaxFactory.ElasticMarker)
-                        : [];
+                    return location == TriviaLocation.AfterBeginningOfSpan ? [SyntaxFactory.ElasticMarker] : [];
                 }
             }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
@@ -181,12 +181,12 @@ internal partial class CSharpMethodExtractor(CSharpSelectionResult result, Extra
         {
             var originalMethodDefinition = methodDefinition;
             var newLine = Options.LineFormattingOptions.NewLine;
-            methodDefinition = methodDefinition.WithPrependedLeadingTrivia(SpecializedCollections.SingletonEnumerable(SyntaxFactory.EndOfLine(newLine)));
+            methodDefinition = methodDefinition.WithPrependedLeadingTrivia(SyntaxFactory.EndOfLine(newLine));
 
             if (!originalMethodDefinition.FindTokenOnLeftOfPosition(originalMethodDefinition.SpanStart).TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia))
             {
                 // Add a second new line since there were no line endings in the original form
-                methodDefinition = methodDefinition.WithPrependedLeadingTrivia(SpecializedCollections.SingletonEnumerable(SyntaxFactory.EndOfLine(newLine)));
+                methodDefinition = methodDefinition.WithPrependedLeadingTrivia(SyntaxFactory.EndOfLine(newLine));
             }
 
             // Generating the new document and associated variables.

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceService.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceService.cs
@@ -59,7 +59,7 @@ internal class CSharpImplementInterfaceService : AbstractImplementInterfaceServi
                         {
                             classOrStructDecl = interfaceNode.Parent.Parent.Parent as TypeDeclarationSyntax;
                             classOrStructType = model.GetDeclaredSymbol(classOrStructDecl, cancellationToken) as INamedTypeSymbol;
-                            interfaceTypes = SpecializedCollections.SingletonEnumerable(interfaceType);
+                            interfaceTypes = [interfaceType];
 
                             return interfaceTypes != null && classOrStructType != null;
                         }

--- a/src/Features/CSharp/Portable/SignatureHelp/AbstractOrdinaryMethodSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AbstractOrdinaryMethodSignatureHelpProvider.cs
@@ -86,5 +86,5 @@ internal abstract class AbstractOrdinaryMethodSignatureHelpProvider : AbstractCS
     }
 
     private static IList<SymbolDisplayPart> GetMethodGroupPostambleParts()
-        => SpecializedCollections.SingletonList(Punctuation(SyntaxKind.CloseParenToken));
+        => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/AttributeSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AttributeSignatureHelpProvider.cs
@@ -217,17 +217,9 @@ internal partial class AttributeSignatureHelpProvider : AbstractCSharpSignatureH
         SemanticModel semanticModel,
         int position)
     {
-        var result = new List<SymbolDisplayPart>();
-
-        result.AddRange(method.ContainingType.ToMinimalDisplayParts(semanticModel, position));
-        result.Add(Punctuation(SyntaxKind.OpenParenToken));
-
-        return result;
+        return [.. method.ContainingType.ToMinimalDisplayParts(semanticModel, position), Punctuation(SyntaxKind.OpenParenToken)];
     }
 
     private static IList<SymbolDisplayPart> GetPostambleParts()
-    {
-        return SpecializedCollections.SingletonList(
-            Punctuation(SyntaxKind.CloseParenToken));
-    }
+        => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
@@ -155,17 +155,9 @@ internal partial class ConstructorInitializerSignatureHelpProvider : AbstractCSh
         SemanticModel semanticModel,
         int position)
     {
-        var result = new List<SymbolDisplayPart>();
-
-        result.AddRange(method.ContainingType.ToMinimalDisplayParts(semanticModel, position));
-        result.Add(Punctuation(SyntaxKind.OpenParenToken));
-
-        return result;
+        return [.. method.ContainingType.ToMinimalDisplayParts(semanticModel, position), Punctuation(SyntaxKind.OpenParenToken)];
     }
 
     private static IList<SymbolDisplayPart> GetPostambleParts()
-    {
-        return SpecializedCollections.SingletonList(
-            Punctuation(SyntaxKind.CloseParenToken));
-    }
+        => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -276,10 +276,7 @@ internal sealed class ElementAccessExpressionSignatureHelpProvider : AbstractCSh
     }
 
     private static IList<SymbolDisplayPart> GetPostambleParts()
-    {
-        return SpecializedCollections.SingletonList(
-            Punctuation(SyntaxKind.CloseBracketToken));
-    }
+        => [Punctuation(SyntaxKind.CloseBracketToken)];
 
     private static class CompleteElementAccessExpression
     {

--- a/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider_NamedType.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider_NamedType.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 

--- a/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider_NamedType.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider_NamedType.cs
@@ -14,17 +14,9 @@ internal partial class GenericNameSignatureHelpProvider
         SemanticModel semanticModel,
         int position)
     {
-        var result = new List<SymbolDisplayPart>();
-
-        result.AddRange(namedType.ToMinimalDisplayParts(semanticModel, position, MinimallyQualifiedWithoutTypeParametersFormat));
-        result.Add(Punctuation(SyntaxKind.LessThanToken));
-
-        return result;
+        return [.. namedType.ToMinimalDisplayParts(semanticModel, position, MinimallyQualifiedWithoutTypeParametersFormat), Punctuation(SyntaxKind.LessThanToken)];
     }
 
     private static IList<SymbolDisplayPart> GetPostambleParts()
-    {
-        return SpecializedCollections.SingletonList(
-            Punctuation(SyntaxKind.GreaterThanToken));
-    }
+        => [Punctuation(SyntaxKind.GreaterThanToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProviderBase_DelegateAndFunctionPointerInvoke.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProviderBase_DelegateAndFunctionPointerInvoke.cs
@@ -53,7 +53,7 @@ internal partial class InvocationExpressionSignatureHelpProviderBase
         // Since we're returning a single item, we can selected it as the "best one".
         selectedItem = 0;
 
-        return SpecializedCollections.SingletonList(item);
+        return [item];
     }
 
     private static IList<SymbolDisplayPart> GetDelegateOrFunctionPointerInvokePreambleParts(IMethodSymbol invokeMethod, SemanticModel semanticModel, int position)
@@ -96,8 +96,5 @@ internal partial class InvocationExpressionSignatureHelpProviderBase
     }
 
     private static IList<SymbolDisplayPart> GetDelegateOrFunctionPointerInvokePostambleParts()
-    {
-        return SpecializedCollections.SingletonList(
-            Punctuation(SyntaxKind.CloseParenToken));
-    }
+        => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_DelegateType.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_DelegateType.cs
@@ -70,17 +70,13 @@ internal partial class ObjectCreationExpressionSignatureHelpProvider
         parts.Add(Space());
         parts.Add(new SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, null, TargetName));
 
-        return SpecializedCollections.SingletonList(
-            new SignatureHelpSymbolParameter(
-                TargetName,
-                isOptional: false,
-                documentationFactory: null,
-                displayParts: parts));
+        return [new SignatureHelpSymbolParameter(
+            TargetName,
+            isOptional: false,
+            documentationFactory: null,
+            displayParts: parts)];
     }
 
     private static IList<SymbolDisplayPart> GetDelegateTypePostambleParts()
-    {
-        return SpecializedCollections.SingletonList(
-            Punctuation(SyntaxKind.CloseParenToken));
-    }
+        => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
@@ -51,8 +51,5 @@ internal partial class ObjectCreationExpressionSignatureHelpProvider
     }
 
     private static IList<SymbolDisplayPart> GetNormalTypePostambleParts()
-    {
-        return SpecializedCollections.SingletonList(
-            Punctuation(SyntaxKind.CloseParenToken));
-    }
+        => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/PrimaryConstructorBaseTypeSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/PrimaryConstructorBaseTypeSignatureHelpProvider.cs
@@ -151,8 +151,6 @@ internal partial class PrimaryConstructorBaseTypeSignatureHelpProvider : Abstrac
         }
 
         static IList<SymbolDisplayPart> GetPostambleParts()
-        {
-            return SpecializedCollections.SingletonList(Punctuation(SyntaxKind.CloseParenToken));
-        }
+            => [Punctuation(SyntaxKind.CloseParenToken)];
     }
 }

--- a/src/Features/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/Features/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -457,7 +457,7 @@ class Class
                         diagnosticService,
                         SpecializedCollections.EmptyEnumerable<Lazy<IErrorLoggerService>>(),
                         SpecializedCollections.EmptyEnumerable<Lazy<CodeFixProvider, CodeChangeProviderMetadata>>(),
-                        SpecializedCollections.SingletonEnumerable(suppressionProviderFactory));
+                        [suppressionProviderFactory]);
                     var document = GetDocumentAndSelectSpan(workspace, out var span);
                     var diagnostics = await diagnosticService.GetDiagnosticsForSpanAsync(document, span, CancellationToken.None);
                     Assert.Equal(2, diagnostics.Where(d => d.Id == "CS0219").Count());

--- a/src/Features/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/Features/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
                     FileName = FileName
                 };
 
-                return SpecializedCollections.SingletonEnumerable(new CSharpExtractClassCodeRefactoringProvider(service));
+                return [new CSharpExtractClassCodeRefactoringProvider(service)];
             }
 
             protected override Task<Workspace> CreateWorkspaceImplAsync()

--- a/src/Features/Core/Portable/AddImport/CodeActions/SymbolReference.SymbolReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/SymbolReference.SymbolReferenceCodeAction.cs
@@ -33,12 +33,7 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         protected override async Task<IEnumerable<CodeActionOperation>> ComputePreviewOperationsAsync(CancellationToken cancellationToken)
         {
             var operation = await GetChangeSolutionOperationAsync(isPreview: true, cancellationToken).ConfigureAwait(false);
-            if (operation is null)
-            {
-                return [];
-            }
-
-            return SpecializedCollections.SingletonEnumerable(operation);
+            return operation is null ? [] : [operation];
         }
 
         protected override async Task<ImmutableArray<CodeActionOperation>> ComputeOperationsAsync(

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
@@ -38,9 +38,7 @@ internal class ChangeSignatureCodeAction(AbstractChangeSignatureService changeSi
             var changeSignatureResult = await _changeSignatureService.ChangeSignatureWithContextAsync(_context, changeSignatureOptions, cancellationToken).ConfigureAwait(false);
 
             if (changeSignatureResult.Succeeded)
-            {
-                return SpecializedCollections.SingletonEnumerable<CodeActionOperation>(new ChangeSignatureCodeActionOperation(changeSignatureResult.UpdatedSolution, changeSignatureResult.ConfirmationMessage));
-            }
+                return [new ChangeSignatureCodeActionOperation(changeSignatureResult.UpdatedSolution, changeSignatureResult.ConfirmationMessage)];
         }
 
         return [];

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigurationUpdater.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigurationUpdater.cs
@@ -203,7 +203,7 @@ internal sealed partial class ConfigurationUpdater
         Project project,
         CancellationToken cancellationToken)
     => ConfigureCodeStyleOptionsAsync(
-            SpecializedCollections.SingletonEnumerable((optionName, optionValue, isPerLanguage)),
+            [(optionName, optionValue, isPerLanguage)],
             diagnostic.Severity.ToEditorConfigString(),
             diagnostic, project, configurationKind: ConfigurationKind.OptionValue, cancellationToken);
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaBatchFixHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaBatchFixHelpers.cs
@@ -86,7 +86,7 @@ internal partial class AbstractSuppressionCodeFixProvider
                     properties: diagnostic.Properties,
                     isSuppressed: diagnostic.IsSuppressed);
 
-                var newSuppressionFixes = await suppressionFixProvider.GetFixesAsync(currentDocument, currentDiagnosticSpan, SpecializedCollections.SingletonEnumerable(diagnostic), fallbackOptions, cancellationToken).ConfigureAwait(false);
+                var newSuppressionFixes = await suppressionFixProvider.GetFixesAsync(currentDocument, currentDiagnosticSpan, [diagnostic], fallbackOptions, cancellationToken).ConfigureAwait(false);
                 var newSuppressionFix = newSuppressionFixes.SingleOrDefault();
                 if (newSuppressionFix != null)
                 {

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningBatchFixAllProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningBatchFixAllProvider.cs
@@ -36,7 +36,7 @@ internal abstract partial class AbstractSuppressionCodeFixProvider : IConfigurat
             {
                 var span = diagnostic.Location.SourceSpan;
                 var pragmaSuppressions = await _suppressionFixProvider.GetPragmaSuppressionsAsync(
-                    document, span, SpecializedCollections.SingletonEnumerable(diagnostic), fixAllState.CodeActionOptionsProvider, cancellationToken).ConfigureAwait(false);
+                    document, span, [diagnostic], fixAllState.CodeActionOptionsProvider, cancellationToken).ConfigureAwait(false);
                 var pragmaSuppression = pragmaSuppressions.SingleOrDefault();
                 if (pragmaSuppression != null)
                 {

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
@@ -44,7 +44,7 @@ internal abstract partial class AbstractSuppressionCodeFixProvider : IConfigurat
                 {
                     var span = diagnostic.Location.SourceSpan;
                     var removeSuppressionFixes = await _suppressionFixProvider.GetFixesAsync(
-                        document, span, SpecializedCollections.SingletonEnumerable(diagnostic), fixAllState.CodeActionOptionsProvider, cancellationToken).ConfigureAwait(false);
+                        document, span, [diagnostic], fixAllState.CodeActionOptionsProvider, cancellationToken).ConfigureAwait(false);
                     var removeSuppressionFix = removeSuppressionFixes.SingleOrDefault();
                     if (removeSuppressionFix != null)
                     {
@@ -89,7 +89,7 @@ internal abstract partial class AbstractSuppressionCodeFixProvider : IConfigurat
                 foreach (var diagnostic in diagnostics.Where(d => !d.Location.IsInSource && d.IsSuppressed))
                 {
                     var removeSuppressionFixes = await _suppressionFixProvider.GetFixesAsync(
-                        project, SpecializedCollections.SingletonEnumerable(diagnostic), fixAllState.CodeActionOptionsProvider, cancellationToken).ConfigureAwait(false);
+                        project, [diagnostic], fixAllState.CodeActionOptionsProvider, cancellationToken).ConfigureAwait(false);
                     if (removeSuppressionFixes.SingleOrDefault()?.Action is RemoveSuppressionCodeAction removeSuppressionCodeAction)
                     {
                         if (fixAllState.IsFixMultiple)

--- a/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
+++ b/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
@@ -490,7 +490,7 @@ internal abstract class AbstractDocumentationCommentFormattingService : IDocumen
                 ? attribute.Value
                 : null;
             var navigationHint = navigationTarget;
-            state.AppendParts(SpecializedCollections.SingletonEnumerable(new TaggedText(displayKind, text, style, navigationTarget, navigationHint)));
+            state.AppendParts([new TaggedText(displayKind, text, style, navigationTarget, navigationHint)]);
         }
     }
 

--- a/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
+++ b/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
@@ -514,8 +514,7 @@ internal abstract class AbstractDocumentationCommentFormattingService : IDocumen
         }
 
         // if any of that fails fall back to just displaying the raw text
-        return SpecializedCollections.SingletonEnumerable(
-            new SymbolDisplayPart(kind, symbol: null, text: TrimCrefPrefix(crefValue)));
+        return [new SymbolDisplayPart(kind, symbol: null, text: TrimCrefPrefix(crefValue))];
     }
 
     internal static IEnumerable<SymbolDisplayPart> TypeParameterRefToSymbolDisplayParts(
@@ -535,8 +534,7 @@ internal abstract class AbstractDocumentationCommentFormattingService : IDocumen
         }
 
         // if any of that fails fall back to just displaying the raw text
-        return SpecializedCollections.SingletonEnumerable(
-            new SymbolDisplayPart(SymbolDisplayPartKind.TypeParameterName, symbol: null, text: TrimCrefPrefix(crefValue)));
+        return [new SymbolDisplayPart(SymbolDisplayPartKind.TypeParameterName, symbol: null, text: TrimCrefPrefix(crefValue))];
     }
 
     private static string TrimCrefPrefix(string value)

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
@@ -67,11 +67,7 @@ internal partial class AbstractGenerateVariableService<TService, TSimpleNameSynt
             var context = new CodeGenerationContext(beforeThisLocation: _state.IdentifierToken.GetLocation());
             var info = await _document.GetCodeGenerationInfoAsync(context, _fallbackOptions, cancellationToken).ConfigureAwait(false);
 
-            return info.Service.AddStatements(
-                root,
-                SpecializedCollections.SingletonEnumerable(localStatement),
-                info,
-                cancellationToken: cancellationToken);
+            return info.Service.AddStatements(root, [localStatement], info, cancellationToken);
         }
     }
 }

--- a/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
+++ b/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
@@ -55,7 +55,7 @@ internal sealed class ImplementAbstractClassData(
             return null;
 
         var unimplementedMembers = classType.GetAllUnimplementedMembers(
-            SpecializedCollections.SingletonEnumerable(abstractClassType),
+            [abstractClassType],
             includeMembersRequiringExplicitImplementation: false,
             cancellationToken);
 

--- a/src/Features/Core/Portable/IntroduceParameter/IntroduceParameterDocumentRewriter.cs
+++ b/src/Features/Core/Portable/IntroduceParameter/IntroduceParameterDocumentRewriter.cs
@@ -668,9 +668,7 @@ internal abstract partial class AbstractIntroduceParameterCodeRefactoringProvide
         private async Task<IEnumerable<TExpressionSyntax>> FindMatchesAsync(CancellationToken cancellationToken)
         {
             if (!_allOccurrences)
-            {
-                return SpecializedCollections.SingletonEnumerable(_expression);
-            }
+                return [_expression];
 
             var syntaxFacts = _originalDocument.GetRequiredLanguageService<ISyntaxFactsService>();
             var originalSemanticModel = await _originalDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/InvertIf/AbstractInvertIfCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InvertIf/AbstractInvertIfCodeRefactoringProvider.cs
@@ -550,8 +550,7 @@ internal abstract partial class AbstractInvertIfCodeRefactoringProvider<
                         text,
                         ifNode: ifNode,
                         condition: negatedExpression,
-                        trueStatement: AsEmbeddedStatement(
-                            SpecializedCollections.SingletonEnumerable(newIfBody), ifBody));
+                        trueStatement: AsEmbeddedStatement([newIfBody], ifBody));
 
                     var statementsBeforeIf = statements.Take(index);
 

--- a/src/Features/Core/Portable/InvertIf/AbstractInvertIfCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InvertIf/AbstractInvertIfCodeRefactoringProvider.cs
@@ -524,8 +524,7 @@ internal abstract partial class AbstractInvertIfCodeRefactoringProvider<
                         text,
                         ifNode: ifNode,
                         condition: negatedExpression,
-                        trueStatement: AsEmbeddedStatement(
-                            SpecializedCollections.SingletonEnumerable(newIfBody), original: ifBody));
+                        trueStatement: AsEmbeddedStatement([newIfBody], original: ifBody));
 
                     var statementsBeforeIf = statements.Take(index);
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
@@ -71,7 +71,7 @@ internal abstract partial class AbstractMetadataAsSourceService : IMetadataAsSou
 
         var formattedDoc = await Formatter.FormatAsync(
             docWithAssemblyInfo,
-            SpecializedCollections.SingletonEnumerable(node.FullSpan),
+            [node.FullSpan],
             options.CleanupOptions.FormattingOptions,
             GetFormattingRules(docWithAssemblyInfo),
             cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Organizing/Organizers/AbstractSyntaxNodeOrganizer.cs
+++ b/src/Features/Core/Portable/Organizing/Organizers/AbstractSyntaxNodeOrganizer.cs
@@ -14,10 +14,7 @@ namespace Microsoft.CodeAnalysis.Organizing.Organizers;
 internal abstract class AbstractSyntaxNodeOrganizer<TSyntaxNode> : ISyntaxOrganizer
     where TSyntaxNode : SyntaxNode
 {
-    public IEnumerable<Type> SyntaxNodeTypes
-    {
-        get { return SpecializedCollections.SingletonEnumerable(typeof(TSyntaxNode)); }
-    }
+    public IEnumerable<Type> SyntaxNodeTypes => [typeof(TSyntaxNode)];
 
     public SyntaxNode OrganizeNode(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
         => Organize((TSyntaxNode)node, cancellationToken);

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
@@ -27,9 +27,9 @@ internal abstract class AbstractMainMethodSnippetProvider<TMethodDeclarationSynt
         var generator = SyntaxGenerator.GetGenerator(document);
         var method = generator.MethodDeclaration(
             name: WellKnownMemberNames.EntryPointMethodName,
-            parameters: SpecializedCollections.SingletonEnumerable(generator.ParameterDeclaration(
+            parameters: [generator.ParameterDeclaration(
                 name: "args",
-                type: generator.ArrayTypeExpression(generator.TypeExpression(SpecialType.System_String)))),
+                type: generator.ArrayTypeExpression(generator.TypeExpression(SpecialType.System_String)))],
             returnType: GenerateReturnType(generator),
             modifiers: DeclarationModifiers.Static,
             statements: GenerateInnerStatements(generator));

--- a/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
+++ b/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
@@ -71,7 +71,7 @@ internal static class MiscellaneousFileUtilities
                 hasAllInformation: sourceCodeKind == SourceCodeKind.Script),
             compilationOptions: compilationOptions,
             parseOptions: parseOptions,
-            documents: SpecializedCollections.SingletonEnumerable(documentInfo),
+            documents: [documentInfo],
             metadataReferences: metadataReferences);
 
         return projectInfo;

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionAllCodeTests.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionAllCodeTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                         continue;
                     }
 
-                    var fixes = fixer.GetFixesAsync(document, diagnostic.Location.SourceSpan, SpecializedCollections.SingletonEnumerable(diagnostic), CodeActionOptions.DefaultProvider, CancellationToken.None).GetAwaiter().GetResult();
+                    var fixes = fixer.GetFixesAsync(document, diagnostic.Location.SourceSpan, [diagnostic], CodeActionOptions.DefaultProvider, CancellationToken.None).GetAwaiter().GetResult();
                     if (fixes == null || fixes.Count() <= 0)
                     {
                         continue;

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_NoEditor.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             if (scope == FixAllScope.Custom)
             {
                 // Bulk fixing diagnostics in selected scope.                    
-                var diagnosticsToFix = ImmutableDictionary.CreateRange(SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(document, diagnostics.ToImmutableArray())));
+                var diagnosticsToFix = ImmutableDictionary.CreateRange([KeyValuePairUtil.Create(document, diagnostics.ToImmutableArray())]);
                 return FixAllState.Create(fixAllProvider, diagnosticsToFix, fixer, equivalenceKey, optionsProvider);
             }
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestDiscoverer.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestDiscoverer.cs
@@ -57,7 +57,7 @@ internal partial class TestDiscoverer(ILoggerFactory loggerFactory)
         var stopwatch = SharedStopwatch.StartNew();
 
         // The async APIs for vs test are broken (current impl ends up just hanging), so we must use the sync API instead.
-        var discoveryTask = Task.Run(() => vsTestConsoleWrapper.DiscoverTests(SpecializedCollections.SingletonEnumerable(projectOutputPath), discoverySettings: runSettings, discoveryHandler), cancellationToken);
+        var discoveryTask = Task.Run(() => vsTestConsoleWrapper.DiscoverTests([projectOutputPath], discoverySettings: runSettings, discoveryHandler), cancellationToken);
         cancellationToken.Register(() => vsTestConsoleWrapper.CancelDiscovery());
         await discoveryTask;
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         return [];
 
                     // we do have diagnostics
-                    return SpecializedCollections.SingletonEnumerable(documentId.ProjectId);
+                    return [documentId.ProjectId];
                 }
 
                 return new HashSet<ProjectId>(

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         return GetDiagnosticData();
                     }
 
-                    var documentIds = (DocumentId != null) ? SpecializedCollections.SingletonEnumerable(DocumentId) : project.DocumentIds;
+                    var documentIds = DocumentId != null ? [DocumentId] : project.DocumentIds;
 
                     // return diagnostics specific to one project or document
                     var includeProjectNonLocalResult = DocumentId == null;

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var formattingOptions = await ProtocolConversions.GetFormattingOptionsAsync(options, document, globalOptions, cancellationToken).ConfigureAwait(false);
 
             var services = document.Project.Solution.Services;
-            var textChanges = Formatter.GetFormattedTextChanges(root, SpecializedCollections.SingletonEnumerable(formattingSpan), services, formattingOptions, rules: null, cancellationToken);
+            var textChanges = Formatter.GetFormattedTextChanges(root, [formattingSpan], services, formattingOptions, rules: null, cancellationToken);
 
             var edits = new ArrayBuilder<LSP.TextEdit>();
             edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text)));

--- a/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -157,7 +157,7 @@ public class A { }";
             Assert.Equal(supportedOptions.Sum(option => option is IPerLanguageValuedOption ? 2 : 1), expectedValues.Count);
             var optionsAndLanguageToVerify = supportedOptions.SelectManyAsArray(option => option is IPerLanguageValuedOption
                 ? DidChangeConfigurationNotificationHandler.SupportedLanguages.SelectAsArray(lang => (option, lang))
-                : SpecializedCollections.SingletonEnumerable((option, string.Empty)));
+                : [(option, string.Empty)]);
 
             for (var i = 0; i < expectedValues.Count; i++)
             {

--- a/src/Features/Lsif/Generator/Graph/Edge.cs
+++ b/src/Features/Lsif/Generator/Graph/Edge.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
         [JsonProperty("inVs", NullValueHandling = NullValueHandling.Ignore)]
         public Id<Vertex>[]? InVertices { get; }
 
-        public IEnumerable<Id<Vertex>> GetInVerticies() => InVertices ?? SpecializedCollections.SingletonEnumerable(InVertex!.Value);
+        public IEnumerable<Id<Vertex>> GetInVerticies() => InVertices ?? [InVertex!.Value];
 
         public Edge(string label, Id<Vertex> outVertex, Id<Vertex> inVertex, IdFactory idFactory)
             : base(type: "edge", label: label, idFactory)

--- a/src/VisualStudio/Core/Def/CallHierarchy/CallHierarchyProvider.cs
+++ b/src/VisualStudio/Core/Def/CallHierarchy/CallHierarchyProvider.cs
@@ -144,7 +144,7 @@ internal partial class CallHierarchyProvider
 
         if (symbol.Kind == SymbolKind.Field)
         {
-            return SpecializedCollections.SingletonEnumerable(new FieldReferenceFinder(symbol, project.Id, AsyncListener, this));
+            return [new FieldReferenceFinder(symbol, project.Id, AsyncListener, this)];
         }
 
         return null;

--- a/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
@@ -160,7 +160,7 @@ internal sealed class RemoteCodeLensReferencesService : ICodeLensReferencesServi
             }
 
             var span = new TextSpan(descriptor.SpanStart, descriptor.SpanLength);
-            var results = await spanMapper.MapSpansAsync(document, SpecializedCollections.SingletonEnumerable(span), cancellationToken).ConfigureAwait(false);
+            var results = await spanMapper.MapSpansAsync(document, [span], cancellationToken).ConfigureAwait(false);
 
             // external component violated contracts. the mapper should preserve input order/count. 
             // since we gave in 1 span, it should return 1 span back

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -81,7 +81,7 @@ internal partial class StreamingFindUsagesPresenter
             }
 
             var results = await service.MapSpansAsync(
-                documentSpan.Document, SpecializedCollections.SingletonEnumerable(documentSpan.SourceSpan), cancellationToken).ConfigureAwait(false);
+                documentSpan.Document, [documentSpan.SourceSpan], cancellationToken).ConfigureAwait(false);
 
             if (results.IsDefaultOrEmpty)
             {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
@@ -70,7 +70,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
 
         // use formatting that return text changes rather than tree rewrite which is more expensive
         var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();
-        var originalChanges = formatter.GetFormattingResult(root, SpecializedCollections.SingletonEnumerable(adjustedSpan), formattingOptions, rules, cancellationToken)
+        var originalChanges = formatter.GetFormattingResult(root, [adjustedSpan], formattingOptions, rules, cancellationToken)
             .GetTextChanges(cancellationToken);
 
         var originalSpan = RoslynTextSpan.FromBounds(start, end);

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -787,7 +787,7 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
 
         if (IsWebsite(project))
         {
-            AddDocumentToFolder(project, info.Id, SpecializedCollections.SingletonEnumerable(AppCodeFolderName), info.Name, documentKind, initialText, info.FilePath);
+            AddDocumentToFolder(project, info.Id, [AppCodeFolderName], info.Name, documentKind, initialText, info.FilePath);
         }
         else if (folders.Any())
         {

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
@@ -313,7 +313,7 @@ internal sealed class VisualStudioDocumentNavigationService(
         ISpanMappingService spanMappingService, Document generatedDocument, TextSpan textSpan, CancellationToken cancellationToken)
     {
         var results = await spanMappingService.MapSpansAsync(
-            generatedDocument, SpecializedCollections.SingletonEnumerable(textSpan), cancellationToken).ConfigureAwait(false);
+            generatedDocument, [textSpan], cancellationToken).ConfigureAwait(false);
 
         if (!results.IsDefaultOrEmpty)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/BasesCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/BasesCollection.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             }
             else
             {
-                return SpecializedCollections.SingletonEnumerable<ITypeSymbol>(symbol.BaseType);
+                return [symbol.BaseType];
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
@@ -282,7 +282,7 @@ internal sealed class CSharpSyntaxFormattingService : CSharpSyntaxFormatting, IS
             return [];
         }
 
-        return SpecializedCollections.SingletonEnumerable(TypingFormattingRule.Instance);
+        return [TypingFormattingRule.Instance];
     }
 
     private static bool IsEndToken(SyntaxToken endToken)
@@ -331,7 +331,7 @@ internal sealed class CSharpSyntaxFormattingService : CSharpSyntaxFormatting, IS
         var rules = new List<AbstractFormattingRule>() { new PasteFormattingRule() };
         rules.AddRange(service.GetDefaultFormattingRules());
 
-        var result = service.GetFormattingResult(document.Root, SpecializedCollections.SingletonEnumerable(formattingSpan), options, rules, cancellationToken);
+        var result = service.GetFormattingResult(document.Root, [formattingSpan], options, rules, cancellationToken);
         return result.GetTextChanges(cancellationToken).ToImmutableArray();
     }
 

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -478,15 +478,15 @@ internal class CSharpRenameConflictLanguageService : AbstractRenameRewriterLangu
                 }
                 else
                 {
-                    symbols = SpecializedCollections.SingletonEnumerable(symbolInfo.Symbol);
+                    symbols = [symbolInfo.Symbol];
                 }
 
                 var renameDeclarationLocations =
-                                                                            ConflictResolver.CreateDeclarationLocationAnnotationsAsync(
-                                                                                _solution,
-                                                                                symbols,
-                                                                                _cancellationToken)
-                                                                                    .WaitAndGetResult_CanCallOnBackground(_cancellationToken);
+                    ConflictResolver.CreateDeclarationLocationAnnotationsAsync(
+                        _solution,
+                        symbols,
+                        _cancellationToken)
+                            .WaitAndGetResult_CanCallOnBackground(_cancellationToken);
 
                 var renameAnnotation = new RenameActionAnnotation(
                                             identifierToken.Span,
@@ -810,7 +810,7 @@ internal class CSharpRenameConflictLanguageService : AbstractRenameRewriterLangu
             if (renamedSymbol.ContainingSymbol is INamedTypeSymbol { TypeKind: not TypeKind.Enum } containingNamedType &&
                 containingNamedType.Name == renamedSymbol.Name)
             {
-                AddSymbolSourceSpans(conflicts, SpecializedCollections.SingletonEnumerable(containingNamedType), reverseMappedLocations);
+                AddSymbolSourceSpans(conflicts, [containingNamedType], reverseMappedLocations);
             }
 
             if (renamedSymbol.Kind is SymbolKind.Parameter or

--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/VirtualChars/CSharpVirtualCharServiceTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/VirtualChars/CSharpVirtualCharServiceTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.VirtualChars
 
             if (expression is LiteralExpressionSyntax literal)
             {
-                return SpecializedCollections.SingletonEnumerable(literal.Token);
+                return [literal.Token];
             }
             else if (expression is InterpolatedStringExpressionSyntax interpolation)
             {

--- a/src/Workspaces/CSharpTest/Formatting/CSharpFormattingTestBase.cs
+++ b/src/Workspaces/CSharpTest/Formatting/CSharpFormattingTestBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
             bool testWithTransformation = true,
             ParseOptions parseOptions = null)
         {
-            return AssertFormatAsync(code, code, SpecializedCollections.SingletonEnumerable(new TextSpan(0, code.Length)), debugMode, changedOptionSet, testWithTransformation, parseOptions);
+            return AssertFormatAsync(code, code, [new TextSpan(0, code.Length)], debugMode, changedOptionSet, testWithTransformation, parseOptions);
         }
 
         private protected Task AssertFormatAsync(
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
             bool testWithTransformation = true,
             ParseOptions parseOptions = null)
         {
-            return AssertFormatAsync(expected, code, SpecializedCollections.SingletonEnumerable(new TextSpan(0, code.Length)), debugMode, changedOptionSet, testWithTransformation, parseOptions);
+            return AssertFormatAsync(expected, code, [new TextSpan(0, code.Length)], debugMode, changedOptionSet, testWithTransformation, parseOptions);
         }
 
         private protected Task AssertFormatAsync(

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -284,7 +284,7 @@ public abstract class CodeAction
         var changedSolution = await GetChangedSolutionAsync(CodeAnalysisProgress.None, cancellationToken).ConfigureAwait(false);
         return changedSolution == null
             ? []
-            : SpecializedCollections.SingletonEnumerable<CodeActionOperation>(new ApplyChangesOperation(changedSolution));
+            : [new ApplyChangesOperation(changedSolution)];
     }
 
 #pragma warning disable RS0030 // Do not use banned APIs

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
@@ -78,8 +78,7 @@ public partial class FixAllContext
                     {
                         case FixAllScope.Project:
                             var diagnostics = await fixAllContext.GetProjectDiagnosticsAsync(project).ConfigureAwait(false);
-                            var kvp = SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(project, diagnostics));
-                            return ImmutableDictionary.CreateRange(kvp);
+                            return ImmutableDictionary.CreateRange([KeyValuePairUtil.Create(project, diagnostics)]);
 
                         case FixAllScope.Solution:
                             var projectsAndDiagnostics = ImmutableDictionary.CreateBuilder<Project, ImmutableArray<Diagnostic>>();

--- a/src/Workspaces/Core/Portable/CodeRefactorings/FixAllOccurences/FixAllState.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/FixAllOccurences/FixAllState.cs
@@ -110,7 +110,7 @@ internal sealed class FixAllState : CommonFixAllState<CodeRefactoringProvider, F
 
             case FixAllScope.Document:
                 Contract.ThrowIfNull(Document);
-                documentsToFix = SpecializedCollections.SingletonEnumerable(Document);
+                documentsToFix = [Document];
                 break;
 
             case FixAllScope.Project:

--- a/src/Workspaces/Core/Portable/Editing/ImportAdder.cs
+++ b/src/Workspaces/Core/Portable/Editing/ImportAdder.cs
@@ -20,7 +20,7 @@ public static class ImportAdder
     private static async ValueTask<IEnumerable<TextSpan>> GetSpansAsync(Document document, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        return SpecializedCollections.SingletonEnumerable(root.FullSpan);
+        return [root.FullSpan];
     }
 
     private static async ValueTask<IEnumerable<TextSpan>> GetSpansAsync(Document document, SyntaxAnnotation annotation, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Formatting/Formatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Formatter.cs
@@ -202,10 +202,10 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, TextSpan span, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => Format(node, SpecializedCollections.SingletonEnumerable(span), workspace, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, [span], workspace, options, rules: null, cancellationToken: cancellationToken);
 
     internal static SyntaxNode Format(SyntaxNode node, TextSpan span, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, SpecializedCollections.SingletonEnumerable(span), services, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, [span], services, options, rules: null, cancellationToken: cancellationToken);
 
     /// <summary>
     /// Formats the whitespace in areas of a syntax tree identified by multiple non-overlapping spans.
@@ -247,7 +247,7 @@ public static class Formatter
             return null;
         }
 
-        spans ??= SpecializedCollections.SingletonEnumerable(node.FullSpan);
+        spans ??= [node.FullSpan];
         var formattingOptions = GetFormattingOptions(workspace, options, node.Language);
         return languageFormatter.GetFormattingResult(node, spans, formattingOptions, rules, cancellationToken);
     }
@@ -267,10 +267,10 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The changes necessary to format the tree.</returns>
     public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => GetFormattedTextChanges(node, SpecializedCollections.SingletonEnumerable(node.FullSpan), workspace, options, rules: null, cancellationToken: cancellationToken);
+        => GetFormattedTextChanges(node, [node.FullSpan], workspace, options, rules: null, cancellationToken: cancellationToken);
 
     internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => GetFormattedTextChanges(node, SpecializedCollections.SingletonEnumerable(node.FullSpan), services, options, rules: null, cancellationToken: cancellationToken);
+        => GetFormattedTextChanges(node, [node.FullSpan], services, options, rules: null, cancellationToken: cancellationToken);
 
     /// <summary>
     /// Determines the changes necessary to format the whitespace of a syntax tree.
@@ -282,10 +282,10 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The changes necessary to format the tree.</returns>
     public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, TextSpan span, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => GetFormattedTextChanges(node, SpecializedCollections.SingletonEnumerable(span), workspace, options, rules: null, cancellationToken);
+        => GetFormattedTextChanges(node, [span], workspace, options, rules: null, cancellationToken);
 
     internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, TextSpan span, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken = default)
-        => GetFormattedTextChanges(node, SpecializedCollections.SingletonEnumerable(span), services, options, rules: null, cancellationToken);
+        => GetFormattedTextChanges(node, [span], services, options, rules: null, cancellationToken);
 
     /// <summary>
     /// Determines the changes necessary to format the whitespace of a syntax tree.

--- a/src/Workspaces/Core/Portable/Formatting/Formatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Formatter.cs
@@ -64,11 +64,11 @@ public static class Formatter
     /// <returns>The formatted document.</returns>
     public static Task<Document> FormatAsync(Document document, TextSpan span, OptionSet? options = null, CancellationToken cancellationToken = default)
 #pragma warning disable RS0030 // Do not used banned APIs
-        => FormatAsync(document, SpecializedCollections.SingletonEnumerable(span), options, cancellationToken);
+        => FormatAsync(document, [span], options, cancellationToken);
 #pragma warning restore
 
     internal static Task<Document> FormatAsync(Document document, TextSpan span, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => FormatAsync(document, SpecializedCollections.SingletonEnumerable(span), options, rules: null, cancellationToken);
+        => FormatAsync(document, [span], options, rules: null, cancellationToken);
 
     /// <summary>
     /// Formats the whitespace in areas of a document corresponding to multiple non-overlapping spans.
@@ -187,10 +187,10 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => Format(node, SpecializedCollections.SingletonEnumerable(node.FullSpan), workspace, options, rules: null, cancellationToken);
+        => Format(node, [node.FullSpan], workspace, options, rules: null, cancellationToken);
 
     internal static SyntaxNode Format(SyntaxNode node, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, SpecializedCollections.SingletonEnumerable(node.FullSpan), services, options, rules: null, cancellationToken);
+        => Format(node, [node.FullSpan], services, options, rules: null, cancellationToken);
 
     /// <summary>
     /// Formats the whitespace in areas of a syntax tree identified by a span.

--- a/src/Workspaces/Core/Portable/LanguageServices/FixAllSpanMappingService/AbstractFixAllSpanMappingService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/FixAllSpanMappingService/AbstractFixAllSpanMappingService.cs
@@ -37,8 +37,7 @@ internal abstract class AbstractFixAllSpanMappingService : IFixAllSpanMappingSer
 
         if (fixAllInContainingMember)
         {
-            return ImmutableDictionary.CreateRange(SpecializedCollections.SingletonEnumerable(
-                KeyValuePairUtil.Create(document, ImmutableArray.Create(decl.FullSpan))));
+            return ImmutableDictionary.CreateRange([KeyValuePairUtil.Create(document, ImmutableArray.Create(decl.FullSpan))]);
         }
         else
         {
@@ -64,8 +63,7 @@ internal abstract class AbstractFixAllSpanMappingService : IFixAllSpanMappingSer
             }
             else
             {
-                return ImmutableDictionary.CreateRange(SpecializedCollections.SingletonEnumerable(
-                    KeyValuePairUtil.Create(document, ImmutableArray.Create(decl.FullSpan))));
+                return ImmutableDictionary.CreateRange([KeyValuePairUtil.Create(document, ImmutableArray.Create(decl.FullSpan))]);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Rename/TokenRenameInfo.cs
+++ b/src/Workspaces/Core/Portable/Rename/TokenRenameInfo.cs
@@ -29,7 +29,7 @@ internal sealed class TokenRenameInfo(bool hasSymbols, IEnumerable<ISymbol> symb
         (
             hasSymbols: true,
             isMemberGroup: false,
-            symbols: SpecializedCollections.SingletonEnumerable(symbol)
+            symbols: [symbol]
         );
     }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IFindReferencesResultExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IFindReferencesResultExtensions.cs
@@ -20,7 +20,7 @@ internal static partial class IFindReferencesResultExtensions
         this ISymbol definition)
     {
         return definition.IsKind(SymbolKind.Namespace)
-            ? SpecializedCollections.SingletonEnumerable(definition.Locations.First())
+            ? [definition.Locations.First()]
             : definition.Locations;
     }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -191,9 +191,7 @@ internal static partial class SyntaxGeneratorExtensions
         var throwStatement = factory.CreateThrowArgumentNullExceptionStatement(semanticModel.Compilation, parameter);
 
         // generates: if (s is null) { throw new ArgumentNullException(nameof(s)); }
-        return factory.IfStatement(
-            condition,
-            SpecializedCollections.SingletonEnumerable(throwStatement));
+        return factory.IfStatement(condition, [throwStatement]);
     }
 
     public static SyntaxNode CreateThrowArgumentNullExceptionStatement(this SyntaxGenerator factory, Compilation compilation, IParameterSymbol parameter)

--- a/src/Workspaces/Core/Portable/Simplification/Simplifier.cs
+++ b/src/Workspaces/Core/Portable/Simplification/Simplifier.cs
@@ -208,12 +208,12 @@ public static partial class Simplifier
         }
 
 #pragma warning disable RS0030 // Do not used banned APIs
-        return ReduceAsync(document, SpecializedCollections.SingletonEnumerable(span), optionSet, cancellationToken);
+        return ReduceAsync(document, [span], optionSet, cancellationToken);
     }
 #pragma warning restore
 
     internal static Task<Document> ReduceAsync(Document document, TextSpan span, SimplifierOptions options, CancellationToken cancellationToken)
-        => ReduceAsync(document, SpecializedCollections.SingletonEnumerable(span), options, cancellationToken);
+        => ReduceAsync(document, [span], options, cancellationToken);
 
     /// <summary>
     /// Reduce the sub-trees annotated with <see cref="Annotation" /> found within the specified spans.

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.BatchingDocumentCollection.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.BatchingDocumentCollection.cs
@@ -425,7 +425,7 @@ internal sealed partial class ProjectSystemProject
                             solutionChanges.UpdateSolutionForDocumentAction(
                                 _documentTextLoaderChangedAction(solutionChanges.Solution, documentId, textLoader),
                                 _documentChangedWorkspaceKind,
-                                SpecializedCollections.SingletonEnumerable(documentId));
+                                [documentId]);
                         }
                     }
                 }).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -788,7 +788,7 @@ public partial class Solution
     public Solution AddAnalyzerReference(AnalyzerReference analyzerReference)
     {
         return AddAnalyzerReferences(
-            analyzerReference ?? throw new ArgumentNullException(nameof(analyzerReference))]);
+            [analyzerReference ?? throw new ArgumentNullException(nameof(analyzerReference))]);
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -788,8 +788,7 @@ public partial class Solution
     public Solution AddAnalyzerReference(AnalyzerReference analyzerReference)
     {
         return AddAnalyzerReferences(
-            SpecializedCollections.SingletonEnumerable(
-                analyzerReference ?? throw new ArgumentNullException(nameof(analyzerReference))));
+            analyzerReference ?? throw new ArgumentNullException(nameof(analyzerReference))]);
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -535,8 +535,7 @@ public partial class Solution
     public Solution AddProjectReference(ProjectId projectId, ProjectReference projectReference)
     {
         return AddProjectReferences(projectId,
-            SpecializedCollections.SingletonEnumerable(
-                projectReference ?? throw new ArgumentNullException(nameof(projectReference))));
+            [projectReference ?? throw new ArgumentNullException(nameof(projectReference))]);
     }
 
     /// <summary>
@@ -627,8 +626,7 @@ public partial class Solution
     public Solution AddMetadataReference(ProjectId projectId, MetadataReference metadataReference)
     {
         return AddMetadataReferences(projectId,
-            SpecializedCollections.SingletonEnumerable(
-                metadataReference ?? throw new ArgumentNullException(nameof(metadataReference))));
+            [metadataReference ?? throw new ArgumentNullException(nameof(metadataReference))]);
     }
 
     /// <summary>
@@ -708,8 +706,7 @@ public partial class Solution
     public Solution AddAnalyzerReference(ProjectId projectId, AnalyzerReference analyzerReference)
     {
         return AddAnalyzerReferences(projectId,
-            SpecializedCollections.SingletonEnumerable(
-                analyzerReference ?? throw new ArgumentNullException(nameof(analyzerReference))));
+            [analyzerReference ?? throw new ArgumentNullException(nameof(analyzerReference))]);
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -311,8 +311,7 @@ internal sealed partial class SolutionState
                 if (projectReference.ProjectId == projectId)
                 {
                     newDependencyGraph = newDependencyGraph.WithAdditionalProjectReferences(
-                        newState.Key,
-                        SpecializedCollections.SingletonReadOnlyList(projectReference));
+                        newState.Key, [projectReference]);
 
                     break;
                 }

--- a/src/Workspaces/CoreTest/CodeCleanup/CodeCleanupTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/CodeCleanupTests.cs
@@ -180,7 +180,7 @@ End Class", LanguageNames.VisualBasic);
                     var root = await document.GetSyntaxRootAsync(cancellationToken);
                     root = root.RemoveCSharpMember(0);
 
-                    expectedResult = SpecializedCollections.SingletonEnumerable(root.FullSpan);
+                    expectedResult = [root.FullSpan];
 
                     return document.WithSyntaxRoot(root);
                 }
@@ -202,7 +202,7 @@ End Class", LanguageNames.VisualBasic);
                     var classWithMember = @class.AddCSharpMember(CreateCSharpMethod(), 0);
                     root = root.ReplaceNode(@class, classWithMember);
 
-                    expectedResult = SpecializedCollections.SingletonEnumerable(root.FullSpan);
+                    expectedResult = [root.FullSpan];
 
                     return document.WithSyntaxRoot(root);
                 }
@@ -224,7 +224,7 @@ End Class", LanguageNames.VisualBasic);
                     var classWithMember = @class.AddCSharpMember(CreateCSharpMethod(), 0);
                     root = root.ReplaceNode(@class, classWithMember);
 
-                    expectedResult = SpecializedCollections.SingletonEnumerable(root.GetMember(0).GetMember(0).GetCodeCleanupSpan());
+                    expectedResult = [root.GetMember(0).GetMember(0).GetCodeCleanupSpan()];
 
                     return document.WithSyntaxRoot(root);
                 }
@@ -246,7 +246,7 @@ End Class", LanguageNames.VisualBasic);
                     var classWithMember = @class.RemoveCSharpMember(0);
                     root = root.ReplaceNode(@class, classWithMember);
 
-                    expectedResult = SpecializedCollections.SingletonEnumerable(root.GetMember(0).GetMember(0).GetCodeCleanupSpan());
+                    expectedResult = [root.GetMember(0).GetMember(0).GetCodeCleanupSpan()];
 
                     return document.WithSyntaxRoot(root);
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
@@ -162,9 +162,9 @@ internal partial class ITypeSymbolExtensions
             }
 
             var parameters = symbol.Signature.Parameters.Select(p => (p.Type, RefKindModifiers: CSharpSyntaxGeneratorInternal.GetParameterModifiers(p.RefKind)))
-                .Concat(SpecializedCollections.SingletonEnumerable((
+                .Concat([(
                     Type: symbol.Signature.ReturnType,
-                    RefKindModifiers: CSharpSyntaxGeneratorInternal.GetParameterModifiers(symbol.Signature.RefKind, forFunctionPointerReturnParameter: true))))
+                    RefKindModifiers: CSharpSyntaxGeneratorInternal.GetParameterModifiers(symbol.Signature.RefKind, forFunctionPointerReturnParameter: true))])
                 .SelectAsArray(t => SyntaxFactory.FunctionPointerParameter(t.Type.GenerateTypeSyntax()).WithModifiers(t.RefKindModifiers));
 
             return AddInformationTo(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -114,9 +114,7 @@ internal partial class CSharpTypeInferenceService
                     }
 
                     if (IsUsableTypeFunc(typeInferenceInfo))
-                    {
-                        return SpecializedCollections.SingletonEnumerable(typeInferenceInfo);
-                    }
+                        return [typeInferenceInfo];
                 }
             }
 
@@ -1609,8 +1607,7 @@ internal partial class CSharpTypeInferenceService
                 if (invoke != null)
                 {
                     var isAsync = anonymousFunction.AsyncKeyword.Kind() != SyntaxKind.None;
-                    return SpecializedCollections.SingletonEnumerable(
-                        new TypeInferenceInfo(UnwrapTaskLike(invoke.ReturnType, isAsync)));
+                    return [new TypeInferenceInfo(UnwrapTaskLike(invoke.ReturnType, isAsync))];
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -1976,7 +1976,7 @@ internal partial class CSharpTypeInferenceService
             // We don't care what the type is, as long as it has 1 type argument. This will work for IEnumerable, IEnumerator,
             // IAsyncEnumerable, IAsyncEnumerator and it's also good for error recovery in case there is a missing using.
             return memberType is INamedTypeSymbol namedType && namedType.TypeArguments.Length == 1
-                ? SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(namedType.TypeArguments[0]))
+                ? [new TypeInferenceInfo(namedType.TypeArguments[0])]
                 : [];
         }
 
@@ -2028,7 +2028,7 @@ internal partial class CSharpTypeInferenceService
             var isAsync = symbol is IMethodSymbol methodSymbol && methodSymbol.IsAsync;
 
             return type != null
-                ? SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(UnwrapTaskLike(type, isAsync)))
+                ? [new TypeInferenceInfo(UnwrapTaskLike(type, isAsync))]
                 : [];
         }
 
@@ -2239,8 +2239,8 @@ internal partial class CSharpTypeInferenceService
                         return inferredFutureUsage.Length > 0 ? inferredFutureUsage[0].InferredType : Compilation.ObjectType;
                     });
 
-                    return SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(
-                        Compilation.CreateTupleTypeSymbol(elementTypes, elementNames)));
+                    return [new TypeInferenceInfo(
+                        Compilation.CreateTupleTypeSymbol(elementTypes, elementNames))];
                 }
 
                 return GetTypes(declExpr.Type);
@@ -2355,7 +2355,7 @@ internal partial class CSharpTypeInferenceService
             if (previousToken.HasValue && previousToken.Value != whenClause.WhenKeyword)
                 return [];
 
-            return SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(Compilation.GetSpecialType(SpecialType.System_Boolean)));
+            return [new TypeInferenceInfo(Compilation.GetSpecialType(SpecialType.System_Boolean))];
         }
 
         private IEnumerable<TypeInferenceInfo> InferTypeInWhileStatement(WhileStatementSyntax whileStatement, SyntaxToken? previousToken = null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/IAddImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/IAddImportsService.cs
@@ -47,6 +47,6 @@ internal static class IAddImportServiceExtensions
         CancellationToken cancellationToken)
     {
         return service.AddImports(compilation, root, contextLocation,
-            SpecializedCollections.SingletonEnumerable(newImport), generator, options, cancellationToken);
+            [newImport], generator, options, cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.AbstractTypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.AbstractTypeInferrer.cs
@@ -112,9 +112,7 @@ internal partial class AbstractTypeInferenceService : ITypeInferenceService
 
                 var elementType = parameters.ElementAtOrDefault(0);
                 if (elementType != null)
-                {
-                    return SpecializedCollections.SingletonCollection(new TypeInferenceInfo(elementType));
-                }
+                    return [new TypeInferenceInfo(elementType)];
             }
 
             return [];

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.AbstractTypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.AbstractTypeInferrer.cs
@@ -84,9 +84,7 @@ internal partial class AbstractTypeInferenceService : ITypeInferenceService
             => CreateResult(Compilation.GetSpecialType(type).WithNullableAnnotation(nullableAnnotation));
 
         protected static IEnumerable<TypeInferenceInfo> CreateResult(ITypeSymbol type)
-            => type == null
-                ? SpecializedCollections.EmptyCollection<TypeInferenceInfo>()
-                : SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(type));
+            => type == null ? [] : [new TypeInferenceInfo(type)];
 
         protected static IEnumerable<ITypeSymbol> ExpandParamsParameter(IParameterSymbol parameterSymbol)
         {


### PR DESCRIPTION
Compiler has built in support for optimizing this case.  If you have a singleton collection expr, you already get an optimal readonly compiler collection with space for just that single element.