### PR TITLE
Provide completion for `new()` in collection expressions relying on a custom collection builder

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectAndWithInitializerCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectAndWithInitializerCompletionProvider.cs
@@ -190,11 +190,7 @@ internal class ObjectAndWithInitializerCompletionProvider : AbstractObjectInitia
                     return immutableArrayElementType;
                 }
                 var collectionExpressionElement = collectionExpressionOperation.Elements.FirstOrDefault();
-                var elementType = collectionExpressionElement switch
-                {
-                    ISpreadOperation spread => spread.ElementType,
-                    _ => collectionExpressionElement?.Type,
-                };
+                var elementType = ElementTypeOfCollectionExpressionElement(collectionExpressionElement);
                 if (elementType is not null)
                 {
                     return elementType;
@@ -220,6 +216,15 @@ internal class ObjectAndWithInitializerCompletionProvider : AbstractObjectInitia
         }
 
         return null;
+    }
+
+    private static ITypeSymbol? ElementTypeOfCollectionExpressionElement(IOperation? element)
+    {
+        return element switch
+        {
+            ISpreadOperation spread => ElementTypeOfCollectionExpressionElement(spread.Operand),
+            _ => element?.Type,
+        };
     }
 
     private static bool IsImmutableArrayType(INamedTypeSymbol? type, [NotNullWhen(true)] out ITypeSymbol? elementType)


### PR DESCRIPTION
Closes #72872

## Implementation Notes

This PR modifies `ObjectAndWithInitializerCompletionProvider`, and if it encounters a target-typed new() within a collection expression, it evaluates the element type of the collection expression by requesting the collection expression operation from the semantic model, and retrieving the type of the first element (minding the nesting in the case of a spread).

It is probably better to target changes at another place, but I thought it would be best to get this bug fixed without introducing massive changes to the binder.