### PR TITLE
Improve asset hints to speed up searching

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             public AssetProvider(SerializationValidator validator)
                 => _validator = validator;
 
-            public override async ValueTask<T> GetAssetAsync<T>(AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken)
+            public override async ValueTask<T> GetAssetAsync<T>(AssetPath assetPath, Checksum checksum, CancellationToken cancellationToken)
                 => await _validator.GetValueAsync<T>(checksum).ConfigureAwait(false);
         }
 

--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.VisualStudio.PlatformUI;
 using Roslyn.Test.Utilities;
@@ -21,15 +22,23 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 {
     internal sealed class SerializationValidator
     {
-        private sealed class AssetProvider : AbstractAssetProvider
+        private sealed class AssetProvider(SerializationValidator validator) : AbstractAssetProvider
         {
-            private readonly SerializationValidator _validator;
-
-            public AssetProvider(SerializationValidator validator)
-                => _validator = validator;
-
             public override async ValueTask<T> GetAssetAsync<T>(AssetPath assetPath, Checksum checksum, CancellationToken cancellationToken)
-                => await _validator.GetValueAsync<T>(checksum).ConfigureAwait(false);
+                => await validator.GetValueAsync<T>(checksum).ConfigureAwait(false);
+
+            public override async ValueTask<ImmutableArray<(Checksum checksum, T asset)>> GetAssetsAsync<T>(AssetPath assetPath, HashSet<Checksum> checksums, CancellationToken cancellationToken)
+            {
+                using var _ = ArrayBuilder<(Checksum checksum, T asset)>.GetInstance(out var result);
+
+                foreach (var checksum in checksums)
+                {
+                    var value = await GetAssetAsync<T>(assetPath, checksum, cancellationToken).ConfigureAwait(false);
+                    result.Add((checksum, value));
+                }
+
+                return result.ToImmutable();
+            }
         }
 
         internal sealed class ChecksumObjectCollection<T> : IEnumerable<T>

--- a/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
@@ -53,10 +53,10 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), new Dictionary<Checksum, object>() { { checksum, data } });
 
             var provider = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
-            var stored = await provider.GetAssetAsync<object>(AssetHint.FullLookupForTesting, checksum, CancellationToken.None);
+            var stored = await provider.GetAssetAsync<object>(AssetPath.FullLookupForTesting, checksum, CancellationToken.None);
             Assert.Equal(data, stored);
 
-            var stored2 = await provider.GetAssetsAsync<object>(AssetHint.FullLookupForTesting, [checksum], CancellationToken.None);
+            var stored2 = await provider.GetAssetsAsync<object>(AssetPath.FullLookupForTesting, [checksum], CancellationToken.None);
             Assert.Equal(1, stored2.Length);
 
             Assert.Equal(checksum, stored2[0].Item1);
@@ -83,7 +83,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
             var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
-            await service.SynchronizeAssetsAsync(AssetHint.FullLookupForTesting, new HashSet<Checksum>(map.Keys), results: null, CancellationToken.None);
+            await service.SynchronizeAssetsAsync(AssetPath.FullLookupForTesting, new HashSet<Checksum>(map.Keys), results: null, CancellationToken.None);
 
             foreach (var kv in map)
             {

--- a/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
@@ -56,7 +56,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var stored = await provider.GetAssetAsync<object>(AssetPath.FullLookupForTesting, checksum, CancellationToken.None);
             Assert.Equal(data, stored);
 
-            var stored2 = await provider.GetAssetsAsync<object>(AssetPath.FullLookupForTesting, [checksum], CancellationToken.None);
+            var stored2 = await provider.GetAssetsAsync<object>(AssetPath.FullLookupForTesting, new HashSet<Checksum> { checksum }, CancellationToken.None);
             Assert.Equal(1, stored2.Length);
 
             Assert.Equal(checksum, stored2[0].Item1);

--- a/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
@@ -53,10 +53,10 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), new Dictionary<Checksum, object>() { { checksum, data } });
 
             var provider = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
-            var stored = await provider.GetAssetAsync<object>(assetHint: AssetHint.None, checksum, CancellationToken.None);
+            var stored = await provider.GetAssetAsync<object>(AssetHint.FullLookupForTesting, checksum, CancellationToken.None);
             Assert.Equal(data, stored);
 
-            var stored2 = await provider.GetAssetsAsync<object>(assetHint: AssetHint.None, [checksum], CancellationToken.None);
+            var stored2 = await provider.GetAssetsAsync<object>(AssetHint.FullLookupForTesting, [checksum], CancellationToken.None);
             Assert.Equal(1, stored2.Length);
 
             Assert.Equal(checksum, stored2[0].Item1);
@@ -83,7 +83,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
             var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
-            await service.SynchronizeAssetsAsync(assetHint: AssetHint.None, new HashSet<Checksum>(map.Keys), results: null, CancellationToken.None);
+            await service.SynchronizeAssetsAsync(AssetHint.FullLookupForTesting, new HashSet<Checksum>(map.Keys), results: null, CancellationToken.None);
 
             foreach (var kv in map)
             {

--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/DocumentBasedFixAllProviderHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/DocumentBasedFixAllProviderHelpers.cs
@@ -56,6 +56,10 @@ internal static class DocumentBasedFixAllProviderHelpers
 
                 // TODO: consider computing this in parallel.
                 var singleContextDocIdToNewRootOrText = await getFixedDocumentsAsync(fixAllContext, progressTracker).ConfigureAwait(false);
+
+                // Note: it is safe to blindly add the dictionary for a particular context to the full dictionary.  Each
+                // dictionary will only update documents within that context, and each context represents a distinct
+                // project, so these should all be distinct without collisions.
                 allContextsDocIdToNewRootOrText.AddRange(singleContextDocIdToNewRootOrText);
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -19,7 +19,7 @@ internal readonly struct AssetHint
     public static AssetHint SolutionOnly = default;
 
     /// <summary>
-    /// Special instance, allowed in tests, that can do a full lookup across the entire checksum tree.
+    /// Special instance, allowed only in tests, that can do a full lookup across the entire checksum tree.
     /// </summary>
     public static AssetHint FullLookupForTesting = new(projectId: null, documentId: null, true);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -13,21 +13,32 @@ namespace Microsoft.CodeAnalysis.Serialization;
 [DataContract]
 internal readonly struct AssetHint
 {
+    /// <summary>
+    /// Instance that will only look up solution-level data when searching for checksums.
+    /// </summary>
     public static AssetHint SolutionOnly = default;
+
+    /// <summary>
+    /// Special instance, allowed in tests, that can do a full lookup across the entire checksum tree.
+    /// </summary>
+    public static AssetHint FullLookupForTesting = new(projectId: null, documentId: null, true);
 
     [DataMember(Order = 0)]
     public readonly ProjectId? ProjectId;
     [DataMember(Order = 1)]
     public readonly DocumentId? DocumentId;
+    [DataMember(Order = 2)]
+    public readonly bool IsFullLookup_ForTestingPurposesOnly;
 
-    public bool IsSolutionOnly => ProjectId is null;
+    public bool IsSolutionOnly => !IsFullLookup_ForTestingPurposesOnly && ProjectId is null;
 
-    private AssetHint(ProjectId? projectId, DocumentId? documentId)
+    private AssetHint(ProjectId? projectId, DocumentId? documentId, bool isFullLookup_ForTestingPurposesOnly)
     {
         ProjectId = projectId;
         DocumentId = documentId;
+        IsFullLookup_ForTestingPurposesOnly = isFullLookup_ForTestingPurposesOnly;
     }
 
-    public static implicit operator AssetHint(ProjectId projectId) => new(projectId, documentId: null);
-    public static implicit operator AssetHint(DocumentId documentId) => new(documentId.ProjectId, documentId);
+    public static implicit operator AssetHint(ProjectId projectId) => new(projectId, documentId: null, false);
+    public static implicit operator AssetHint(DocumentId documentId) => new(documentId.ProjectId, documentId, false);
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -19,26 +19,35 @@ internal readonly struct AssetHint
     public static AssetHint SolutionOnly = default;
 
     /// <summary>
+    /// Instance that will only look up solution-level, as well as the top level nodes for projects when searching for
+    /// checksums.  It will not descend into projects.
+    /// </summary>
+    public static AssetHint SolutionAndTopLevelProjectsOnly = new(projectId: null, documentId: null, topLevelProjects: true, isFullLookup_ForTestingPurposesOnly: false);
+
+    /// <summary>
     /// Special instance, allowed only in tests, that can do a full lookup across the entire checksum tree.
     /// </summary>
-    public static AssetHint FullLookupForTesting = new(projectId: null, documentId: null, true);
+    public static AssetHint FullLookupForTesting = new(projectId: null, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: true);
 
     [DataMember(Order = 0)]
     public readonly ProjectId? ProjectId;
     [DataMember(Order = 1)]
     public readonly DocumentId? DocumentId;
-    [DataMember(Order = 2)]
+    [DataMember(Order = 3)]
+    public readonly bool TopLevelProjects;
+    [DataMember(Order = 4)]
     public readonly bool IsFullLookup_ForTestingPurposesOnly;
 
     public bool IsSolutionOnly => !IsFullLookup_ForTestingPurposesOnly && ProjectId is null;
 
-    private AssetHint(ProjectId? projectId, DocumentId? documentId, bool isFullLookup_ForTestingPurposesOnly)
+    private AssetHint(ProjectId? projectId, DocumentId? documentId, bool topLevelProjects, bool isFullLookup_ForTestingPurposesOnly)
     {
         ProjectId = projectId;
         DocumentId = documentId;
+        TopLevelProjects = topLevelProjects;
         IsFullLookup_ForTestingPurposesOnly = isFullLookup_ForTestingPurposesOnly;
     }
 
-    public static implicit operator AssetHint(ProjectId projectId) => new(projectId, documentId: null, false);
-    public static implicit operator AssetHint(DocumentId documentId) => new(documentId.ProjectId, documentId, false);
+    public static implicit operator AssetHint(ProjectId projectId) => new(projectId, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: false);
+    public static implicit operator AssetHint(DocumentId documentId) => new(documentId.ProjectId, documentId, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: false);
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -81,16 +81,16 @@ internal readonly struct AssetPath
     public static implicit operator AssetPath(DocumentId documentId) => new(AssetPathKind.Documents, forTesting: false, documentId.ProjectId, documentId);
 
     /// <summary>
-    /// Searches the requested project, and all documents underneath it.
+    /// Searches the requested project, and all documents underneath it.  Used only in tests.
     /// </summary>
     /// <param name="projectId"></param>
     /// <returns></returns>
-    public static AssetPath SolutionAndProject(ProjectId projectId)
-        => new(AssetPathKind.Solution | AssetPathKind.Projects, forTesting: false, projectId);
-
+    public static AssetPath SolutionAndProjectForTesting(ProjectId projectId)
+        => new(AssetPathKind.Solution | AssetPathKind.Projects, forTesting: true, projectId);
 
     /// <summary>
-    /// Searches the requested project, and all documents underneath it.
+    /// Searches the requested project, and all documents underneath it.  used during normal sync when bulk syncing a
+    /// project.
     /// </summary>
     /// <param name="projectId"></param>
     /// <returns></returns>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -25,7 +25,8 @@ internal readonly struct AssetHint
     public static AssetHint SolutionAndTopLevelProjectsOnly = new(projectId: null, documentId: null, topLevelProjects: true, isFullLookup_ForTestingPurposesOnly: false);
 
     /// <summary>
-    /// Special instance, allowed only in tests, that can do a full lookup across the entire checksum tree.
+    /// Special instance, allowed only in tests/debug-asserts, that can do a full lookup across the entire checksum
+    /// tree.  Should not be used in normal release-mode product code.
     /// </summary>
     public static AssetHint FullLookupForTesting = new(projectId: null, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: true);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -61,6 +61,7 @@ internal readonly struct AssetPath
             }
             else if (IncludeDocuments)
             {
+                Contract.ThrowIfNull(projectId);
                 Contract.ThrowIfNull(documentId);
             }
         }
@@ -77,9 +78,9 @@ internal readonly struct AssetPath
     [Flags]
     private enum AssetPathKind
     {
-        Solution = 1,
-        TopLevelProjects = 1 >> 1,
-        Projects = 1 >> 2,
-        Documents = 1 >> 3,
+        Solution = 1 << 0,
+        TopLevelProjects = 1 << 1,
+        Projects = 1 << 2,
+        Documents = 1 << 3,
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -19,39 +19,30 @@ internal readonly struct AssetPath
     /// <summary>
     /// Instance that will only look up solution-level data when searching for checksums.
     /// </summary>
-    public static readonly AssetPath SolutionOnly = new(AssetPathKind.Solution, forTesting: false);
+    public static readonly AssetPath SolutionOnly = new(AssetPathKind.Solution);
 
     /// <summary>
     /// Instance that will only look up solution-level, as well as the top level nodes for projects when searching for
     /// checksums.  It will not descend into projects.
     /// </summary>
-    public static readonly AssetPath SolutionAndTopLevelProjectsOnly = new(AssetPathKind.Solution | AssetPathKind.TopLevelProjects, forTesting: false);
+    public static readonly AssetPath SolutionAndTopLevelProjectsOnly = new(AssetPathKind.Solution | AssetPathKind.TopLevelProjects);
 
     /// <summary>
     /// Special instance, allowed only in tests/debug-asserts, that can do a full lookup across the entire checksum
     /// tree.  Should not be used in normal release-mode product code.
     /// </summary>
-    public static readonly AssetPath FullLookupForTesting = new(AssetPathKind.Solution | AssetPathKind.TopLevelProjects | AssetPathKind.Projects | AssetPathKind.Documents, forTesting: true);
+    public static readonly AssetPath FullLookupForTesting = new(AssetPathKind.Solution | AssetPathKind.TopLevelProjects | AssetPathKind.Projects | AssetPathKind.Documents | AssetPathKind.Testing);
 
     [DataMember(Order = 0)]
     private readonly AssetPathKind _kind;
-#pragma warning disable IDE0052 // Remove unread private members
-    /// <summary>
-    /// Indicates if this was a full-search done by a test utility.  Useful when debugging tests to know what sort of
-    /// caller was doing the search.
-    /// </summary>
     [DataMember(Order = 1)]
-    private readonly bool _forTesting;
-#pragma warning restore IDE0052 // Remove unread private members
-    [DataMember(Order = 2)]
     public readonly ProjectId? ProjectId;
-    [DataMember(Order = 3)]
+    [DataMember(Order = 2)]
     public readonly DocumentId? DocumentId;
 
-    private AssetPath(AssetPathKind kind, bool forTesting, ProjectId? projectId = null, DocumentId? documentId = null)
+    private AssetPath(AssetPathKind kind, ProjectId? projectId = null, DocumentId? documentId = null)
     {
         _kind = kind;
-        _forTesting = forTesting;
         ProjectId = projectId;
         DocumentId = documentId;
     }
@@ -64,12 +55,12 @@ internal readonly struct AssetPath
     /// <summary>
     /// Searches only for information about this project.
     /// </summary>
-    public static implicit operator AssetPath(ProjectId projectId) => new(AssetPathKind.Projects, forTesting: false, projectId, documentId: null);
+    public static implicit operator AssetPath(ProjectId projectId) => new(AssetPathKind.Projects, projectId, documentId: null);
 
     /// <summary>
     /// Searches only for information about this document.
     /// </summary>
-    public static implicit operator AssetPath(DocumentId documentId) => new(AssetPathKind.Documents, forTesting: false, documentId.ProjectId, documentId);
+    public static implicit operator AssetPath(DocumentId documentId) => new(AssetPathKind.Documents, documentId.ProjectId, documentId);
 
     /// <summary>
     /// Searches the requested project, and all documents underneath it.  Used only in tests.
@@ -77,7 +68,7 @@ internal readonly struct AssetPath
     /// <param name="projectId"></param>
     /// <returns></returns>
     public static AssetPath SolutionAndProjectForTesting(ProjectId projectId)
-        => new(AssetPathKind.Solution | AssetPathKind.Projects, forTesting: true, projectId);
+        => new(AssetPathKind.Solution | AssetPathKind.Projects | AssetPathKind.Testing, projectId);
 
     /// <summary>
     /// Searches the requested project, and all documents underneath it.  used during normal sync when bulk syncing a
@@ -86,14 +77,36 @@ internal readonly struct AssetPath
     /// <param name="projectId"></param>
     /// <returns></returns>
     public static AssetPath ProjectAndDocuments(ProjectId projectId)
-        => new(AssetPathKind.Projects | AssetPathKind.Documents, forTesting: false, projectId);
+        => new(AssetPathKind.Projects | AssetPathKind.Documents, projectId);
 
     [Flags]
     private enum AssetPathKind
     {
+        /// <summary>
+        /// Search solution-level information.
+        /// </summary>
         Solution = 1 << 0,
+
+        /// <summary>
+        /// Search projects, with descending into them. In effect, only finding direct ProjectStateChecksum children of
+        /// the solution.
+        /// </summary>
         TopLevelProjects = 1 << 1,
+
+        /// <summary>
+        /// Search projects for results.
+        /// </summary>
         Projects = 1 << 2,
+
+        /// <summary>
+        /// Search documents for results.
+        /// </summary>
         Documents = 1 << 3,
+
+        /// <summary>
+        /// Indicates that this is a special search performed during testing.  These searches are allowed to search
+        /// everything for expediency purposes.
+        /// </summary>
+        Testing = 1 << 4,
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -16,19 +16,19 @@ internal readonly struct AssetHint
     /// <summary>
     /// Instance that will only look up solution-level data when searching for checksums.
     /// </summary>
-    public static AssetHint SolutionOnly = default;
+    public static readonly AssetHint SolutionOnly = default;
 
     /// <summary>
     /// Instance that will only look up solution-level, as well as the top level nodes for projects when searching for
     /// checksums.  It will not descend into projects.
     /// </summary>
-    public static AssetHint SolutionAndTopLevelProjectsOnly = new(projectId: null, documentId: null, topLevelProjects: true, isFullLookup_ForTestingPurposesOnly: false);
+    public static readonly AssetHint SolutionAndTopLevelProjectsOnly = new(projectId: null, documentId: null, topLevelProjects: true, isFullLookup_ForTestingPurposesOnly: false);
 
     /// <summary>
     /// Special instance, allowed only in tests/debug-asserts, that can do a full lookup across the entire checksum
     /// tree.  Should not be used in normal release-mode product code.
     /// </summary>
-    public static AssetHint FullLookupForTesting = new(projectId: null, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: true);
+    public static readonly AssetHint FullLookupForTesting = new(projectId: null, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: true);
 
     [DataMember(Order = 0)]
     public readonly ProjectId? ProjectId;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -45,6 +45,15 @@ internal readonly struct AssetPath
         _kind = kind;
         ProjectId = projectId;
         DocumentId = documentId;
+
+        // If this isn't a test lookup, and we're searching into projects or documents, then we must have at least a
+        // projectId to limit the search.  If we don't, that risks very expensive searches where we look into *every*
+        // project in the solution for matches.
+        if ((kind & AssetPathKind.Testing) == 0)
+        {
+            if (IncludeProjects || IncludeDocuments)
+                Contract.ThrowIfNull(projectId);
+        }
     }
 
     public bool IncludeSolution => (_kind & AssetPathKind.Solution) == AssetPathKind.Solution;
@@ -88,8 +97,8 @@ internal readonly struct AssetPath
         Solution = 1 << 0,
 
         /// <summary>
-        /// Search projects, with descending into them. In effect, only finding direct ProjectStateChecksum children of
-        /// the solution.
+        /// Search projects, without descending into them. In effect, only finding direct ProjectStateChecksum children
+        /// of the solution.
         /// </summary>
         TopLevelProjects = 1 << 1,
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -17,39 +17,46 @@ internal readonly struct AssetPath
     /// <summary>
     /// Instance that will only look up solution-level data when searching for checksums.
     /// </summary>
-    public static readonly AssetPath SolutionOnly = default;
+    public static readonly AssetPath SolutionOnly = new(kind: AssetPathKind.Solution);
 
     /// <summary>
     /// Instance that will only look up solution-level, as well as the top level nodes for projects when searching for
     /// checksums.  It will not descend into projects.
     /// </summary>
-    public static readonly AssetPath SolutionAndTopLevelProjectsOnly = new(projectId: null, documentId: null, topLevelProjects: true, isFullLookup_ForTestingPurposesOnly: false);
+    public static readonly AssetPath SolutionAndTopLevelProjectsOnly = new(kind: AssetPathKind.SolutionAndTopLevelProjects);
 
     /// <summary>
     /// Special instance, allowed only in tests/debug-asserts, that can do a full lookup across the entire checksum
     /// tree.  Should not be used in normal release-mode product code.
     /// </summary>
-    public static readonly AssetPath FullLookupForTesting = new(projectId: null, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: true);
+    public static readonly AssetPath FullLookupForTesting = new(kind: AssetPathKind.FullLookupForTests);
 
     [DataMember(Order = 0)]
-    public readonly ProjectId? ProjectId;
+    private readonly AssetPathKind _kind;
     [DataMember(Order = 1)]
+    public readonly ProjectId? ProjectId;
+    [DataMember(Order = 2)]
     public readonly DocumentId? DocumentId;
-    [DataMember(Order = 3)]
-    public readonly bool TopLevelProjects;
-    [DataMember(Order = 4)]
-    public readonly bool IsFullLookup_ForTestingPurposesOnly;
 
-    public bool IsSolutionOnly => !IsFullLookup_ForTestingPurposesOnly && ProjectId is null;
+    public bool TopLevelProjects => _kind == AssetPathKind.SolutionAndTopLevelProjects;
+    public bool IsFullLookup_ForTestingPurposesOnly => _kind == AssetPathKind.FullLookupForTests;
+    public bool IsSolutionOnly => _kind == AssetPathKind.Solution;
 
-    private AssetPath(ProjectId? projectId, DocumentId? documentId, bool topLevelProjects, bool isFullLookup_ForTestingPurposesOnly)
+    private AssetPath(AssetPathKind kind, ProjectId? projectId = null, DocumentId? documentId = null)
     {
+        _kind = kind;
         ProjectId = projectId;
         DocumentId = documentId;
-        TopLevelProjects = topLevelProjects;
-        IsFullLookup_ForTestingPurposesOnly = isFullLookup_ForTestingPurposesOnly;
     }
 
-    public static implicit operator AssetPath(ProjectId projectId) => new(projectId, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: false);
-    public static implicit operator AssetPath(DocumentId documentId) => new(documentId.ProjectId, documentId, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: false);
+    public static implicit operator AssetPath(ProjectId projectId) => new(kind: AssetPathKind.ProjectOrDocument, projectId, documentId: null);
+    public static implicit operator AssetPath(DocumentId documentId) => new(kind: AssetPathKind.ProjectOrDocument, documentId.ProjectId, documentId);
+
+    private enum AssetPathKind
+    {
+        Solution = 0,
+        SolutionAndTopLevelProjects = 1,
+        FullLookupForTests = 2,
+        ProjectOrDocument = 3,
+    }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -70,12 +70,24 @@ internal readonly struct AssetPath
     public bool IncludeProjects => (_kind & AssetPathKind.Projects) == AssetPathKind.Projects;
     public bool IncludeDocuments => (_kind & AssetPathKind.Documents) == AssetPathKind.Documents;
 
-    public static implicit operator AssetPath(ProjectId projectId) => new(AssetPathKind.Solution | AssetPathKind.Projects, forTesting: false, projectId, documentId: null);
+    /// <summary>
+    /// Searches only for information about this project.
+    /// </summary>
+    public static implicit operator AssetPath(ProjectId projectId) => new(AssetPathKind.Projects, forTesting: false, projectId, documentId: null);
 
     /// <summary>
     /// Searches only for information about this document.
     /// </summary>
     public static implicit operator AssetPath(DocumentId documentId) => new(AssetPathKind.Documents, forTesting: false, documentId.ProjectId, documentId);
+
+    /// <summary>
+    /// Searches the requested project, and all documents underneath it.
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <returns></returns>
+    public static AssetPath SolutionAndProject(ProjectId projectId)
+        => new(AssetPathKind.Solution | AssetPathKind.Projects, forTesting: false, projectId);
+
 
     /// <summary>
     /// Searches the requested project, and all documents underneath it.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -13,12 +13,14 @@ namespace Microsoft.CodeAnalysis.Serialization;
 [DataContract]
 internal readonly struct AssetHint
 {
-    public static readonly AssetHint None = default;
+    public static AssetHint SolutionOnly = default;
 
     [DataMember(Order = 0)]
     public readonly ProjectId? ProjectId;
     [DataMember(Order = 1)]
     public readonly DocumentId? DocumentId;
+
+    public bool IsSolutionOnly => ProjectId is null;
 
     private AssetHint(ProjectId? projectId, DocumentId? documentId)
     {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -36,6 +36,10 @@ internal readonly struct AssetPath
     [DataMember(Order = 0)]
     private readonly AssetPathKind _kind;
 #pragma warning disable IDE0052 // Remove unread private members
+    /// <summary>
+    /// Indicates if this was a full-search done by a test utility.  Useful when debugging tests to know what sort of
+    /// caller was doing the search.
+    /// </summary>
     [DataMember(Order = 1)]
     private readonly bool _forTesting;
 #pragma warning restore IDE0052 // Remove unread private members
@@ -50,19 +54,6 @@ internal readonly struct AssetPath
         _forTesting = forTesting;
         ProjectId = projectId;
         DocumentId = documentId;
-
-        if (forTesting)
-        {
-            // Only tests are allowed to search everything.  And, in that case, they don't pass any doc/project along.
-            Contract.ThrowIfTrue(projectId != null);
-            Contract.ThrowIfTrue(documentId != null);
-        }
-        else
-        {
-            // Otherwise, if not in testing, if we say we're searching projects or documents, we have to supply those IDs as well.
-            if (IncludeProjects || IncludeDocuments)
-                Contract.ThrowIfNull(projectId);
-        }
     }
 
     public bool IncludeSolution => (_kind & AssetPathKind.Solution) == AssetPathKind.Solution;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -7,28 +7,29 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.Serialization;
 
 /// <summary>
-/// Optional information passed with an asset synchronization request to allow the request to be scoped down to a
-/// particular <see cref="Project"/> or <see cref="Document"/>.
+/// Required information passed with an asset synchronization request to tell the host where to scope the request to. In
+/// particular, this is often used to scope to a particular <see cref="Project"/> or <see cref="Document"/> to avoid
+/// having to search the entire solution.
 /// </summary>
 [DataContract]
-internal readonly struct AssetHint
+internal readonly struct AssetPath
 {
     /// <summary>
     /// Instance that will only look up solution-level data when searching for checksums.
     /// </summary>
-    public static readonly AssetHint SolutionOnly = default;
+    public static readonly AssetPath SolutionOnly = default;
 
     /// <summary>
     /// Instance that will only look up solution-level, as well as the top level nodes for projects when searching for
     /// checksums.  It will not descend into projects.
     /// </summary>
-    public static readonly AssetHint SolutionAndTopLevelProjectsOnly = new(projectId: null, documentId: null, topLevelProjects: true, isFullLookup_ForTestingPurposesOnly: false);
+    public static readonly AssetPath SolutionAndTopLevelProjectsOnly = new(projectId: null, documentId: null, topLevelProjects: true, isFullLookup_ForTestingPurposesOnly: false);
 
     /// <summary>
     /// Special instance, allowed only in tests/debug-asserts, that can do a full lookup across the entire checksum
     /// tree.  Should not be used in normal release-mode product code.
     /// </summary>
-    public static readonly AssetHint FullLookupForTesting = new(projectId: null, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: true);
+    public static readonly AssetPath FullLookupForTesting = new(projectId: null, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: true);
 
     [DataMember(Order = 0)]
     public readonly ProjectId? ProjectId;
@@ -41,7 +42,7 @@ internal readonly struct AssetHint
 
     public bool IsSolutionOnly => !IsFullLookup_ForTestingPurposesOnly && ProjectId is null;
 
-    private AssetHint(ProjectId? projectId, DocumentId? documentId, bool topLevelProjects, bool isFullLookup_ForTestingPurposesOnly)
+    private AssetPath(ProjectId? projectId, DocumentId? documentId, bool topLevelProjects, bool isFullLookup_ForTestingPurposesOnly)
     {
         ProjectId = projectId;
         DocumentId = documentId;
@@ -49,6 +50,6 @@ internal readonly struct AssetHint
         IsFullLookup_ForTestingPurposesOnly = isFullLookup_ForTestingPurposesOnly;
     }
 
-    public static implicit operator AssetHint(ProjectId projectId) => new(projectId, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: false);
-    public static implicit operator AssetHint(DocumentId documentId) => new(documentId.ProjectId, documentId, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: false);
+    public static implicit operator AssetPath(ProjectId projectId) => new(projectId, documentId: null, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: false);
+    public static implicit operator AssetPath(DocumentId documentId) => new(documentId.ProjectId, documentId, topLevelProjects: false, isFullLookup_ForTestingPurposesOnly: false);
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AssetHint.cs
@@ -35,14 +35,19 @@ internal readonly struct AssetPath
 
     [DataMember(Order = 0)]
     private readonly AssetPathKind _kind;
+#pragma warning disable IDE0052 // Remove unread private members
     [DataMember(Order = 1)]
-    public readonly ProjectId? ProjectId;
+    private readonly bool _forTesting;
+#pragma warning restore IDE0052 // Remove unread private members
     [DataMember(Order = 2)]
+    public readonly ProjectId? ProjectId;
+    [DataMember(Order = 3)]
     public readonly DocumentId? DocumentId;
 
     private AssetPath(AssetPathKind kind, bool forTesting, ProjectId? projectId = null, DocumentId? documentId = null)
     {
         _kind = kind;
+        _forTesting = forTesting;
         ProjectId = projectId;
         DocumentId = documentId;
 
@@ -72,7 +77,7 @@ internal readonly struct AssetPath
     public bool IncludeProjects => (_kind & AssetPathKind.Projects) == AssetPathKind.Projects;
     public bool IncludeDocuments => (_kind & AssetPathKind.Documents) == AssetPathKind.Documents;
 
-    public static implicit operator AssetPath(ProjectId projectId) => new(kind: AssetPathKind.Projects, forTesting: false, projectId, documentId: null);
+    public static implicit operator AssetPath(ProjectId projectId) => new(kind: AssetPathKind.Solution | AssetPathKind.Projects, forTesting: false, projectId, documentId: null);
     public static implicit operator AssetPath(DocumentId documentId) => new(kind: AssetPathKind.Documents, forTesting: false, documentId.ProjectId, documentId);
 
     [Flags]

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -111,7 +111,7 @@ internal sealed class SolutionCompilationStateChecksums
     public async Task FindAsync(
         SolutionCompilationState compilationState,
         ProjectCone? projectCone,
-        AssetHint assetHint,
+        AssetHint? assetHint,
         HashSet<Checksum> searchingChecksumsLeft,
         Dictionary<Checksum, object> result,
         CancellationToken cancellationToken)
@@ -135,7 +135,7 @@ internal sealed class SolutionCompilationStateChecksums
             Contract.ThrowIfFalse(FrozenSourceGeneratedDocumentIdentities.HasValue);
 
             // This could either be the checksum for the text (which we'll use our regular helper for first)...
-            await ChecksumCollection.FindAsync(compilationState.FrozenSourceGeneratedDocumentStates, assetHint.DocumentId, searchingChecksumsLeft, result, cancellationToken).ConfigureAwait(false);
+            await ChecksumCollection.FindAsync(compilationState.FrozenSourceGeneratedDocumentStates, hintDocument: null, searchingChecksumsLeft, result, cancellationToken).ConfigureAwait(false);
 
             // ... or one of the identities. In this case, we'll use the fact that there's a 1:1 correspondence between the
             // two collections we hold onto.
@@ -235,7 +235,7 @@ internal sealed class SolutionStateChecksums(
     public async Task FindAsync(
         SolutionState solution,
         ProjectCone? projectCone,
-        AssetHint assetHint,
+        AssetHint? assetHintOpt,
         HashSet<Checksum> searchingChecksumsLeft,
         Dictionary<Checksum, object> result,
         CancellationToken cancellationToken)
@@ -256,19 +256,67 @@ internal sealed class SolutionStateChecksums(
         if (searchingChecksumsLeft.Count == 0)
             return;
 
-        if (assetHint.IsSolutionOnly)
-            return;
-
-        Contract.ThrowIfNull(assetHint.ProjectId);
-        Contract.ThrowIfTrue(
-            projectCone != null && !projectCone.Contains(assetHint.ProjectId),
-            "Requesting an asset outside of the cone explicitly being asked for!");
-
-        var projectState = solution.GetProjectState(assetHint.ProjectId);
-        if (projectState != null &&
-            projectState.TryGetStateChecksums(out var projectStateChecksums))
+        if (assetHintOpt != null)
         {
-            await projectStateChecksums.FindAsync(projectState, assetHint.DocumentId, searchingChecksumsLeft, result, cancellationToken).ConfigureAwait(false);
+            var assetHint = assetHintOpt.Value;
+            // Caller said they were only looking for solution level assets.  no need to go any further.
+            if (assetHint.IsSolutionOnly)
+                return;
+
+            Contract.ThrowIfNull(assetHint.ProjectId);
+            Contract.ThrowIfTrue(
+                projectCone != null && !projectCone.Contains(assetHint.ProjectId),
+                "Requesting an asset outside of the cone explicitly being asked for!");
+
+            var projectState = solution.GetProjectState(assetHint.ProjectId);
+            if (projectState != null &&
+                projectState.TryGetStateChecksums(out var projectStateChecksums))
+            {
+                await projectStateChecksums.FindAsync(projectState, assetHint.DocumentId, searchingChecksumsLeft, result, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            // Full search, used for test purposes.
+
+            // Before doing a depth-first-search *into* each project, first run across all the project at their top
+            // level. This ensures that when we are trying to sync the projects referenced by a SolutionStateChecksums'
+            // instance that we don't unnecessarily walk all documents looking just for those.
+
+            foreach (var (projectId, projectState) in solution.ProjectStates)
+            {
+                if (searchingChecksumsLeft.Count == 0)
+                    break;
+
+                // If we're syncing a project cone, no point at all at looking at child projects of the solution that
+                // are not in that cone.
+                if (projectCone != null && !projectCone.Contains(projectId))
+                    continue;
+
+                if (projectState.TryGetStateChecksums(out var projectStateChecksums) &&
+                    searchingChecksumsLeft.Remove(projectStateChecksums.Checksum))
+                {
+                    result[projectStateChecksums.Checksum] = projectStateChecksums;
+                }
+            }
+
+            // Now actually do the depth first search into each project.
+
+            foreach (var (projectId, projectState) in solution.ProjectStates)
+            {
+                if (searchingChecksumsLeft.Count == 0)
+                    break;
+
+                // If we're syncing a project cone, no point at all at looking at child projects of the solution that
+                // are not in that cone.
+                if (projectCone != null && !projectCone.Contains(projectId))
+                    continue;
+
+                // It's possible not all all our projects have checksums.  Specifically, we may have only been asked to
+                // compute the checksum tree for a subset of projects that were all that a feature needed.
+                if (projectState.TryGetStateChecksums(out var projectStateChecksums))
+                    await projectStateChecksums.FindAsync(projectState, hintDocument: null, searchingChecksumsLeft, result, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -253,9 +253,6 @@ internal sealed class SolutionStateChecksums(
 
         ChecksumCollection.Find(solution.AnalyzerReferences, AnalyzerReferences, searchingChecksumsLeft, result, cancellationToken);
 
-        if (searchingChecksumsLeft.Count == 0)
-            return;
-
         if (assetHint.TopLevelProjects)
         {
             // Caller is trying to fetch the top level ProjectStateChecksums as well. Look for those without diving deeper.
@@ -275,10 +272,10 @@ internal sealed class SolutionStateChecksums(
                     result[projectStateChecksums.Checksum] = projectStateChecksums;
                 }
             }
-
-            if (searchingChecksumsLeft.Count == 0)
-                return;
         }
+
+        if (searchingChecksumsLeft.Count == 0)
+            return;
 
         if (!assetHint.IsFullLookup_ForTestingPurposesOnly)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -442,6 +442,13 @@ internal sealed class DocumentStateChecksums(
         this.Text.WriteTo(writer);
     }
 
+    public void AddAllTo(HashSet<Checksum> checksums)
+    {
+        checksums.AddIfNotNullChecksum(this.Checksum);
+        checksums.AddIfNotNullChecksum(this.Info);
+        checksums.AddIfNotNullChecksum(this.Text);
+    }
+
     public static DocumentStateChecksums Deserialize(ObjectReader reader)
     {
         return new DocumentStateChecksums(

--- a/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing;
 internal sealed class SimpleAssetSource(ISerializerService serializerService, IReadOnlyDictionary<Checksum, object> map) : IAssetSource
 {
     public ValueTask<ImmutableArray<object>> GetAssetsAsync(
-        Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
+        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
     {
         var results = new List<object>();
 

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -20,7 +20,7 @@ internal abstract class AbstractAssetProvider
     /// <summary>
     /// return data of type T whose checksum is the given checksum
     /// </summary>
-    public abstract ValueTask<T> GetAssetAsync<T>(AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken);
+    public abstract ValueTask<T> GetAssetAsync<T>(AssetHint? assetHint, Checksum checksum, CancellationToken cancellationToken);
 
     public async Task<SolutionInfo> CreateSolutionInfoAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -24,17 +24,17 @@ internal abstract class AbstractAssetProvider
 
     public async Task<SolutionInfo> CreateSolutionInfoAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
     {
-        var solutionCompilationChecksums = await GetAssetAsync<SolutionCompilationStateChecksums>(AssetHint.None, solutionChecksum, cancellationToken).ConfigureAwait(false);
-        var solutionChecksums = await GetAssetAsync<SolutionStateChecksums>(AssetHint.None, solutionCompilationChecksums.SolutionState, cancellationToken).ConfigureAwait(false);
+        var solutionCompilationChecksums = await GetAssetAsync<SolutionCompilationStateChecksums>(AssetHint.SolutionOnly, solutionChecksum, cancellationToken).ConfigureAwait(false);
+        var solutionChecksums = await GetAssetAsync<SolutionStateChecksums>(AssetHint.SolutionOnly, solutionCompilationChecksums.SolutionState, cancellationToken).ConfigureAwait(false);
 
-        var solutionAttributes = await GetAssetAsync<SolutionInfo.SolutionAttributes>(AssetHint.None, solutionChecksums.Attributes, cancellationToken).ConfigureAwait(false);
-        await GetAssetAsync<SourceGeneratorExecutionVersionMap>(AssetHint.None, solutionCompilationChecksums.SourceGeneratorExecutionVersionMap, cancellationToken).ConfigureAwait(false);
+        var solutionAttributes = await GetAssetAsync<SolutionInfo.SolutionAttributes>(AssetHint.SolutionOnly, solutionChecksums.Attributes, cancellationToken).ConfigureAwait(false);
+        await GetAssetAsync<SourceGeneratorExecutionVersionMap>(AssetHint.SolutionOnly, solutionCompilationChecksums.SourceGeneratorExecutionVersionMap, cancellationToken).ConfigureAwait(false);
 
         using var _ = ArrayBuilder<ProjectInfo>.GetInstance(solutionChecksums.Projects.Length, out var projects);
         foreach (var (projectChecksum, projectId) in solutionChecksums.Projects)
             projects.Add(await CreateProjectInfoAsync(projectId, projectChecksum, cancellationToken).ConfigureAwait(false));
 
-        var analyzerReferences = await CreateCollectionAsync<AnalyzerReference>(AssetHint.None, solutionChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false);
+        var analyzerReferences = await CreateCollectionAsync<AnalyzerReference>(AssetHint.SolutionOnly, solutionChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false);
 
         return SolutionInfo.Create(
             solutionAttributes.Id, solutionAttributes.Version, solutionAttributes.FilePath, projects.ToImmutableAndClear(), analyzerReferences).WithTelemetryId(solutionAttributes.TelemetryId);

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -20,7 +20,7 @@ internal abstract class AbstractAssetProvider
     /// <summary>
     /// return data of type T whose checksum is the given checksum
     /// </summary>
-    public abstract ValueTask<T> GetAssetAsync<T>(AssetHint? assetHint, Checksum checksum, CancellationToken cancellationToken);
+    public abstract ValueTask<T> GetAssetAsync<T>(AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken);
 
     public async Task<SolutionInfo> CreateSolutionInfoAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
@@ -22,9 +22,9 @@ internal interface ISolutionAssetProvider
     /// <param name="pipeWriter">The writer to write the assets into.  Implementations of this method must call<see
     /// cref="PipeWriter.Complete"/> on it (in the event of failure or success).  Failing to do so will lead to hangs on
     /// the code that reads from the corresponding <see cref="PipeReader"/> side of this.</param>
-    /// <param name="assetHint">Optional project and document ids to scope the search for checksums down to.  This can
+    /// <param name="assetPath">Optional project and document ids to scope the search for checksums down to.  This can
     /// save substantially on performance by avoiding having to search the full solution tree to find matching items for
     /// a particular checksum.</param>
     ValueTask WriteAssetsAsync(
-        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken);
+        PipeWriter pipeWriter, Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
@@ -26,5 +26,5 @@ internal interface ISolutionAssetProvider
     /// save substantially on performance by avoiding having to search the full solution tree to find matching items for
     /// a particular checksum.</param>
     ValueTask WriteAssetsAsync(
-        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint? assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken);
+        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
@@ -26,5 +26,5 @@ internal interface ISolutionAssetProvider
     /// save substantially on performance by avoiding having to search the full solution tree to find matching items for
     /// a particular checksum.</param>
     ValueTask WriteAssetsAsync(
-        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken);
+        PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint? assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask WriteAssetsAsync(
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
-            AssetHint assetHint,
+            AssetPath assetPath,
             ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {
@@ -39,9 +39,9 @@ namespace Microsoft.CodeAnalysis.Remote
             // ⚠ DO NOT AWAIT INSIDE THE USING. The Dispose method that restores ExecutionContext flow must run on the
             // same thread where SuppressFlow was originally run.
             using var _ = FlowControlHelper.TrySuppressFlow();
-            return WriteAssetsSuppressedFlowAsync(pipeWriter, solutionChecksum, assetHint, checksums, cancellationToken);
+            return WriteAssetsSuppressedFlowAsync(pipeWriter, solutionChecksum, assetPath, checksums, cancellationToken);
 
-            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
+            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
             {
                 // The responsibility is on us (as per the requirements of RemoteCallback.InvokeAsync) to Complete the
                 // pipewriter.  This will signal to streamjsonrpc that the writer passed into it is complete, which will
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 Exception? exception = null;
                 try
                 {
-                    await WriteAssetsWorkerAsync(pipeWriter, solutionChecksum, assetHint, checksums, cancellationToken).ConfigureAwait(false);
+                    await WriteAssetsWorkerAsync(pipeWriter, solutionChecksum, assetPath, checksums, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when ((exception = ex) == null)
                 {
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private async ValueTask WriteAssetsWorkerAsync(
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
-            AssetHint assetHint,
+            AssetPath assetPath,
             ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             using var _ = Creator.CreateResultMap(out var resultMap);
 
-            await scope.AddAssetsAsync(assetHint, checksums, resultMap, cancellationToken).ConfigureAwait(false);
+            await scope.AddAssetsAsync(assetPath, checksums, resultMap, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask WriteAssetsAsync(
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
-            AssetHint? assetHint,
+            AssetHint assetHint,
             ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Remote
             using var _ = FlowControlHelper.TrySuppressFlow();
             return WriteAssetsSuppressedFlowAsync(pipeWriter, solutionChecksum, assetHint, checksums, cancellationToken);
 
-            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint? assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
+            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
             {
                 // The responsibility is on us (as per the requirements of RemoteCallback.InvokeAsync) to Complete the
                 // pipewriter.  This will signal to streamjsonrpc that the writer passed into it is complete, which will
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private async ValueTask WriteAssetsWorkerAsync(
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
-            AssetHint? assetHint,
+            AssetHint assetHint,
             ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask WriteAssetsAsync(
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
-            AssetHint assetHint,
+            AssetHint? assetHint,
             ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Remote
             using var _ = FlowControlHelper.TrySuppressFlow();
             return WriteAssetsSuppressedFlowAsync(pipeWriter, solutionChecksum, assetHint, checksums, cancellationToken);
 
-            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
+            async ValueTask WriteAssetsSuppressedFlowAsync(PipeWriter pipeWriter, Checksum solutionChecksum, AssetHint? assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
             {
                 // The responsibility is on us (as per the requirements of RemoteCallback.InvokeAsync) to Complete the
                 // pipewriter.  This will signal to streamjsonrpc that the writer passed into it is complete, which will
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private async ValueTask WriteAssetsWorkerAsync(
             PipeWriter pipeWriter,
             Checksum solutionChecksum,
-            AssetHint assetHint,
+            AssetHint? assetHint,
             ReadOnlyMemory<Checksum> checksums,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -45,7 +45,7 @@ internal partial class SolutionAssetStorage
         /// the storage.
         /// </summary>
         public async Task AddAssetsAsync(
-            AssetHint assetHint,
+            AssetHint? assetHint,
             ReadOnlyMemory<Checksum> checksums,
             Dictionary<Checksum, object> assetMap,
             CancellationToken cancellationToken)
@@ -65,7 +65,7 @@ internal partial class SolutionAssetStorage
         }
 
         private async Task FindAssetsAsync(
-            AssetHint assetHint, HashSet<Checksum> remainingChecksumsToFind, Dictionary<Checksum, object> result, CancellationToken cancellationToken)
+            AssetHint? assetHint, HashSet<Checksum> remainingChecksumsToFind, Dictionary<Checksum, object> result, CancellationToken cancellationToken)
         {
             var solutionState = this.CompilationState;
 

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -45,7 +45,7 @@ internal partial class SolutionAssetStorage
         /// the storage.
         /// </summary>
         public async Task AddAssetsAsync(
-            AssetHint? assetHint,
+            ssetHint? assetHint,
             ReadOnlyMemory<Checksum> checksums,
             Dictionary<Checksum, object> assetMap,
             CancellationToken cancellationToken)
@@ -65,7 +65,7 @@ internal partial class SolutionAssetStorage
         }
 
         private async Task FindAssetsAsync(
-            AssetHint? assetHint, HashSet<Checksum> remainingChecksumsToFind, Dictionary<Checksum, object> result, CancellationToken cancellationToken)
+            AssetHint assetHint, HashSet<Checksum> remainingChecksumsToFind, Dictionary<Checksum, object> result, CancellationToken cancellationToken)
         {
             var solutionState = this.CompilationState;
 

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -45,7 +45,7 @@ internal partial class SolutionAssetStorage
         /// the storage.
         /// </summary>
         public async Task AddAssetsAsync(
-            ssetHint? assetHint,
+            AssetHint assetHint,
             ReadOnlyMemory<Checksum> checksums,
             Dictionary<Checksum, object> assetMap,
             CancellationToken cancellationToken)
@@ -100,7 +100,7 @@ internal partial class SolutionAssetStorage
                 using var checksumPool = Creator.CreateChecksumSet(checksum);
                 using var _ = Creator.CreateResultMap(out var resultPool);
 
-                await scope.FindAssetsAsync(assetHint: null, checksumPool.Object, resultPool, cancellationToken).ConfigureAwait(false);
+                await scope.FindAssetsAsync(AssetHint.FullLookupForTesting, checksumPool.Object, resultPool, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfTrue(resultPool.Count != 1);
 
                 var (resultingChecksum, value) = resultPool.First();

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -93,14 +93,14 @@ internal partial class SolutionAssetStorage
             /// Retrieve asset of a specified <paramref name="checksum"/> available within <see langword="this"/> from
             /// the storage.
             /// </summary>
-            public async ValueTask<object> GetAssetAsync(Checksum checksum, CancellationToken cancellationToken)
+            public async ValueTask<object> GetAssetAsync(AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken)
             {
                 Contract.ThrowIfTrue(checksum == Checksum.Null);
 
                 using var checksumPool = Creator.CreateChecksumSet(checksum);
                 using var _ = Creator.CreateResultMap(out var resultPool);
 
-                await scope.FindAssetsAsync(AssetHint.None, checksumPool.Object, resultPool, cancellationToken).ConfigureAwait(false);
+                await scope.FindAssetsAsync(assetHint, checksumPool.Object, resultPool, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfTrue(resultPool.Count != 1);
 
                 var (resultingChecksum, value) = resultPool.First();

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -93,14 +93,14 @@ internal partial class SolutionAssetStorage
             /// Retrieve asset of a specified <paramref name="checksum"/> available within <see langword="this"/> from
             /// the storage.
             /// </summary>
-            public async ValueTask<object> GetAssetAsync(AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken)
+            public async ValueTask<object> GetAssetAsync(Checksum checksum, CancellationToken cancellationToken)
             {
                 Contract.ThrowIfTrue(checksum == Checksum.Null);
 
                 using var checksumPool = Creator.CreateChecksumSet(checksum);
                 using var _ = Creator.CreateResultMap(out var resultPool);
 
-                await scope.FindAssetsAsync(assetHint, checksumPool.Object, resultPool, cancellationToken).ConfigureAwait(false);
+                await scope.FindAssetsAsync(assetHint: null, checksumPool.Object, resultPool, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfTrue(resultPool.Count != 1);
 
                 var (resultingChecksum, value) = resultPool.First();

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -127,9 +127,9 @@ internal partial class SolutionAssetStorage
             _solutionAssetStorage = solutionAssetStorage;
         }
 
-        public async ValueTask<object> GetRequiredAssetAsync(AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken)
+        public async ValueTask<object> GetRequiredAssetAsync(Checksum checksum, CancellationToken cancellationToken)
         {
-            return await _solutionAssetStorage._checksumToScope.Single().Value.GetTestAccessor().GetAssetAsync(assetHint, checksum, cancellationToken).ConfigureAwait(false);
+            return await _solutionAssetStorage._checksumToScope.Single().Value.GetTestAccessor().GetAssetAsync(checksum, cancellationToken).ConfigureAwait(false);
         }
 
         public bool IsPinned(Checksum checksum)

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote;
@@ -126,9 +127,9 @@ internal partial class SolutionAssetStorage
             _solutionAssetStorage = solutionAssetStorage;
         }
 
-        public async ValueTask<object> GetRequiredAssetAsync(Checksum checksum, CancellationToken cancellationToken)
+        public async ValueTask<object> GetRequiredAssetAsync(AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken)
         {
-            return await _solutionAssetStorage._checksumToScope.Single().Value.GetTestAccessor().GetAssetAsync(checksum, cancellationToken).ConfigureAwait(false);
+            return await _solutionAssetStorage._checksumToScope.Single().Value.GetTestAccessor().GetAssetAsync(assetHint, checksum, cancellationToken).ConfigureAwait(false);
         }
 
         public bool IsPinned(Checksum checksum)

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -131,25 +131,5 @@ internal partial class SolutionAssetStorage
         {
             return await _solutionAssetStorage._checksumToScope.Single().Value.GetTestAccessor().GetAssetAsync(checksum, cancellationToken).ConfigureAwait(false);
         }
-
-        public bool IsPinned(Checksum checksum)
-        {
-            lock (_solutionAssetStorage._gate)
-            {
-                return _solutionAssetStorage._checksumToScope.TryGetValue(checksum, out var scope) &&
-                    scope.RefCount >= 1;
-            }
-        }
-
-        public int PinnedScopesCount
-        {
-            get
-            {
-                lock (_solutionAssetStorage._gate)
-                {
-                    return _solutionAssetStorage._checksumToScope.Count;
-                }
-            }
-        }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -51,9 +51,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     {
         using var _ = PooledDictionary<Checksum, object>.GetInstance(out var results);
 
-        // bulk synchronize checksums first
-        var syncer = new ChecksumSynchronizer(this);
-        await syncer.SynchronizeAssetsAsync(assetPath, checksums, results, cancellationToken).ConfigureAwait(false);
+        await this.SynchronizeAssetsAsync(assetPath, checksums, results, cancellationToken).ConfigureAwait(false);
 
         var result = new (Checksum checksum, T asset)[checksums.Count];
         var index = 0;

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -31,7 +31,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     private readonly IAssetSource _assetSource = assetSource;
 
     public override async ValueTask<T> GetAssetAsync<T>(
-        AssetHint? assetHint, Checksum checksum, CancellationToken cancellationToken)
+        AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken)
     {
         Contract.ThrowIfTrue(checksum == Checksum.Null);
         if (_assetCache.TryGetAsset<T>(checksum, out var asset))
@@ -113,7 +113,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     }
 
     public async ValueTask SynchronizeAssetsAsync(
-        AssetHint? assetHint, HashSet<Checksum> checksums, Dictionary<Checksum, object>? results, CancellationToken cancellationToken)
+        AssetHint assetHint, HashSet<Checksum> checksums, Dictionary<Checksum, object>? results, CancellationToken cancellationToken)
     {
         Contract.ThrowIfTrue(checksums.Contains(Checksum.Null));
         if (checksums.Count == 0)
@@ -193,7 +193,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     }
 
     private async ValueTask<ImmutableArray<object>> RequestAssetsAsync(
-        AssetHint? assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
+        AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
     {
 #if NETCOREAPP
         Contract.ThrowIfTrue(checksums.Span.Contains(Checksum.Null));

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -31,7 +31,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     private readonly IAssetSource _assetSource = assetSource;
 
     public override async ValueTask<T> GetAssetAsync<T>(
-        AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken)
+        AssetPath assetPath, Checksum checksum, CancellationToken cancellationToken)
     {
         Contract.ThrowIfTrue(checksum == Checksum.Null);
         if (_assetCache.TryGetAsset<T>(checksum, out var asset))
@@ -41,19 +41,19 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
         checksums.Add(checksum);
 
         using var _2 = PooledDictionary<Checksum, object>.GetInstance(out var results);
-        await this.SynchronizeAssetsAsync(assetHint, checksums, results, cancellationToken).ConfigureAwait(false);
+        await this.SynchronizeAssetsAsync(assetPath, checksums, results, cancellationToken).ConfigureAwait(false);
 
         return (T)results[checksum];
     }
 
     public async ValueTask<ImmutableArray<(Checksum checksum, T asset)>> GetAssetsAsync<T>(
-        AssetHint assetHint, HashSet<Checksum> checksums, CancellationToken cancellationToken)
+        AssetPath assetPath, HashSet<Checksum> checksums, CancellationToken cancellationToken)
     {
         using var _ = PooledDictionary<Checksum, object>.GetInstance(out var results);
 
         // bulk synchronize checksums first
         var syncer = new ChecksumSynchronizer(this);
-        await syncer.SynchronizeAssetsAsync(assetHint, checksums, results, cancellationToken).ConfigureAwait(false);
+        await syncer.SynchronizeAssetsAsync(assetPath, checksums, results, cancellationToken).ConfigureAwait(false);
 
         var result = new (Checksum checksum, T asset)[checksums.Count];
         var index = 0;
@@ -113,7 +113,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     }
 
     public async ValueTask SynchronizeAssetsAsync(
-        AssetHint assetHint, HashSet<Checksum> checksums, Dictionary<Checksum, object>? results, CancellationToken cancellationToken)
+        AssetPath assetPath, HashSet<Checksum> checksums, Dictionary<Checksum, object>? results, CancellationToken cancellationToken)
     {
         Contract.ThrowIfTrue(checksums.Contains(Checksum.Null));
         if (checksums.Count == 0)
@@ -165,7 +165,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
             if (missingChecksumsCount > 0)
             {
                 var missingChecksumsMemory = new ReadOnlyMemory<Checksum>(missingChecksums, 0, missingChecksumsCount);
-                var missingAssets = await RequestAssetsAsync(assetHint, missingChecksumsMemory, cancellationToken).ConfigureAwait(false);
+                var missingAssets = await RequestAssetsAsync(assetPath, missingChecksumsMemory, cancellationToken).ConfigureAwait(false);
 
                 Contract.ThrowIfTrue(missingChecksumsMemory.Length != missingAssets.Length);
 
@@ -193,7 +193,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     }
 
     private async ValueTask<ImmutableArray<object>> RequestAssetsAsync(
-        AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
+        AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
     {
 #if NETCOREAPP
         Contract.ThrowIfTrue(checksums.Span.Contains(Checksum.Null));
@@ -204,6 +204,6 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
         if (checksums.Length == 0)
             return [];
 
-        return await _assetSource.GetAssetsAsync(_solutionChecksum, assetHint, checksums, _serializerService, cancellationToken).ConfigureAwait(false);
+        return await _assetSource.GetAssetsAsync(_solutionChecksum, assetPath, checksums, _serializerService, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -31,7 +31,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     private readonly IAssetSource _assetSource = assetSource;
 
     public override async ValueTask<T> GetAssetAsync<T>(
-        AssetHint assetHint, Checksum checksum, CancellationToken cancellationToken)
+        AssetHint? assetHint, Checksum checksum, CancellationToken cancellationToken)
     {
         Contract.ThrowIfTrue(checksum == Checksum.Null);
         if (_assetCache.TryGetAsset<T>(checksum, out var asset))
@@ -113,7 +113,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     }
 
     public async ValueTask SynchronizeAssetsAsync(
-        AssetHint assetHint, HashSet<Checksum> checksums, Dictionary<Checksum, object>? results, CancellationToken cancellationToken)
+        AssetHint? assetHint, HashSet<Checksum> checksums, Dictionary<Checksum, object>? results, CancellationToken cancellationToken)
     {
         Contract.ThrowIfTrue(checksums.Contains(Checksum.Null));
         if (checksums.Count == 0)
@@ -193,7 +193,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     }
 
     private async ValueTask<ImmutableArray<object>> RequestAssetsAsync(
-        AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
+        AssetHint? assetHint, ReadOnlyMemory<Checksum> checksums, CancellationToken cancellationToken)
     {
 #if NETCOREAPP
         Contract.ThrowIfTrue(checksums.Span.Contains(Checksum.Null));

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -46,7 +46,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
         return (T)results[checksum];
     }
 
-    public async ValueTask<ImmutableArray<(Checksum checksum, T asset)>> GetAssetsAsync<T>(
+    public override async ValueTask<ImmutableArray<(Checksum checksum, T asset)>> GetAssetsAsync<T>(
         AssetPath assetPath, HashSet<Checksum> checksums, CancellationToken cancellationToken)
     {
         using var _ = PooledDictionary<Checksum, object>.GetInstance(out var results);

--- a/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
@@ -107,14 +107,14 @@ internal sealed partial class AssetProvider
 
             async ValueTask CollectChecksumChildrenAsync(ChecksumSynchronizer @this, ChecksumsAndIds<DocumentId> collection)
             {
-                foreach (var (checksum, documentId) in collection)
+                // This GetAssetsAsync call should be fast since they were just retrieved above.  There's a small chance
+                // the asset-cache GC pass may have cleaned them up, but that should be exceedingly rare.
+                var allDocChecksums = await @this._assetProvider.GetAssetsAsync<DocumentStateChecksums>(
+                    AssetPath.ProjectAndDocuments(projectChecksum.ProjectId), collection.Checksums, cancellationToken).ConfigureAwait(false);
+                foreach (var docChecksums in allDocChecksums)
                 {
-                    // These GetAssetAsync calls should be fast since they were just retrieved above.  There's a small
-                    // chance the asset-cache GC pass may have cleaned them up, but that should be exceedingly rare.
-                    var checksumObject = await @this._assetProvider.GetAssetAsync<DocumentStateChecksums>(
-                        assetPath: documentId, checksum, cancellationToken).ConfigureAwait(false);
-                    checksums.Add(checksumObject.Info);
-                    checksums.Add(checksumObject.Text);
+                    checksums.Add(docChecksums.Info);
+                    checksums.Add(docChecksums.Text);
                 }
             }
         }

--- a/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
@@ -49,8 +49,8 @@ internal sealed partial class AssetProvider
                 {
                     using var _ = PooledHashSet<Checksum>.GetInstance(out var checksums);
 
-                    checksums.Add(solutionCompilationChecksumObject.SourceGeneratorExecutionVersionMap);
-                    solutionChecksumObject.AddAllTo(checksums);
+                    solutionCompilationChecksumObject.AddAllTo(checksums);
+                    solutionChecksumObject.AnalyzerReferences.AddAllTo(checksums);
                     await _assetProvider.SynchronizeAssetsAsync(assetHint: AssetHint.SolutionOnly, checksums, results: null, cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -58,8 +58,6 @@ internal sealed partial class AssetProvider
             // third and last get direct children for all projects and documents in the solution 
             foreach (var (projectChecksum, projectId) in solutionChecksumObject.Projects)
             {
-                // These GetAssetAsync calls should be fast since they were just retrieved above.  There's a small
-                // chance the asset-cache GC pass may have cleaned them up, but that should be exceedingly rare.
                 var projectStateChecksums = await _assetProvider.GetAssetAsync<ProjectStateChecksums>(
                     assetHint: projectId, projectChecksum, cancellationToken).ConfigureAwait(false);
                 await SynchronizeProjectAssetsAsync(projectStateChecksums, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
@@ -93,26 +93,26 @@ internal sealed partial class AssetProvider
 
             // First synchronize all the top-level info about this project.
             await _assetProvider.SynchronizeAssetsAsync(
-                assetPath: projectChecksum.ProjectId, checksums, results: null, cancellationToken).ConfigureAwait(false);
+                assetPath: AssetPath.ProjectAndDocuments(projectChecksum.ProjectId), checksums, results: null, cancellationToken).ConfigureAwait(false);
 
             checksums.Clear();
 
             // Then synchronize the info about all the documents within.
-            await CollectChecksumChildrenAsync(this, projectChecksum.Documents.Checksums).ConfigureAwait(false);
-            await CollectChecksumChildrenAsync(this, projectChecksum.AdditionalDocuments.Checksums).ConfigureAwait(false);
-            await CollectChecksumChildrenAsync(this, projectChecksum.AnalyzerConfigDocuments.Checksums).ConfigureAwait(false);
+            await CollectChecksumChildrenAsync(this, projectChecksum.Documents).ConfigureAwait(false);
+            await CollectChecksumChildrenAsync(this, projectChecksum.AdditionalDocuments).ConfigureAwait(false);
+            await CollectChecksumChildrenAsync(this, projectChecksum.AnalyzerConfigDocuments).ConfigureAwait(false);
 
             await _assetProvider.SynchronizeAssetsAsync(
-                assetPath: projectChecksum.ProjectId, checksums, results: null, cancellationToken).ConfigureAwait(false);
+                assetPath: AssetPath.ProjectAndDocuments(projectChecksum.ProjectId), checksums, results: null, cancellationToken).ConfigureAwait(false);
 
-            async ValueTask CollectChecksumChildrenAsync(ChecksumSynchronizer @this, ChecksumCollection collection)
+            async ValueTask CollectChecksumChildrenAsync(ChecksumSynchronizer @this, ChecksumsAndIds<DocumentId> collection)
             {
-                foreach (var checksum in collection)
+                foreach (var (checksum, documentId) in collection)
                 {
                     // These GetAssetAsync calls should be fast since they were just retrieved above.  There's a small
                     // chance the asset-cache GC pass may have cleaned them up, but that should be exceedingly rare.
                     var checksumObject = await @this._assetProvider.GetAssetAsync<DocumentStateChecksums>(
-                        assetPath: projectChecksum.ProjectId, checksum, cancellationToken).ConfigureAwait(false);
+                        assetPath: documentId, checksum, cancellationToken).ConfigureAwait(false);
                     checksums.Add(checksumObject.Info);
                     checksums.Add(checksumObject.Text);
                 }

--- a/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
@@ -41,9 +41,9 @@ internal sealed partial class AssetProvider
 
                 // first, get solution checksum object for the given solution checksum
                 var solutionCompilationChecksumObject = await _assetProvider.GetAssetAsync<SolutionCompilationStateChecksums>(
-                    assetHint: AssetHint.None, solutionChecksum, cancellationToken).ConfigureAwait(false);
+                    assetHint: AssetHint.SolutionOnly, solutionChecksum, cancellationToken).ConfigureAwait(false);
                 solutionChecksumObject = await _assetProvider.GetAssetAsync<SolutionStateChecksums>(
-                    assetHint: AssetHint.None, solutionCompilationChecksumObject.SolutionState, cancellationToken).ConfigureAwait(false);
+                    assetHint: AssetHint.SolutionOnly, solutionCompilationChecksumObject.SolutionState, cancellationToken).ConfigureAwait(false);
 
                 // second, get direct children of the solution
                 {
@@ -51,17 +51,17 @@ internal sealed partial class AssetProvider
 
                     checksums.Add(solutionCompilationChecksumObject.SourceGeneratorExecutionVersionMap);
                     solutionChecksumObject.AddAllTo(checksums);
-                    await _assetProvider.SynchronizeAssetsAsync(assetHint: AssetHint.None, checksums, results: null, cancellationToken).ConfigureAwait(false);
+                    await _assetProvider.SynchronizeAssetsAsync(assetHint: AssetHint.SolutionOnly, checksums, results: null, cancellationToken).ConfigureAwait(false);
                 }
             }
 
             // third and last get direct children for all projects and documents in the solution 
-            foreach (var (projectChecksum, _) in solutionChecksumObject.Projects)
+            foreach (var (projectChecksum, projectId) in solutionChecksumObject.Projects)
             {
                 // These GetAssetAsync calls should be fast since they were just retrieved above.  There's a small
                 // chance the asset-cache GC pass may have cleaned them up, but that should be exceedingly rare.
                 var projectStateChecksums = await _assetProvider.GetAssetAsync<ProjectStateChecksums>(
-                    assetHint: AssetHint.None, projectChecksum, cancellationToken).ConfigureAwait(false);
+                    assetHint: projectId, projectChecksum, cancellationToken).ConfigureAwait(false);
                 await SynchronizeProjectAssetsAsync(projectStateChecksums, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -16,5 +16,5 @@ namespace Microsoft.CodeAnalysis.Remote;
 internal interface IAssetSource
 {
     ValueTask<ImmutableArray<object>> GetAssetsAsync(
-        Checksum solutionChecksum, AssetHint? assetHint, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
+        Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -16,5 +16,5 @@ namespace Microsoft.CodeAnalysis.Remote;
 internal interface IAssetSource
 {
     ValueTask<ImmutableArray<object>> GetAssetsAsync(
-        Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
+        Checksum solutionChecksum, AssetHint? assetHint, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -16,5 +16,5 @@ namespace Microsoft.CodeAnalysis.Remote;
 internal interface IAssetSource
 {
     ValueTask<ImmutableArray<object>> GetAssetsAsync(
-        Checksum solutionChecksum, AssetHint assetHint, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
+        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteSolutionCache.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteSolutionCache.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote;
@@ -156,6 +157,12 @@ internal sealed class RemoteSolutionCache<TChecksum, TSolution>
             m.Add(nameof(_cacheMissesNotInHistory), _cacheMissesNotInHistory);
             _cacheHitIndexHistogram.WriteTelemetryPropertiesTo(m, prefix: nameof(_cacheHitIndexHistogram));
         }));
+    }
+
+    public void AddAllTo(HashSet<TSolution> solutions)
+    {
+        foreach (var node in _cacheNodes)
+            solutions.AddIfNotNull(node.Solution);
     }
 
     private sealed class CacheNode(TChecksum checksum)

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     if (oldSolutionChecksums.AnalyzerReferences.Checksum != newSolutionChecksums.AnalyzerReferences.Checksum)
                     {
-                        solution = solution.WithAnalyzerReferences(await _assetProvider.CreateCollectionAsync<AnalyzerReference>(
+                        solution = solution.WithAnalyzerReferences(await _assetProvider.GetAssetsAsync<AnalyzerReference>(
                             assetPath: AssetPath.SolutionOnly, newSolutionChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false));
                     }
 
@@ -323,21 +323,21 @@ namespace Microsoft.CodeAnalysis.Remote
                 // changed project references
                 if (oldProjectChecksums.ProjectReferences.Checksum != newProjectChecksums.ProjectReferences.Checksum)
                 {
-                    project = project.WithProjectReferences(await _assetProvider.CreateCollectionAsync<ProjectReference>(
+                    project = project.WithProjectReferences(await _assetProvider.GetAssetsAsync<ProjectReference>(
                         assetPath: project.Id, newProjectChecksums.ProjectReferences, cancellationToken).ConfigureAwait(false));
                 }
 
                 // changed metadata references
                 if (oldProjectChecksums.MetadataReferences.Checksum != newProjectChecksums.MetadataReferences.Checksum)
                 {
-                    project = project.WithMetadataReferences(await _assetProvider.CreateCollectionAsync<MetadataReference>(
+                    project = project.WithMetadataReferences(await _assetProvider.GetAssetsAsync<MetadataReference>(
                         assetPath: project.Id, newProjectChecksums.MetadataReferences, cancellationToken).ConfigureAwait(false));
                 }
 
                 // changed analyzer references
                 if (oldProjectChecksums.AnalyzerReferences.Checksum != newProjectChecksums.AnalyzerReferences.Checksum)
                 {
-                    project = project.WithAnalyzerReferences(await _assetProvider.CreateCollectionAsync<AnalyzerReference>(
+                    project = project.WithAnalyzerReferences(await _assetProvider.GetAssetsAsync<AnalyzerReference>(
                         assetPath: project.Id, newProjectChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false));
                 }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -504,7 +504,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 newChecksumsToSync.AddRange(newDocumentIdToChecksum.Values);
 
                 var documentStateChecksums = await _assetProvider.GetAssetsAsync<DocumentStateChecksums>(
-                    assetPath: project.Id, newChecksumsToSync, cancellationToken).ConfigureAwait(false);
+                    assetPath: AssetPath.ProjectAndDocuments(project.Id), newChecksumsToSync, cancellationToken).ConfigureAwait(false);
 
                 foreach (var (checksum, documentStateChecksum) in documentStateChecksums)
                 {

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -3,14 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -36,12 +36,12 @@ namespace Microsoft.CodeAnalysis.Remote
             public async Task<bool> IsIncrementalUpdateAsync(Checksum newSolutionChecksum, CancellationToken cancellationToken)
             {
                 var newSolutionCompilationChecksums = await _assetProvider.GetAssetAsync<SolutionCompilationStateChecksums>(
-                    assetHint: AssetHint.SolutionOnly, newSolutionChecksum, cancellationToken).ConfigureAwait(false);
+                    assetPath: AssetPath.SolutionOnly, newSolutionChecksum, cancellationToken).ConfigureAwait(false);
                 var newSolutionChecksums = await _assetProvider.GetAssetAsync<SolutionStateChecksums>(
-                    assetHint: AssetHint.SolutionOnly, newSolutionCompilationChecksums.SolutionState, cancellationToken).ConfigureAwait(false);
+                    assetPath: AssetPath.SolutionOnly, newSolutionCompilationChecksums.SolutionState, cancellationToken).ConfigureAwait(false);
 
                 var newSolutionInfo = await _assetProvider.GetAssetAsync<SolutionInfo.SolutionAttributes>(
-                    assetHint: AssetHint.SolutionOnly, newSolutionChecksums.Attributes, cancellationToken).ConfigureAwait(false);
+                    assetPath: AssetPath.SolutionOnly, newSolutionChecksums.Attributes, cancellationToken).ConfigureAwait(false);
 
                 // if either solution id or file path changed, then we consider it as new solution
                 return _baseSolution.Id == newSolutionInfo.Id && _baseSolution.FilePath == newSolutionInfo.FilePath;
@@ -58,9 +58,9 @@ namespace Microsoft.CodeAnalysis.Remote
                     solution = solution.WithoutFrozenSourceGeneratedDocuments();
 
                     var newSolutionCompilationChecksums = await _assetProvider.GetAssetAsync<SolutionCompilationStateChecksums>(
-                        assetHint: AssetHint.SolutionOnly, newSolutionChecksum, cancellationToken).ConfigureAwait(false);
+                        assetPath: AssetPath.SolutionOnly, newSolutionChecksum, cancellationToken).ConfigureAwait(false);
                     var newSolutionChecksums = await _assetProvider.GetAssetAsync<SolutionStateChecksums>(
-                        assetHint: AssetHint.SolutionOnly, newSolutionCompilationChecksums.SolutionState, cancellationToken).ConfigureAwait(false);
+                        assetPath: AssetPath.SolutionOnly, newSolutionCompilationChecksums.SolutionState, cancellationToken).ConfigureAwait(false);
 
                     var oldSolutionCompilationChecksums = await solution.CompilationState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                     var oldSolutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     if (oldSolutionChecksums.Attributes != newSolutionChecksums.Attributes)
                     {
                         var newSolutionInfo = await _assetProvider.GetAssetAsync<SolutionInfo.SolutionAttributes>(
-                            assetHint: AssetHint.SolutionOnly, newSolutionChecksums.Attributes, cancellationToken).ConfigureAwait(false);
+                            assetPath: AssetPath.SolutionOnly, newSolutionChecksums.Attributes, cancellationToken).ConfigureAwait(false);
 
                         // if either id or file path has changed, then this is not update
                         Contract.ThrowIfFalse(solution.Id == newSolutionInfo.Id && solution.FilePath == newSolutionInfo.FilePath);
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     if (oldSolutionChecksums.AnalyzerReferences.Checksum != newSolutionChecksums.AnalyzerReferences.Checksum)
                     {
                         solution = solution.WithAnalyzerReferences(await _assetProvider.CreateCollectionAsync<AnalyzerReference>(
-                            assetHint: AssetHint.SolutionOnly, newSolutionChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false));
+                            assetPath: AssetPath.SolutionOnly, newSolutionChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false));
                     }
 
                     if (newSolutionCompilationChecksums.FrozenSourceGeneratedDocumentIdentities.HasValue &&
@@ -96,12 +96,12 @@ namespace Microsoft.CodeAnalysis.Remote
                         for (var i = 0; i < count; i++)
                         {
                             var identity = await _assetProvider.GetAssetAsync<SourceGeneratedDocumentIdentity>(
-                                assetHint: AssetHint.SolutionOnly, newSolutionCompilationChecksums.FrozenSourceGeneratedDocumentIdentities.Value[i], cancellationToken).ConfigureAwait(false);
+                                assetPath: AssetPath.SolutionOnly, newSolutionCompilationChecksums.FrozenSourceGeneratedDocumentIdentities.Value[i], cancellationToken).ConfigureAwait(false);
 
                             var documentStateChecksums = await _assetProvider.GetAssetAsync<DocumentStateChecksums>(
-                                assetHint: AssetHint.SolutionOnly, newSolutionCompilationChecksums.FrozenSourceGeneratedDocuments.Value.Checksums[i], cancellationToken).ConfigureAwait(false);
+                                assetPath: AssetPath.SolutionOnly, newSolutionCompilationChecksums.FrozenSourceGeneratedDocuments.Value.Checksums[i], cancellationToken).ConfigureAwait(false);
 
-                            var serializableSourceText = await _assetProvider.GetAssetAsync<SerializableSourceText>(assetHint: newSolutionCompilationChecksums.FrozenSourceGeneratedDocuments.Value.Ids[i], documentStateChecksums.Text, cancellationToken).ConfigureAwait(false);
+                            var serializableSourceText = await _assetProvider.GetAssetAsync<SerializableSourceText>(assetPath: newSolutionCompilationChecksums.FrozenSourceGeneratedDocuments.Value.Ids[i], documentStateChecksums.Text, cancellationToken).ConfigureAwait(false);
 
                             var generationDateTime = newSolutionCompilationChecksums.FrozenSourceGeneratedDocumentGenerationDateTimes[i];
                             var text = await serializableSourceText.GetTextAsync(cancellationToken).ConfigureAwait(false);
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         newSolutionCompilationChecksums.SourceGeneratorExecutionVersionMap)
                     {
                         var newVersions = await _assetProvider.GetAssetAsync<SourceGeneratorExecutionVersionMap>(
-                            assetHint: AssetHint.SolutionOnly, newSolutionCompilationChecksums.SourceGeneratorExecutionVersionMap, cancellationToken).ConfigureAwait(false);
+                            assetPath: AssetPath.SolutionOnly, newSolutionCompilationChecksums.SourceGeneratorExecutionVersionMap, cancellationToken).ConfigureAwait(false);
 
                         // The execution version map will be for the entire solution on the host side.  However, we may
                         // only be syncing over a partial cone.  In that case, filter down the version map we apply to
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 newChecksumsToSync.AddRange(newProjectIdToChecksum.Values);
 
                 var newProjectStateChecksums = await _assetProvider.GetAssetsAsync<ProjectStateChecksums>(
-                    assetHint: AssetHint.SolutionAndTopLevelProjectsOnly, newChecksumsToSync, cancellationToken).ConfigureAwait(false);
+                    assetPath: AssetPath.SolutionAndTopLevelProjectsOnly, newChecksumsToSync, cancellationToken).ConfigureAwait(false);
 
                 foreach (var (checksum, newProjectStateChecksum) in newProjectStateChecksums)
                 {
@@ -310,35 +310,35 @@ namespace Microsoft.CodeAnalysis.Remote
                     project = project.WithCompilationOptions(
                         project.State.ProjectInfo.Attributes.FixUpCompilationOptions(
                             await _assetProvider.GetAssetAsync<CompilationOptions>(
-                                assetHint: project.Id, newProjectChecksums.CompilationOptions, cancellationToken).ConfigureAwait(false)));
+                                assetPath: project.Id, newProjectChecksums.CompilationOptions, cancellationToken).ConfigureAwait(false)));
                 }
 
                 // changed parse options
                 if (oldProjectChecksums.ParseOptions != newProjectChecksums.ParseOptions)
                 {
                     project = project.WithParseOptions(await _assetProvider.GetAssetAsync<ParseOptions>(
-                        assetHint: project.Id, newProjectChecksums.ParseOptions, cancellationToken).ConfigureAwait(false));
+                        assetPath: project.Id, newProjectChecksums.ParseOptions, cancellationToken).ConfigureAwait(false));
                 }
 
                 // changed project references
                 if (oldProjectChecksums.ProjectReferences.Checksum != newProjectChecksums.ProjectReferences.Checksum)
                 {
                     project = project.WithProjectReferences(await _assetProvider.CreateCollectionAsync<ProjectReference>(
-                        assetHint: project.Id, newProjectChecksums.ProjectReferences, cancellationToken).ConfigureAwait(false));
+                        assetPath: project.Id, newProjectChecksums.ProjectReferences, cancellationToken).ConfigureAwait(false));
                 }
 
                 // changed metadata references
                 if (oldProjectChecksums.MetadataReferences.Checksum != newProjectChecksums.MetadataReferences.Checksum)
                 {
                     project = project.WithMetadataReferences(await _assetProvider.CreateCollectionAsync<MetadataReference>(
-                        assetHint: project.Id, newProjectChecksums.MetadataReferences, cancellationToken).ConfigureAwait(false));
+                        assetPath: project.Id, newProjectChecksums.MetadataReferences, cancellationToken).ConfigureAwait(false));
                 }
 
                 // changed analyzer references
                 if (oldProjectChecksums.AnalyzerReferences.Checksum != newProjectChecksums.AnalyzerReferences.Checksum)
                 {
                     project = project.WithAnalyzerReferences(await _assetProvider.CreateCollectionAsync<AnalyzerReference>(
-                        assetHint: project.Id, newProjectChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false));
+                        assetPath: project.Id, newProjectChecksums.AnalyzerReferences, cancellationToken).ConfigureAwait(false));
                 }
 
                 // changed analyzer references
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Remote
             private async Task<Project> UpdateProjectInfoAsync(Project project, Checksum infoChecksum, CancellationToken cancellationToken)
             {
                 var newProjectAttributes = await _assetProvider.GetAssetAsync<ProjectInfo.ProjectAttributes>(
-                    assetHint: project.Id, infoChecksum, cancellationToken).ConfigureAwait(false);
+                    assetPath: project.Id, infoChecksum, cancellationToken).ConfigureAwait(false);
 
                 // there is no API to change these once project is created
                 Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.Id == newProjectAttributes.Id);
@@ -504,7 +504,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 newChecksumsToSync.AddRange(newDocumentIdToChecksum.Values);
 
                 var documentStateChecksums = await _assetProvider.GetAssetsAsync<DocumentStateChecksums>(
-                    assetHint: project.Id, newChecksumsToSync, cancellationToken).ConfigureAwait(false);
+                    assetPath: project.Id, newChecksumsToSync, cancellationToken).ConfigureAwait(false);
 
                 foreach (var (checksum, documentStateChecksum) in documentStateChecksums)
                 {
@@ -599,7 +599,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (oldDocumentChecksums.Text != newDocumentChecksums.Text)
                 {
                     var serializableSourceText = await _assetProvider.GetAssetAsync<SerializableSourceText>(
-                        assetHint: document.Id, newDocumentChecksums.Text, cancellationToken).ConfigureAwait(false);
+                        assetPath: document.Id, newDocumentChecksums.Text, cancellationToken).ConfigureAwait(false);
                     var sourceText = await serializableSourceText.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
                     document = document.Kind switch
@@ -617,7 +617,7 @@ namespace Microsoft.CodeAnalysis.Remote
             private async Task<TextDocument> UpdateDocumentInfoAsync(TextDocument document, Checksum infoChecksum, CancellationToken cancellationToken)
             {
                 var newDocumentInfo = await _assetProvider.GetAssetAsync<DocumentInfo.DocumentAttributes>(
-                    assetHint: document.Id, infoChecksum, cancellationToken).ConfigureAwait(false);
+                    assetPath: document.Id, infoChecksum, cancellationToken).ConfigureAwait(false);
 
                 // there is no api to change these once document is created
                 Contract.ThrowIfFalse(document.State.Attributes.Id == newDocumentInfo.Id);

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
@@ -37,11 +37,11 @@ namespace Microsoft.CodeAnalysis.Remote
         /// allowing it to get too full.
         /// <para>
         /// Also note that the asset cache will not remove items associated with the <see
-        /// cref="Workspace.CurrentSolution"/> of the workspace it is created against.  This ensures that the assets
-        /// associated with the solution that most closely corresponds to what the user is working with will stay pinned
-        /// on the remote side and not get purged just because the user stopped interactive for a while.  This ensures
-        /// the next sync (which likely overlaps heavily with the current solution) will not force the same assets to be
-        /// resent.
+        /// cref="Workspace.CurrentSolution"/> of the workspace it is created against (as well as any recent in-flight
+        /// solutions).  This ensures that the assets associated with the solution that most closely corresponds to what
+        /// the user is working with will stay pinned on the remote side and not get purged just because the user
+        /// stopped interactive for a while.  This ensures the next sync (which likely overlaps heavily with the current
+        /// solution) will not force the same assets to be resent.
         /// </para>
         /// <list type="bullet">
         /// <item>CleanupInterval=30s gives what feels to be a reasonable non-aggressive amount of time to let the cache

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
@@ -123,8 +123,17 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
+                // Ensure everything in the workspace's current solution is pinned.  We def don't want any of its data
+                // dropped from the checksum->asset cache.
                 solutions.Add(this.CurrentSolution);
+
+                // Also the data for the last 'current solution' this workspace had that we actually got an OOP request
+                // for. this is commonly the same as CurrentSolution, but technically could be slightly behind if the
+                // primary solution just got updated.
                 solutions.AddIfNotNull(_lastRequestedPrimaryBranchSolution.solution);
+
+                // Also add the last few forked solutions we were asked about.  As with the above solutions, there's a
+                // reasonable chance it will refer to data needed by future oop calls.
                 _lastRequestedAnyBranchSolutions.AddAllTo(solutions);
             };
         }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 // Also add the last few forked solutions we were asked about.  As with the above solutions, there's a
                 // reasonable chance it will refer to data needed by future oop calls.
                 _lastRequestedAnyBranchSolutions.AddAllTo(solutions);
-            };
+            }
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
@@ -123,6 +123,7 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
+                solutions.Add(this.CurrentSolution);
                 solutions.AddIfNotNull(_lastRequestedPrimaryBranchSolution.solution);
                 _lastRequestedAnyBranchSolutions.AddAllTo(solutions);
             };

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
@@ -186,7 +186,6 @@ internal sealed class SolutionAssetCache
             // Ensure that if our remote workspace has a current solution, that we don't purge any items associated
             // with that solution.
             using var _1 = PooledHashSet<Checksum>.GetInstance(out var pinnedChecksums);
-            var computePinnedInformation = false;
 
             foreach (var (checksum, entry) in _assets)
             {
@@ -195,11 +194,8 @@ internal sealed class SolutionAssetCache
                     continue;
 
                 // If this is a checksum we want to pin, do not remove it.
-                if (!computePinnedInformation)
-                {
+                if (pinnedChecksums.Count == 0)
                     await AddPinnedChecksumsAsync(pinnedChecksums, cancellationToken).ConfigureAwait(false);
-                    computePinnedInformation = true;
-                }
 
                 if (pinnedChecksums.Contains(checksum))
                     continue;

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
@@ -11,230 +11,248 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.Remote
+namespace Microsoft.CodeAnalysis.Remote;
+
+internal sealed class SolutionAssetCache
 {
-    internal sealed class SolutionAssetCache
+    static SolutionAssetCache()
     {
-        static SolutionAssetCache()
+        // CRITICAL: The size SharedStopwatch is the size of a TimeSpan (which itself is the size of a long).  This
+        // allows stopwatches to be atomically overwritten, without a concern for torn writes, as long as we're
+        // running on 64bit machines.  Make sure this value doesn't change as that will cause these current
+        // consumers to be invalid.
+        RoslynDebug.Assert(Marshal.SizeOf(typeof(SharedStopwatch)) == 8);
+    }
+
+    /// <summary>
+    /// Workspace we are associated with.  When we purge items from teh cache, we will avoid any items associated
+    /// with the items in its 'CurrentSolution'.
+    /// </summary>
+    private readonly RemoteWorkspace? _remoteWorkspace;
+
+    /// <summary>
+    /// Time interval we check storage for cleanup
+    /// </summary>
+    private readonly TimeSpan _cleanupIntervalTimeSpan;
+
+    /// <summary>
+    /// Time span data can sit inside of cache (<see cref="_assets"/>) without being used.
+    /// after that, it will be removed from the cache.
+    /// </summary>
+    private readonly TimeSpan _purgeAfterTimeSpan;
+
+    /// <summary>
+    /// Time we will wait after the last activity before doing explicit GC cleanup.
+    /// We monitor all resource access and service call to track last activity time.
+    /// 
+    /// We do this since 64bit process can hold onto quite big unused memory when
+    /// OOP is running as AnyCpu
+    /// </summary>
+    private readonly TimeSpan _gcAfterTimeSpan;
+
+    private readonly ConcurrentDictionary<Checksum, Entry> _assets = new(concurrencyLevel: 4, capacity: 10);
+
+    private DateTime _lastGCRun;
+    private DateTime _lastActivityTime;
+
+    // constructor for testing
+    public SolutionAssetCache()
+    {
+    }
+
+    /// <summary>
+    /// Create central data cache
+    /// </summary>
+    /// <param name="cleanupInterval">time interval to clean up</param>
+    /// <param name="purgeAfter">time unused data can sit in the cache</param>
+    /// <param name="gcAfter">time we wait before it call GC since last activity</param>
+    public SolutionAssetCache(RemoteWorkspace? remoteWorkspace, TimeSpan cleanupInterval, TimeSpan purgeAfter, TimeSpan gcAfter)
+    {
+        _remoteWorkspace = remoteWorkspace;
+        _cleanupIntervalTimeSpan = cleanupInterval;
+        _purgeAfterTimeSpan = purgeAfter;
+        _gcAfterTimeSpan = gcAfter;
+
+        _lastActivityTime = DateTime.UtcNow;
+        _lastGCRun = DateTime.UtcNow;
+
+        Task.Run(CleanAssetsAsync, CancellationToken.None);
+    }
+
+    public object GetOrAdd(Checksum checksum, object value)
+    {
+        UpdateLastActivityTime();
+
+        var entry = _assets.GetOrAdd(checksum, new Entry(value));
+        Update(entry);
+        return entry.Object;
+    }
+
+    public bool TryGetAsset<T>(Checksum checksum, [MaybeNullWhen(false)] out T value)
+    {
+        UpdateLastActivityTime();
+
+        using (Logger.LogBlock(FunctionId.AssetStorage_TryGetAsset, Checksum.GetChecksumLogInfo, checksum, CancellationToken.None))
         {
-            // CRITICAL: The size SharedStopwatch is the size of a TimeSpan (which itself is the size of a long).  This
-            // allows stopwatches to be atomically overwritten, without a concern for torn writes, as long as we're
-            // running on 64bit machines.  Make sure this value doesn't change as that will cause these current
-            // consumers to be invalid.
-            RoslynDebug.Assert(Marshal.SizeOf(typeof(SharedStopwatch)) == 8);
-        }
+            if (!_assets.TryGetValue(checksum, out var entry))
+            {
+                value = default;
+                return false;
+            }
 
-        /// <summary>
-        /// Workspace we are associated with.  When we purge items from teh cache, we will avoid any items associated
-        /// with the items in its 'CurrentSolution'.
-        /// </summary>
-        private readonly RemoteWorkspace? _remoteWorkspace;
-
-        /// <summary>
-        /// Time interval we check storage for cleanup
-        /// </summary>
-        private readonly TimeSpan _cleanupIntervalTimeSpan;
-
-        /// <summary>
-        /// Time span data can sit inside of cache (<see cref="_assets"/>) without being used.
-        /// after that, it will be removed from the cache.
-        /// </summary>
-        private readonly TimeSpan _purgeAfterTimeSpan;
-
-        /// <summary>
-        /// Time we will wait after the last activity before doing explicit GC cleanup.
-        /// We monitor all resource access and service call to track last activity time.
-        /// 
-        /// We do this since 64bit process can hold onto quite big unused memory when
-        /// OOP is running as AnyCpu
-        /// </summary>
-        private readonly TimeSpan _gcAfterTimeSpan;
-
-        private readonly ConcurrentDictionary<Checksum, Entry> _assets = new(concurrencyLevel: 4, capacity: 10);
-
-        private DateTime _lastGCRun;
-        private DateTime _lastActivityTime;
-
-        // constructor for testing
-        public SolutionAssetCache()
-        {
-        }
-
-        /// <summary>
-        /// Create central data cache
-        /// </summary>
-        /// <param name="cleanupInterval">time interval to clean up</param>
-        /// <param name="purgeAfter">time unused data can sit in the cache</param>
-        /// <param name="gcAfter">time we wait before it call GC since last activity</param>
-        public SolutionAssetCache(RemoteWorkspace? remoteWorkspace, TimeSpan cleanupInterval, TimeSpan purgeAfter, TimeSpan gcAfter)
-        {
-            _remoteWorkspace = remoteWorkspace;
-            _cleanupIntervalTimeSpan = cleanupInterval;
-            _purgeAfterTimeSpan = purgeAfter;
-            _gcAfterTimeSpan = gcAfter;
-
-            _lastActivityTime = DateTime.UtcNow;
-            _lastGCRun = DateTime.UtcNow;
-
-            Task.Run(CleanAssetsAsync, CancellationToken.None);
-        }
-
-        public object GetOrAdd(Checksum checksum, object value)
-        {
-            UpdateLastActivityTime();
-
-            var entry = _assets.GetOrAdd(checksum, new Entry(value));
+            // Update timestamp
             Update(entry);
-            return entry.Object;
+
+            value = (T)entry.Object;
+            return true;
+        }
+    }
+
+    public bool ContainsAsset(Checksum checksum)
+        => _assets.ContainsKey(checksum);
+
+    public void UpdateLastActivityTime()
+        => _lastActivityTime = DateTime.UtcNow;
+
+    private static void Update(Entry entry)
+    {
+        // Stopwatch wraps a TimeSpan (which is only 64bits) (asserted in our shared constructor). so this
+        // assignment can be done safely without a concern for torn writes on 64 systems.
+        //
+        // Note: on 32 bit systems there could be an issue here both with a torn write/read or torn write/write. We
+        // think that's probably ok as a torn read only leads to suboptimal behavior (dropping something early, or
+        // keeping something around till the next purge), and a torn write should likely still lead to reasonable
+        // data being written as both writers will likely still write something reasonable once both writes go
+        // through.  e.g. if you have a writer writing 1234-5678 and one writing 1235-0000, then getting 1235-5678
+        // or 1234-0000 is still fine as a final outcome.
+        entry.Stopwatch = SharedStopwatch.StartNew();
+    }
+
+    private async Task CleanAssetsAsync()
+    {
+        // Todo: associate this with a real CancellationToken that can shutdown this work.
+        var cancellationToken = CancellationToken.None;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await CleanAssetsWorkerAsync(cancellationToken).ConfigureAwait(false);
+
+            ForceGC();
+
+            await Task.Delay(_cleanupIntervalTimeSpan, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private void ForceGC()
+    {
+        // if there was no activity since last GC run. we don't have anything to do
+        if (_lastGCRun >= _lastActivityTime)
+        {
+            return;
         }
 
-        public bool TryGetAsset<T>(Checksum checksum, [MaybeNullWhen(false)] out T value)
+        var current = DateTime.UtcNow;
+        if (current - _lastActivityTime < _gcAfterTimeSpan)
         {
-            UpdateLastActivityTime();
+            // we are having activities.
+            return;
+        }
 
-            using (Logger.LogBlock(FunctionId.AssetStorage_TryGetAsset, Checksum.GetChecksumLogInfo, checksum, CancellationToken.None))
+        using (Logger.LogBlock(FunctionId.AssetStorage_ForceGC, CancellationToken.None))
+        {
+            // we didn't have activity for 5 min. spend some time to drop 
+            // unused memory
+            for (var i = 0; i < 3; i++)
             {
-                if (!_assets.TryGetValue(checksum, out var entry))
+                GC.Collect();
+            }
+        }
+
+        // update gc run time
+        _lastGCRun = current;
+    }
+
+    private async ValueTask CleanAssetsWorkerAsync(CancellationToken cancellationToken)
+    {
+        if (_assets.IsEmpty)
+        {
+            // no asset, nothing to do.
+            return;
+        }
+
+        using (Logger.LogBlock(FunctionId.AssetStorage_CleanAssets, cancellationToken))
+        {
+            // Ensure that if our remote workspace has a current solution, that we don't purge any items associated
+            // with that solution.
+            using var _1 = PooledHashSet<Checksum>.GetInstance(out var pinnedChecksums);
+            var computePinnedChecksums = false;
+
+            foreach (var (checksum, entry) in _assets)
+            {
+                // If not enough time has passed, keep in the cache.
+                if (entry.Stopwatch.Elapsed <= _purgeAfterTimeSpan)
+                    continue;
+
+                // If this is a checksum we want to pin, do not remove it.
+                if (!computePinnedChecksums)
                 {
-                    value = default;
-                    return false;
+                    await AddPinnedChecksumsAsync(pinnedChecksums, cancellationToken).ConfigureAwait(false);
+                    computePinnedChecksums = true;
                 }
 
-                // Update timestamp
-                Update(entry);
+                if (pinnedChecksums.Contains(checksum))
+                    continue;
 
-                value = (T)entry.Object;
-                return true;
+                _assets.TryRemove(checksum, out _);
             }
         }
+    }
 
-        public bool ContainsAsset(Checksum checksum)
-            => _assets.ContainsKey(checksum);
+    private async ValueTask AddPinnedChecksumsAsync(HashSet<Checksum> pinnedChecksums, CancellationToken cancellationToken)
+    {
+        if (_remoteWorkspace is null)
+            return;
 
-        public void UpdateLastActivityTime()
-            => _lastActivityTime = DateTime.UtcNow;
+        var currentSolution = _remoteWorkspace.CurrentSolution;
+        var compilationStateChecksums = await currentSolution.CompilationState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
+        compilationStateChecksums.AddAllTo(pinnedChecksums);
 
-        private static void Update(Entry entry)
+        Contract.ThrowIfFalse(currentSolution.CompilationState.SolutionState.TryGetStateChecksums(out var stateChecksums));
+        stateChecksums.AddAllTo(pinnedChecksums);
+
+        foreach (var (_, projectState) in currentSolution.CompilationState.SolutionState.ProjectStates)
         {
-            // Stopwatch wraps a TimeSpan (which is only 64bits) (asserted in our shared constructor). so this
-            // assignment can be done safely without a concern for torn writes on 64 systems.
-            //
-            // Note: on 32 bit systems there could be an issue here both with a torn write/read or torn write/write. We
-            // think that's probably ok as a torn read only leads to suboptimal behavior (dropping something early, or
-            // keeping something around till the next purge), and a torn write should likely still lead to reasonable
-            // data being written as both writers will likely still write something reasonable once both writes go
-            // through.  e.g. if you have a writer writing 1234-5678 and one writing 1235-0000, then getting 1235-5678
-            // or 1234-0000 is still fine as a final outcome.
-            entry.Stopwatch = SharedStopwatch.StartNew();
+            Contract.ThrowIfFalse(projectState.TryGetStateChecksums(out var projectStateChecksums));
+            projectStateChecksums.AddAllTo(pinnedChecksums);
+
+            AddAll(projectState.DocumentStates);
+            AddAll(projectState.AdditionalDocumentStates);
+            AddAll(projectState.AnalyzerConfigDocumentStates);
         }
 
-        private async Task CleanAssetsAsync()
+        return;
+
+        void AddAll<TState>(TextDocumentStates<TState> states) where TState : TextDocumentState
         {
-            // Todo: associate this with a real CancellationToken that can shutdown this work.
-            var cancellationToken = CancellationToken.None;
-            while (!cancellationToken.IsCancellationRequested)
+            foreach (var (_, documentState) in states.States)
             {
-                await CleanAssetsWorkerAsync(cancellationToken).ConfigureAwait(false);
-
-                ForceGC();
-
-                await Task.Delay(_cleanupIntervalTimeSpan, cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfFalse(documentState.TryGetStateChecksums(out var documentChecksums));
+                documentChecksums.AddAllTo(pinnedChecksums);
             }
         }
+    }
 
-        private void ForceGC()
+    private sealed class Entry
+    {
+        public SharedStopwatch Stopwatch = SharedStopwatch.StartNew();
+
+        // This can't change for same checksum
+        public readonly object Object;
+
+        public Entry(object @object)
         {
-            // if there was no activity since last GC run. we don't have anything to do
-            if (_lastGCRun >= _lastActivityTime)
-            {
-                return;
-            }
-
-            var current = DateTime.UtcNow;
-            if (current - _lastActivityTime < _gcAfterTimeSpan)
-            {
-                // we are having activities.
-                return;
-            }
-
-            using (Logger.LogBlock(FunctionId.AssetStorage_ForceGC, CancellationToken.None))
-            {
-                // we didn't have activity for 5 min. spend some time to drop 
-                // unused memory
-                for (var i = 0; i < 3; i++)
-                {
-                    GC.Collect();
-                }
-            }
-
-            // update gc run time
-            _lastGCRun = current;
-        }
-
-        private async ValueTask CleanAssetsWorkerAsync(CancellationToken cancellationToken)
-        {
-            if (_assets.IsEmpty)
-            {
-                // no asset, nothing to do.
-                return;
-            }
-
-            using (Logger.LogBlock(FunctionId.AssetStorage_CleanAssets, cancellationToken))
-            {
-                // Ensure that if our remote workspace has a current solution, that we don't purge any items associated
-                // with that solution.
-                PooledHashSet<Checksum>? pinnedChecksums = null;
-                try
-                {
-                    foreach (var (checksum, entry) in _assets)
-                    {
-                        // If not enough time has passed, keep in the cache.
-                        if (entry.Stopwatch.Elapsed <= _purgeAfterTimeSpan)
-                            continue;
-
-                        // If this is a checksum we want to pin, do not remove it.
-                        if (pinnedChecksums == null)
-                        {
-                            pinnedChecksums = PooledHashSet<Checksum>.GetInstance();
-                            await AddPinnedChecksumsAsync(pinnedChecksums, cancellationToken).ConfigureAwait(false);
-                        }
-
-                        if (pinnedChecksums.Contains(checksum))
-                            continue;
-
-                        _assets.TryRemove(checksum, out _);
-                    }
-                }
-                finally
-                {
-                    pinnedChecksums?.Free();
-                }
-            }
-        }
-
-        private async ValueTask AddPinnedChecksumsAsync(HashSet<Checksum> pinnedChecksums, CancellationToken cancellationToken)
-        {
-            if (_remoteWorkspace is null)
-                return;
-
-            var checksums = await _remoteWorkspace.CurrentSolution.CompilationState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-            checksums.AddAllTo(pinnedChecksums);
-        }
-
-        private sealed class Entry
-        {
-            public SharedStopwatch Stopwatch = SharedStopwatch.StartNew();
-
-            // This can't change for same checksum
-            public readonly object Object;
-
-            public Entry(object @object)
-            {
-                Object = @object;
-            }
+            Object = @object;
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -18,7 +18,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
 
     public async ValueTask<ImmutableArray<object>> GetAssetsAsync(
         Checksum solutionChecksum,
-        AssetHint assetHint,
+        AssetPath assetPath,
         ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
         CancellationToken cancellationToken)
@@ -30,7 +30,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
             _client,
             SolutionAssetProvider.ServiceDescriptor,
             (callback, cancellationToken) => callback.InvokeAsync(
-                (proxy, pipeWriter, cancellationToken) => proxy.WriteAssetsAsync(pipeWriter, solutionChecksum, assetHint, checksums, cancellationToken),
+                (proxy, pipeWriter, cancellationToken) => proxy.WriteAssetsAsync(pipeWriter, solutionChecksum, assetPath, checksums, cancellationToken),
                 (pipeReader, cancellationToken) => RemoteHostAssetSerialization.ReadDataAsync(pipeReader, solutionChecksum, checksums.Length, serializerService, cancellationToken),
                 cancellationToken),
             cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -18,7 +18,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
 
     public async ValueTask<ImmutableArray<object>> GetAssetsAsync(
         Checksum solutionChecksum,
-        AssetHint assetHint,
+        AssetHint? assetHint,
         ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
         CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -18,7 +18,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
 
     public async ValueTask<ImmutableArray<object>> GetAssetsAsync(
         Checksum solutionChecksum,
-        AssetHint? assetHint,
+        AssetHint assetHint,
         ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
         CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -215,11 +215,11 @@ namespace Microsoft.CodeAnalysis.Remote
             else
             {
                 var (compilationChecksums, projectCone) = await solution.CompilationState.GetStateChecksumsAsync(projectId, cancellationToken).ConfigureAwait(false);
-                await compilationChecksums.FindAsync(solution.CompilationState, projectCone, AssetPath.SolutionAndProject(projectId), Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
+                await compilationChecksums.FindAsync(solution.CompilationState, projectCone, AssetPath.SolutionAndProjectForTesting(projectId), Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(projectId, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfFalse(projectCone.Equals(solutionChecksums.ProjectCone));
-                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, AssetPath.SolutionAndProject(projectId), Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
+                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, AssetPath.SolutionAndProjectForTesting(projectId), Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 var project = solution.GetRequiredProject(projectId);
                 await project.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             var projectChecksums = await project.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-            await projectChecksums.FindAsync(project.State, hintDocument: null, Flatten(projectChecksums), map, cancellationToken).ConfigureAwait(false);
+            await projectChecksums.FindAsync(project.State, AssetPath.FullLookupForTesting, Flatten(projectChecksums), map, cancellationToken).ConfigureAwait(false);
 
             foreach (var document in project.Documents.Concat(project.AdditionalDocuments).Concat(project.AnalyzerConfigDocuments))
             {

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 foreach (var checksum in checksums)
                 {
                     items.Add(new KeyValuePair<Checksum, object>(checksum, await assetService.GetAssetAsync<object>(
-                        assetHint: null, checksum, CancellationToken.None).ConfigureAwait(false)));
+                        AssetHint.FullLookupForTesting, checksum, CancellationToken.None).ConfigureAwait(false)));
                 }
 
                 return items;
@@ -197,17 +197,17 @@ namespace Microsoft.CodeAnalysis.Remote
             if (projectId == null)
             {
                 var compilationChecksums = await solution.CompilationState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-                await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, assetHint: null, Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
+                await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, AssetHint.FullLookupForTesting, Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 foreach (var frozenSourceGeneratedDocumentState in solution.CompilationState.FrozenSourceGeneratedDocumentStates?.States.Values ?? [])
                 {
                     var documentChecksums = await frozenSourceGeneratedDocumentState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-                    await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, assetHint: null, Flatten(documentChecksums), map, cancellationToken).ConfigureAwait(false);
+                    await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, AssetHint.FullLookupForTesting, Flatten(documentChecksums), map, cancellationToken).ConfigureAwait(false);
                 }
 
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfTrue(solutionChecksums.ProjectCone != null);
-                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone: null, assetHintOpt: null, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
+                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone: null, AssetHint.FullLookupForTesting, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 foreach (var project in solution.Projects)
                     await project.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(projectId, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfFalse(projectCone.Equals(solutionChecksums.ProjectCone));
-                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, assetHintOpt: projectId, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
+                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, assetHint: projectId, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 var project = solution.GetRequiredProject(projectId);
                 await project.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 foreach (var checksum in checksums)
                 {
                     items.Add(new KeyValuePair<Checksum, object>(checksum, await assetService.GetAssetAsync<object>(
-                        assetHint: AssetHint.None, checksum, CancellationToken.None).ConfigureAwait(false)));
+                        assetHint: null, checksum, CancellationToken.None).ConfigureAwait(false)));
                 }
 
                 return items;
@@ -115,9 +115,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 var set = new HashSet<Checksum>();
 
                 var solutionCompilationChecksums = await assetService.GetAssetAsync<SolutionCompilationStateChecksums>(
-                    assetHint: AssetHint.None, solutionChecksum, CancellationToken.None).ConfigureAwait(false);
+                    assetHint: AssetHint.SolutionOnly, solutionChecksum, CancellationToken.None).ConfigureAwait(false);
                 var solutionChecksums = await assetService.GetAssetAsync<SolutionStateChecksums>(
-                    assetHint: AssetHint.None, solutionCompilationChecksums.SolutionState, CancellationToken.None).ConfigureAwait(false);
+                    assetHint: AssetHint.SolutionOnly, solutionCompilationChecksums.SolutionState, CancellationToken.None).ConfigureAwait(false);
 
                 solutionCompilationChecksums.AddAllTo(set);
                 solutionChecksums.AddAllTo(set);
@@ -197,17 +197,17 @@ namespace Microsoft.CodeAnalysis.Remote
             if (projectId == null)
             {
                 var compilationChecksums = await solution.CompilationState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-                await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, assetHint: AssetHint.None, Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
+                await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, assetHint: null, Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 foreach (var frozenSourceGeneratedDocumentState in solution.CompilationState.FrozenSourceGeneratedDocumentStates?.States.Values ?? [])
                 {
                     var documentChecksums = await frozenSourceGeneratedDocumentState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-                    await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, assetHint: AssetHint.None, Flatten(documentChecksums), map, cancellationToken).ConfigureAwait(false);
+                    await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, assetHint: null, Flatten(documentChecksums), map, cancellationToken).ConfigureAwait(false);
                 }
 
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfTrue(solutionChecksums.ProjectCone != null);
-                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone: null, assetHint: AssetHint.None, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
+                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone: null, assetHintOpt: null, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 foreach (var project in solution.Projects)
                     await project.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(projectId, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfFalse(projectCone.Equals(solutionChecksums.ProjectCone));
-                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, assetHint: projectId, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
+                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, assetHintOpt: projectId, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 var project = solution.GetRequiredProject(projectId);
                 await project.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -215,11 +215,11 @@ namespace Microsoft.CodeAnalysis.Remote
             else
             {
                 var (compilationChecksums, projectCone) = await solution.CompilationState.GetStateChecksumsAsync(projectId, cancellationToken).ConfigureAwait(false);
-                await compilationChecksums.FindAsync(solution.CompilationState, projectCone, assetPath: projectId, Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
+                await compilationChecksums.FindAsync(solution.CompilationState, projectCone, AssetPath.SolutionAndProject(projectId), Flatten(compilationChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(projectId, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfFalse(projectCone.Equals(solutionChecksums.ProjectCone));
-                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, assetPath: projectId, Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
+                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, AssetPath.SolutionAndProject(projectId), Flatten(solutionChecksums), map, cancellationToken).ConfigureAwait(false);
 
                 var project = solution.GetRequiredProject(projectId);
                 await project.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -161,8 +161,8 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         /// <summary>
-        /// create checksum to correspoing object map from solution
-        /// this map should contain every parts of solution that can be used to re-create the solution back
+        /// create checksum to corresponding object map from solution this map should contain every parts of solution
+        /// that can be used to re-create the solution back
         /// </summary>
         public static async Task<Dictionary<Checksum, object>> GetAssetMapAsync(this Solution solution, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
There are two major changes here to help out with oop->to->host searching.

1. When OOP calls back into the host to query for information, the asset-hint it passes back can say explicitly that it is only for top-level solution information, and not information associated with some child project or document.  This allows the host to just search the top level and never dive deep into any large subtrees.
2. the oop asset cache now pins not just the top level objects (which was just buggy to begin with), but all the objects trully pinned by any of the solutions it is holding onto.  I noticed issues here with some *very* long running operations (think 'fix all in solution') where despite already being synced over to oop, we were resync'ing data due to the cache on the oop side throwing it away, thinking it wasn't being needed.