### PR TITLE
Fix returning valid pp symbol info on unrelated preprocessor directives

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4859,13 +4859,27 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             CheckSyntaxNode(node);
 
-            if (node.Ancestors().Any(n => SyntaxFacts.IsPreprocessorDirective(n.Kind())))
+            if (node.Ancestors().Any(n => isPreprocessorDirectiveAcceptingPreprocessingSymbols(n.Kind())))
             {
                 bool isDefined = this.SyntaxTree.IsPreprocessorSymbolDefined(node.Identifier.ValueText, node.Identifier.SpanStart);
                 return new PreprocessingSymbolInfo(new Symbols.PublicModel.PreprocessingSymbol(node.Identifier.ValueText), isDefined);
             }
 
             return PreprocessingSymbolInfo.None;
+
+            static bool isPreprocessorDirectiveAcceptingPreprocessingSymbols(SyntaxKind kind)
+            {
+                switch (kind)
+                {
+                    case SyntaxKind.IfDirectiveTrivia:
+                    case SyntaxKind.ElifDirectiveTrivia:
+                    case SyntaxKind.DefineDirectiveTrivia:
+                    case SyntaxKind.UndefDirectiveTrivia:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -5027,6 +5027,51 @@ public class T
             Assert.False(symbolInfo.IsDefined, "must not be defined");
         }
 
+        [Fact, WorkItem(72907, "https://github.com/dotnet/roslyn/issues/72907")]
+        public void GetPreprocessingSymbolInfoOnUnrelatedDirective()
+        {
+            const string sourceCode = """
+                #define Z
+
+                #region Z //bind region
+                #endregion Z //bind endregion
+
+                #pragma warning disable Z //bind pragma warning disable
+                #warning Z //bind warning
+                #error Z //bind error
+                """;
+
+            var compilation = CreateCompilation(sourceCode);
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree) as CSharpSemanticModel;
+
+            var symbolInfo = symbolInfoAt("Z //bind region");
+            Assert.Null(symbolInfo.Symbol);
+
+            symbolInfo = symbolInfoAt("Z //bind endregion");
+            Assert.Null(symbolInfo.Symbol);
+
+            symbolInfo = symbolInfoAt("Z //bind pragma warning disable");
+            Assert.Null(symbolInfo.Symbol);
+
+            symbolInfo = symbolInfoAt("Z //bind warning");
+            Assert.Null(symbolInfo.Symbol);
+
+            symbolInfo = symbolInfoAt("Z //bind error");
+            Assert.Null(symbolInfo.Symbol);
+
+            PreprocessingSymbolInfo symbolInfoAt(string substringToMatch)
+            {
+                var position = sourceCode.IndexOf(substringToMatch, StringComparison.Ordinal);
+                var nameSyntaxToBind = tree.GetRoot().FindToken(position, findInsideTrivia: true).Parent as IdentifierNameSyntax;
+
+                if (nameSyntaxToBind is null)
+                    return PreprocessingSymbolInfo.None;
+
+                return model.GetPreprocessingSymbolInfo(nameSyntaxToBind);
+            }
+        }
+
         [Fact, WorkItem(720566, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/720566")]
         public void Bug720566_01()
         {


### PR DESCRIPTION
Closes #72907 