### PR TITLE
Fixed wrong access moddificator in IncrementalValueProviderExtensions

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis
         // helper for filtering
         public static IncrementalValuesProvider<TSource> Where<TSource>(this IncrementalValuesProvider<TSource> source, Func<TSource, bool> predicate) => source.SelectMany((item, _) => predicate(item) ? ImmutableArray.Create(item) : ImmutableArray<TSource>.Empty);
 
-        internal static IncrementalValuesProvider<TSource> Where<TSource>(this IncrementalValuesProvider<TSource> source, Func<TSource, CancellationToken, bool> predicate) => source.SelectMany((item, c) => predicate(item, c) ? ImmutableArray.Create(item) : ImmutableArray<TSource>.Empty);
+        public static IncrementalValuesProvider<TSource> Where<TSource>(this IncrementalValuesProvider<TSource> source, Func<TSource, CancellationToken, bool> predicate) => source.SelectMany((item, c) => predicate(item, c) ? ImmutableArray.Create(item) : ImmutableArray<TSource>.Empty);
 
         // custom comparer for given node
         public static IncrementalValueProvider<TSource> WithComparer<TSource>(this IncrementalValueProvider<TSource> source, IEqualityComparer<TSource> comparer) => new IncrementalValueProvider<TSource>(source.Node.WithComparer(comparer.WrapUserComparer(source.CatchAnalyzerExceptions)), source.CatchAnalyzerExceptions);


### PR DESCRIPTION
Closes: #72919

Using this method from custom code is presented in the documentation:
https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.cookbook.md#additional-file-transformation

But the `Where` method with `cancallationToken` is set as `internal`.
I suspect this is unintentional so I changed the accessibility of that method to `public`