### PR TITLE
Use generics in syncing code.

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
@@ -83,7 +83,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
             var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
-            await service.SynchronizeAssetsAsync(AssetPath.FullLookupForTesting, new HashSet<Checksum>(map.Keys), results: null, CancellationToken.None);
+            await service.SynchronizeAssetsAsync<object>(AssetPath.FullLookupForTesting, new HashSet<Checksum>(map.Keys), results: null, CancellationToken.None);
 
             foreach (var kv in map)
             {

--- a/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
@@ -18,10 +18,10 @@ namespace Microsoft.CodeAnalysis.Remote.Testing;
 /// </summary>
 internal sealed class SimpleAssetSource(ISerializerService serializerService, IReadOnlyDictionary<Checksum, object> map) : IAssetSource
 {
-    public ValueTask<ImmutableArray<object>> GetAssetsAsync(
+    public ValueTask<ImmutableArray<T>> GetAssetsAsync<T>(
         Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
     {
-        var results = new List<object>();
+        var results = new List<T>();
 
         foreach (var checksum in checksums.Span)
         {
@@ -39,7 +39,7 @@ internal sealed class SimpleAssetSource(ISerializerService serializerService, IR
             using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
             var asset = deserializerService.Deserialize(data.GetWellKnownSynchronizationKind(), reader, cancellationToken);
             Contract.ThrowIfNull(asset);
-            results.Add(asset);
+            results.Add((T)asset);
         }
 
         return ValueTaskFactory.FromResult(results.ToImmutableArray());

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -248,7 +248,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
                     var missingAsset = missingAssets[i];
 
                     AddResult(missingChecksum, missingAsset);
-                    _assetCache.GetOrAdd(missingChecksum, missingAsset);
+                    _assetCache.GetOrAdd(missingChecksum, missingAsset!);
                 }
             }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -15,6 +15,6 @@ namespace Microsoft.CodeAnalysis.Remote;
 /// </summary>
 internal interface IAssetSource
 {
-    ValueTask<ImmutableArray<object>> GetAssetsAsync(
+    ValueTask<ImmutableArray<T>> GetAssetsAsync<T>(
         Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
@@ -83,6 +83,7 @@ internal sealed class SolutionAssetCache
 
     public object GetOrAdd(Checksum checksum, object value)
     {
+        Contract.ThrowIfNull(value);
         UpdateLastActivityTime();
 
         var entry = _assets.GetOrAdd(checksum, new Entry(value));

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -16,7 +16,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
 {
     private readonly ServiceBrokerClient _client = client;
 
-    public async ValueTask<ImmutableArray<object>> GetAssetsAsync(
+    public async ValueTask<ImmutableArray<T>> GetAssetsAsync<T>(
         Checksum solutionChecksum,
         AssetPath assetPath,
         ReadOnlyMemory<Checksum> checksums,
@@ -31,7 +31,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
             SolutionAssetProvider.ServiceDescriptor,
             (callback, cancellationToken) => callback.InvokeAsync(
                 (proxy, pipeWriter, cancellationToken) => proxy.WriteAssetsAsync(pipeWriter, solutionChecksum, assetPath, checksums, cancellationToken),
-                (pipeReader, cancellationToken) => RemoteHostAssetSerialization.ReadDataAsync(pipeReader, solutionChecksum, checksums.Length, serializerService, cancellationToken),
+                (pipeReader, cancellationToken) => RemoteHostAssetSerialization.ReadDataAsync<T>(pipeReader, solutionChecksum, checksums.Length, serializerService, cancellationToken),
                 cancellationToken),
             cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
This has the added benefit of being able to add logs that can track what type teh caller is asking for.