### PR TITLE
Avoid asserting unvisited nested binary operators

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4055,6 +4055,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.BinaryOperator:
                     var binary = (BoundBinaryOperator)expr;
 
+#if DEBUG
+                    // Nested binary operators on the left-hand side are not visited by BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator.
+                    if (binary.Left is BoundBinaryOperator)
+                    {
+                        _visited.Add(binary.Left);
+                    }
+#endif
+
                     if (binary.Method is { } binaryMethod)
                     {
                         return GetInvocationEscapeScope(
@@ -4733,6 +4741,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         return true;
                     }
+
+#if DEBUG
+                    // Nested binary operators on the left-hand side are not visited by BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator.
+                    if (binary.Left is BoundBinaryOperator)
+                    {
+                        _visited.Add(binary.Left);
+                    }
+#endif
 
                     if (binary.Method is { } binaryMethod)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -3689,17 +3689,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// 
         /// NOTE: unless the type of expression is ref-like, the result is Binder.ExternalScope since ordinary values can always be returned from methods. 
         /// </summary>
-        internal uint GetValEscape(BoundExpression expr, uint scopeOfTheContainingExpression
-#if DEBUG
-            , bool assertVisited = true
-#endif
-            )
+        internal uint GetValEscape(BoundExpression expr, uint scopeOfTheContainingExpression)
         {
 #if DEBUG
-            if (assertVisited)
-            {
-                AssertVisited(expr);
-            }
+            AssertVisited(expr);
 #endif
 
             // cannot infer anything from errors
@@ -4076,21 +4069,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             isRefEscape: false);
                     }
 
-#if DEBUG
-                    // Nested binary operators on the left side are not visited by BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator.
-                    var assertNestedVisited = binary.Left is not BoundBinaryOperator;
-#endif
-
-                    return Math.Max(GetValEscape(binary.Left, scopeOfTheContainingExpression
-#if DEBUG
-                                        , assertNestedVisited
-#endif
-                                    ),
-                                    GetValEscape(binary.Right, scopeOfTheContainingExpression
-#if DEBUG
-                                        , assertNestedVisited
-#endif
-                                    ));
+                    return Math.Max(GetValEscape(binary.Left, scopeOfTheContainingExpression),
+                                    GetValEscape(binary.Right, scopeOfTheContainingExpression));
 
                 case BoundKind.RangeExpression:
                     var range = (BoundRangeExpression)expr;

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (_visited is { } && _visited.Count <= MaxTrackVisited)
             {
-                Debug.Assert(_visited.Contains(expr));
+                Debug.Assert(_visited.Contains(expr), $"Expected {expr} `{expr.Syntax}` to be visited.");
             }
         }
 #endif

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -8531,5 +8531,16 @@ public struct Vec4
                 //         return new R(1) | new R(2);
                 Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "1").WithLocation(18, 22));
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72873")]
+        public void Utf8Addition()
+        {
+            var code = """
+                using System;
+                ReadOnlySpan<byte> x = "Hello"u8 + " "u8 + "World!"u8;
+                Console.WriteLine(x.Length);
+                """;
+            CreateCompilation(code, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/72873.