### PR TITLE
Move to a callback-style approach to deserializing objects

### DIFF
--- a/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
@@ -18,11 +18,10 @@ namespace Microsoft.CodeAnalysis.Remote.Testing;
 /// </summary>
 internal sealed class SimpleAssetSource(ISerializerService serializerService, IReadOnlyDictionary<Checksum, object> map) : IAssetSource
 {
-    public ValueTask<ImmutableArray<T>> GetAssetsAsync<T>(
-        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
+    public ValueTask GetAssetsAsync<T>(
+        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, Action<int, T> callback, CancellationToken cancellationToken)
     {
-        var results = new List<T>();
-
+        var index = 0;
         foreach (var checksum in checksums.Span)
         {
             Contract.ThrowIfFalse(map.TryGetValue(checksum, out var data));
@@ -39,9 +38,10 @@ internal sealed class SimpleAssetSource(ISerializerService serializerService, IR
             using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
             var asset = deserializerService.Deserialize(data.GetWellKnownSynchronizationKind(), reader, cancellationToken);
             Contract.ThrowIfNull(asset);
-            results.Add((T)asset);
+            callback(index, (T)asset);
+            index++;
         }
 
-        return ValueTaskFactory.FromResult(results.ToImmutableArray());
+        return ValueTaskFactory.CompletedTask;
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -239,18 +239,20 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
             {
                 var missingChecksumsMemory = new ReadOnlyMemory<Checksum>(missingChecksums, 0, missingChecksumsCount);
 
-                var lastIndexNotification = -1;
+                var currentIndex = 0;
                 await RequestAssetsAsync(assetPath, missingChecksumsMemory, (int index, T missingAsset) =>
                 {
-                    lastIndexNotification = index;
+                    Contract.ThrowIfTrue(currentIndex != index);
 
                     var missingChecksum = missingChecksums[index];
 
                     AddResult(missingChecksum, missingAsset);
                     _assetCache.GetOrAdd(missingChecksum, missingAsset!);
+
+                    currentIndex++;
                 }, cancellationToken).ConfigureAwait(false);
 
-                Contract.ThrowIfTrue(lastIndexNotification != missingChecksumsCount - 1);
+                Contract.ThrowIfTrue(currentIndex != missingChecksumsCount);
             }
 
             if (usePool)

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Serialization;
@@ -15,6 +14,11 @@ namespace Microsoft.CodeAnalysis.Remote;
 /// </summary>
 internal interface IAssetSource
 {
-    ValueTask<ImmutableArray<T>> GetAssetsAsync<T>(
-        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
+    ValueTask GetAssetsAsync<T>(
+        Checksum solutionChecksum,
+        AssetPath assetPath,
+        ReadOnlyMemory<Checksum> checksums,
+        ISerializerService serializerService,
+        Action<int, T> callback,
+        CancellationToken cancellationToken);
 }


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/72929

Instead of allocating a large, temporary, array just to pass values around, only to then add those values to a cache, now we just pass a callback to the deserializer to allow it to directly add to the cache.

Note: this also has the benefit of allowing the cache to be filled *as* we deserialize an item, versus having to deserialize them all.  This can help concurrent requests that then may find those items in teh cache, and not have to requery them.

--

Note: it's been a long standing goal of mine to make it so that we can read/write from those pipes without needing the intermediary stream.  that would then allow us to populate the cache on the OOP side *immediately* as objects come across, without having to wait for them all to be written.  I intend to make that possible this week.