### PR TITLE
Move to a callback-style approach to deserializing objects (part2)

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -27,17 +27,13 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             public override async ValueTask<T> GetAssetAsync<T>(AssetPath assetPath, Checksum checksum, CancellationToken cancellationToken)
                 => await validator.GetValueAsync<T>(checksum).ConfigureAwait(false);
 
-            public override async ValueTask<ImmutableArray<(Checksum checksum, T asset)>> GetAssetsAsync<T>(AssetPath assetPath, HashSet<Checksum> checksums, CancellationToken cancellationToken)
+            public override async ValueTask GetAssetsAsync<T, TArg>(AssetPath assetPath, HashSet<Checksum> checksums, Action<Checksum, T, TArg> callback, TArg arg, CancellationToken cancellationToken)
             {
-                using var _ = ArrayBuilder<(Checksum checksum, T asset)>.GetInstance(out var result);
-
                 foreach (var checksum in checksums)
                 {
                     var value = await GetAssetAsync<T>(assetPath, checksum, cancellationToken).ConfigureAwait(false);
-                    result.Add((checksum, value));
+                    callback(checksum, value, arg);
                 }
-
-                return result.ToImmutable();
             }
         }
 

--- a/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
@@ -56,8 +56,9 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var stored = await provider.GetAssetAsync<object>(AssetPath.FullLookupForTesting, checksum, CancellationToken.None);
             Assert.Equal(data, stored);
 
-            var stored2 = await provider.GetAssetsAsync<object>(AssetPath.FullLookupForTesting, new HashSet<Checksum> { checksum }, CancellationToken.None);
-            Assert.Equal(1, stored2.Length);
+            var stored2 = new List<(Checksum, object)>();
+            await provider.GetAssetsAsync<object, VoidResult>(AssetPath.FullLookupForTesting, new HashSet<Checksum> { checksum }, (checksum, asset, _) => stored2.Add((checksum, asset)), default, CancellationToken.None);
+            Assert.Equal(1, stored2.Count);
 
             Assert.Equal(checksum, stored2[0].Item1);
             Assert.Equal(data, stored2[0].Item2);
@@ -83,7 +84,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
             var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
-            await service.SynchronizeAssetsAsync<object>(AssetPath.FullLookupForTesting, new HashSet<Checksum>(map.Keys), results: null, CancellationToken.None);
+            await service.SynchronizeAssetsAsync<object, VoidResult>(AssetPath.FullLookupForTesting, new HashSet<Checksum>(map.Keys), callback: null, arg: default, CancellationToken.None);
 
             foreach (var kv in map)
             {

--- a/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.Remote.Testing;
 /// </summary>
 internal sealed class SimpleAssetSource(ISerializerService serializerService, IReadOnlyDictionary<Checksum, object> map) : IAssetSource
 {
-    public ValueTask GetAssetsAsync<T>(
-        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, Action<int, T> callback, CancellationToken cancellationToken)
+    public ValueTask GetAssetsAsync<T, TArg>(
+        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, Action<int, T, TArg> callback, TArg arg, CancellationToken cancellationToken)
     {
         var index = 0;
         foreach (var checksum in checksums.Span)
@@ -38,7 +38,7 @@ internal sealed class SimpleAssetSource(ISerializerService serializerService, IR
             using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
             var asset = deserializerService.Deserialize(data.GetWellKnownSynchronizationKind(), reader, cancellationToken);
             Contract.ThrowIfNull(asset);
-            callback(index, (T)asset);
+            callback(index, (T)asset, arg);
             index++;
         }
 

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -24,7 +24,7 @@ internal abstract class AbstractAssetProvider
     /// return data of type T whose checksum is the given checksum
     /// </summary>
     public abstract ValueTask<T> GetAssetAsync<T>(AssetPath assetPath, Checksum checksum, CancellationToken cancellationToken);
-    public abstract ValueTask GetAssetsAsync<T, TArg>(AssetPath assetPath, HashSet<Checksum> checksums, Action<Checksum, int, T, TArg> callback, TArg arg, CancellationToken cancellationToken);
+    public abstract ValueTask GetAssetsAsync<T, TArg>(AssetPath assetPath, HashSet<Checksum> checksums, Action<Checksum, T, TArg> callback, TArg arg, CancellationToken cancellationToken);
 
     public async Task<SolutionInfo> CreateSolutionInfoAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
     {
@@ -114,9 +114,9 @@ internal abstract class AbstractAssetProvider
 
         var results = new T[checksumSet.Count];
 
-        await this.GetAssetsAsync<T, T[]>(
+        await this.GetAssetsAsync<T, VoidResult>(
             assetPath, checksumSet,
-            static (checksum, index, asset, results) => results[index] = asset,
+            (checksum, asset, results) => results[index] = asset,
             results,
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -108,17 +108,17 @@ internal abstract class AbstractAssetProvider
     public async Task<ImmutableArray<T>> GetAssetsAsync<T>(
         AssetPath assetPath, ChecksumCollection checksums, CancellationToken cancellationToken) where T : class
     {
-        using var _ = PooledHashSet<Checksum>.GetInstance(out var checksumSet);
+        using var _1 = PooledHashSet<Checksum>.GetInstance(out var checksumSet);
         checksumSet.AddAll(checksums.Children);
 
-        var results = ImmutableArray.CreateBuilder<T>(checksumSet.Count);
+        using var _2 = ArrayBuilder<T>.GetInstance(checksumSet.Count, out var builder);
 
-        await this.GetAssetsAsync<T, ImmutableArray<T>.Builder>(
+        await this.GetAssetsAsync<T, ArrayBuilder<T>>(
             assetPath, checksumSet,
-            static (checksum, asset, results) => results.Add(asset),
-            results,
+            static (checksum, asset, builder) => builder.Add(asset),
+            builder,
             cancellationToken).ConfigureAwait(false);
 
-        return results.MoveToImmutable();
+        return builder.ToImmutableAndClear();
     }
 }

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -112,14 +112,14 @@ internal abstract class AbstractAssetProvider
         using var _ = PooledHashSet<Checksum>.GetInstance(out var checksumSet);
         checksumSet.AddAll(checksums.Children);
 
-        var results = new T[checksumSet.Count];
+        var results = ImmutableArray.CreateBuilder<T>(checksumSet.Count);
 
-        await this.GetAssetsAsync<T, VoidResult>(
+        await this.GetAssetsAsync<T, ImmutableArray<T>.Builder>(
             assetPath, checksumSet,
-            (checksum, asset, results) => results[index] = asset,
+            static (checksum, asset, results) => results.Add(asset),
             results,
             cancellationToken).ConfigureAwait(false);
 
-        return ImmutableCollectionsMarshal.AsImmutableArray(results);
+        return results.MoveToImmutable();
     }
 }

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -4,14 +4,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
 using Nerdbank.Streams;
 using Roslyn.Utilities;
@@ -67,8 +64,8 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public static ValueTask ReadDataAsync<T>(
-            PipeReader pipeReader, Checksum solutionChecksum, int objectCount, ISerializerService serializerService, Action<int, T> callback, CancellationToken cancellationToken)
+        public static ValueTask ReadDataAsync<T, TArg>(
+            PipeReader pipeReader, Checksum solutionChecksum, int objectCount, ISerializerService serializerService, Action<T, TArg> callback, TArg arg, CancellationToken cancellationToken)
         {
             // Suppress ExecutionContext flow for asynchronous operations operate on the pipe. In addition to avoiding
             // ExecutionContext allocations, this clears the LogicalCallContext and avoids the need to clone data set by
@@ -77,18 +74,18 @@ namespace Microsoft.CodeAnalysis.Remote
             // ⚠ DO NOT AWAIT INSIDE THE USING. The Dispose method that restores ExecutionContext flow must run on the
             // same thread where SuppressFlow was originally run.
             using var _ = FlowControlHelper.TrySuppressFlow();
-            return ReadDataSuppressedFlowAsync(pipeReader, solutionChecksum, objectCount, serializerService, callback, cancellationToken);
+            return ReadDataSuppressedFlowAsync(pipeReader, solutionChecksum, objectCount, serializerService, callback, arg, cancellationToken);
 
             static async ValueTask ReadDataSuppressedFlowAsync(
-                PipeReader pipeReader, Checksum solutionChecksum, int objectCount, ISerializerService serializerService, Action<int, T> callback, CancellationToken cancellationToken)
+                PipeReader pipeReader, Checksum solutionChecksum, int objectCount, ISerializerService serializerService, Action<T, TArg> callback, TArg arg, CancellationToken cancellationToken)
             {
                 using var stream = await pipeReader.AsPrebufferedStreamAsync(cancellationToken).ConfigureAwait(false);
-                ReadData<T>(stream, solutionChecksum, objectCount, serializerService, callback, cancellationToken);
+                ReadData(stream, solutionChecksum, objectCount, serializerService, callback, arg, cancellationToken);
             }
         }
 
-        public static void ReadData<T>(
-            Stream stream, Checksum solutionChecksum, int objectCount, ISerializerService serializerService, Action<int, T> callback, CancellationToken cancellationToken)
+        public static void ReadData<T, TArg>(
+            Stream stream, Checksum solutionChecksum, int objectCount, ISerializerService serializerService, Action<T, TArg> callback, TArg arg, CancellationToken cancellationToken)
         {
             using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
 
@@ -104,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 // in service hub, cancellation means simply closed stream
                 var result = serializerService.Deserialize(kind, reader, cancellationToken);
                 Contract.ThrowIfNull(result);
-                callback(i, (T)result);
+                callback((T)result, arg);
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -103,7 +103,8 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
             using var _2 = PooledDictionary<Checksum, object>.GetInstance(out var checksumToObjects);
 
             await this.SynchronizeAssetsAsync<object, Dictionary<Checksum, object>>(
-                assetPath: AssetPath.SolutionAndTopLevelProjectsOnly, checksums,
+                assetPath: AssetPath.SolutionAndTopLevelProjectsOnly,
+                checksums,
                 static (checksum, asset, checksumToObjects) => checksumToObjects.Add(checksum, asset),
                 arg: checksumToObjects, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -47,6 +47,8 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
             called = true;
             result = asset;
         }, default, cancellationToken).ConfigureAwait(false);
+
+        Contract.ThrowIfFalse(called);
         Contract.ThrowIfNull((object?)result);
 
         return result;

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -20,7 +20,7 @@ internal interface IAssetSource
         AssetPath assetPath,
         ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
-        Action<T, TArg> callback,
+        Action<int, T, TArg> callback,
         TArg arg,
         CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -14,11 +14,13 @@ namespace Microsoft.CodeAnalysis.Remote;
 /// </summary>
 internal interface IAssetSource
 {
-    ValueTask GetAssetsAsync<T>(
+    /// <param name="callback">Will be called back once per checksum in <paramref name="checksums"/> in the exact order of that array.</param>
+    ValueTask GetAssetsAsync<T, TArg>(
         Checksum solutionChecksum,
         AssetPath assetPath,
         ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
-        Action<int, T> callback,
+        Action<T, TArg> callback,
+        TArg arg,
         CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -218,12 +218,14 @@ namespace Microsoft.CodeAnalysis.Remote
                 using var _5 = PooledHashSet<Checksum>.GetInstance(out var newChecksumsToSync);
                 newChecksumsToSync.AddRange(newProjectIdToChecksum.Values);
 
-                await _assetProvider.GetAssetsAsync<ProjectStateChecksums>(
-                    assetPath: AssetPath.SolutionAndTopLevelProjectsOnly, newChecksumsToSync, (checksum, newProjectStateChecksum) =>
+                await _assetProvider.GetAssetsAsync<ProjectStateChecksums, Dictionary<ProjectId, ProjectStateChecksums>>(
+                    assetPath: AssetPath.SolutionAndTopLevelProjectsOnly, newChecksumsToSync,
+                    static (checksum, _, newProjectStateChecksum, newProjectIdToStateChecksums) =>
                     {
                         Contract.ThrowIfTrue(checksum != newProjectStateChecksum.Checksum);
                         newProjectIdToStateChecksums.Add(newProjectStateChecksum.ProjectId, newProjectStateChecksum);
                     },
+                    arg: newProjectIdToStateChecksums,
                     cancellationToken).ConfigureAwait(false);
 
                 // Now that we've collected the old and new project state checksums, we can actually process them to
@@ -502,12 +504,14 @@ namespace Microsoft.CodeAnalysis.Remote
                 using var _5 = PooledHashSet<Checksum>.GetInstance(out var newChecksumsToSync);
                 newChecksumsToSync.AddRange(newDocumentIdToChecksum.Values);
 
-                await _assetProvider.GetAssetsAsync<DocumentStateChecksums>(
-                    assetPath: AssetPath.ProjectAndDocuments(project.Id), newChecksumsToSync, (checksum, documentStateChecksum) =>
+                await _assetProvider.GetAssetsAsync<DocumentStateChecksums, Dictionary<DocumentId, DocumentStateChecksums>>(
+                    assetPath: AssetPath.ProjectAndDocuments(project.Id), newChecksumsToSync,
+                    static (checksum, _, documentStateChecksum, newDocumentIdToStateChecksums) =>
                     {
                         Contract.ThrowIfTrue(checksum != documentStateChecksum.Checksum);
                         newDocumentIdToStateChecksums.Add(documentStateChecksum.DocumentId, documentStateChecksum);
                     },
+                    arg: newDocumentIdToStateChecksums,
                     cancellationToken).ConfigureAwait(false);
 
                 // If more than two documents changed during a single update, perform a bulk synchronization on the

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 await _assetProvider.GetAssetsAsync<ProjectStateChecksums, Dictionary<ProjectId, ProjectStateChecksums>>(
                     assetPath: AssetPath.SolutionAndTopLevelProjectsOnly, newChecksumsToSync,
-                    static (checksum, _, newProjectStateChecksum, newProjectIdToStateChecksums) =>
+                    static (checksum, newProjectStateChecksum, newProjectIdToStateChecksums) =>
                     {
                         Contract.ThrowIfTrue(checksum != newProjectStateChecksum.Checksum);
                         newProjectIdToStateChecksums.Add(newProjectStateChecksum.ProjectId, newProjectStateChecksum);
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 await _assetProvider.GetAssetsAsync<DocumentStateChecksums, Dictionary<DocumentId, DocumentStateChecksums>>(
                     assetPath: AssetPath.ProjectAndDocuments(project.Id), newChecksumsToSync,
-                    static (checksum, _, documentStateChecksum, newDocumentIdToStateChecksums) =>
+                    static (checksum, documentStateChecksum, newDocumentIdToStateChecksums) =>
                     {
                         Contract.ThrowIfTrue(checksum != documentStateChecksum.Checksum);
                         newDocumentIdToStateChecksums.Add(documentStateChecksum.DocumentId, documentStateChecksum);

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -218,14 +218,13 @@ namespace Microsoft.CodeAnalysis.Remote
                 using var _5 = PooledHashSet<Checksum>.GetInstance(out var newChecksumsToSync);
                 newChecksumsToSync.AddRange(newProjectIdToChecksum.Values);
 
-                var newProjectStateChecksums = await _assetProvider.GetAssetsAsync<ProjectStateChecksums>(
-                    assetPath: AssetPath.SolutionAndTopLevelProjectsOnly, newChecksumsToSync, cancellationToken).ConfigureAwait(false);
-
-                foreach (var (checksum, newProjectStateChecksum) in newProjectStateChecksums)
-                {
-                    Contract.ThrowIfTrue(checksum != newProjectStateChecksum.Checksum);
-                    newProjectIdToStateChecksums.Add(newProjectStateChecksum.ProjectId, newProjectStateChecksum);
-                }
+                await _assetProvider.GetAssetsAsync<ProjectStateChecksums>(
+                    assetPath: AssetPath.SolutionAndTopLevelProjectsOnly, newChecksumsToSync, (checksum, newProjectStateChecksum) =>
+                    {
+                        Contract.ThrowIfTrue(checksum != newProjectStateChecksum.Checksum);
+                        newProjectIdToStateChecksums.Add(newProjectStateChecksum.ProjectId, newProjectStateChecksum);
+                    },
+                    cancellationToken).ConfigureAwait(false);
 
                 // Now that we've collected the old and new project state checksums, we can actually process them to
                 // determine what to remove, what to add, and what to change.
@@ -503,14 +502,13 @@ namespace Microsoft.CodeAnalysis.Remote
                 using var _5 = PooledHashSet<Checksum>.GetInstance(out var newChecksumsToSync);
                 newChecksumsToSync.AddRange(newDocumentIdToChecksum.Values);
 
-                var documentStateChecksums = await _assetProvider.GetAssetsAsync<DocumentStateChecksums>(
-                    assetPath: AssetPath.ProjectAndDocuments(project.Id), newChecksumsToSync, cancellationToken).ConfigureAwait(false);
-
-                foreach (var (checksum, documentStateChecksum) in documentStateChecksums)
-                {
-                    Contract.ThrowIfTrue(checksum != documentStateChecksum.Checksum);
-                    newDocumentIdToStateChecksums.Add(documentStateChecksum.DocumentId, documentStateChecksum);
-                }
+                await _assetProvider.GetAssetsAsync<DocumentStateChecksums>(
+                    assetPath: AssetPath.ProjectAndDocuments(project.Id), newChecksumsToSync, (checksum, documentStateChecksum) =>
+                    {
+                        Contract.ThrowIfTrue(checksum != documentStateChecksum.Checksum);
+                        newDocumentIdToStateChecksums.Add(documentStateChecksum.DocumentId, documentStateChecksum);
+                    },
+                    cancellationToken).ConfigureAwait(false);
 
                 // If more than two documents changed during a single update, perform a bulk synchronization on the
                 // project to avoid large numbers of small synchronization calls during document updates.

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -21,7 +21,7 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
         AssetPath assetPath,
         ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
-        Action<T, TArg> assetCallback,
+        Action<int, T, TArg> assetCallback,
         TArg arg,
         CancellationToken cancellationToken)
     {


### PR DESCRIPTION
This moves to removing even more intermediary allocs, as well as allowing our lambdas to be static through the use of an `TArg` value passed along.