### PR TITLE
Implement Lookup APIs on extensions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -137,7 +137,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (conversion.IsExtensionMemberConversion(out Symbol? extensionMember, out Conversion nestedConversion))
                 {
-                    source = GetExtensionMemberAccess(syntax, ((BoundMethodGroup)source).ReceiverOpt, extensionMember, diagnostics);
+                    var methodGroup = (BoundMethodGroup)source;
+                    source = GetExtensionMemberAccess(syntax, methodGroup.ReceiverOpt, extensionMember,
+                        methodGroup.TypeArgumentsSyntax, methodGroup.TypeArgumentsOpt, diagnostics);
+
                     return CreateConversion(syntax, source, nestedConversion, isCast, conversionGroupOpt, destination, diagnostics);
                 }
 
@@ -503,7 +506,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundExpression GetExtensionMemberAccess(SyntaxNode syntax, BoundExpression? receiver, Symbol extensionMember, BindingDiagnosticBag diagnostics)
+        private BoundExpression GetExtensionMemberAccess(SyntaxNode syntax, BoundExpression? receiver, Symbol extensionMember,
+            SeparatedSyntaxList<TypeSyntax> typeArgumentsSyntax, ImmutableArray<TypeWithAnnotations> typeArgumentsOpt, BindingDiagnosticBag diagnostics)
         {
             Debug.Assert(extensionMember.Kind != SymbolKind.Method);
             receiver = ReplaceTypeOrValueReceiver(receiver, useType: extensionMember.IsStatic || extensionMember.Kind == SymbolKind.NamedType, diagnostics);
@@ -527,8 +531,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case NamedTypeSymbol namedTypeSymbol:
                     bool wasError = false;
 
-                    return BindTypeMemberOfType(receiver, namedTypeSymbol.Name, namedTypeSymbol,
-                        syntax, right: syntax, diagnostics, ref wasError);
+                    if (!typeArgumentsOpt.IsDefault)
+                    {
+                        namedTypeSymbol = ConstructNamedTypeUnlessTypeArgumentOmitted(syntax, namedTypeSymbol, typeArgumentsSyntax, typeArgumentsOpt, diagnostics);
+                    }
+
+                    return BindTypeMemberOfType(receiver, namedTypeSymbol.Name, namedTypeSymbol, syntax, right: syntax, diagnostics, ref wasError);
 
                 case EventSymbol eventSymbol:
                     return BindEventAccess(syntax, receiver, eventSymbol, diagnostics, LookupResultKind.Viable, hasErrors: false);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -2247,6 +2247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             receiverOpt = ReplaceTypeOrValueReceiver(receiverOpt, useType: conversion.Method?.RequiresInstanceReceiver == false && !conversion.IsExtensionMethod, diagnostics);
             return group.Update(
+                group.TypeArgumentsSyntax,
                 group.TypeArgumentsOpt,
                 group.Name,
                 group.Methods,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -417,7 +417,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagnostics.Add(methodGroup.Syntax, useSiteInfo);
             if (resolution.IsExtensionMember(out Symbol? extensionMember))
             {
-                return GetExtensionMemberAccess(methodGroup.Syntax, methodGroup.ReceiverOpt, extensionMember, diagnostics);
+                return GetExtensionMemberAccess(methodGroup.Syntax, methodGroup.ReceiverOpt, extensionMember,
+                    methodGroup.TypeArgumentsSyntax, methodGroup.TypeArgumentsOpt, diagnostics);
             }
 
             // We have a method group so bind to an inferred delegate type
@@ -7499,7 +7500,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (resolution.IsExtensionMember(out Symbol extensionMember))
                         {
                             diagnostics.AddRange(resolution.Diagnostics);
-                            return GetExtensionMemberAccess(methodGroup.Syntax, methodGroup.ReceiverOpt, extensionMember, diagnostics);
+                            return GetExtensionMemberAccess(methodGroup.Syntax, methodGroup.ReceiverOpt, extensionMember,
+                                methodGroup.TypeArgumentsSyntax, methodGroup.TypeArgumentsOpt, diagnostics);
                         }
 
                         if (!expr.HasAnyErrors)
@@ -7541,7 +7543,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             diagnostics.AddRange(resolution.Diagnostics);
                             resolution.Free();
-                            return GetExtensionMemberAccess(methodGroup.Syntax, methodGroup.ReceiverOpt, extensionMember, diagnostics);
+                            return GetExtensionMemberAccess(methodGroup.Syntax, methodGroup.ReceiverOpt, extensionMember,
+                                methodGroup.TypeArgumentsSyntax, methodGroup.TypeArgumentsOpt, diagnostics);
                         }
 
                         resolution.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5044,8 +5044,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (!conv.Exists)
                     {
                         var boundMethodGroup = new BoundMethodGroup(
-                            argument.Syntax, default, WellKnownMemberNames.DelegateInvokeName, ImmutableArray.Create(sourceDelegate.DelegateInvokeMethod),
+                            argument.Syntax, typeArgumentsSyntax: default, typeArgumentsOpt: default,
+                            WellKnownMemberNames.DelegateInvokeName, ImmutableArray.Create(sourceDelegate.DelegateInvokeMethod),
                             sourceDelegate.DelegateInvokeMethod, null, BoundMethodGroupFlags.None, functionType: null, argument, LookupResultKind.Viable);
+
                         if (!Conversions.ReportDelegateOrFunctionPointerMethodGroupDiagnostics(this, boundMethodGroup, type, diagnostics))
                         {
                             // If we could not produce a more specialized diagnostic, we report
@@ -7631,6 +7633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var boundMethodGroup = new BoundMethodGroup(
                 node,
+                typeArgumentsSyntax,
                 typeArgumentsWithAnnotations,
                 boundLeft,
                 rightName,
@@ -7788,7 +7791,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // we've reported other errors.
                 return new BoundMethodGroup(
                     node,
-                    default(ImmutableArray<TypeWithAnnotations>),
+                    typeArgumentsSyntax: default,
+                    typeArgumentsOpt: default,
                     nameString,
                     methods,
                     methods.Length == 1 ? methods[0] : null,
@@ -10058,7 +10062,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 analyzedArguments.Arguments.Add(lengthArgumentPlaceholder);
 
                 var boundMethodGroup = new BoundMethodGroup(
-                    syntax, typeArgumentsOpt: default, method.Name, ImmutableArray.Create(method),
+                    syntax, typeArgumentsSyntax: default, typeArgumentsOpt: default, method.Name, ImmutableArray.Create(method),
                     method, lookupError: null, BoundMethodGroupFlags.None, functionType: null, receiver, LookupResultKind.Viable)
                 { WasCompilerGenerated = true };
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -424,6 +424,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // the base constructor is called. We need to handle this as a type qualified static method call.
                                 // Also applicable to things like field initializers, which run before the ctor initializer.
                                 expression = methodGroup.Update(
+                                    methodGroup.TypeArgumentsSyntax,
                                     methodGroup.TypeArgumentsOpt,
                                     methodGroup.Name,
                                     methodGroup.Methods,
@@ -449,6 +450,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             BoundExpression finalReceiver = ReplaceTypeOrValueReceiver(typeOrValue, useType, diagnostics);
 
                             expression = methodGroup.Update(
+                                    methodGroup.TypeArgumentsSyntax,
                                     methodGroup.TypeArgumentsOpt,
                                     methodGroup.Name,
                                     methodGroup.Methods,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -722,7 +722,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (resolution.IsExtensionMember(out Symbol extensionMember))
             {
                 diagnostics.AddRange(resolution.Diagnostics);
-                var extensionMemberAccess = GetExtensionMemberAccess(expression, methodGroup.ReceiverOpt, extensionMember, diagnostics);
+                var extensionMemberAccess = GetExtensionMemberAccess(expression, methodGroup.ReceiverOpt, extensionMember,
+                    methodGroup.TypeArgumentsSyntax, methodGroup.TypeArgumentsOpt, diagnostics);
+
                 Debug.Assert(extensionMemberAccess.Kind != BoundKind.MethodGroup);
 
                 var extensionMemberInvocation = BindInvocationExpression(syntax, expression, methodName, extensionMemberAccess, analyzedArguments, diagnostics);
@@ -2368,6 +2370,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CheckFeatureAvailability(node, MessageID.IDS_FeatureNameof, diagnostics);
             var argument = node.ArgumentList.Arguments[0].Expression;
             var boundArgument = BindExpression(argument, diagnostics);
+            boundArgument = ResolveToExtensionMemberIfPossible(boundArgument, diagnostics);
 
             bool syntaxIsOk = CheckSyntaxForNameofArgument(argument, out string name, boundArgument.HasAnyErrors ? BindingDiagnosticBag.Discarded : diagnostics);
             if (!boundArgument.HasAnyErrors && syntaxIsOk && boundArgument.Kind == BoundKind.MethodGroup)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -2205,7 +2205,7 @@ symIsHidden:;
 
             void addMemberLookupSymbolsInfoInExtension(LookupSymbolsInfo result, TypeSymbol type, LookupOptions options, Binder originalBinder)
             {
-                AddMemberLookupSymbolsInfoWithoutInheritance(result, type, options, originalBinder, accessThroughType: null);
+                AddMemberLookupSymbolsInfoWithoutInheritance(result, type, options, originalBinder, accessThroughType: type);
 
                 if (type.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
                 {
@@ -2382,6 +2382,7 @@ symIsHidden:;
 
         internal void AddImplicitExtensionMemberLookupSymbolsInfoForType(LookupSymbolsInfo result, TypeSymbol type, LookupOptions options, Binder originalBinder)
         {
+            var accessThroughType = type;
             if (type.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
             {
                 type = extendedType;
@@ -2394,7 +2395,7 @@ symIsHidden:;
 
                 foreach (NamedTypeSymbol extension in compatibleExtensions)
                 {
-                    AddMemberLookupSymbolsInfoWithoutInheritance(result, extension, options, scope.Binder, accessThroughType: null);
+                    AddMemberLookupSymbolsInfoWithoutInheritance(result, extension, options, scope.Binder, accessThroughType);
                 }
 
                 compatibleExtensions.Clear();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -179,10 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        // Note: for public Lookup API purposes, we need to collect results from member lookup and extension member lookup;
-        // we use `skipType` to skip collecting the extension member lookup results from an extension type that we already
-        // collected members from (via direct member lookup).
-        internal void LookupImplicitExtensionMembersInSingleBinder(LookupResult result, TypeSymbol type,
+        protected void LookupImplicitExtensionMembersInSingleBinder(LookupResult result, TypeSymbol type,
             string name, int arity, ConsList<TypeSymbol>? basesBeingResolved, LookupOptions options,
             Binder originalBinder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
@@ -962,10 +959,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // Does a member lookup in a single type, without considering inheritance.
-        protected static void LookupMembersWithoutInheritance(LookupResult result, TypeSymbol type, string? name, int arity,
+        protected static void LookupMembersWithoutInheritance(LookupResult result, TypeSymbol type, string name, int arity,
             LookupOptions options, Binder originalBinder, TypeSymbol accessThroughType, bool diagnose, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, ConsList<TypeSymbol>? basesBeingResolved)
         {
-            var members = name is null ? GetCandidateMembers(type, options, originalBinder) : GetCandidateMembers(type, name, options, originalBinder);
+            var members = GetCandidateMembers(type, name, options, originalBinder);
 
             foreach (Symbol member in members)
             {
@@ -1216,7 +1213,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void LookupMembersInExtension(
             LookupResult current,
             NamedTypeSymbol type,
-            string? name,
+            string name,
             int arity,
             ConsList<TypeSymbol>? basesBeingResolved,
             LookupOptions options,
@@ -1225,6 +1222,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             Debug.Assert(type is { IsExtension: true });
+            Debug.Assert(name is not null);
 
             LookupMembersWithoutInheritance(current, type, name, arity, options, originalBinder, accessThroughType: type, diagnose, ref useSiteInfo, basesBeingResolved);
         }
@@ -2182,8 +2180,7 @@ symIsHidden:;
                     break;
 
                 case TypeKind.Interface:
-                    accessThroughType ??= type;
-                    this.AddMemberLookupSymbolsInfoInInterface(result, type, options, originalBinder, accessThroughType);
+                    this.AddMemberLookupSymbolsInfoInInterface(result, type, options, originalBinder, accessThroughType: accessThroughType ?? type);
                     break;
 
                 case TypeKind.Class:
@@ -2193,8 +2190,7 @@ symIsHidden:;
                 case TypeKind.Array:
                 case TypeKind.Dynamic:
                 case TypeKind.Submission:
-                    accessThroughType ??= type;
-                    this.AddMemberLookupSymbolsInfoInClass(result, type, options, originalBinder, accessThroughType);
+                    this.AddMemberLookupSymbolsInfoInClass(result, type, options, originalBinder, accessThroughType: accessThroughType ?? type);
                     break;
 
                 case TypeKind.Extension:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -247,6 +247,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static void GetCompatibleExtensions(Binder binder, TypeSymbol type, ArrayBuilder<NamedTypeSymbol> compatibleExtensions,
             Binder originalBinder, ConsList<TypeSymbol>? basesBeingResolved)
         {
+            if (type.IsErrorType())
+            {
+                return;
+            }
+
             var extensions = ArrayBuilder<NamedTypeSymbol>.GetInstance();
             binder.GetImplicitExtensionTypes(extensions, originalBinder);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1933,7 +1933,7 @@ symIsHidden:;
             }
         }
 
-        private static TypeSymbol? RefineAccessThroughType(LookupOptions options, TypeSymbol accessThroughType)
+        private static TypeSymbol? RefineAccessThroughType(LookupOptions options, TypeSymbol? accessThroughType)
         {
             // Normally, when we access a protected instance member, we need to know the type of the receiver so we
             // can determine whether the member is actually accessible in the containing type.  There is one exception:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -639,7 +639,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// binder because extension method search stops at the first applicable
         /// method group from the nearest enclosing namespace.
         /// </summary>
-        internal void LookupExtensionMethodsInSingleBinder(ExtensionScope scope, LookupResult result, string? name, int arity, LookupOptions options, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private void LookupExtensionMethodsInSingleBinder(ExtensionScope scope, LookupResult result, string? name, int arity, LookupOptions options, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             var methods = ArrayBuilder<MethodSymbol>.GetInstance();
             var binder = scope.Binder;
@@ -1870,6 +1870,7 @@ symIsHidden:;
                 new CSDiagnosticInfo(ErrorCode.ERR_BindToBogusProp1, symbol, method1 ?? method2);
         }
 
+#nullable enable
         /// <summary>
         /// Used by Add*LookupSymbolsInfo* to determine whether the symbol is of interest.
         /// Distinguish from <see cref="CheckViability"/>, which performs an analogous task for LookupSymbols*.
@@ -1877,7 +1878,7 @@ symIsHidden:;
         /// <remarks>
         /// Does not consider <see cref="Symbol.CanBeReferencedByName"/> - that is left to the caller.
         /// </remarks>
-        internal bool CanAddLookupSymbolInfo(Symbol symbol, LookupOptions options, LookupSymbolsInfo info, TypeSymbol accessThroughType, AliasSymbol aliasSymbol = null)
+        internal bool CanAddLookupSymbolInfo(Symbol symbol, LookupOptions options, LookupSymbolsInfo info, TypeSymbol? accessThroughType, AliasSymbol? aliasSymbol = null)
         {
             Debug.Assert(symbol.Kind != SymbolKind.Alias, "It is the caller's responsibility to unwrap aliased symbols.");
             Debug.Assert(aliasSymbol == null || aliasSymbol.GetAliasTarget(basesBeingResolved: null) == symbol);
@@ -1932,7 +1933,7 @@ symIsHidden:;
             }
         }
 
-        private static TypeSymbol RefineAccessThroughType(LookupOptions options, TypeSymbol accessThroughType)
+        private static TypeSymbol? RefineAccessThroughType(LookupOptions options, TypeSymbol accessThroughType)
         {
             // Normally, when we access a protected instance member, we need to know the type of the receiver so we
             // can determine whether the member is actually accessible in the containing type.  There is one exception:
@@ -1941,6 +1942,7 @@ symIsHidden:;
                 ? null
                 : accessThroughType;
         }
+#nullable disable
 
         /// <summary>
         /// A symbol is accessible for referencing in a cref if it is in the same assembly as the reference
@@ -2203,7 +2205,7 @@ symIsHidden:;
 
             void addMemberLookupSymbolsInfoInExtension(LookupSymbolsInfo result, TypeSymbol type, LookupOptions options, Binder originalBinder)
             {
-                AddMemberLookupSymbolsInfoWithoutInheritance(result, type, options, originalBinder, accessThroughType: type);
+                AddMemberLookupSymbolsInfoWithoutInheritance(result, type, options, originalBinder, accessThroughType: null);
 
                 if (type.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
                 {
@@ -2286,7 +2288,8 @@ symIsHidden:;
             }
         }
 
-        private static void AddMemberLookupSymbolsInfoWithoutInheritance(LookupSymbolsInfo result, TypeSymbol type, LookupOptions options, Binder originalBinder, TypeSymbol accessThroughType)
+#nullable enable
+        private static void AddMemberLookupSymbolsInfoWithoutInheritance(LookupSymbolsInfo result, TypeSymbol type, LookupOptions options, Binder originalBinder, TypeSymbol? accessThroughType)
         {
             var candidateMembers = result.FilterName != null ? GetCandidateMembers(type, result.FilterName, options, originalBinder) : GetCandidateMembers(type, options, originalBinder);
             foreach (var symbol in candidateMembers)
@@ -2297,6 +2300,7 @@ symIsHidden:;
                 }
             }
         }
+#nullable disable
 
         private void AddWinRTMembersLookupSymbolsInfo(LookupSymbolsInfo result, NamedTypeSymbol type, LookupOptions options, Binder originalBinder, TypeSymbol accessThroughType)
         {
@@ -2378,7 +2382,6 @@ symIsHidden:;
 
         internal void AddImplicitExtensionMemberLookupSymbolsInfoForType(LookupSymbolsInfo result, TypeSymbol type, LookupOptions options, Binder originalBinder)
         {
-            var accessThroughType = type;
             if (type.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
             {
                 type = extendedType;
@@ -2391,7 +2394,7 @@ symIsHidden:;
 
                 foreach (NamedTypeSymbol extension in compatibleExtensions)
                 {
-                    AddMemberLookupSymbolsInfoWithoutInheritance(result, extension, options, scope.Binder, accessThroughType: accessThroughType);
+                    AddMemberLookupSymbolsInfoWithoutInheritance(result, extension, options, scope.Binder, accessThroughType: null);
                 }
 
                 compatibleExtensions.Clear();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1478,6 +1478,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SymbolKind.Method:
                     return new BoundMethodGroup(
                         syntax,
+                        typeArgumentsSyntax,
                         typeArguments,
                         receiver,
                         plainName,

--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -72,9 +72,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return true; }
         }
 
+#nullable enable
         internal override void GetCandidateExtensionMethods(
             ArrayBuilder<MethodSymbol> methods,
-            string name,
+            string? name,
             int arity,
             LookupOptions options,
             Binder originalBinder)
@@ -84,6 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ((NamespaceSymbol)_container).GetExtensionMethods(methods, name, arity, options);
             }
         }
+#nullable disable
 
         internal override void GetImplicitExtensionTypes(ArrayBuilder<NamedTypeSymbol> extensions, Binder originalBinder)
         {

--- a/src/Compilers/CSharp/Portable/Binder/InSubmissionClassBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InSubmissionClassBinder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override void GetCandidateExtensionMethods(
             ArrayBuilder<MethodSymbol> methods,
-            string name,
+            string? name,
             int arity,
             LookupOptions options,
             Binder originalBinder)

--- a/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
@@ -75,9 +75,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         UseBaseReferenceAccessibility = 1 << 9,
 
         /// <summary>
-        /// Include extension methods.
+        /// Include extension methods and extension type members.
         /// </summary>
-        IncludeExtensionMethods = 1 << 10,
+        IncludeExtensionMethodsAndMembers = 1 << 10,
 
         /// <summary>
         /// Consider only attribute types.

--- a/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Include extension methods and extension type members.
         /// </summary>
-        IncludeExtensionMethodsAndMembers = 1 << 10,
+        IncludeExtensionMembers = 1 << 10, // PROTOTYPE(instance) confirm we want to use a single flag for both extension methods and extension type members
 
         /// <summary>
         /// Consider only attribute types.

--- a/src/Compilers/CSharp/Portable/Binder/WithUsingNamespacesAndTypesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithUsingNamespacesAndTypesBinder.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override void GetCandidateExtensionMethods(
             ArrayBuilder<MethodSymbol> methods,
-            string name,
+            string? name,
             int arity,
             LookupOptions options,
             Binder originalBinder)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundMethodGroup.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundMethodGroup.cs
@@ -54,6 +54,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public SeparatedSyntaxList<TypeSyntax> TypeArgumentsSyntax
+            => NameSyntax is GenericNameSyntax genericName ? genericName.TypeArgumentList.Arguments : default;
+
         public BoundExpression? InstanceOpt
         {
             get

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundMethodGroup.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundMethodGroup.cs
@@ -12,15 +12,16 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public BoundMethodGroup(
             SyntaxNode syntax,
+            SeparatedSyntaxList<TypeSyntax> typeArgumentsSyntax,
             ImmutableArray<TypeWithAnnotations> typeArgumentsOpt,
             BoundExpression receiverOpt,
             string name,
             ImmutableArray<MethodSymbol> methods,
             LookupResult lookupResult,
             BoundMethodGroupFlags flags,
-            Binder binder,
-            bool hasErrors = false)
-            : this(syntax, typeArgumentsOpt, name, methods, lookupResult.SingleSymbolOrDefault, lookupResult.Error, flags, functionType: GetFunctionType(binder, syntax), receiverOpt, lookupResult.Kind, hasErrors)
+            Binder binder, bool hasErrors = false)
+            : this(syntax, typeArgumentsSyntax, typeArgumentsOpt, name, methods, lookupResult.SingleSymbolOrDefault,
+                  lookupResult.Error, flags, functionType: GetFunctionType(binder, syntax), receiverOpt, lookupResult.Kind, hasErrors)
         {
             FunctionType?.SetExpression(this);
         }
@@ -53,9 +54,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
         }
-
-        public SeparatedSyntaxList<TypeSyntax> TypeArgumentsSyntax
-            => NameSyntax is GenericNameSyntax genericName ? genericName.TypeArgumentList.Arguments : default;
 
         public BoundExpression? InstanceOpt
         {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1787,6 +1787,7 @@
     <!-- SPEC: A method group is a set of overloaded methods resulting from a member lookup. 
          SPEC: A method group may have an associated instance expression and 
          SPEC: an associated type argument list. -->
+    <Field Name="TypeArgumentsSyntax" Type="SeparatedSyntaxList&lt;TypeSyntax>" Null="NotApplicable"/>
     <Field Name="TypeArgumentsOpt" Type="ImmutableArray&lt;TypeWithAnnotations&gt;" Null="allow"/>
     <Field Name="Name" Type="string" Null="disallow"/>
     <Field Name="Methods" Type="ImmutableArray&lt;MethodSymbol&gt;" />

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1770,10 +1770,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    if (arities is null)
-                    {
-                        throw ExceptionUtilities.Unreachable();
-                    }
+                    Debug.Assert(arities is not null);
 
                     // The name maps to multiple symbols. Actually do a real lookup so 
                     // that we will properly figure out hiding and whatnot.
@@ -1800,7 +1797,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (lookupResult.IsMultiViable)
                 {
-                    if (lookupResult.Symbols.Any(t => t.Kind == SymbolKind.NamedType || t.Kind == SymbolKind.Namespace || t.Kind == SymbolKind.ErrorType))
+                    Debug.Assert(!lookupResult.Symbols.Any(t => t.Kind is SymbolKind.ErrorType or SymbolKind.Namespace));
+                    if (lookupResult.Symbols.Any(t => t.Kind is SymbolKind.NamedType))
                     {
                         // binder.ResultSymbol is defined only for type/namespace lookups
                         bool wasError;

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -344,7 +344,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal void DoGetExtensionMethods(ArrayBuilder<MethodSymbol> methods, string nameOpt, int arity, LookupOptions options)
+#nullable enable
+        internal void DoGetExtensionMethods(ArrayBuilder<MethodSymbol> methods, string? nameOpt, int arity, LookupOptions options)
         {
             var members = nameOpt == null
                 ? this.GetMembersUnordered()
@@ -373,6 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
         }
+#nullable disable
 
         // TODO: Probably should provide similar accessors for static constructor, destructor, 
         // TODO: operators, conversions.

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -322,6 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+#nullable enable
         /// <summary>
         /// Add all extension methods in this namespace to the given list. If name or arity
         /// or both are provided, only those extension methods that match are included.
@@ -330,7 +331,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="nameOpt">Optional method name</param>
         /// <param name="arity">Method arity</param>
         /// <param name="options">Lookup options</param>
-        internal virtual void GetExtensionMethods(ArrayBuilder<MethodSymbol> methods, string nameOpt, int arity, LookupOptions options)
+        internal virtual void GetExtensionMethods(ArrayBuilder<MethodSymbol> methods, string? nameOpt, int arity, LookupOptions options)
         {
             var assembly = this.ContainingAssembly;
 
@@ -350,6 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 type.DoGetExtensionMethods(methods, nameOpt, arity, options);
             }
         }
+#nullable disable
 
         internal string QualifiedName
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -365,11 +365,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // Nested type parameter references might not be valid in error scenarios.
                         //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.ConstraintTypes));
                         //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(ImmutableArray<TypeSymbol>.CreateFrom(this.Interfaces)));
-
-                        // PROTOTYPE(static) depending on the resolution for test ExtensionMemberLookup_MatchingExtendedType_GenericMember_TypeOnlyContext_InvalidGenericExtension
-                        //   we may be able to restore these assertions
-                        //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.EffectiveBaseClassNoUseSiteDiagnostics));
-                        //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.DeducedBaseTypeNoUseSiteDiagnostics));
+                        Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.EffectiveBaseClassNoUseSiteDiagnostics));
+                        Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.DeducedBaseTypeNoUseSiteDiagnostics));
                         break;
 
                     case CompletionPart.None:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -365,8 +365,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // Nested type parameter references might not be valid in error scenarios.
                         //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.ConstraintTypes));
                         //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(ImmutableArray<TypeSymbol>.CreateFrom(this.Interfaces)));
-                        Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.EffectiveBaseClassNoUseSiteDiagnostics));
-                        Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.DeducedBaseTypeNoUseSiteDiagnostics));
+
+                        // PROTOTYPE(static) depending on the resolution for test ExtensionMemberLookup_MatchingExtendedType_GenericMember_TypeOnlyContext_InvalidGenericExtension
+                        //   we may be able to restore these assertions
+                        //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.EffectiveBaseClassNoUseSiteDiagnostics));
+                        //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.DeducedBaseTypeNoUseSiteDiagnostics));
                         break;
 
                     case CompletionPart.None:

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -52,10 +52,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(extension is not null);
             Debug.Assert(type is not null);
+            map = null;
 
             if (type.IsErrorType())
             {
-                map = null;
                 return false;
             }
 
@@ -64,14 +64,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (SourceExtensionTypeSymbol.CheckUnderspecifiedGenericExtension(extensionUnderlyingType, extension.TypeParameters,
                     BindingDiagnosticBag.Discarded, Location.None, extension))
             {
-                map = null;
                 return false;
             }
 
             // PROTOTYPE we'll want to adjust the handling for differences that aren't relevant to the CLR, such as object/dynamic
             if (TypeSymbol.Equals(extensionUnderlyingType, type, TypeCompareKind.CLRSignatureCompareOptions))
             {
-                map = null;
                 return true;
             }
 
@@ -79,7 +77,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool result = CanUnifyHelper(extensionUnderlyingType, type, onlySubstituteInLHS: true, ref substitution);
             if (!result)
             {
-                map = null;
                 return false;
             }
 
@@ -99,7 +96,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We cannot allow any of the type parameters of the extension's containing type to be substituted
             if (hasSubstitutionForContainingTypeTypeParameter(extension.ContainingType, substitution))
             {
-                map = null;
                 return false;
             }
 

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -12186,7 +12186,7 @@ implicit extension E for C
 }
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
-        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify)
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("E+Nested`1[System.String]"), verify: Verification.FailsPEVerify)
            .VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.First();

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -7107,9 +7107,17 @@ class C
             Assert.Equal(CandidateReason.None, info.CandidateReason);
             Assert.Equal(0, info.CandidateSymbols.Length);
 
-            // No lookup results.
             var derivedInterface = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("Derived");
-            Assert.Equal(0, model.LookupSymbols(syntax.SpanStart, derivedInterface).Length);
+            AssertEx.SetEqual([
+                "System.String? System.Object.ToString()",
+                "System.Boolean System.Object.Equals(System.Object? obj)",
+                "System.Boolean System.Object.Equals(System.Object? objA, System.Object? objB)",
+                "void System.Object.Finalize()",
+                "System.Int32 System.Object.GetHashCode()",
+                "System.Type System.Object.GetType()",
+                "System.Object System.Object.MemberwiseClone()",
+                "System.Boolean System.Object.ReferenceEquals(System.Object? objA, System.Object? objB)"],
+                model.LookupSymbols(syntax.SpanStart, derivedInterface).ToTestDisplayStrings());
         }
 
         [Fact]


### PR DESCRIPTION
... and fix nested generic extension type scenario

Note: only `LookupStaticMembers` and `LookupNamespacesAndTypes` are implemented. `LookupSymbols` will be implemented later (as we need to integrate the lookup for extension methods and extension type members before implementing it).

Relates to test plan https://github.com/dotnet/roslyn/issues/66722