### PR TITLE
Remove less individual sync calls to get compilation options.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -279,7 +279,7 @@ internal sealed class SolutionStateChecksums(
                         result[projectStateChecksums.Info] = projectState.Attributes;
 
                     if (searchingChecksumsLeft.Remove(projectStateChecksums.CompilationOptions))
-                        result[projectStateChecksums.CompilationOptions] = projectState.CompilationOptions;
+                        result[projectStateChecksums.CompilationOptions] = projectState.CompilationOptions!;
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -277,6 +277,9 @@ internal sealed class SolutionStateChecksums(
 
                     if (searchingChecksumsLeft.Remove(projectStateChecksums.Info))
                         result[projectStateChecksums.Info] = projectState.Attributes;
+
+                    if (searchingChecksumsLeft.Remove(projectStateChecksums.CompilationOptions))
+                        result[projectStateChecksums.CompilationOptions] = projectState.CompilationOptions;
                 }
             }
         }

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -22,6 +22,14 @@ namespace Microsoft.CodeAnalysis.Remote;
 internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionAssetCache assetCache, IAssetSource assetSource, ISerializerService serializerService)
     : AbstractAssetProvider
 {
+    private const string s_logFile = @"c:\temp\sync\synclog.txt";
+    private static readonly SharedStopwatch s_start = SharedStopwatch.StartNew();
+
+    static AssetProvider()
+    {
+        IOUtilities.PerformIO(() => File.Delete(s_logFile));
+    }
+
     private const int PooledChecksumArraySize = 256;
     private static readonly ObjectPool<Checksum[]> s_checksumPool = new(() => new Checksum[PooledChecksumArraySize], 16);
 
@@ -238,6 +246,8 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
             {
                 var missingChecksumsMemory = new ReadOnlyMemory<Checksum>(missingChecksums, 0, missingChecksumsCount);
 
+                var stopwatch = SharedStopwatch.StartNew();
+
                 await RequestAssetsAsync(
                     assetPath, missingChecksumsMemory,
                     static (
@@ -252,6 +262,17 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
                     },
                     (this, missingChecksums, callback, arg),
                     cancellationToken).ConfigureAwait(false);
+
+                var time = stopwatch.Elapsed;
+                var totalTime = s_start.Elapsed;
+
+                IOUtilities.PerformIO(() =>
+                {
+                    lock (this)
+                    {
+                        File.AppendAllText(s_logFile, $"{missingChecksumsCount},{checksums.Count},{time},{totalTime},{typeof(T).Name}\r\n");
+                    }
+                });
             }
 
             if (usePool)

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -22,14 +22,6 @@ namespace Microsoft.CodeAnalysis.Remote;
 internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionAssetCache assetCache, IAssetSource assetSource, ISerializerService serializerService)
     : AbstractAssetProvider
 {
-    private const string s_logFile = @"c:\temp\sync\synclog.txt";
-    private static readonly SharedStopwatch s_start = SharedStopwatch.StartNew();
-
-    static AssetProvider()
-    {
-        IOUtilities.PerformIO(() => File.Delete(s_logFile));
-    }
-
     private const int PooledChecksumArraySize = 256;
     private static readonly ObjectPool<Checksum[]> s_checksumPool = new(() => new Checksum[PooledChecksumArraySize], 16);
 
@@ -246,8 +238,6 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
             {
                 var missingChecksumsMemory = new ReadOnlyMemory<Checksum>(missingChecksums, 0, missingChecksumsCount);
 
-                var stopwatch = SharedStopwatch.StartNew();
-
                 await RequestAssetsAsync(
                     assetPath, missingChecksumsMemory,
                     static (
@@ -262,17 +252,6 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
                     },
                     (this, missingChecksums, callback, arg),
                     cancellationToken).ConfigureAwait(false);
-
-                var time = stopwatch.Elapsed;
-                var totalTime = s_start.Elapsed;
-
-                IOUtilities.PerformIO(() =>
-                {
-                    lock (this)
-                    {
-                        File.AppendAllText(s_logFile, $"{missingChecksumsCount},{checksums.Count},{time},{totalTime},{typeof(T).Name}\r\n");
-                    }
-                });
             }
 
             if (usePool)

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -243,8 +243,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 Dictionary<ProjectId, ProjectStateChecksums> newProjectIdToStateChecksums,
                 CancellationToken cancellationToken)
             {
-                // Note: it's common to see a whole lot of project-infos change.  So attempt to collect that in one go
-                // if we can.
+                // Note: it's common to need to collect a large set of project-attributes and compilation options.  So
+                // attempt to collect all of those in a single call for each kind instead of a call for each instance
+                // needed.
                 {
                     using var _ = PooledHashSet<Checksum>.GetInstance(out var projectItemChecksums);
                     foreach (var (_, newProjectChecksums) in newProjectIdToStateChecksums)


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/72930.

before, we make nearly 400 calls to get compilation options:

![image](https://github.com/dotnet/roslyn/assets/4564579/28eb8e19-c279-4b54-b47f-30721b19d6fb)

After, it's just 8:

![image](https://github.com/dotnet/roslyn/assets/4564579/b11983c3-38a9-4f04-b335-5feadd5f8bcc)

![image](https://github.com/dotnet/roslyn/assets/4564579/292f9250-1606-4c48-8f3e-6f619dc4792e)

