### PR TITLE
Update `InitializeHandler` to support `VSInternalClientCapabilities`

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 [Method(Methods.InitializeName)]
-internal class InitializeHandler : ILspServiceRequestHandler<InitializeParams, InitializeResult>
+internal class InitializeHandler : ILspServiceRequestHandler<VSInternalInitializeParams, InitializeResult>
 {
     public InitializeHandler()
     {
@@ -21,7 +21,7 @@ internal class InitializeHandler : ILspServiceRequestHandler<InitializeParams, I
     public bool MutatesSolutionState => true;
     public bool RequiresLSPSolution => false;
 
-    public Task<InitializeResult> HandleRequestAsync(InitializeParams request, RequestContext context, CancellationToken cancellationToken)
+    public Task<InitializeResult> HandleRequestAsync(VSInternalInitializeParams request, RequestContext context, CancellationToken cancellationToken)
     {
         var clientCapabilitiesManager = context.GetRequiredLspService<IInitializeManager>();
         var clientCapabilities = clientCapabilitiesManager.TryGetClientCapabilities();

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalClientCapabilities.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalClientCapabilities.cs
@@ -18,10 +18,10 @@ namespace Roslyn.LanguageServer.Protocol
         /// </summary>
         [DataMember(Name = "textDocument")]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public VSInternalTextDocumentClientCapabilities? VSInternalTextDocument
+        public new VSInternalTextDocumentClientCapabilities? TextDocument
         {
-            get => TextDocument as VSInternalTextDocumentClientCapabilities;
-            set => TextDocument = value;
+            get => base.TextDocument as VSInternalTextDocumentClientCapabilities;
+            set => base.TextDocument = value;
         }
 
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalClientCapabilities.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalClientCapabilities.cs
@@ -8,11 +8,22 @@ namespace Roslyn.LanguageServer.Protocol
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Extension class for ClientCapabilities with fields specific to Visual Studio.
+    /// Extension class for <see cref="ClientCapabilities"/> with fields specific to Visual Studio.
     /// </summary>
     [DataContract]
     internal class VSInternalClientCapabilities : ClientCapabilities
     {
+        /// <summary>
+        /// Gets or sets the text document capabilities from the Visual Studio client.
+        /// </summary>
+        [DataMember(Name = "textDocument")]
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public VSInternalTextDocumentClientCapabilities? VSInternalTextDocument
+        {
+            get => TextDocument as VSInternalTextDocumentClientCapabilities;
+            set => TextDocument = value;
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether client supports Visual Studio extensions.
         /// </summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInitializeParams.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInitializeParams.cs
@@ -16,10 +16,10 @@ namespace Roslyn.LanguageServer.Protocol
         /// Gets or sets the capabilities supported by the Visual Studio client.
         /// </summary>
         [DataMember(Name = "capabilities")]
-        public VSInternalClientCapabilities VSInternalCapabilities
+        public new VSInternalClientCapabilities Capabilities
         {
-            get => Capabilities as VSInternalClientCapabilities;
-            set => Capabilities = value;
+            get => base.Capabilities as VSInternalClientCapabilities;
+            set => base.Capabilities = value;
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInitializeParams.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInitializeParams.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.LanguageServer.Protocol
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Extension class for <see cref="InitializeParams"/> with fields specific to Visual Studio.
+    /// </summary>
+    [DataContract]
+    internal class VSInternalInitializeParams : InitializeParams
+    {
+        /// <summary>
+        /// Gets or sets the capabilities supported by the Visual Studio client.
+        /// </summary>
+        [DataMember(Name = "capabilities")]
+        public VSInternalClientCapabilities VSInternalCapabilities
+        {
+            get => Capabilities as VSInternalClientCapabilities;
+            set => Capabilities = value;
+        }
+    }
+}

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var clientCapabilities = new LSP.VSInternalClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
-                TextDocument = new TextDocumentClientCapabilities()
+                TextDocument = new LSP.VSInternalTextDocumentClientCapabilities()
                 {
                     Completion = new VSInternalCompletionSetting()
                     {
@@ -138,7 +138,7 @@ class B : A
             var clientCapabilities = new LSP.VSInternalClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
-                TextDocument = new LSP.TextDocumentClientCapabilities
+                TextDocument = new LSP.VSInternalTextDocumentClientCapabilities
                 {
                     Completion = new CompletionSetting
                     {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var clientCapabilities = new LSP.VSInternalClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
-                TextDocument = new LSP.TextDocumentClientCapabilities
+                TextDocument = new LSP.VSInternalTextDocumentClientCapabilities
                 {
                     Completion = new LSP.VSInternalCompletionSetting
                     {
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var clientCapabilities = new LSP.VSInternalClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
-                TextDocument = new LSP.TextDocumentClientCapabilities
+                TextDocument = new LSP.VSInternalTextDocumentClientCapabilities
                 {
                     Completion = new LSP.VSInternalCompletionSetting
                     {
@@ -561,7 +561,7 @@ class A
             var clientCapabilities = new LSP.VSInternalClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
-                TextDocument = new LSP.TextDocumentClientCapabilities
+                TextDocument = new LSP.VSInternalTextDocumentClientCapabilities
                 {
                     Completion = new LSP.VSInternalCompletionSetting
                     {

--- a/src/Tools/ExternalAccess/Xaml/Internal/ClientCapabilityProvider.cs
+++ b/src/Tools/ExternalAccess/Xaml/Internal/ClientCapabilityProvider.cs
@@ -73,6 +73,12 @@ internal class ClientCapabilityProvider : IClientCapabilityProvider
                 return _clientCapabilities?.Workspace?.DidChangeConfiguration?.DynamicRegistration == true;
             case LSP.Methods.WorkspaceDidChangeWatchedFilesName:
                 return _clientCapabilities?.Workspace?.DidChangeWatchedFiles?.DynamicRegistration == true;
+            case VSInternalMethods.OnAutoInsertName:
+                if (_clientCapabilities.TextDocument is VSInternalTextDocumentClientCapabilities internalTextDocumentClientCapabilities)
+                {
+                    return internalTextDocumentClientCapabilities.OnAutoInsert?.DynamicRegistration == true;
+                }
+                return false;
             default:
                 throw new InvalidOperationException($"Unsupported dynamic registration method: {methodName}");
         }

--- a/src/Tools/IdeBenchmarks/Lsp/LspCompletionBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/Lsp/LspCompletionBenchmarks.cs
@@ -75,7 +75,7 @@ class A
 }";
             _testServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace: false, new LSP.VSInternalClientCapabilities
             {
-                TextDocument = new LSP.TextDocumentClientCapabilities
+                TextDocument = new LSP.VSInternalTextDocumentClientCapabilities
                 {
                     Completion = new LSP.CompletionSetting
                     {

--- a/src/Tools/IdeBenchmarks/Lsp/LspCompletionSerializationBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/Lsp/LspCompletionSerializationBenchmarks.cs
@@ -87,7 +87,7 @@ class A
 }";
             await using var testServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace: false, new LSP.VSInternalClientCapabilities
             {
-                TextDocument = new LSP.TextDocumentClientCapabilities
+                TextDocument = new LSP.VSInternalTextDocumentClientCapabilities
                 {
                     Completion = new LSP.CompletionSetting
                     {


### PR DESCRIPTION
Add support for clients that support some or all `VSInternalClientCapabilities`. Unsupported capabilities result in null values.

Validated with VS Code with and without the new OnAutoInsert support from [PR 7033: Created OnAutoInsertFeature to support dynamic capability registration](https://github.com/dotnet/vscode-csharp/pull/7033)