### PR TITLE
Fix notification handler tests to use per server task completion instances

### DIFF
--- a/src/Features/LanguageServer/ProtocolUnitTests/HandlerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/HandlerTests.cs
@@ -135,15 +135,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 
         [ExportCSharpVisualBasicStatelessLspService(typeof(TestDocumentHandler)), PartNotDiscoverable, Shared]
         [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
-        internal sealed class TestDocumentHandler : ILspServiceDocumentRequestHandler<TestRequestTypeOne, string>
+        [method: ImportingConstructor]
+        [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        internal sealed class TestDocumentHandler() : ILspServiceDocumentRequestHandler<TestRequestTypeOne, string>
         {
             public const string MethodName = nameof(TestDocumentHandler);
-
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public TestDocumentHandler()
-            {
-            }
 
             public bool MutatesSolutionState => true;
             public bool RequiresLSPSolution => true;
@@ -161,15 +157,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 
         [ExportCSharpVisualBasicStatelessLspService(typeof(TestRequestHandlerWithNoParams)), PartNotDiscoverable, Shared]
         [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
-        internal sealed class TestRequestHandlerWithNoParams : ILspServiceRequestHandler<string>
+        [method: ImportingConstructor]
+        [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        internal sealed class TestRequestHandlerWithNoParams() : ILspServiceRequestHandler<string>
         {
             public const string MethodName = nameof(TestRequestHandlerWithNoParams);
-
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public TestRequestHandlerWithNoParams()
-            {
-            }
 
             public bool MutatesSolutionState => true;
             public bool RequiresLSPSolution => true;
@@ -181,15 +173,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
-        internal sealed class TestNotificationHandler : ILspServiceNotificationHandler<TestRequestTypeOne>
+        internal sealed class TestNotificationHandler() : ILspServiceNotificationHandler<TestRequestTypeOne>
         {
             public const string MethodName = nameof(TestNotificationHandler);
-            public readonly TaskCompletionSource<string> ResultSource;
-
-            public TestNotificationHandler()
-            {
-                ResultSource = new TaskCompletionSource<string>();
-            }
+            public readonly TaskCompletionSource<string> ResultSource = new();
 
             public bool MutatesSolutionState => true;
             public bool RequiresLSPSolution => true;
@@ -205,14 +192,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         /// Exported via a factory as we need a new instance for each server (the task completion result should be unique per server).
         /// </summary>
         [ExportCSharpVisualBasicLspServiceFactory(typeof(TestNotificationHandler)), PartNotDiscoverable, Shared]
-        internal sealed class TestNotificationHandlerFactory : ILspServiceFactory
+        [method: ImportingConstructor]
+        [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        internal sealed class TestNotificationHandlerFactory() : ILspServiceFactory
         {
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public TestNotificationHandlerFactory()
-            {
-            }
-
             public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
             {
                 return new TestNotificationHandler();
@@ -220,15 +203,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
-        internal sealed class TestNotificationWithoutParamsHandler : ILspServiceNotificationHandler
+        internal sealed class TestNotificationWithoutParamsHandler() : ILspServiceNotificationHandler
         {
             public const string MethodName = nameof(TestNotificationWithoutParamsHandler);
-            public readonly TaskCompletionSource<string> ResultSource;
-
-            public TestNotificationWithoutParamsHandler()
-            {
-                ResultSource = new TaskCompletionSource<string>();
-            }
+            public readonly TaskCompletionSource<string> ResultSource = new();
 
             public bool MutatesSolutionState => true;
             public bool RequiresLSPSolution => true;
@@ -244,14 +222,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         /// Exported via a factory as we need a new instance for each server (the task completion result should be unique per server).
         /// </summary>
         [ExportCSharpVisualBasicLspServiceFactory(typeof(TestNotificationWithoutParamsHandler)), PartNotDiscoverable, Shared]
-        internal sealed class TestNotificationWithoutParamsHandlerFactory : ILspServiceFactory
+        [method: ImportingConstructor]
+        [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        internal sealed class TestNotificationWithoutParamsHandlerFactory() : ILspServiceFactory
         {
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public TestNotificationWithoutParamsHandlerFactory()
-            {
-            }
-
             public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
             {
                 return new TestNotificationWithoutParamsHandler();
@@ -263,14 +237,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         /// </summary>
         [ExportCSharpVisualBasicStatelessLspService(typeof(TestLanguageSpecificHandler)), PartNotDiscoverable, Shared]
         [LanguageServerEndpoint(TestDocumentHandler.MethodName, LanguageNames.FSharp)]
-        internal sealed class TestLanguageSpecificHandler : ILspServiceDocumentRequestHandler<TestRequestTypeOne, string>
+        [method: ImportingConstructor]
+        [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        internal sealed class TestLanguageSpecificHandler() : ILspServiceDocumentRequestHandler<TestRequestTypeOne, string>
         {
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public TestLanguageSpecificHandler()
-            {
-            }
-
             public bool MutatesSolutionState => true;
             public bool RequiresLSPSolution => true;
 
@@ -291,14 +261,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         /// </summary>
         [ExportCSharpVisualBasicStatelessLspService(typeof(TestLanguageSpecificHandlerWithDifferentParams)), PartNotDiscoverable, Shared]
         [LanguageServerEndpoint(TestDocumentHandler.MethodName, LanguageNames.VisualBasic)]
-        internal sealed class TestLanguageSpecificHandlerWithDifferentParams : ILspServiceDocumentRequestHandler<TestRequestTypeTwo, string>
+        [method: ImportingConstructor]
+        [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        internal sealed class TestLanguageSpecificHandlerWithDifferentParams() : ILspServiceDocumentRequestHandler<TestRequestTypeTwo, string>
         {
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public TestLanguageSpecificHandlerWithDifferentParams()
-            {
-            }
-
             public bool MutatesSolutionState => true;
             public bool RequiresLSPSolution => true;
 
@@ -319,14 +285,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         /// </summary>
         [ExportCSharpVisualBasicStatelessLspService(typeof(TestDuplicateLanguageSpecificHandler)), PartNotDiscoverable, Shared]
         [LanguageServerEndpoint(TestDocumentHandler.MethodName, LanguageNames.FSharp)]
-        internal sealed class TestDuplicateLanguageSpecificHandler : ILspServiceRequestHandler<string>
+        [method: ImportingConstructor]
+        [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        internal sealed class TestDuplicateLanguageSpecificHandler() : ILspServiceRequestHandler<string>
         {
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public TestDuplicateLanguageSpecificHandler()
-            {
-            }
-
             public bool MutatesSolutionState => true;
             public bool RequiresLSPSolution => true;
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/HandlerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/HandlerTests.cs
@@ -28,12 +28,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         protected override TestComposition Composition => base.Composition.AddParts(
-            typeof(DocumentHandler),
-            typeof(RequestHandlerWithNoParams),
-            typeof(NotificationHandlerFactory),
-            typeof(NotificationWithoutParamsHandlerFactory),
-            typeof(LanguageSpecificHandler),
-            typeof(LanguageSpecificHandlerWithDifferentParams));
+            typeof(TestDocumentHandler),
+            typeof(TestRequestHandlerWithNoParams),
+            typeof(TestNotificationHandlerFactory),
+            typeof(TestNotificationWithoutParamsHandlerFactory),
+            typeof(TestLanguageSpecificHandler),
+            typeof(TestLanguageSpecificHandlerWithDifferentParams));
 
         [Theory, CombinatorialData]
         public async Task CanExecuteRequestHandler(bool mutatingLspWorkspace)
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             {
                 Uri = ProtocolConversions.CreateAbsoluteUri(@"C:\test.cs")
             });
-            var response = await server.ExecuteRequestAsync<TestRequestTypeOne, string>(DocumentHandler.MethodName, request, CancellationToken.None);
-            Assert.Equal(typeof(DocumentHandler).Name, response);
+            var response = await server.ExecuteRequestAsync<TestRequestTypeOne, string>(TestDocumentHandler.MethodName, request, CancellationToken.None);
+            Assert.Equal(typeof(TestDocumentHandler).Name, response);
         }
 
         [Theory, CombinatorialData]
@@ -53,8 +53,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         {
             await using var server = await CreateTestLspServerAsync("", mutatingLspWorkspace);
 
-            var response = await server.ExecuteRequest0Async<string>(RequestHandlerWithNoParams.MethodName, CancellationToken.None);
-            Assert.Equal(typeof(RequestHandlerWithNoParams).Name, response);
+            var response = await server.ExecuteRequest0Async<string>(TestRequestHandlerWithNoParams.MethodName, CancellationToken.None);
+            Assert.Equal(typeof(TestRequestHandlerWithNoParams).Name, response);
         }
 
         [Theory, CombinatorialData]
@@ -67,9 +67,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
                 Uri = ProtocolConversions.CreateAbsoluteUri(@"C:\test.cs")
             });
 
-            await server.ExecuteNotificationAsync(NotificationHandler.MethodName, request);
-            var response = await server.GetRequiredLspService<NotificationHandler>().ResultSource.Task;
-            Assert.Equal(typeof(NotificationHandler).Name, response);
+            await server.ExecuteNotificationAsync(TestNotificationHandler.MethodName, request);
+            var response = await server.GetRequiredLspService<TestNotificationHandler>().ResultSource.Task;
+            Assert.Equal(typeof(TestNotificationHandler).Name, response);
         }
 
         [Theory, CombinatorialData]
@@ -77,9 +77,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         {
             await using var server = await CreateTestLspServerAsync("", mutatingLspWorkspace);
 
-            await server.ExecuteNotification0Async(NotificationWithoutParamsHandler.MethodName);
-            var response = await server.GetRequiredLspService<NotificationWithoutParamsHandler>().ResultSource.Task;
-            Assert.Equal(typeof(NotificationWithoutParamsHandler).Name, response);
+            await server.ExecuteNotification0Async(TestNotificationWithoutParamsHandler.MethodName);
+            var response = await server.GetRequiredLspService<TestNotificationWithoutParamsHandler>().ResultSource.Task;
+            Assert.Equal(typeof(TestNotificationWithoutParamsHandler).Name, response);
         }
 
         [Theory, CombinatorialData]
@@ -91,8 +91,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             {
                 Uri = ProtocolConversions.CreateAbsoluteUri(@"C:\test.fs")
             });
-            var response = await server.ExecuteRequestAsync<TestRequestTypeOne, string>(DocumentHandler.MethodName, request, CancellationToken.None);
-            Assert.Equal(typeof(LanguageSpecificHandler).Name, response);
+            var response = await server.ExecuteRequestAsync<TestRequestTypeOne, string>(TestDocumentHandler.MethodName, request, CancellationToken.None);
+            Assert.Equal(typeof(TestLanguageSpecificHandler).Name, response);
         }
 
         [Theory, CombinatorialData]
@@ -104,15 +104,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             {
                 Uri = ProtocolConversions.CreateAbsoluteUri(@"C:\test.vb")
             });
-            var response = await server.ExecuteRequestAsync<TestRequestTypeTwo, string>(DocumentHandler.MethodName, request, CancellationToken.None);
-            Assert.Equal(typeof(LanguageSpecificHandlerWithDifferentParams).Name, response);
+            var response = await server.ExecuteRequestAsync<TestRequestTypeTwo, string>(TestDocumentHandler.MethodName, request, CancellationToken.None);
+            Assert.Equal(typeof(TestLanguageSpecificHandlerWithDifferentParams).Name, response);
         }
 
         [Theory, CombinatorialData]
         public async Task ThrowsOnInvalidLanguageSpecificHandler(bool mutatingLspWorkspace)
         {
             // Arrange
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await CreateTestLspServerAsync("", mutatingLspWorkspace, extraExportedTypes: [typeof(DuplicateLanguageSpecificHandler)]));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await CreateTestLspServerAsync("", mutatingLspWorkspace, extraExportedTypes: [typeof(TestDuplicateLanguageSpecificHandler)]));
         }
 
         [Theory, CombinatorialData]
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             await using var server = await CreateTestLspServerAsync("", mutatingLspWorkspace);
 
             var request = new TestRequestTypeThree("value");
-            await Assert.ThrowsAsync<StreamJsonRpc.RemoteInvocationException>(async () => await server.ExecuteRequestAsync<TestRequestTypeThree, string>(DocumentHandler.MethodName, request, CancellationToken.None));
+            await Assert.ThrowsAsync<StreamJsonRpc.RemoteInvocationException>(async () => await server.ExecuteRequestAsync<TestRequestTypeThree, string>(TestDocumentHandler.MethodName, request, CancellationToken.None));
         }
 
         [DataContract]
@@ -133,15 +133,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         [DataContract]
         internal record TestRequestTypeThree([property: DataMember(Name = "someValue")] string SomeValue);
 
-        [ExportCSharpVisualBasicStatelessLspService(typeof(DocumentHandler)), PartNotDiscoverable, Shared]
+        [ExportCSharpVisualBasicStatelessLspService(typeof(TestDocumentHandler)), PartNotDiscoverable, Shared]
         [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
-        internal class DocumentHandler : ILspServiceDocumentRequestHandler<TestRequestTypeOne, string>
+        internal sealed class TestDocumentHandler : ILspServiceDocumentRequestHandler<TestRequestTypeOne, string>
         {
-            public const string MethodName = nameof(DocumentHandler);
+            public const string MethodName = nameof(TestDocumentHandler);
 
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public DocumentHandler()
+            public TestDocumentHandler()
             {
             }
 
@@ -159,15 +159,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             }
         }
 
-        [ExportCSharpVisualBasicStatelessLspService(typeof(RequestHandlerWithNoParams)), PartNotDiscoverable, Shared]
+        [ExportCSharpVisualBasicStatelessLspService(typeof(TestRequestHandlerWithNoParams)), PartNotDiscoverable, Shared]
         [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
-        internal class RequestHandlerWithNoParams : ILspServiceRequestHandler<string>
+        internal sealed class TestRequestHandlerWithNoParams : ILspServiceRequestHandler<string>
         {
-            public const string MethodName = nameof(RequestHandlerWithNoParams);
+            public const string MethodName = nameof(TestRequestHandlerWithNoParams);
 
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public RequestHandlerWithNoParams()
+            public TestRequestHandlerWithNoParams()
             {
             }
 
@@ -181,12 +181,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
-        internal class NotificationHandler : ILspServiceNotificationHandler<TestRequestTypeOne>
+        internal sealed class TestNotificationHandler : ILspServiceNotificationHandler<TestRequestTypeOne>
         {
-            public const string MethodName = nameof(NotificationHandler);
+            public const string MethodName = nameof(TestNotificationHandler);
             public readonly TaskCompletionSource<string> ResultSource;
 
-            public NotificationHandler()
+            public TestNotificationHandler()
             {
                 ResultSource = new TaskCompletionSource<string>();
             }
@@ -204,28 +204,28 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         /// <summary>
         /// Exported via a factory as we need a new instance for each server (the task completion result should be unique per server).
         /// </summary>
-        [ExportCSharpVisualBasicLspServiceFactory(typeof(NotificationHandler)), PartNotDiscoverable, Shared]
-        internal class NotificationHandlerFactory : ILspServiceFactory
+        [ExportCSharpVisualBasicLspServiceFactory(typeof(TestNotificationHandler)), PartNotDiscoverable, Shared]
+        internal sealed class TestNotificationHandlerFactory : ILspServiceFactory
         {
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public NotificationHandlerFactory()
+            public TestNotificationHandlerFactory()
             {
             }
 
             public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
             {
-                return new NotificationHandler();
+                return new TestNotificationHandler();
             }
         }
 
         [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
-        internal class NotificationWithoutParamsHandler : ILspServiceNotificationHandler
+        internal sealed class TestNotificationWithoutParamsHandler : ILspServiceNotificationHandler
         {
-            public const string MethodName = nameof(NotificationWithoutParamsHandler);
+            public const string MethodName = nameof(TestNotificationWithoutParamsHandler);
             public readonly TaskCompletionSource<string> ResultSource;
 
-            public NotificationWithoutParamsHandler()
+            public TestNotificationWithoutParamsHandler()
             {
                 ResultSource = new TaskCompletionSource<string>();
             }
@@ -243,31 +243,31 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         /// <summary>
         /// Exported via a factory as we need a new instance for each server (the task completion result should be unique per server).
         /// </summary>
-        [ExportCSharpVisualBasicLspServiceFactory(typeof(NotificationWithoutParamsHandler)), PartNotDiscoverable, Shared]
-        internal class NotificationWithoutParamsHandlerFactory : ILspServiceFactory
+        [ExportCSharpVisualBasicLspServiceFactory(typeof(TestNotificationWithoutParamsHandler)), PartNotDiscoverable, Shared]
+        internal sealed class TestNotificationWithoutParamsHandlerFactory : ILspServiceFactory
         {
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public NotificationWithoutParamsHandlerFactory()
+            public TestNotificationWithoutParamsHandlerFactory()
             {
             }
 
             public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
             {
-                return new NotificationWithoutParamsHandler();
+                return new TestNotificationWithoutParamsHandler();
             }
         }
 
         /// <summary>
-        /// Defines a language specific handler with the same method as <see cref="DocumentHandler"/>
+        /// Defines a language specific handler with the same method as <see cref="TestDocumentHandler"/>
         /// </summary>
-        [ExportCSharpVisualBasicStatelessLspService(typeof(LanguageSpecificHandler)), PartNotDiscoverable, Shared]
-        [LanguageServerEndpoint(DocumentHandler.MethodName, LanguageNames.FSharp)]
-        internal class LanguageSpecificHandler : ILspServiceDocumentRequestHandler<TestRequestTypeOne, string>
+        [ExportCSharpVisualBasicStatelessLspService(typeof(TestLanguageSpecificHandler)), PartNotDiscoverable, Shared]
+        [LanguageServerEndpoint(TestDocumentHandler.MethodName, LanguageNames.FSharp)]
+        internal sealed class TestLanguageSpecificHandler : ILspServiceDocumentRequestHandler<TestRequestTypeOne, string>
         {
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public LanguageSpecificHandler()
+            public TestLanguageSpecificHandler()
             {
             }
 
@@ -286,16 +286,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         /// <summary>
-        /// Defines a language specific handler with the same method as <see cref="DocumentHandler"/>
+        /// Defines a language specific handler with the same method as <see cref="TestDocumentHandler"/>
         /// but using different request and response types.
         /// </summary>
-        [ExportCSharpVisualBasicStatelessLspService(typeof(LanguageSpecificHandlerWithDifferentParams)), PartNotDiscoverable, Shared]
-        [LanguageServerEndpoint(DocumentHandler.MethodName, LanguageNames.VisualBasic)]
-        internal class LanguageSpecificHandlerWithDifferentParams : ILspServiceDocumentRequestHandler<TestRequestTypeTwo, string>
+        [ExportCSharpVisualBasicStatelessLspService(typeof(TestLanguageSpecificHandlerWithDifferentParams)), PartNotDiscoverable, Shared]
+        [LanguageServerEndpoint(TestDocumentHandler.MethodName, LanguageNames.VisualBasic)]
+        internal sealed class TestLanguageSpecificHandlerWithDifferentParams : ILspServiceDocumentRequestHandler<TestRequestTypeTwo, string>
         {
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public LanguageSpecificHandlerWithDifferentParams()
+            public TestLanguageSpecificHandlerWithDifferentParams()
             {
             }
 
@@ -314,16 +314,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         /// <summary>
-        /// Defines a language specific handler with the same method and language as <see cref="LanguageSpecificHandler"/>
+        /// Defines a language specific handler with the same method and language as <see cref="TestLanguageSpecificHandler"/>
         /// but with different params (an error)
         /// </summary>
-        [ExportCSharpVisualBasicStatelessLspService(typeof(DuplicateLanguageSpecificHandler)), PartNotDiscoverable, Shared]
-        [LanguageServerEndpoint(DocumentHandler.MethodName, LanguageNames.FSharp)]
-        internal class DuplicateLanguageSpecificHandler : ILspServiceRequestHandler<string>
+        [ExportCSharpVisualBasicStatelessLspService(typeof(TestDuplicateLanguageSpecificHandler)), PartNotDiscoverable, Shared]
+        [LanguageServerEndpoint(TestDocumentHandler.MethodName, LanguageNames.FSharp)]
+        internal sealed class TestDuplicateLanguageSpecificHandler : ILspServiceRequestHandler<string>
         {
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public DuplicateLanguageSpecificHandler()
+            public TestDuplicateLanguageSpecificHandler()
             {
             }
 


### PR DESCRIPTION
Reproduced locally using multiple iterations.  Issue was the static task completion source was being re-used across multiple server instances, causing the test to exit too early after a previous test completed.

Fixes failures like https://dnceng-public.visualstudio.com/public/_build/results?buildId=636591&view=ms.vss-test-web.build-test-results-tab&runId=15674606&resultId=230727&paneView=dotnet-dnceng.dnceng-anon-build-release-tasks.helix-anon-test-information-tab

```
[06:38:20.827][Info]Using C# from request text document
 [06:38:20.827][Info]Shutting down
 [06:38:20.827][Error]Could not find appropriate workspace or solution on NotificationHandler
 [06:38:20.827][Start]NotificationHandler
 [06:38:20.827][Warning]
 System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
    at System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
    at Microsoft.CodeAnalysis.LanguageServer.UnitTests.HandlerTests.NotificationHandler.HandleNotificationAsync(TestRequestTypeOne request, RequestContext context, CancellationToken cancellationToken) in /_/src/Features/LanguageServer/ProtocolUnitTests/HandlerTests.cs:line 200
    at Microsoft.CommonLanguageServerProtocol.Framework.QueueItem`3.<StartRequestAsync>d__20.MoveNext() in /_/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/QueueItem.cs:line 162
 [06:38:20.827][End]NotificationHandler
```