### PR TITLE
Restore case insensitivity with file paths and related doc ids in the workspace

### DIFF
--- a/src/Features/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -79,15 +79,17 @@ public class UriTests : AbstractLanguageServerProtocolTests
     {
         var documentFilePath = @"C:\A.cs";
         var markup =
-@$"<Workspace>
-    <Project Language=""C#"" Name=""CSProj1"" CommonReferences=""true"" FilePath=""C:\CSProj1.csproj"">
-        <Document FilePath=""{documentFilePath}"">
-            public class A
-            {{
-            }}
-        </Document>
-    </Project>
-</Workspace>";
+            $$"""
+            <Workspace>
+                <Project Language="C#" Name="CSProj1" CommonReferences="true" FilePath="C:\CSProj1.csproj">
+                    <Document FilePath="{{documentFilePath}}">
+                        public class A
+                        {
+                        }
+                    </Document>
+                </Project>
+            </Workspace>
+            """;
         await using var testLspServer = await CreateXmlTestLspServerAsync(markup, mutatingLspWorkspace);
 
         var workspaceDocument = testLspServer.TestWorkspace.CurrentSolution.Projects.Single().Documents.Single();
@@ -95,12 +97,25 @@ public class UriTests : AbstractLanguageServerProtocolTests
 
         await testLspServer.OpenDocumentAsync(expectedDocumentUri).ConfigureAwait(false);
 
-        // Verify file is added to the misc file workspace.
-        var (workspace, _, document) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = expectedDocumentUri }, CancellationToken.None);
-        Assert.False(workspace is LspMiscellaneousFilesWorkspace);
-        AssertEx.NotNull(document);
-        Assert.Equal(expectedDocumentUri, document.GetURI());
-        Assert.Equal(documentFilePath, document.FilePath);
+        // Verify file is not added to the misc file workspace.
+        {
+            var (workspace, _, document) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = expectedDocumentUri }, CancellationToken.None);
+            Assert.False(workspace is LspMiscellaneousFilesWorkspace);
+            AssertEx.NotNull(document);
+            Assert.Equal(expectedDocumentUri, document.GetURI());
+            Assert.Equal(documentFilePath, document.FilePath);
+        }
+
+        // Try again, this time with a uri with different case sensitivity
+        {
+            var lowercaseUri = ProtocolConversions.CreateAbsoluteUri(documentFilePath.ToLowerInvariant());
+            Assert.NotEqual(expectedDocumentUri.AbsolutePath, lowercaseUri.AbsolutePath);
+            var (workspace, _, document) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = lowercaseUri }, CancellationToken.None);
+            Assert.False(workspace is LspMiscellaneousFilesWorkspace);
+            AssertEx.NotNull(document);
+            Assert.Equal(expectedDocumentUri, document.GetURI());
+            Assert.Equal(documentFilePath, document.FilePath);
+        }
     }
 
     [Theory, CombinatorialData]

--- a/src/Features/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -106,7 +106,7 @@ public class UriTests : AbstractLanguageServerProtocolTests
             Assert.Equal(documentFilePath, document.FilePath);
         }
 
-        // Try again, this time with a uri with different case sensitivity
+        // Try again, this time with a uri with different case sensitivity.  This is supported, and is needed by Xaml.
         {
             var lowercaseUri = ProtocolConversions.CreateAbsoluteUri(documentFilePath.ToLowerInvariant());
             Assert.NotEqual(expectedDocumentUri.AbsolutePath, lowercaseUri.AbsolutePath);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -33,6 +33,12 @@ internal readonly record struct StateChange(
 /// </summary>
 internal sealed partial class SolutionState
 {
+    /// <summary>
+    /// Note: this insensitive comparer is bused on many systems.  But we do things this way for copmat with the logic
+    /// we've had on windows since forever.
+    /// </summary>
+    public static readonly StringComparer FilePathComparer = StringComparer.OrdinalIgnoreCase;
+
     // the version of the workspace this solution is from
     public int WorkspaceVersion { get; }
     public string? WorkspaceKind { get; }
@@ -47,7 +53,7 @@ internal sealed partial class SolutionState
     // holds on data calculated based on the AnalyzerReferences list
     private readonly Lazy<HostDiagnosticAnalyzers> _lazyAnalyzers;
 
-    private ImmutableDictionary<string, ImmutableArray<DocumentId>> _lazyFilePathToRelatedDocumentIds = ImmutableDictionary<string, ImmutableArray<DocumentId>>.Empty;
+    private ImmutableDictionary<string, ImmutableArray<DocumentId>> _lazyFilePathToRelatedDocumentIds = ImmutableDictionary<string, ImmutableArray<DocumentId>>.Empty.WithComparers(FilePathComparer);
 
     private SolutionState(
         string? workspaceKind,

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -4845,6 +4845,23 @@ class C
             Assert.Single(solution.GetRelatedDocumentIds(regularDocumentId));
         }
 
+        [Theory, CombinatorialData]
+        public void GetRelatedDocumentsCaseInsensitive(
+            [CombinatorialValues("file", "File", "FILE", "FiLe")] string prefix,
+            [CombinatorialValues("cs", "Cs", "cS", "CS")] string extension)
+        {
+            using var workspace = CreateWorkspace();
+
+            var solution = workspace.CurrentSolution
+                .AddProject("TestProject1", "TestProject1", LanguageNames.CSharp)
+                .AddDocument("File.cs", "", filePath: "File.cs").Project.Solution
+                .AddProject("TestProject2", "TestProject2", LanguageNames.CSharp)
+                .AddDocument("file.cs", "", filePath: "file.cs").Project.Solution;
+
+            // GetDocumentIdsWithFilePath should return two, since it'll count all types of documents
+            Assert.Equal(2, solution.GetDocumentIdsWithFilePath($"{prefix}.{extension}").Length);
+        }
+
         [Fact]
         public async Task TestFrozenPartialSolution1()
         {


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/72959