### PR TITLE
Optimize OOP compilation of HasSourceGenerators.

### DIFF
--- a/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
@@ -33,10 +33,10 @@ internal interface IRemoteSourceGenerationService
         Checksum solutionChecksum, ProjectId projectId, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Whether or not the specified <paramref name="projectId"/> has source generators or not.
+    /// Whether or not the specified analyzer references have source generators or not.
     /// </summary>
     ValueTask<bool> HasGeneratorsAsync(
-        Checksum solutionChecksum, ProjectId projectId, CancellationToken cancellationToken);
+        Checksum solutionChecksum, ProjectId projectId, ImmutableArray<Checksum> analyzerReferenceChecksums, CancellationToken cancellationToken);
 }
 
 /// <summary>

--- a/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneration/IRemoteSourceGenerationService.cs
@@ -36,7 +36,7 @@ internal interface IRemoteSourceGenerationService
     /// Whether or not the specified analyzer references have source generators or not.
     /// </summary>
     ValueTask<bool> HasGeneratorsAsync(
-        Checksum solutionChecksum, ProjectId projectId, ImmutableArray<Checksum> analyzerReferenceChecksums, CancellationToken cancellationToken);
+        Checksum solutionChecksum, ProjectId projectId, ImmutableArray<Checksum> analyzerReferenceChecksums, string language, CancellationToken cancellationToken);
 }
 
 /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState_SourceGenerators.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState_SourceGenerators.cs
@@ -47,7 +47,7 @@ internal partial class SolutionCompilationState
     private static readonly Dictionary<string, AnalyzerReferenceMap> s_languageToAnalyzerReferenceMap = new()
     {
         { LanguageNames.CSharp, new() },
-        {LanguageNames.VisualBasic, new() },
+        { LanguageNames.VisualBasic, new() },
     };
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState_SourceGenerators.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState_SourceGenerators.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -16,6 +17,11 @@ using Microsoft.CodeAnalysis.SourceGeneration;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
+
+// Cache of list of analyzer references to whether or not they have source generators.  Keyed based off
+// IReadOnlyList<AnalyzerReference> so that we can cache the value even as project-states fork based on 
+// document edits.
+using AnalyzerReferenceMap = ConditionalWeakTable<IReadOnlyList<AnalyzerReference>, AsyncLazy<bool>>;
 
 internal partial class SolutionCompilationState
 {
@@ -38,7 +44,11 @@ internal partial class SolutionCompilationState
     /// process (if present) and having it make the determination, without the host necessarily loading generators
     /// itself.
     /// </summary>
-    private static readonly ConditionalWeakTable<ProjectState, AsyncLazy<bool>> s_hasSourceGeneratorsMap = new();
+    private static readonly Dictionary<string, AnalyzerReferenceMap> s_languageToAnalyzerReferenceMap = new()
+    {
+        { LanguageNames.CSharp, new() },
+        {LanguageNames.VisualBasic, new() },
+    };
 
     /// <summary>
     /// This method should only be called in a .net core host like our out of process server.
@@ -97,20 +107,23 @@ internal partial class SolutionCompilationState
         if (projectState.AnalyzerReferences.Count == 0)
             return false;
 
-        if (!s_hasSourceGeneratorsMap.TryGetValue(projectState, out var lazy))
+        if (!RemoteSupportedLanguages.IsSupported(projectState.Language))
+            return false;
+
+        var analyzerReferenceMap = s_languageToAnalyzerReferenceMap[projectState.Language];
+        if (!analyzerReferenceMap.TryGetValue(projectState.AnalyzerReferences, out var lazy))
         {
             // Extracted into local function to prevent allocations in the case where we find a value in the cache.
-            lazy = GetLazy(projectState);
+            lazy = GetLazy(analyzerReferenceMap, projectState);
         }
 
         return await lazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
-        AsyncLazy<bool> GetLazy(ProjectState projectState)
-            => s_hasSourceGeneratorsMap.GetValue(
-                projectState,
-                projectState => AsyncLazy.Create(
-                    static (tuple, cancellationToken) => ComputeHasSourceGeneratorsAsync(tuple.@this, tuple.projectState, cancellationToken),
-                    (@this: this, projectState)));
+        AsyncLazy<bool> GetLazy(AnalyzerReferenceMap analyzerReferenceMap, ProjectState projectState)
+            => analyzerReferenceMap.GetValue(
+                projectState.AnalyzerReferences,
+                _ => AsyncLazy.Create(
+                    cancellationToken => ComputeHasSourceGeneratorsAsync(this, projectState, cancellationToken)));
 
         static async Task<bool> ComputeHasSourceGeneratorsAsync(
             SolutionCompilationState solution, ProjectState projectState, CancellationToken cancellationToken)
@@ -128,7 +141,7 @@ internal partial class SolutionCompilationState
             var result = await client.TryInvokeAsync<IRemoteSourceGenerationService, bool>(
                 solution,
                 projectId,
-                (service, solution, cancellationToken) => service.HasGeneratorsAsync(solution, projectId, analyzerReferences, cancellationToken),
+                (service, solution, cancellationToken) => service.HasGeneratorsAsync(solution, projectId, analyzerReferences, projectState.Language, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
             return result.HasValue && result.Value;
         }

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -57,6 +57,10 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
         await this.SynchronizeAssetsAsync(assetPath, checksums, callback, arg, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// This is the function called when we are <em>not</em> doing an incremental update, but are instead doing a bulk
+    /// full sync.
+    /// </summary>
     public async ValueTask SynchronizeSolutionAssetsAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
     {
         var timer = SharedStopwatch.StartNew();

--- a/src/Workspaces/Remote/ServiceHub/Services/SourceGeneration/RemoteSourceGenerationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SourceGeneration/RemoteSourceGenerationService.cs
@@ -71,11 +71,11 @@ internal sealed partial class RemoteSourceGenerationService(in BrokeredServiceBa
         }, cancellationToken);
     }
 
-    private static readonly ImmutableArray<(string language, AnalyzerReferenceMap analyzerReferenceMap, AnalyzerReferenceMap.CreateValueCallback callback)> s_languageToAnalyzerReferenceMap =
-    [
-        (LanguageNames.CSharp, new(), static analyzerReference => HasSourceGenerators(analyzerReference, LanguageNames.CSharp)),
-        (LanguageNames.VisualBasic, new(), static analyzerReference => HasSourceGenerators(analyzerReference, LanguageNames.VisualBasic))
-    ];
+    private static readonly Dictionary<string, (AnalyzerReferenceMap analyzerReferenceMap, AnalyzerReferenceMap.CreateValueCallback callback)> s_languageToAnalyzerReferenceMap = new()
+    {
+        { LanguageNames.CSharp, (new(), static analyzerReference => HasSourceGenerators(analyzerReference, LanguageNames.CSharp)) },
+        { LanguageNames.VisualBasic, (new(), static analyzerReference => HasSourceGenerators(analyzerReference, LanguageNames.VisualBasic)) },
+    };
 
     private static StrongBox<bool> HasSourceGenerators(
         AnalyzerReference analyzerReference, string language)
@@ -122,10 +122,7 @@ internal sealed partial class RemoteSourceGenerationService(in BrokeredServiceBa
             analyzerReferences,
             cancellationToken).ConfigureAwait(false);
 
-        var tuple = s_languageToAnalyzerReferenceMap.Single(static (val, language) => val.language == language, language);
-        var analyzerReferenceMap = tuple.analyzerReferenceMap;
-        var callback = tuple.callback;
-
+        var (analyzerReferenceMap, callback) = s_languageToAnalyzerReferenceMap[language];
         foreach (var analyzerReference in analyzerReferences)
         {
             var hasGenerators = analyzerReferenceMap.GetValue(analyzerReference, callback);


### PR DESCRIPTION
We had two problems with the prior approach.

1. the information was cached with ProjectStates.  But htat meant if the project-state cahnged (which it does on any doc-change) we would recompute if the project had generators.
2. when calling to OOP to have it determine if the project had generators, we would do a full-project sync (which included document contents).  So, again, when a doc changed, this would increase the cost of computing this info.

The new approach is much more lightweight.  

First, On the host side, we now cache the information along with the list-of-analyzer-references a project has.  That list almost never changes when projects fork (unless hte user literally adds/removes references).  So the information is reused virtually all the time on the host side.

Second, when we do make the call to oop, oop only needs to sync over the analyzer references, which it can do in in a much more lightweight fashion.  Oop also caches the information on a per-analyzer-reference, so that different projects which reference the same analyzer references can call to oop and have the question answered the first time without a call back to the host at all.

--

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=9398165&view=results
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=9398506&view=results