### PR TITLE
Use a frozendictionary on net-core and a readonly one on netfx

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -360,9 +360,9 @@ internal sealed class TextDocumentStates<TState>
     {
 #if NET
         using var pooledObject = s_filePathPool.GetPooledObject();
-        var dictionary = pooledObject.Object;
+        var result = pooledObject.Object;
 #else
-        var dictionary = new Dictionary<string, OneOrMany<DocumentId>>(SolutionState.FilePathComparer);
+        var result = new Dictionary<string, OneOrMany<DocumentId>>(SolutionState.FilePathComparer);
 #endif
 
         foreach (var (documentId, state) in _map)
@@ -371,15 +371,15 @@ internal sealed class TextDocumentStates<TState>
             if (filePath is null)
                 continue;
 
-            dictionary[filePath] = dictionary.TryGetValue(filePath, out var existingValue)
+            result[filePath] = result.TryGetValue(filePath, out var existingValue)
                 ? existingValue.Add(documentId)
                 : OneOrMany.Create(documentId);
         }
 
 #if NET
-        return dictionary.ToFrozenDictionary(SolutionState.FilePathComparer);
+        return result.ToFrozenDictionary(SolutionState.FilePathComparer);
 #else
-        return new(dictionary);
+        return new(result);
 #endif
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -359,8 +359,8 @@ internal sealed class TextDocumentStates<TState>
     private FilePathToDocumentIds ComputeFilePathToDocumentIds()
     {
 #if NET
-        using var pooledObject = s_filePathPool.GetPooledObject();
-        var result = pooledObject.Object;
+        using var pooledDictionary = s_filePathPool.GetPooledObject();
+        var result = pooledDictionary.Object;
 #else
         var result = new Dictionary<string, OneOrMany<DocumentId>>(SolutionState.FilePathComparer);
 #endif

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -19,16 +20,29 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
 
+// On NetFx, frozen dictionary is very expensive when you give it a case insensitive comparer.  This is due to
+// unavoidable allocations it performs while doing its key-analysis that involve going through the non-span-aware
+// culture types.  So, on netfx, we use a plain ReadOnlyDictionary here.
+#if NET
+using FilePathToDocumentIds = FrozenDictionary<string, OneOrMany<DocumentId>>;
+#else
+using FilePathToDocumentIds = ReadOnlyDictionary<string, OneOrMany<DocumentId>>;
+#endif
+
 /// <summary>
 /// Holds on a <see cref="DocumentId"/> to <see cref="TextDocumentState"/> map and an ordering.
 /// </summary>
 internal sealed class TextDocumentStates<TState>
     where TState : TextDocumentState
 {
+#if NET
     private static readonly ObjectPool<Dictionary<string, OneOrMany<DocumentId>>> s_filePathPool = new(() => new(SolutionState.FilePathComparer));
+#endif
 
     public static readonly TextDocumentStates<TState> Empty =
-        new([], ImmutableSortedDictionary.Create<DocumentId, TState>(DocumentIdComparer.Instance), FrozenDictionary<string, OneOrMany<DocumentId>>.Empty);
+        new([],
+            ImmutableSortedDictionary.Create<DocumentId, TState>(DocumentIdComparer.Instance),
+            filePathToDocumentIds: null);
 
     private readonly ImmutableList<DocumentId> _ids;
 
@@ -39,12 +53,12 @@ internal sealed class TextDocumentStates<TState>
     /// </summary>
     private readonly ImmutableSortedDictionary<DocumentId, TState> _map;
 
-    private FrozenDictionary<string, OneOrMany<DocumentId>>? _filePathToDocumentIds;
+    private FilePathToDocumentIds? _filePathToDocumentIds;
 
     private TextDocumentStates(
         ImmutableList<DocumentId> ids,
         ImmutableSortedDictionary<DocumentId, TState> map,
-        FrozenDictionary<string, OneOrMany<DocumentId>>? filePathToDocumentIds)
+        FilePathToDocumentIds? filePathToDocumentIds)
     {
         Debug.Assert(map.KeyComparer == DocumentIdComparer.Instance);
 
@@ -342,10 +356,14 @@ internal sealed class TextDocumentStates<TState>
             : null;
     }
 
-    private FrozenDictionary<string, OneOrMany<DocumentId>> ComputeFilePathToDocumentIds()
+    private FilePathToDocumentIds ComputeFilePathToDocumentIds()
     {
-        using var pooledDictionary = s_filePathPool.GetPooledObject();
-        var result = pooledDictionary.Object;
+#if NET
+        using var pooledObject = s_filePathPool.GetPooledObject();
+        var dictionary = pooledObject.Object;
+#else
+        var dictionary = new Dictionary<string, OneOrMany<DocumentId>>(SolutionState.FilePathComparer);
+#endif
 
         foreach (var (documentId, state) in _map)
         {
@@ -353,11 +371,15 @@ internal sealed class TextDocumentStates<TState>
             if (filePath is null)
                 continue;
 
-            result[filePath] = result.TryGetValue(filePath, out var existingValue)
+            dictionary[filePath] = dictionary.TryGetValue(filePath, out var existingValue)
                 ? existingValue.Add(documentId)
                 : OneOrMany.Create(documentId);
         }
 
-        return result.ToFrozenDictionary(SolutionState.FilePathComparer);
+#if NET
+        return dictionary.ToFrozenDictionary(SolutionState.FilePathComparer);
+#else
+        return new(dictionary);
+#endif
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -42,7 +42,11 @@ internal sealed class TextDocumentStates<TState>
     public static readonly TextDocumentStates<TState> Empty =
         new([],
             ImmutableSortedDictionary.Create<DocumentId, TState>(DocumentIdComparer.Instance),
-            filePathToDocumentIds: null);
+#if NET
+            FilePathToDocumentIds.Empty);
+#else
+            new(new Dictionary<string, OneOrMany<DocumentId>>()));
+#endif
 
     private readonly ImmutableList<DocumentId> _ids;
 


### PR DESCRIPTION
Running a test insertion to see if this removes the recent regressions caused by: https://github.com/dotnet/roslyn/pull/72965

PR1: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=9406987&view=results
PR2: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=9407001&view=results

FrozenDicts turn out to be quite expensive on NetFx if you're using StringComparer.CaseInsensitive.  It causes thsi sort of blowup as the dict analyzes keys:

![image](https://github.com/dotnet/roslyn/assets/4564579/32109a61-b28d-410a-ae08-c55586f77dc7)

This issue is not present on netcore, where FrozenDict can do all of this work in a non-allocating fashion.