### PR TITLE
Remove unused using

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Threading;


### PR DESCRIPTION
Turns out the Razor build is a _little_ fussy: https://dev.azure.com/dnceng-public/public/_build/results?buildId=641702&view=logs&j=2f0d093c-1064-5c86-fc5b-b7b1eca8e66a&t=d2b639a6-cb19-5f1f-66fd-8047f66b3026&l=216

I'll see if I can tweak Razor to not care so much about the source package, but until then may as well clean this up too :)