### PR TITLE
Fix Double-to-Long overflow check

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Semantics/CompileTimeCalculations.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/CompileTimeCalculations.vb
@@ -603,7 +603,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If sourceValue > &H7000000000000000L Then
                         Dim temporary As Double = (sourceValue - &H7000000000000000L)
 
-                        If temporary < &H7000000000000000L AndAlso UncheckedCLng(temporary) > &H1000000000000000L Then
+                        If temporary < &H7000000000000000L AndAlso UncheckedCLng(temporary) < &H1000000000000000L Then
                             Return False
                         End If
                     Else

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -605,7 +605,8 @@ End Class
                     New TypeAndValue(uint64Type, CULng(18)),
                     New TypeAndValue(decimalType, CDec(-11.3)),
                     New TypeAndValue(doubleType, CDbl(&HF000000000000000UL)),
-                    New TypeAndValue(doubleType, CDbl(&H70000000000000F0L)),
+                    New TypeAndValue(doubleType, CDbl(&H8000000000000000L)),
+                    New TypeAndValue(doubleType, CDbl(&H7FFFFFFFFFFFFC00L)),
                     New TypeAndValue(typeCodeType, Int32.MinValue),
                     New TypeAndValue(typeCodeType, Int32.MaxValue),
                     New TypeAndValue(typeCodeType, CInt(-3)),
@@ -1165,7 +1166,8 @@ End Class
                     New TypeAndValue(uint64Type, CULng(18)),
                     New TypeAndValue(decimalType, CDec(-11.3)),
                     New TypeAndValue(doubleType, CDbl(&HF000000000000000UL)),
-                    New TypeAndValue(doubleType, CDbl(&H70000000000000F0L)),
+                    New TypeAndValue(doubleType, CDbl(&H8000000000000000L)),
+                    New TypeAndValue(doubleType, CDbl(&H7FFFFFFFFFFFFC00L)),
                     New TypeAndValue(typeCodeType, Int32.MinValue),
                     New TypeAndValue(typeCodeType, Int32.MaxValue),
                     New TypeAndValue(typeCodeType, CInt(-3)),
@@ -5093,6 +5095,43 @@ End Module
   IL_0010:  ret
 }
 ]]>)
+        End Sub
+
+        <WorkItem(73032, "https://github.com/dotnet/roslyn/issues/73032")>
+        <Fact()>
+        Public Sub ConvertLargeDoubleConstantsAndLiteralsToLong()
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntime(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Module Program
+    Sub Main()
+        System.Console.WriteLine(CType(CDbl(&H8000000000000000L), Long))
+        System.Console.WriteLine(CType(CDbl(&H8000000000000400L), Long))
+        System.Console.WriteLine(CType(-9.0E+18, Long))
+        System.Console.WriteLine(CType(CDbl(&H8FFFFFFFFFFFFC00L), Long))
+        System.Console.WriteLine(CType(CDbl(&H9000000000000000L), Long))
+        System.Console.WriteLine(CType(CDbl(&H7000000000000000L), Long))
+        System.Console.WriteLine(CType(CDbl(&H7000000000000400L), Long))
+        System.Console.WriteLine(CType(9.0E+18, Long))
+        System.Console.WriteLine(CType(CDbl(&H7FFFFFFFFFFFFC00L), Long))
+    End Sub
+End Module
+    ]]></file>
+    </compilation>, options:=TestOptions.ReleaseExe)
+
+            Dim expectedOutput = <![CDATA[
+-9223372036854775808
+-9223372036854774784
+-9000000000000000000
+-8070450532247929856
+-8070450532247928832
+8070450532247928832
+8070450532247929856
+9000000000000000000
+9223372036854774784
+]]>
+
+            CompileAndVerify(compilation, expectedOutput:=expectedOutput).VerifyDiagnostics()
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -5105,30 +5105,34 @@ End Module
         <file name="a.vb"><![CDATA[
 Module Program
     Sub Main()
-        System.Console.WriteLine(CType(CDbl(&H8000000000000000L), Long))
-        System.Console.WriteLine(CType(CDbl(&H8000000000000400L), Long))
-        System.Console.WriteLine(CType(-9.0E+18, Long))
-        System.Console.WriteLine(CType(CDbl(&H8FFFFFFFFFFFFC00L), Long))
-        System.Console.WriteLine(CType(CDbl(&H9000000000000000L), Long))
-        System.Console.WriteLine(CType(CDbl(&H7000000000000000L), Long))
-        System.Console.WriteLine(CType(CDbl(&H7000000000000400L), Long))
-        System.Console.WriteLine(CType(9.0E+18, Long))
-        System.Console.WriteLine(CType(CDbl(&H7FFFFFFFFFFFFC00L), Long))
+        System.Console.WriteLine(CType(CDbl(&H8000000000000000L), Long) = ConvertToLong(CDbl(&H8000000000000000L)))
+        System.Console.WriteLine(CType(CDbl(&H8000000000000400L), Long) = ConvertToLong(CDbl(&H8000000000000400L)))
+        System.Console.WriteLine(CType(-9.0E+18, Long) = ConvertToLong(-9.0E+18))
+        System.Console.WriteLine(CType(CDbl(&H8FFFFFFFFFFFFC00L), Long) = ConvertToLong(CDbl(&H8FFFFFFFFFFFFC00L)))
+        System.Console.WriteLine(CType(CDbl(&H9000000000000000L), Long) = ConvertToLong(CDbl(&H9000000000000000L)))
+        System.Console.WriteLine(CType(CDbl(&H7000000000000000L), Long) = ConvertToLong(CDbl(&H7000000000000000L)))
+        System.Console.WriteLine(CType(CDbl(&H7000000000000400L), Long) = ConvertToLong(CDbl(&H7000000000000400L)))
+        System.Console.WriteLine(CType(9.0E+18, Long) = ConvertToLong(9.0E+18))
+        System.Console.WriteLine(CType(CDbl(&H7FFFFFFFFFFFFC00L), Long) = ConvertToLong(CDbl(&H7FFFFFFFFFFFFC00L)))
     End Sub
+
+    Function ConvertToLong(x as Double) As Long
+        Return CType(x, Long)
+    End Function
 End Module
     ]]></file>
-    </compilation>, options:=TestOptions.ReleaseExe)
+    </compilation>, options:=TestOptions.ReleaseExe.WithOverflowChecks(True))
 
             Dim expectedOutput = <![CDATA[
--9223372036854775808
--9223372036854774784
--9000000000000000000
--8070450532247929856
--8070450532247928832
-8070450532247928832
-8070450532247929856
-9000000000000000000
-9223372036854774784
+True
+True
+True
+True
+True
+True
+True
+True
+True
 ]]>
 
             CompileAndVerify(compilation, expectedOutput:=expectedOutput).VerifyDiagnostics()


### PR DESCRIPTION
Fixes #73032.

This PR addresses a bug in the VB.NET compiler.

# Description

Any constant or literal `Double` should be convertible at compile time to `Long` if its value is within the range of the `Long` data type (approximately ±9.223E+18). However, if the value is a large positive number between `&H7000000000000400L` and `&H7FFFFFFFFFFFFC00L`, then the error `"BC30439: Constant expression not representable in type 'Long'."` occurs:
```vb
Const w As Long = CType(9.0E+18, Long)
'                       ~~~~~~~ BC30439
Const x As Long = &H7000000000000400L
Const y As Double = x
Const z As Long = CType(y, Long)
'                       ~ BC30439
```

In contrast, large negative numbers are unaffected:
```vb
Const w As Long = CType(-9.0E+18, Long) ' OK

Const x As Long = Long.MinValue
Const y As Double = x
Const z As Long = CType(y, Long) ' OK
```

# Root Cause

Lines 603-609 of the [CompileTimeCalculations.DetectFloatingToIntegralOverflow method](https://github.com/dotnet/roslyn/blob/Visual-Studio-2022-Version-17.9/src/Compilers/VisualBasic/Portable/Semantics/CompileTimeCalculations.vb#L603,L609) check whether the input value is between `&H7000000000000000L` and `&H8000000000000000UL`, exclusive:

```vb
If sourceValue > &H7000000000000000L Then
    Dim temporary As Double = (sourceValue - &H7000000000000000L)

    If temporary < &H7000000000000000L AndAlso UncheckedCLng(temporary) > &H1000000000000000L Then
        Return False
    End If
Else
    Return False
End If
```

On line 606, however, the comparison `UncheckedCLng(temporary) > &H1000000000000000L` is incorrect; it should use `<` instead. This can be confirmed in two ways:

1.  In the `isUnsigned` branch earlier in this same method, the analogous comparison uses the correct operator:
    ```vb
    Dim temporary As Double = (sourceValue - &HF000000000000000UL)

    If temporary < &H7000000000000000L AndAlso UncheckedCLng(temporary) < &H1000000000000000L Then
        Return False
    End If
    ```

2.  Comments in this method reference the Shared Source CLI source file fjitdef.h, from which this code was presumably adapted. [There](https://github.com/SSCLI/sscli20_20060311/blob/707ae167cb556e76297df525369a5bdb0c6abee7/clr/src/fjit/fjitdef.h#L4440), the comparison also uses the correct operator:

    ```cpp
    if (val > I64(0x7000000000000000)) {
        double tmp = val - I64(0x7000000000000000);
        if (tmp < I64(0x7000000000000000) &&
            (__int64)tmp < I64(0x1000000000000000)) {
            goto success;
        }
    }
    else {
        goto success;
    }
    ```

# Unit Tests

I added test cases for the minimum and maximum `Double` values that are convertible to `Long`: `CDbl(&H8000000000000000L)` (which has always worked) and `CDbl(&H7FFFFFFFFFFFFC00L)` (which was previously broken).

The original test case `CDbl(&H70000000000000F0L)` failed to catch this bug because `CDbl` rounded it down to `&H7000000000000000L`.