### PR TITLE
Fix issue in editor config filepath comparison

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -1084,6 +1084,28 @@ dotnet_diagnostic.cs001.severity = error", "/subdir/.editorconfig"));
         }
 
         [Fact]
+        public void FolderNamePrefixOfFileName()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.severity = suggestion", "/root/.editorconfig"));
+            configs.Add(Parse(@"
+root=true", "/root/test/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/root/testing.cs" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[]
+            {
+                CreateImmutableDictionary(
+                    ("cs000", ReportDiagnostic.Info)),
+            }, options.Select(o => o.TreeOptions).ToArray());
+        }
+
+        [Fact]
         public void InheritOuterConfig()
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -292,14 +292,24 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
             Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\B\C", @"C:\A\B\C\D"));
         }
 
-        [Fact]
-        public void IsSameDirectoryOrChildOfSpecifyingCaseSensitivity()
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void IsSameDirectoryOrChildOfSpecifyingCaseSensitivity_Windows()
         {
             Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\a\B\C", @"C:\A\B", StringComparison.OrdinalIgnoreCase));
             Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\b\C", @"C:\A\B", StringComparison.OrdinalIgnoreCase));
 
             Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\a\B\C", @"C:\A\B", StringComparison.Ordinal));
             Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\b\C", @"C:\A\B", StringComparison.Ordinal));
+        }
+
+        [ConditionalFact(typeof(UnixLikeOnly))]
+        public void IsSameDirectoryOrChildOfSpecifyingCaseSensitivity_Unix()
+        {
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"/a/B/C", @"/A/B", StringComparison.OrdinalIgnoreCase));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"/A/b/C", @"/A/B", StringComparison.OrdinalIgnoreCase));
+
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"/a/B/C", @"/A/B", StringComparison.Ordinal));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"/A/b/C", @"/A/B", StringComparison.Ordinal));
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -295,11 +295,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
         [Fact]
         public void IsSameDirectoryOrChildOfSpecifyingCaseSensitivity()
         {
-            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"c:\ABCD\EFGH", @"C:\ABCD", StringComparison.OrdinalIgnoreCase));
-            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\abcd\EFGH", @"C:\ABCD", StringComparison.OrdinalIgnoreCase));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\a\B\C", @"C:\A\B", StringComparison.OrdinalIgnoreCase));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\b\C", @"C:\A\B", StringComparison.OrdinalIgnoreCase));
 
-            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"c:\ABCD\EFGH", @"C:\ABCD", StringComparison.Ordinal));
-            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\abcd\EFGH", @"C:\ABCD", StringComparison.Ordinal));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\a\B\C", @"C:\A\B", StringComparison.Ordinal));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\b\C", @"C:\A\B", StringComparison.Ordinal));
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.IO;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -289,6 +290,16 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
             Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCDE", @"C:\ABCD"));
 
             Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\B\C", @"C:\A\B\C\D"));
+        }
+
+        [Fact]
+        public void IsSameDirectoryOrChildOfSpecifyingCaseSensitivity()
+        {
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"c:\ABCD\EFGH", @"C:\ABCDH", StringComparison.OrdinalIgnoreCase));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\abcd\EFGH", @"C:\ABCDH", StringComparison.OrdinalIgnoreCase));
+
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"c:\ABCD\EFGH", @"C:\ABCDH", StringComparison.Ordinal));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\abcd\EFGH", @"C:\ABCDH", StringComparison.Ordinal));
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -295,11 +295,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
         [Fact]
         public void IsSameDirectoryOrChildOfSpecifyingCaseSensitivity()
         {
-            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"c:\ABCD\EFGH", @"C:\ABCDH", StringComparison.OrdinalIgnoreCase));
-            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\abcd\EFGH", @"C:\ABCDH", StringComparison.OrdinalIgnoreCase));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"c:\ABCD\EFGH", @"C:\ABCD", StringComparison.OrdinalIgnoreCase));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\abcd\EFGH", @"C:\ABCD", StringComparison.OrdinalIgnoreCase));
 
-            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"c:\ABCD\EFGH", @"C:\ABCDH", StringComparison.Ordinal));
-            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\abcd\EFGH", @"C:\ABCDH", StringComparison.Ordinal));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"c:\ABCD\EFGH", @"C:\ABCD", StringComparison.Ordinal));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\abcd\EFGH", @"C:\ABCD", StringComparison.Ordinal));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var config = _analyzerConfigs[analyzerConfigIndex];
 
-                if (isNormalizedPathInDirectory(normalizedPath, config.NormalizedDirectory))
+                if (PathUtilities.IsSameDirectoryOrChildOf(normalizedPath, config.NormalizedDirectory, StringComparison.Ordinal))
                 {
                     // If this config is a root config, then clear earlier options since they don't apply
                     // to this source file.
@@ -324,26 +324,6 @@ namespace Microsoft.CodeAnalysis
             {
                 sectionKey.Clear();
                 pool.Free(sectionKey);
-            }
-
-            static bool isNormalizedPathInDirectory(string path, string directory)
-            {
-                if (path.StartsWith(directory, StringComparison.Ordinal))
-                {
-                    if (directory[^1] == '/')
-                    {
-                        // directory had trailing '/', prefix comparison is good enough
-                        return true;
-                    }
-
-                    if (path.Length > directory.Length && path[directory.Length] == '/')
-                    {
-                        // directory didn't have trailing '/', but still would have matched if it had
-                        return true;
-                    }
-                }
-
-                return false;
             }
         }
 

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var config = _analyzerConfigs[analyzerConfigIndex];
 
-                if (normalizedPath.StartsWith(config.NormalizedDirectory, StringComparison.Ordinal))
+                if (isNormalizedPathInDirectory(normalizedPath, config.NormalizedDirectory))
                 {
                     // If this config is a root config, then clear earlier options since they don't apply
                     // to this source file.
@@ -324,6 +324,26 @@ namespace Microsoft.CodeAnalysis
             {
                 sectionKey.Clear();
                 pool.Free(sectionKey);
+            }
+
+            static bool isNormalizedPathInDirectory(string path, string directory)
+            {
+                if (path.StartsWith(directory, StringComparison.Ordinal))
+                {
+                    if (directory[^1] == '/')
+                    {
+                        // directory had trailing '/', prefix comparison is good enough
+                        return true;
+                    }
+
+                    if (path.Length > directory.Length && path[directory.Length] == '/')
+                    {
+                        // directory didn't have trailing '/', but still would have matched if it had
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
 

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -159,7 +159,7 @@ namespace Roslyn.Utilities
             return null;
         }
 
-        internal static bool IsSameDirectoryOrChildOf(string child, string parent)
+        internal static bool IsSameDirectoryOrChildOf(string child, string parent, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
             parent = RemoveTrailingDirectorySeparator(parent);
             string? currentChild = child;
@@ -167,7 +167,7 @@ namespace Roslyn.Utilities
             {
                 currentChild = RemoveTrailingDirectorySeparator(currentChild);
 
-                if (currentChild.Equals(parent, StringComparison.OrdinalIgnoreCase))
+                if (currentChild.Equals(parent, comparison))
                 {
                     return true;
                 }


### PR DESCRIPTION
This code previously just did a simple string.StartsWith to check if a file was in a folder. However, this would incorrectly return true for a case such as testing if c:\foo\test.txt was in folder c:\foo\test.