### PR TITLE
Only trigger corehost integration tests on supported release branches

### DIFF
--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -4,17 +4,11 @@
 trigger:
   branches:
     include:
-    - main
-    - main-vs-deps
-    - release/*
-    - features/*
-    - demos/*
-    exclude:
-    # Since the version of VS on the integration VM images are a moving target,
-    # we are unable to reliably run integration tests on servicing branches.
-    - release/dev17.0-vs-deps
-    - release/dev17.2
-    - release/dev17.3
+    - release/dev17.4
+    - release/dev17.6
+    - release/dev17.8
+    - release/dev17.9
+    - release/dev17.10
 
 # Branches that are allowed to trigger a build via /azp run.
 # Automatic building of all PRs is disabled in the pipeline's trigger page.
@@ -22,17 +16,11 @@ trigger:
 pr:
   branches:
     include:
-    - main
-    - main-vs-deps
-    - release/*
-    - features/*
-    - demos/*
-    exclude:
-    # Since the version of VS on the integration VM images are a moving target,
-    # we are unable to reliably run integration tests on servicing branches.
-    - release/dev17.0-vs-deps
-    - release/dev17.2
-    - release/dev17.3
+    - release/dev17.4
+    - release/dev17.6
+    - release/dev17.8
+    - release/dev17.9
+    - release/dev17.10
   paths:
     exclude:
       - docs/*


### PR DESCRIPTION
We have removed option to use desktop OOP in 17.11