### PR TITLE
Port https://github.com/dotnet/roslyn/pull/72964 to release/dev17.10

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -310,8 +310,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #nullable enable
 
-        private BoundIndexerAccess BindIndexerDefaultArgumentsAndParamsCollection(BoundIndexerAccess indexerAccess, BindValueKind valueKind, BindingDiagnosticBag diagnostics)
+        /// <param name="dynamificationOfAssignmentResultIsHandled">
+        /// When an indexer is accessed with dynamic argument is resolved statically,
+        /// in some scenarios its result type is set to 'dynamic' type.
+        /// Assignments to such indexers should be bound statically as well, reverting back
+        /// to the indexer's type for the target and setting result type of the assignment to 'dynamic' type.
+        /// This flag and the assertion below help catch any new assignment scenarios and
+        /// make them aware of this subtlety.
+        /// The flag itself doesn't affect semantic analysis beyond the assertion.
+        /// </param>
+        private BoundIndexerAccess BindIndexerDefaultArgumentsAndParamsCollection(BoundIndexerAccess indexerAccess, BindValueKind valueKind, BindingDiagnosticBag diagnostics, bool dynamificationOfAssignmentResultIsHandled = false)
         {
+            Debug.Assert((valueKind & BindValueKind.Assignable) == 0 || (valueKind & BindValueKind.RefersToLocation) != 0 || dynamificationOfAssignmentResultIsHandled);
+
             var useSetAccessor = valueKind == BindValueKind.Assignable && !indexerAccess.Indexer.ReturnsByRef;
             var accessorForDefaultArguments = useSetAccessor
                 ? indexerAccess.Indexer.GetOwnOrInheritedSetMethod()
@@ -404,15 +415,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// method returns a BoundBadExpression node. The method returns the original
         /// expression without generating any error if the expression has errors.
         /// </summary>
-        private BoundExpression CheckValue(BoundExpression expr, BindValueKind valueKind, BindingDiagnosticBag diagnostics)
+        /// <param name="dynamificationOfAssignmentResultIsHandled">
+        /// When an indexer is accessed with dynamic argument is resolved statically,
+        /// in some scenarios its result type is set to 'dynamic' type.
+        /// Assignments to such indexers should be bound statically as well, reverting back
+        /// to the indexer's type for the target and setting result type of the assignment to 'dynamic' type.
+        /// This flag and the assertion below help catch any new assignment scenarios and
+        /// make them aware of this subtlety.
+        /// The flag itself doesn't affect semantic analysis beyond the assertion.
+        /// </param>
+        private BoundExpression CheckValue(BoundExpression expr, BindValueKind valueKind, BindingDiagnosticBag diagnostics, bool dynamificationOfAssignmentResultIsHandled = false)
         {
+            Debug.Assert((valueKind & BindValueKind.Assignable) == 0 || (valueKind & BindValueKind.RefersToLocation) != 0 || dynamificationOfAssignmentResultIsHandled);
+
             switch (expr.Kind)
             {
                 case BoundKind.PropertyGroup:
                     expr = BindIndexedPropertyAccess((BoundPropertyGroup)expr, mustHaveAllOptionalParameters: false, diagnostics: diagnostics);
                     if (expr is BoundIndexerAccess indexerAccess)
                     {
-                        expr = BindIndexerDefaultArgumentsAndParamsCollection(indexerAccess, valueKind, diagnostics);
+                        expr = BindIndexerDefaultArgumentsAndParamsCollection(indexerAccess, valueKind, diagnostics, dynamificationOfAssignmentResultIsHandled: dynamificationOfAssignmentResultIsHandled);
                     }
                     break;
 
@@ -430,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return expr;
 
                 case BoundKind.IndexerAccess:
-                    expr = BindIndexerDefaultArgumentsAndParamsCollection((BoundIndexerAccess)expr, valueKind, diagnostics);
+                    expr = BindIndexerDefaultArgumentsAndParamsCollection((BoundIndexerAccess)expr, valueKind, diagnostics, dynamificationOfAssignmentResultIsHandled: dynamificationOfAssignmentResultIsHandled);
                     break;
 
                 case BoundKind.UnconvertedObjectCreationExpression:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var type = boundRHS.Type ?? voidType;
                 return new BoundDeconstructionAssignmentOperator(
                             node,
-                            DeconstructionVariablesAsTuple(left, checkedVariables, diagnostics, ignoreDiagnosticsFromTuple: true),
+                            DeconstructionVariablesAsTuple(left, checkedVariables, assignmentResultTupleType: out _, diagnostics, ignoreDiagnosticsFromTuple: true),
                             new BoundConversion(boundRHS.Syntax, boundRHS, Conversion.Deconstruction, @checked: false, explicitCastInCode: false, conversionGroupOpt: null,
                                 constantValueOpt: null, type: type, hasErrors: true),
                             resultIsUsed,
@@ -154,9 +154,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             FailRemainingInferences(checkedVariables, diagnostics);
 
-            var lhsTuple = DeconstructionVariablesAsTuple(left, checkedVariables, diagnostics, ignoreDiagnosticsFromTuple: diagnostics.HasAnyErrors() || !resultIsUsed);
+            var lhsTuple = DeconstructionVariablesAsTuple(left, checkedVariables, out NamedTypeSymbol returnType, diagnostics, ignoreDiagnosticsFromTuple: diagnostics.HasAnyErrors() || !resultIsUsed);
             Debug.Assert(hasErrors || lhsTuple.Type is object);
-            TypeSymbol returnType = hasErrors ? CreateErrorType() : lhsTuple.Type!;
+            returnType = hasErrors ? CreateErrorType() : returnType;
 
             var boundConversion = new BoundConversion(
                 boundRHS.Syntax,
@@ -316,8 +316,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    var single = variable.Single;
-                    Debug.Assert(single is object);
+                    Debug.Assert(variable.Single is object);
+                    var single = AdjustAssignmentTargetForDynamic(variable.Single, forceDynamicResult: out _);
                     Debug.Assert(single.Type is not null);
                     CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                     nestedConversion = this.Conversions.ClassifyConversionFromType(tupleOrDeconstructedTypes[i], single.Type, isChecked: CheckOverflowAtRuntime, ref useSiteInfo);
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if ((object?)variable.Single.Type != null)
                         {
                             // typed-variable on the left
-                            mergedType = variable.Single.Type;
+                            mergedType = AdjustAssignmentTargetForDynamic(variable.Single, forceDynamicResult: out _).Type;
                         }
                     }
                 }
@@ -542,11 +542,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 syntax: syntax);
         }
 
-        private BoundTupleExpression DeconstructionVariablesAsTuple(CSharpSyntaxNode syntax, ArrayBuilder<DeconstructionVariable> variables,
+        private BoundTupleExpression DeconstructionVariablesAsTuple(
+            CSharpSyntaxNode syntax, ArrayBuilder<DeconstructionVariable> variables,
+            out NamedTypeSymbol assignmentResultTupleType,
             BindingDiagnosticBag diagnostics, bool ignoreDiagnosticsFromTuple)
         {
             int count = variables.Count;
             var valuesBuilder = ArrayBuilder<BoundExpression>.GetInstance(count);
+            var resultTypesWithAnnotationsBuilder = ArrayBuilder<TypeWithAnnotations>.GetInstance(count);
             var typesWithAnnotationsBuilder = ArrayBuilder<TypeWithAnnotations>.GetInstance(count);
             var locationsBuilder = ArrayBuilder<Location?>.GetInstance(count);
             var namesBuilder = ArrayBuilder<string?>.GetInstance(count);
@@ -554,18 +557,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var variable in variables)
             {
                 BoundExpression value;
+                TypeSymbol resultType;
                 if (variable.NestedVariables is object)
                 {
-                    value = DeconstructionVariablesAsTuple(variable.Syntax, variable.NestedVariables, diagnostics, ignoreDiagnosticsFromTuple);
+                    value = DeconstructionVariablesAsTuple(variable.Syntax, variable.NestedVariables, out NamedTypeSymbol nestedResultType, diagnostics, ignoreDiagnosticsFromTuple);
+                    resultType = nestedResultType;
                     namesBuilder.Add(null);
                 }
                 else
                 {
                     Debug.Assert(variable.Single is object);
                     value = variable.Single;
+                    Debug.Assert(value.Type is not null);
+                    resultType = value.Type;
+                    value = AdjustAssignmentTargetForDynamic(value, forceDynamicResult: out _);
                     namesBuilder.Add(ExtractDeconstructResultElementName(value));
                 }
                 valuesBuilder.Add(value);
+                resultTypesWithAnnotationsBuilder.Add(TypeWithAnnotations.Create(resultType));
                 typesWithAnnotationsBuilder.Add(TypeWithAnnotations.Create(value.Type));
                 locationsBuilder.Add(variable.Syntax.Location);
             }
@@ -579,14 +588,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<bool> inferredPositions = tupleNames.IsDefault ? default : tupleNames.SelectAsArray(n => n != null);
             bool disallowInferredNames = this.Compilation.LanguageVersion.DisallowInferredTupleElementNames();
 
+            ImmutableArray<Location?> elementLocations = locationsBuilder.ToImmutableAndFree();
+            var createTupleDiagnostics = ignoreDiagnosticsFromTuple ? null : BindingDiagnosticBag.GetInstance(diagnostics);
+
             var type = NamedTypeSymbol.CreateTuple(
                 syntax.Location,
-                typesWithAnnotationsBuilder.ToImmutableAndFree(), locationsBuilder.ToImmutableAndFree(),
+                typesWithAnnotationsBuilder.ToImmutableAndFree(), elementLocations,
                 tupleNames, this.Compilation,
-                shouldCheckConstraints: !ignoreDiagnosticsFromTuple,
+                shouldCheckConstraints: createTupleDiagnostics is not null,
                 includeNullability: false,
                 errorPositions: disallowInferredNames ? inferredPositions : default,
-                syntax: syntax, diagnostics: ignoreDiagnosticsFromTuple ? null : diagnostics);
+                syntax: syntax, diagnostics: createTupleDiagnostics);
+
+            if (createTupleDiagnostics is { AccumulatesDiagnostics: true, DiagnosticBag: { } bag } &&
+                bag.HasAnyResolvedErrors())
+            {
+                diagnostics.AddRangeAndFree(createTupleDiagnostics);
+                createTupleDiagnostics = null; // Suppress possibly duplicate errors from CreateTuple call below.
+            }
+
+            // This type is the same as the 'type' above, or differs only by using 'dynamic' for some elements.
+            assignmentResultTupleType = NamedTypeSymbol.CreateTuple(
+                syntax.Location,
+                resultTypesWithAnnotationsBuilder.ToImmutableAndFree(), elementLocations,
+                tupleNames, this.Compilation,
+                shouldCheckConstraints: createTupleDiagnostics is not null,
+                includeNullability: false,
+                errorPositions: disallowInferredNames ? inferredPositions : default,
+                syntax: syntax, diagnostics: createTupleDiagnostics);
+
+            if (createTupleDiagnostics is not null)
+            {
+                diagnostics.AddRangeAndFree(createTupleDiagnostics);
+            }
 
             return (BoundTupleExpression)BindToNaturalType(new BoundTupleLiteral(syntax, arguments, tupleNames, inferredPositions, type), diagnostics);
         }
@@ -788,12 +822,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 default:
                     var boundVariable = BindExpression(node, diagnostics, invoked: false, indexed: false);
-                    var checkedVariable = CheckValue(boundVariable, BindValueKind.Assignable, diagnostics);
+                    var checkedVariable = CheckValue(boundVariable, BindValueKind.Assignable, diagnostics, dynamificationOfAssignmentResultIsHandled: true);
+
                     if (expression == null && checkedVariable.Kind != BoundKind.DiscardExpression)
                     {
                         expression = node;
                     }
 
+                    // This object doesn't escape BindDeconstruction method, we don't call AdjustAssignmentTargetForDynamic
+                    // for checkedVariable here, instead we call it where binder accesses DeconstructionVariable.Single
+                    // In some of the places we need to be able to detect the fact that the type used to be dynamic, and,
+                    // if we erase the fact here, there will be no other place for us to look at.
                     return new DeconstructionVariable(checkedVariable, node);
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -233,10 +233,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// did not meet the requirements, the return value will be a <see cref="BoundBadExpression"/> that
         /// (typically) wraps the subexpression.
         /// </summary>
-        internal BoundExpression BindValue(ExpressionSyntax node, BindingDiagnosticBag diagnostics, BindValueKind valueKind)
+        internal BoundExpression BindValue(ExpressionSyntax node, BindingDiagnosticBag diagnostics, BindValueKind valueKind, bool dynamificationOfAssignmentResultIsHandled = false)
         {
             var result = this.BindExpression(node, diagnostics: diagnostics, invoked: false, indexed: false);
-            return CheckValue(result, valueKind, diagnostics);
+            return CheckValue(result, valueKind, diagnostics, dynamificationOfAssignmentResultIsHandled);
         }
 
         internal BoundExpression BindRValueWithoutTargetType(ExpressionSyntax node, BindingDiagnosticBag diagnostics, bool reportNoTargetType = true)
@@ -5703,7 +5703,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // D = { ..., <identifier> = <expr>, ... }, where D : dynamic
                     boundMember = new BoundDynamicObjectInitializerMember(leftSyntax, memberName.Identifier.Text, implicitReceiver.Type, initializerType, hasErrors: false);
-                    return CheckValue(boundMember, valueKind, diagnostics);
+                    return CheckValue(boundMember, valueKind, diagnostics, dynamificationOfAssignmentResultIsHandled: true);
                 }
                 else
                 {
@@ -5806,7 +5806,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.IndexerAccess:
                     {
-                        var indexer = BindIndexerDefaultArgumentsAndParamsCollection((BoundIndexerAccess)boundMember, valueKind, diagnostics);
+                        var indexer = BindIndexerDefaultArgumentsAndParamsCollection((BoundIndexerAccess)boundMember, valueKind, diagnostics, dynamificationOfAssignmentResultIsHandled: true);
+
+                        Debug.Assert(valueKind is BindValueKind.RValue or BindValueKind.RefAssignable or BindValueKind.Assignable);
+
+                        if (valueKind == BindValueKind.Assignable)
+                        {
+                            indexer = (BoundIndexerAccess)AdjustAssignmentTargetForDynamic(indexer, forceDynamicResult: out _);
+                        }
+
                         boundMember = indexer;
                         hasErrors |= isRhsNestedInitializer && !CheckNestedObjectInitializerPropertySymbol(indexer.Indexer, leftSyntax, diagnostics, hasErrors, ref resultKind);
                         arguments = indexer.Arguments;
@@ -5846,7 +5854,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         hasErrors |= !CheckNestedObjectInitializerPropertySymbol(property, leftSyntax, diagnostics, hasErrors, ref resultKind);
                     }
 
-                    return hasErrors ? boundMember : CheckValue(boundMember, valueKind, diagnostics);
+                    Debug.Assert(boundMember is not BoundIndexerAccess);
+                    return hasErrors ?
+                               boundMember :
+                               CheckValue(boundMember, valueKind, diagnostics, dynamificationOfAssignmentResultIsHandled: true);
 
                 case BoundKind.DynamicObjectInitializerMember:
                     break;
@@ -5863,7 +5874,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.ArrayAccess:
                 case BoundKind.PointerElementAccess:
-                    return CheckValue(boundMember, valueKind, diagnostics);
+                    Debug.Assert(boundMember is not BoundIndexerAccess);
+                    return CheckValue(boundMember, valueKind, diagnostics, dynamificationOfAssignmentResultIsHandled: true);
 
                 default:
                     return BadObjectInitializerMemberAccess(boundMember, implicitReceiver, leftSyntax, diagnostics, valueKind, hasErrors);
@@ -5948,7 +5960,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
 
                     case LookupResultKind.Inaccessible:
-                        boundMember = CheckValue(boundMember, valueKind, diagnostics);
+                        Debug.Assert(boundMember is not BoundIndexerAccess);
+                        boundMember = CheckValue(boundMember, valueKind, diagnostics, dynamificationOfAssignmentResultIsHandled: true);
                         Debug.Assert(boundMember.HasAnyErrors);
                         break;
 
@@ -9719,13 +9732,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 argumentSyntax, singleCandidate);
                         }
                     }
-                    else
+                    // For C# 12 and earlier statically bind invocations in presence of dynamic arguments only for expanded non-array params cases.
+                    else if (Compilation.LanguageVersion > LanguageVersion.CSharp12 || IsMemberWithExpandedNonArrayParamsCollection(finalApplicableCandidates[0]))
                     {
                         var resultWithSingleCandidate = OverloadResolutionResult<PropertySymbol>.GetInstance();
                         resultWithSingleCandidate.ResultsBuilder.Add(finalApplicableCandidates[0]);
                         overloadResolutionResult.Free();
 
-                        return BindIndexerOrIndexedPropertyAccessContinued(syntax, receiver, propertyGroup, analyzedArguments, resultWithSingleCandidate, diagnostics);
+                        return BindIndexerOrIndexedPropertyAccessContinued(syntax, receiver, propertyGroup, analyzedArguments, resultWithSingleCandidate, hasDynamicArgument: true, diagnostics);
                     }
                 }
 
@@ -9741,7 +9755,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BindDynamicIndexer(syntax, receiver, analyzedArguments, finalApplicableCandidates.SelectAsArray(r => r.Member), diagnostics);
             }
 
-            return BindIndexerOrIndexedPropertyAccessContinued(syntax, receiver, propertyGroup, analyzedArguments, overloadResolutionResult, diagnostics);
+            return BindIndexerOrIndexedPropertyAccessContinued(syntax, receiver, propertyGroup, analyzedArguments, overloadResolutionResult, hasDynamicArgument: false, diagnostics);
         }
 
         private BoundExpression BindIndexerOrIndexedPropertyAccessContinued(
@@ -9750,6 +9764,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<PropertySymbol> propertyGroup,
             AnalyzedArguments analyzedArguments,
             OverloadResolutionResult<PropertySymbol> overloadResolutionResult,
+            bool hasDynamicArgument,
             BindingDiagnosticBag diagnostics)
         {
             BoundExpression propertyAccess;
@@ -9811,6 +9826,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MemberResolutionResult<PropertySymbol> resolutionResult = overloadResolutionResult.ValidResult;
                 PropertySymbol property = resolutionResult.Member;
 
+                bool forceDynamicResultType = false;
+                var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+
+                // Due to backward compatibility, invocations statically bound in presence of dynamic arguments
+                // should have dynamic result if their dynamic binding succeeded in C# 12 and there are no
+                // obvious reasons for the runtime binder to fail (ref return, for example).
+                if (hasDynamicArgument &&
+                    !(property.Type.IsDynamic() || property.ReturnsByRef ||
+                     !Conversions.ClassifyConversionFromExpressionType(property.Type, Compilation.DynamicType, isChecked: false, ref useSiteInfo).IsImplicit ||
+                     IsMemberWithExpandedNonArrayParamsCollection(resolutionResult)))
+                {
+                    var tryDynamicAccessDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false);
+                    BindDynamicIndexer(syntax, receiver, analyzedArguments, ImmutableArray.Create(property), tryDynamicAccessDiagnostics);
+                    forceDynamicResultType = !tryDynamicAccessDiagnostics.HasAnyResolvedErrors();
+                    tryDynamicAccessDiagnostics.Free();
+                }
+
+                diagnostics.Add(syntax, useSiteInfo);
+
                 ReportDiagnosticsIfObsolete(diagnostics, property, syntax, hasBaseReceiver: receiver != null && receiver.Kind == BoundKind.BaseReference);
 
                 // Make sure that the result of overload resolution is valid.
@@ -9841,7 +9875,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     expanded: resolutionResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm,
                     argsToParams,
                     defaultArguments: default,
-                    property.Type,
+                    forceDynamicResultType ? Compilation.DynamicType : property.Type,
                     gotError);
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -638,14 +638,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     result = BindDynamicInvocation(node, boundExpression, analyzedArguments, overloadResolutionResult.GetAllApplicableMembers(), diagnostics, queryClause);
                 }
+                // For C# 12 and earlier statically bind invocations in presence of dynamic arguments only for expanded non-array params cases.
+                else if (Compilation.LanguageVersion > LanguageVersion.CSharp12 || IsMemberWithExpandedNonArrayParamsCollection(applicable))
+                {
+                    result = BindInvocationExpressionContinued(node, expression, methodName, overloadResolutionResult, analyzedArguments, methodGroup, delegateType, hasDynamicArgument: true, boundExpression, diagnostics, queryClause);
+                }
                 else
                 {
-                    result = BindInvocationExpressionContinued(node, expression, methodName, overloadResolutionResult, analyzedArguments, methodGroup, delegateType, diagnostics, queryClause);
+                    result = BindDynamicInvocation(node, boundExpression, analyzedArguments, overloadResolutionResult.GetAllApplicableMembers(), diagnostics, queryClause);
                 }
             }
             else
             {
-                result = BindInvocationExpressionContinued(node, expression, methodName, overloadResolutionResult, analyzedArguments, methodGroup, delegateType, diagnostics, queryClause);
+                result = BindInvocationExpressionContinued(node, expression, methodName, overloadResolutionResult, analyzedArguments, methodGroup, delegateType, hasDynamicArgument: false, boundExpression, diagnostics, queryClause);
             }
 
             overloadResolutionResult.Free();
@@ -680,6 +685,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return false;
+        }
+
+        private bool IsMemberWithExpandedNonArrayParamsCollection<TMember>(MemberResolutionResult<TMember> candidate)
+            where TMember : Symbol
+        {
+            return candidate.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm &&
+                   !candidate.Member.GetParameters().Last().Type.IsSZArray();
         }
 
         private BoundExpression BindMethodGroupInvocation(
@@ -756,7 +768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // we want to force any unbound lambda arguments to cache an appropriate conversion if possible; see 9448.
                         result = BindInvocationExpressionContinued(
                             syntax, expression, methodName, resolution.OverloadResolutionResult, resolution.AnalyzedArguments,
-                            resolution.MethodGroup, delegateTypeOpt: null, diagnostics: BindingDiagnosticBag.Discarded, queryClause: queryClause);
+                            resolution.MethodGroup, delegateTypeOpt: null, hasDynamicArgument: false, methodGroup, diagnostics: BindingDiagnosticBag.Discarded, queryClause: queryClause);
                     }
 
                     // Since the resolution is non-empty and has no diagnostics, the LookupResultKind in its MethodGroup is uninteresting.
@@ -820,7 +832,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         result = BindInvocationExpressionContinued(
                             syntax, expression, methodName, resolution.OverloadResolutionResult, resolution.AnalyzedArguments,
-                            resolution.MethodGroup, delegateTypeOpt: null, diagnostics: diagnostics, queryClause: queryClause);
+                            resolution.MethodGroup, delegateTypeOpt: null, hasDynamicArgument: false, methodGroup, diagnostics: diagnostics, queryClause: queryClause);
                     }
                 }
             }
@@ -975,23 +987,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            var resultWithSingleCandidate = OverloadResolutionResult<MethodSymbol>.GetInstance();
-            resultWithSingleCandidate.ResultsBuilder.Add(methodResolutionResult);
+            // For C# 12 and earlier statically bind invocations in presence of dynamic arguments only for local functions or expanded non-array params cases.
+            if (Compilation.LanguageVersion > LanguageVersion.CSharp12 ||
+                singleCandidate.MethodKind == MethodKind.LocalFunction ||
+                IsMemberWithExpandedNonArrayParamsCollection(methodResolutionResult))
+            {
+                var resultWithSingleCandidate = OverloadResolutionResult<MethodSymbol>.GetInstance();
+                resultWithSingleCandidate.ResultsBuilder.Add(methodResolutionResult);
 
-            BoundExpression result = BindInvocationExpressionContinued(
-                node: syntax,
-                expression: expression,
-                methodName: methodName,
-                result: resultWithSingleCandidate,
-                analyzedArguments: resolution.AnalyzedArguments,
-                methodGroup: resolution.MethodGroup,
-                delegateTypeOpt: null,
-                diagnostics: diagnostics,
-                queryClause: queryClause);
+                BoundExpression result = BindInvocationExpressionContinued(
+                    node: syntax,
+                    expression: expression,
+                    methodName: methodName,
+                    result: resultWithSingleCandidate,
+                    analyzedArguments: resolution.AnalyzedArguments,
+                    methodGroup: resolution.MethodGroup,
+                    delegateTypeOpt: null,
+                    hasDynamicArgument: true,
+                    boundMethodGroup,
+                    diagnostics: diagnostics,
+                    queryClause: queryClause);
 
-            resultWithSingleCandidate.Free();
+                resultWithSingleCandidate.Free();
 
-            return result;
+                return result;
+            }
+
+            return null;
         }
 
         private ImmutableArray<MemberResolutionResult<TMethodOrPropertySymbol>> GetCandidatesPassingFinalValidation<TMethodOrPropertySymbol>(
@@ -1130,6 +1152,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             AnalyzedArguments analyzedArguments,
             MethodGroup methodGroup,
             NamedTypeSymbol delegateTypeOpt,
+            bool hasDynamicArgument,
+            BoundExpression targetMethodGroupOrDelegateInstance,
             BindingDiagnosticBag diagnostics,
             CSharpSyntaxNode queryClause = null)
         {
@@ -1205,12 +1229,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                     GetOriginalMethods(result), methodGroup.ResultKind, methodGroup.TypeArguments.ToImmutable(), analyzedArguments, invokedAsExtensionMethod: invokedAsExtensionMethod, isDelegate: ((object)delegateTypeOpt != null));
             }
 
-            // Otherwise, there were no dynamic arguments and overload resolution found a unique best candidate. 
+            // Otherwise, overload resolution found a unique best candidate. 
             // We still have to determine if it passes final validation.
 
             var methodResult = result.ValidResult;
             var returnType = methodResult.Member.ReturnType;
             var method = methodResult.Member;
+            bool forceDynamicResultType = false;
+
+            var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+
+            // Due to backward compatibility, invocations statically bound in presence of dynamic arguments
+            // should have dynamic result if their dynamic binding succeeded in C# 12 and there are no
+            // obvious reasons for the runtime binder to fail (ref return, for example).
+            if (hasDynamicArgument &&
+                !(methodGroup.IsExtensionMethodGroup || method.MethodKind == MethodKind.LocalFunction ||
+                  method.ReturnsVoid || method.ReturnsByRef || returnType.IsDynamic() ||
+                  !Conversions.ClassifyConversionFromExpressionType(returnType, Compilation.DynamicType, isChecked: false, ref useSiteInfo).IsImplicit ||
+                  IsMemberWithExpandedNonArrayParamsCollection(methodResult)))
+            {
+                var tryDynamicInvocationDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false);
+                BindDynamicInvocation(node, targetMethodGroupOrDelegateInstance, analyzedArguments, ImmutableArray.Create(method), tryDynamicInvocationDiagnostics, queryClause);
+                forceDynamicResultType = !tryDynamicInvocationDiagnostics.HasAnyResolvedErrors();
+                tryDynamicInvocationDiagnostics.Free();
+            }
+
+            diagnostics.Add(node, useSiteInfo);
 
             // It is possible that overload resolution succeeded, but we have chosen an
             // instance method and we're in a static method. A careful reading of the
@@ -1340,7 +1384,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return new BoundCall(node, receiver, initialBindingReceiverIsSubjectToCloning: ReceiverIsSubjectToCloning(receiver, method), method, args, argNames, argRefKinds, isDelegateCall: isDelegateCall,
                         expanded: expanded, invokedAsExtensionMethod: invokedAsExtensionMethod,
-                        argsToParamsOpt: argsToParams, defaultArguments, resultKind: LookupResultKind.Viable, type: returnType, hasErrors: gotError);
+                        argsToParamsOpt: argsToParams, defaultArguments, resultKind: LookupResultKind.Viable,
+                        type: forceDynamicResultType ? Compilation.DynamicType : returnType,
+                        hasErrors: gotError);
         }
 
 #nullable enable

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             node.Left.CheckDeconstructionCompatibleArgument(diagnostics);
 
-            BoundExpression left = BindValue(node.Left, diagnostics, GetBinaryAssignmentKind(node.Kind()));
+            BoundExpression left = BindValue(node.Left, diagnostics, GetBinaryAssignmentKind(node.Kind()), dynamificationOfAssignmentResultIsHandled: true);
             ReportSuppressionIfNeeded(left, diagnostics);
             BoundExpression right = BindValue(node.Right, diagnostics, BindValueKind.RValue);
             BinaryOperatorKind kind = SyntaxKindToBinaryOperatorKind(node.Kind());
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // fall-through for other operators, if RHS is dynamic we produce dynamic operation, otherwise we'll report an error ...
                 }
             }
+
+            left = AdjustAssignmentTargetForDynamic(left, out bool forceDynamicResult);
 
             if (left.HasAnyErrors || right.HasAnyErrors)
             {
@@ -81,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         finalPlaceholder: placeholder,
                         finalConversion: conversion,
                         LookupResultKind.Viable,
-                        left.Type,
+                        AdjustAssignmentTypeToDynamicIfNecessary(left.Type, forceDynamicResult),
                         hasErrors: false);
                 }
                 else
@@ -244,7 +246,56 @@ namespace Microsoft.CodeAnalysis.CSharp
             var leftConversion = CreateConversion(node.Left, leftPlaceholder, best.LeftConversion, isCast: false, conversionGroupOpt: null, best.Signature.LeftType, diagnostics);
 
             return new BoundCompoundAssignmentOperator(node, bestSignature, left, rightConverted,
-                leftPlaceholder, leftConversion, finalPlaceholder, finalConversion, resultKind, originalUserDefinedOperators, leftType, hasError);
+                leftPlaceholder, leftConversion, finalPlaceholder, finalConversion, resultKind, originalUserDefinedOperators, AdjustAssignmentTypeToDynamicIfNecessary(left.Type, forceDynamicResult), hasError);
+        }
+
+        /// <summary>
+        /// When an indexer is accessed with dynamic argument is resolved statically,
+        /// in some scenarios its result type is set to 'dynamic' type.
+        /// Assignments to such indexers should be bound statically as well, reverting back
+        /// to the indexer's type for the target and setting result type of the assignment to 'dynamic' type.
+        /// 
+        /// This helper takes care of the "reverting back to the indexer's type for the target" part.
+        /// See <see cref="AdjustAssignmentTypeToDynamicIfNecessary"/> for the helper for the second part.
+        /// </summary>
+        private static BoundExpression AdjustAssignmentTargetForDynamic(BoundExpression target, out bool forceDynamicResult)
+        {
+            if (target is BoundIndexerAccess { Type.TypeKind: TypeKind.Dynamic, Indexer.Type.TypeKind: not TypeKind.Dynamic } indexerAccess)
+            {
+                Debug.Assert(!indexerAccess.Indexer.ReturnsByRef);
+                forceDynamicResult = true;
+                target = indexerAccess.Update(
+                        indexerAccess.ReceiverOpt,
+                        indexerAccess.InitialBindingReceiverIsSubjectToCloning,
+                        indexerAccess.Indexer,
+                        indexerAccess.Arguments,
+                        indexerAccess.ArgumentNamesOpt,
+                        indexerAccess.ArgumentRefKindsOpt,
+                        indexerAccess.Expanded,
+                        indexerAccess.ArgsToParamsOpt,
+                        indexerAccess.DefaultArguments,
+                        indexerAccess.Indexer.Type);
+            }
+            else
+            {
+                forceDynamicResult = false;
+            }
+
+            return target;
+        }
+
+        /// <summary>
+        /// When an indexer is accessed with dynamic argument is resolved statically,
+        /// in some scenarios its result type is set to 'dynamic' type.
+        /// Assignments to such indexers should be bound statically as well, reverting back
+        /// to the indexer's type for the target and setting result type of the assignment to 'dynamic' type.
+        /// 
+        /// This helper takes care of the "setting result type of the assignment to 'dynamic' type" part.
+        /// See <see cref="AdjustAssignmentTargetForDynamic"/> helper for the first part.
+        /// </summary>
+        TypeSymbol AdjustAssignmentTypeToDynamicIfNecessary(TypeSymbol leftType, bool forceDynamicResult)
+        {
+            return forceDynamicResult ? Compilation.DynamicType : leftType;
         }
 
         /// <summary>
@@ -2261,7 +2312,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             operandSyntax.CheckDeconstructionCompatibleArgument(diagnostics);
 
-            BoundExpression operand = BindToNaturalType(BindValue(operandSyntax, diagnostics, BindValueKind.IncrementDecrement), diagnostics);
+            BoundExpression operand = BindToNaturalType(BindValue(operandSyntax, diagnostics, BindValueKind.IncrementDecrement, dynamificationOfAssignmentResultIsHandled: true),
+                                                        diagnostics);
+
             UnaryOperatorKind kind = SyntaxKindToUnaryOperatorKind(node.Kind());
 
             // If the operand is bad, avoid generating cascading errors.
@@ -2282,6 +2335,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CreateErrorType(),
                     hasErrors: true);
             }
+
+            operand = AdjustAssignmentTargetForDynamic(operand, out bool forceDynamicResult);
 
             // The operand has to be a variable, property or indexer, so it must have a type.
             var operandType = operand.Type;
@@ -2369,7 +2424,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 resultConversion,
                 resultKind,
                 originalUserDefinedOperators,
-                operandType,
+                AdjustAssignmentTypeToDynamicIfNecessary(operandType, forceDynamicResult),
                 hasErrors);
         }
 
@@ -4134,8 +4189,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             MessageID.IDS_FeatureCoalesceAssignmentExpression.CheckFeatureAvailability(diagnostics, node.OperatorToken);
 
-            BoundExpression leftOperand = BindValue(node.Left, diagnostics, BindValueKind.CompoundAssignment);
+            BoundExpression leftOperand = BindValue(node.Left, diagnostics, BindValueKind.CompoundAssignment, dynamificationOfAssignmentResultIsHandled: true);
             ReportSuppressionIfNeeded(leftOperand, diagnostics);
+
+            leftOperand = AdjustAssignmentTargetForDynamic(leftOperand, out bool forceDynamicResult);
+
             BoundExpression rightOperand = BindValue(node.Right, diagnostics, BindValueKind.RValue);
 
             // If either operand is bad, bail out preventing more cascading errors
@@ -4170,7 +4228,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     diagnostics.Add(node, useSiteInfo);
                     var convertedRightOperand = CreateConversion(rightOperand, underlyingRightConversion, underlyingLeftType, diagnostics);
-                    return new BoundNullCoalescingAssignmentOperator(node, leftOperand, convertedRightOperand, underlyingLeftType);
+                    var result = new BoundNullCoalescingAssignmentOperator(node, leftOperand, convertedRightOperand, AdjustAssignmentTypeToDynamicIfNecessary(underlyingLeftType, forceDynamicResult));
+                    Debug.Assert(result.IsNullableValueTypeAssignment);
+                    return result;
                 }
             }
 
@@ -4184,7 +4244,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (rightConversion.Exists)
             {
                 var convertedRightOperand = CreateConversion(rightOperand, rightConversion, leftType, diagnostics);
-                return new BoundNullCoalescingAssignmentOperator(node, leftOperand, convertedRightOperand, leftType);
+                var result = new BoundNullCoalescingAssignmentOperator(node, leftOperand, convertedRightOperand, AdjustAssignmentTypeToDynamicIfNecessary(leftType, forceDynamicResult));
+                Debug.Assert(!result.IsNullableValueTypeAssignment);
+                return result;
             }
 
             // a and b are incompatible and a compile-time error occurs

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1429,8 +1429,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (isRef)
                 MessageID.IDS_FeatureRefReassignment.CheckFeatureAvailability(diagnostics, node.Right.GetFirstToken());
 
-            var op1 = BindValue(node.Left, diagnostics, lhsKind);
+            var op1 = BindValue(node.Left, diagnostics, lhsKind, dynamificationOfAssignmentResultIsHandled: true);
             ReportSuppressionIfNeeded(op1, diagnostics);
+
+            op1 = AdjustAssignmentTargetForDynamic(op1, out bool forceDynamicResult);
 
             var rhsKind = isRef ? GetRequiredRHSValueKindForRefAssignment(op1) : BindValueKind.RValue;
             var op2 = BindValue(rhsExpr, diagnostics, rhsKind);
@@ -1442,7 +1444,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 op1 = InferTypeForDiscardAssignment((BoundDiscardExpression)op1, op2, diagnostics);
             }
 
-            return BindAssignment(node, op1, op2, isRef, diagnostics);
+            BoundAssignmentOperator result = BindAssignment(node, op1, op2, isRef, diagnostics);
+            result = result.Update(result.Left, result.Right, result.IsRef, AdjustAssignmentTypeToDynamicIfNecessary(result.Type, forceDynamicResult));
+
+            return result;
         }
 
         private static BindValueKind GetRequiredRHSValueKindForRefAssignment(BoundExpression boundLeft)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -3847,9 +3847,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert((object)increment.MethodOpt == null && increment.OriginalUserDefinedOperatorsOpt.IsDefaultOrEmpty);
                 UnaryOperatorKind op = increment.OperatorKind.Operator();
-                symbols = OneOrMany.Create<Symbol>(new SynthesizedIntrinsicOperatorSymbol(increment.Operand.Type.StrippedType(),
+                TypeSymbol opType = increment.Operand.Type.StrippedType();
+                symbols = OneOrMany.Create<Symbol>(new SynthesizedIntrinsicOperatorSymbol(opType,
                                                                                           OperatorFacts.UnaryOperatorNameFromOperatorKind(op, isChecked: increment.OperatorKind.IsChecked()),
-                                                                                          increment.Type.StrippedType()));
+                                                                                          opType));
                 resultKind = increment.ResultKind;
             }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -81,14 +81,56 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
-            return MakeStaticAssignmentOperator(node.Syntax, loweredLeft, loweredRight, node.IsRef, node.Type, used);
+            var result = MakeStaticAssignmentOperator(node.Syntax, loweredLeft, loweredRight, node.IsRef, used);
+
+            result = ConvertResultOfAssignmentToDynamicIfNecessary(node, left, result, used);
+
+            Debug.Assert(used || result.Type?.IsVoidType() == true ||
+                        (left switch { BoundIndexerAccess indexer => indexer.Indexer, BoundPropertyAccess property => property.PropertySymbol, _ => null }) is not PropertySymbol prop ||
+                        prop.GetOwnOrInheritedSetMethod() is null);
+
+            Debug.Assert(result.Type?.IsVoidType() == true || TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.AllIgnoreOptions));
+
+            return result;
+        }
+
+        private static bool ShouldConvertResultOfAssignmentToDynamic(TypeSymbol? assignmentResultType, BoundExpression target)
+        {
+            if (assignmentResultType?.IsDynamic() == true && target is BoundIndexerAccess { Type.TypeKind: not TypeKind.Dynamic } indexerAccess)
+            {
+                Debug.Assert(!indexerAccess.Indexer.Type.IsDynamic());
+                Debug.Assert(!indexerAccess.Indexer.ReturnsByRef);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static bool ShouldConvertResultOfAssignmentToDynamic(BoundExpression assignment, BoundExpression target)
+        {
+            Debug.Assert(assignment is BoundAssignmentOperator or BoundIncrementOperator or BoundCompoundAssignmentOperator or BoundNullCoalescingAssignmentOperator);
+            return ShouldConvertResultOfAssignmentToDynamic(assignment.Type, target);
+        }
+
+        private BoundExpression ConvertResultOfAssignmentToDynamicIfNecessary(BoundExpression originalAssignment, BoundExpression originalTarget, BoundExpression result, bool used)
+        {
+            Debug.Assert(originalAssignment.Type is not null);
+            if (used && ShouldConvertResultOfAssignmentToDynamic(originalAssignment, originalTarget))
+            {
+                Debug.Assert(result.Type is not null);
+                Debug.Assert(!result.Type.IsDynamic());
+                result = _factory.Convert(originalAssignment.Type, result);
+            }
+
+            return result;
         }
 
         /// <summary>
         /// Generates a lowered form of the assignment operator for the given left and right sub-expressions.
         /// Left and right sub-expressions must be in lowered form.
         /// </summary>
-        private BoundExpression MakeAssignmentOperator(SyntaxNode syntax, BoundExpression rewrittenLeft, BoundExpression rewrittenRight, TypeSymbol type,
+        private BoundExpression MakeAssignmentOperator(SyntaxNode syntax, BoundExpression rewrittenLeft, BoundExpression rewrittenRight,
             bool used, bool isChecked, bool isCompoundAssignment)
         {
             switch (rewrittenLeft.Kind)
@@ -132,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     throw ExceptionUtilities.Unreachable();
 
                 default:
-                    return MakeStaticAssignmentOperator(syntax, rewrittenLeft, rewrittenRight, isRef: false, type: type, used: used);
+                    return MakeStaticAssignmentOperator(syntax, rewrittenLeft, rewrittenRight, isRef: false, used: used);
             }
         }
 
@@ -168,7 +210,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rewrittenLeft,
             BoundExpression rewrittenRight,
             bool isRef,
-            TypeSymbol type,
             bool used)
         {
             switch (rewrittenLeft.Kind)
@@ -193,7 +234,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             false,
                             default(ImmutableArray<int>),
                             rewrittenRight,
-                            type,
                             used);
                     }
 
@@ -214,7 +254,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             indexerAccess.Expanded,
                             indexerAccess.ArgsToParamsOpt,
                             rewrittenRight,
-                            type,
                             used);
                     }
 
@@ -227,7 +266,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             syntax,
                             rewrittenLeft,
                             rewrittenRight,
-                            type,
                             isRef);
                     }
 
@@ -252,9 +290,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 sequence.Value,
                                 rewrittenRight,
                                 isRef,
-                                type,
                                 used),
-                            type);
+                            sequence.Type);
                     }
                     goto default;
 
@@ -264,8 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return _factory.AssignmentExpression(
                             syntax,
                             rewrittenLeft,
-                            rewrittenRight,
-                            type);
+                            rewrittenRight);
                     }
             }
         }
@@ -279,7 +315,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool expanded,
             ImmutableArray<int> argsToParamsOpt,
             BoundExpression rewrittenRight,
-            TypeSymbol type,
             bool used)
         {
             // Rewrite property assignment into call to setter.
@@ -350,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     AppendToPossibleNull(argTemps, rhsTemp),
                     ImmutableArray.Create(setterCall),
                     boundRhs,
-                    type);
+                    rhsTemp.Type);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -410,11 +410,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Instrumenter.InterceptCallAndAdjustArguments(ref method, ref rewrittenReceiver, ref rewrittenArguments, ref argRefKindsOpt);
                 }
 
-                var rewrittenCall = MakeCall(node, node.Syntax, rewrittenReceiver, method, rewrittenArguments, argRefKindsOpt, node.ResultKind, node.Type, temps.ToImmutableAndFree());
+                var rewrittenCall = MakeCall(node, node.Syntax, rewrittenReceiver, method, rewrittenArguments, argRefKindsOpt, node.ResultKind, temps.ToImmutableAndFree());
 
                 if (Instrument)
                 {
                     rewrittenCall = Instrumenter.InstrumentCall(node, rewrittenCall);
+                }
+
+                if (node.Type.IsDynamic() && !method.ReturnType.IsDynamic())
+                {
+                    Debug.Assert(node.Type.IsDynamic());
+                    Debug.Assert(!method.ReturnsByRef);
+                    Debug.Assert(rewrittenCall.Type is not null);
+                    Debug.Assert(!rewrittenCall.Type.IsDynamic());
+                    Debug.Assert(!rewrittenCall.Type.IsVoidType());
+                    rewrittenCall = _factory.Convert(node.Type, rewrittenCall);
                 }
 
                 return rewrittenCall;
@@ -429,7 +439,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> rewrittenArguments,
             ImmutableArray<RefKind> argumentRefKinds,
             LookupResultKind resultKind,
-            TypeSymbol type,
             ImmutableArray<LocalSymbol> temps)
         {
             BoundExpression rewrittenBoundCall;
@@ -454,7 +463,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultKind,
                     rewrittenArguments[0],
                     rewrittenArguments[1],
-                    type);
+                    method.ReturnType);
             }
             else if (node == null)
             {
@@ -472,7 +481,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     argsToParamsOpt: default(ImmutableArray<int>),
                     defaultArguments: default(BitVector),
                     resultKind: resultKind,
-                    type: type);
+                    type: method.ReturnType);
             }
             else
             {
@@ -489,8 +498,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     argsToParamsOpt: default(ImmutableArray<int>),
                     defaultArguments: default(BitVector),
                     node.ResultKind,
-                    node.Type);
+                    method.ReturnType);
             }
+
+            Debug.Assert(rewrittenBoundCall.Type is not null);
 
             if (!temps.IsDefaultOrEmpty)
             {
@@ -499,13 +510,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     locals: temps,
                     sideEffects: ImmutableArray<BoundExpression>.Empty,
                     value: rewrittenBoundCall,
-                    type: type);
+                    type: rewrittenBoundCall.Type);
             }
 
             return rewrittenBoundCall;
         }
 
-        private BoundExpression MakeCall(SyntaxNode syntax, BoundExpression? rewrittenReceiver, MethodSymbol method, ImmutableArray<BoundExpression> rewrittenArguments, TypeSymbol type)
+        private BoundExpression MakeCall(SyntaxNode syntax, BoundExpression? rewrittenReceiver, MethodSymbol method, ImmutableArray<BoundExpression> rewrittenArguments)
         {
             return MakeCall(
                 node: null,
@@ -515,7 +526,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenArguments: rewrittenArguments,
                 argumentRefKinds: default(ImmutableArray<RefKind>),
                 resultKind: LookupResultKind.Viable,
-                type: type,
                 temps: default);
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -113,6 +113,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             temps.Free();
             stores.Free();
+
+            result = ConvertResultOfAssignmentToDynamicIfNecessary(node, node.Left, result, used);
+
+            Debug.Assert(used || node.Left is not (BoundIndexerAccess { Indexer.RefKind: RefKind.None } or BoundPropertyAccess { PropertySymbol.RefKind: RefKind.None }) || result.Type?.IsVoidType() == true);
             return result;
 
             BoundExpression rewriteAssignment(BoundExpression leftRead)
@@ -153,7 +157,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     RemovePlaceholderReplacement(node.FinalPlaceholder);
                 }
 
-                return MakeAssignmentOperator(syntax, transformedLHS, opFinal, node.Left.Type, used: used, isChecked: isChecked, isCompoundAssignment: true);
+                Debug.Assert(TypeSymbol.Equals(transformedLHS.Type, node.Left.Type, TypeCompareKind.AllIgnoreOptions));
+                return MakeAssignmentOperator(syntax, transformedLHS, opFinal, used: used, isChecked: isChecked, isCompoundAssignment: true);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -1421,9 +1421,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             rewrittenOperand = MakeConversionNode(rewrittenOperand, method.GetParameterType(0), @checked);
 
-            var returnType = method.ReturnType;
-            Debug.Assert((object)returnType != null);
-
             if (_inExpressionLambda)
             {
                 return BoundConversion.Synthesized(syntax, rewrittenOperand, conversion, @checked, explicitCastInCode: explicitCastInCode, conversionGroupOpt: null, constantValueOpt, rewrittenType);
@@ -1433,8 +1430,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     syntax: syntax,
                     rewrittenReceiver: null,
                     method: method,
-                    rewrittenArguments: ImmutableArray.Create(rewrittenOperand),
-                    type: returnType);
+                    rewrittenArguments: ImmutableArray.Create(rewrittenOperand));
 
             return MakeConversionNode(rewrittenCall, rewrittenType, @checked, markAsChecked: true);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -55,7 +55,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             MethodSymbol? method = node.IsAddition ? node.Event.AddMethod : node.Event.RemoveMethod;
             Debug.Assert(method is { });
-            return MakeCall(node.Syntax, rewrittenReceiverOpt, method, rewrittenArguments, node.Type);
+            Debug.Assert(method.ReturnType.Equals(node.Type, TypeCompareKind.AllIgnoreOptions));
+            return MakeCall(node.Syntax, rewrittenReceiverOpt, method, rewrittenArguments);
         }
 
         private enum EventAssignmentKind
@@ -120,8 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         syntax: syntax,
                         rewrittenReceiver: null,
                         method: clearMethod,
-                        rewrittenArguments: ImmutableArray.Create<BoundExpression>(removeDelegate),
-                        type: clearMethod.ReturnType);
+                        rewrittenArguments: ImmutableArray.Create<BoundExpression>(removeDelegate));
                 }
                 else
                 {
@@ -163,8 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     syntax: syntax,
                     rewrittenReceiver: null,
                     method: marshalMethod,
-                    rewrittenArguments: marshalArguments,
-                    type: marshalMethod.ReturnType);
+                    rewrittenArguments: marshalArguments);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -91,7 +91,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 node.Expanded,
                 node.ArgsToParamsOpt,
                 node.DefaultArguments,
-                node.Type,
                 node,
                 isLeftOfAssignment);
         }
@@ -106,17 +105,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool expanded,
             ImmutableArray<int> argsToParamsOpt,
             BitVector defaultArguments,
-            TypeSymbol type,
-            BoundIndexerAccess? oldNodeOpt,
+            BoundExpression originalIndexerAccessOrObjectInitializerMember,
             bool isLeftOfAssignment)
         {
+            Debug.Assert(originalIndexerAccessOrObjectInitializerMember is BoundIndexerAccess or BoundObjectInitializerMember);
+            Debug.Assert(originalIndexerAccessOrObjectInitializerMember.Type is not null);
+
             if (isLeftOfAssignment && indexer.RefKind == RefKind.None)
             {
+                TypeSymbol type = indexer.Type;
+                Debug.Assert(originalIndexerAccessOrObjectInitializerMember.Type.Equals(type, TypeCompareKind.ConsiderEverything));
+
                 // This is an indexer set access. We return a BoundIndexerAccess node here.
                 // This node will be rewritten with MakePropertyAssignment when rewriting the enclosing BoundAssignmentOperator.
 
-                return oldNodeOpt != null ?
-                    oldNodeOpt.Update(rewrittenReceiver, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, indexer, arguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, defaultArguments, type) :
+                return originalIndexerAccessOrObjectInitializerMember is BoundIndexerAccess indexerAccess ?
+                    indexerAccess.Update(rewrittenReceiver, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, indexer, arguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, defaultArguments, type) :
                     new BoundIndexerAccess(syntax, rewrittenReceiver, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, indexer, arguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, defaultArguments, type);
             }
             else
@@ -145,6 +149,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 BoundExpression call = MakePropertyGetAccess(syntax, rewrittenReceiver, indexer, rewrittenArguments, argumentRefKindsOpt, getMethod);
 
+                if (originalIndexerAccessOrObjectInitializerMember.Type.IsDynamic() == true && !indexer.Type.IsDynamic())
+                {
+                    Debug.Assert(call.Type is not null);
+                    Debug.Assert(!call.Type.IsDynamic());
+                    Debug.Assert(!getMethod.ReturnsByRef);
+                    call = _factory.Convert(originalIndexerAccessOrObjectInitializerMember.Type, call);
+                }
+
+                Debug.Assert(call.Type is not null);
+
                 if (temps.Count == 0)
                 {
                     temps.Free();
@@ -157,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         temps.ToImmutableAndFree(),
                         ImmutableArray<BoundExpression>.Empty,
                         call,
-                        type);
+                        call.Type);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.cs
@@ -63,7 +63,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         localSymbol.Type
                     ),
                     rewrittenInitializer,
-                    localSymbol.Type,
                     localSymbol.IsRef),
                 hasErrors);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingAssignmentOperator.cs
@@ -25,9 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             var lhsRead = MakeRValue(transformedLHS);
             BoundExpression loweredRight = VisitExpression(node.RightOperand);
 
-            return node.IsNullableValueTypeAssignment ?
+            var result = node.IsNullableValueTypeAssignment ?
                     rewriteNullCoalescingAssignmentForValueType() :
                     rewriteNullCoalscingAssignmentStandard();
+
+            return ConvertResultOfAssignmentToDynamicIfNecessary(node, node.LeftOperand, result, used: true);
 
             BoundExpression rewriteNullCoalscingAssignmentStandard()
             {
@@ -38,7 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // isCompoundAssignment is only used for dynamic scenarios, and we want those scenarios to treat this like a standard assignment.
                 // See CodeGenNullCoalescingAssignmentTests.CoalescingAssignment_DynamicRuntimeCastFailure, which will fail if
                 // isCompoundAssignment is set to true. It will fail to throw a runtime binder cast exception.
-                BoundExpression assignment = MakeAssignmentOperator(syntax, transformedLHS, loweredRight, node.LeftOperand.Type, used: true, isChecked: false, isCompoundAssignment: false);
+                Debug.Assert(TypeSymbol.Equals(transformedLHS.Type, node.LeftOperand.Type, TypeCompareKind.AllIgnoreOptions));
+                BoundExpression assignment = MakeAssignmentOperator(syntax, transformedLHS, loweredRight, used: true, isChecked: false, isCompoundAssignment: false);
 
                 // lhsRead ?? (transformedLHS = loweredRight)
                 var leftPlaceholder = new BoundValuePlaceholder(lhsRead.Syntax, lhsRead.Type);
@@ -60,7 +63,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rewriteNullCoalescingAssignmentForValueType()
             {
                 Debug.Assert(node.LeftOperand.Type.IsNullableType());
-                Debug.Assert(node.Type.Equals(node.RightOperand.Type));
 
                 // We lower the expression to this form:
                 //
@@ -107,17 +109,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 temps.Add(tmp.LocalSymbol);
 
                 // tmp = loweredRight;
-                var tmpAssignment = MakeAssignmentOperator(node.Syntax, tmp, loweredRight, node.Type, used: true, isChecked: false, isCompoundAssignment: false);
+                var tmpAssignment = MakeAssignmentOperator(node.Syntax, tmp, loweredRight, used: true, isChecked: false, isCompoundAssignment: false);
 
                 Debug.Assert(transformedLHS.Type.GetNullableUnderlyingType().Equals(tmp.Type.StrippedType(), TypeCompareKind.AllIgnoreOptions));
 
                 // transformedLhs = tmp;
+                Debug.Assert(TypeSymbol.Equals(transformedLHS.Type, node.LeftOperand.Type, TypeCompareKind.AllIgnoreOptions));
                 var transformedLhsAssignment =
                     MakeAssignmentOperator(
                         node.Syntax,
                         transformedLHS,
                         MakeConversionNode(tmp, transformedLHS.Type, @checked: false, markAsChecked: true),
-                        node.LeftOperand.Type,
                         used: true,
                         isChecked: false,
                         isCompoundAssignment: false);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -532,7 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ref temps,
                 invokedAsExtensionMethod: method.IsExtensionMethod);
 
-            return MakeCall(null, syntax, expression, method, rewrittenArguments, argumentRefKindsOpt, LookupResultKind.Viable, method.ReturnType, temps.ToImmutableAndFree());
+            return MakeCall(null, syntax, expression, method, rewrittenArguments, argumentRefKindsOpt, LookupResultKind.Viable, temps.ToImmutableAndFree());
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -469,20 +469,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public BoundExpression AssignmentExpression(BoundExpression left, BoundExpression right, bool isRef = false)
         {
-            Debug.Assert(left.Type is { } && right.Type is { } &&
-                (left.Type.Equals(right.Type, TypeCompareKind.AllIgnoreOptions) ||
-                 StackOptimizerPass1.IsFixedBufferAssignmentToRefLocal(left, right, isRef) ||
-                 right.Type.IsErrorType() || left.Type.IsErrorType()));
-
-            return AssignmentExpression(Syntax, left, right, left.Type, isRef: isRef, wasCompilerGenerated: true);
+            return AssignmentExpression(Syntax, left, right, isRef: isRef, wasCompilerGenerated: true);
         }
 
         /// <summary>
         /// Creates a general assignment that might be instrumented.
         /// </summary>
-        public BoundExpression AssignmentExpression(SyntaxNode syntax, BoundExpression left, BoundExpression right, TypeSymbol type, bool isRef = false, bool hasErrors = false, bool wasCompilerGenerated = false)
+        public BoundExpression AssignmentExpression(SyntaxNode syntax, BoundExpression left, BoundExpression right, bool isRef = false, bool hasErrors = false, bool wasCompilerGenerated = false)
         {
-            var assignment = new BoundAssignmentOperator(syntax, left, right, isRef, type, hasErrors) { WasCompilerGenerated = wasCompilerGenerated };
+            Debug.Assert(left.Type is { } && right.Type is { } &&
+                (left.Type.Equals(right.Type, TypeCompareKind.AllIgnoreOptions) ||
+                 StackOptimizerPass1.IsFixedBufferAssignmentToRefLocal(left, right, isRef) ||
+                 right.Type.IsErrorType() || left.Type.IsErrorType()));
+
+            var assignment = new BoundAssignmentOperator(syntax, left, right, isRef, left.Type, hasErrors) { WasCompilerGenerated = wasCompilerGenerated };
 
             return (InstrumentationState?.IsSuppressed == false && left is BoundLocal { LocalSymbol.SynthesizedKind: SynthesizedLocalKind.UserDefined } or BoundParameter) ?
                 InstrumentationState.Instrumenter.InstrumentUserDefinedLocalAssignment(assignment) :

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
@@ -13,11 +13,32 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public partial class SyntaxBinderTests
+    public partial class DynamicTests : CompilingTestBase
     {
+        private static void TestTypes(string source)
+        {
+            SyntaxBinderTests.TestTypes(source);
+        }
+
+        private static void TestOperatorKinds(string source)
+        {
+            SyntaxBinderTests.TestOperatorKinds(source);
+        }
+
+        private static void TestDynamicMemberAccessCore(string source)
+        {
+            SyntaxBinderTests.TestDynamicMemberAccessCore(source);
+        }
+
+        private static void TestCompoundAssignment(string source)
+        {
+            SyntaxBinderTests.TestCompoundAssignment(source);
+        }
+
         #region Conversions
 
         [Fact]
@@ -3013,7 +3034,7 @@ class C1
     public C1(long x){}
 }
 ";
-            CreateCompilationWithMscorlib40AndSystemCore(new[] { Parse(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp5)) }).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndSystemCore(new[] { Parse(source, options: TestOptions.RegularPreview) }).VerifyDiagnostics(
 
                 // (43,55): warning CS1981: Using 'is' to test compatibility with 'dynamic' is essentially identical to testing compatibility with 'Object' and will succeed for all non-null values
                 //         Expression<Func<dynamic, dynamic>> e18 = x => d is dynamic; // ok, warning
@@ -3066,6 +3087,76 @@ class C1
                 // (33,54): error CS1963: An expression tree may not contain a dynamic operation
                 //         Expression<Func<dynamic, dynamic>> e8 = x => -x;
                 Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "-x").WithLocation(33, 54),
+                // (38,55): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e13 = x => d ? 1 : 2;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(38, 55),
+                // (39,56): error CS1989: Async lambda expressions cannot be converted to expression trees
+                //         Expression<Func<dynamic, Task<dynamic>>> e14 = async x => await d;
+                Diagnostic(ErrorCode.ERR_BadAsyncExpressionTree, "async x => await d").WithLocation(39, 56),
+                // (47,84): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e22 = x => from a in new[] { d } select a + 1;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "a + 1").WithLocation(47, 84),
+                // (49,55): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e24 = x => new C1(x);
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "new C1(x)").WithLocation(49, 55)
+                );
+
+            CreateCompilationWithMscorlib40AndSystemCore(new[] { Parse(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp5)) }).VerifyDiagnostics(
+
+                // (43,55): warning CS1981: Using 'is' to test compatibility with 'dynamic' is essentially identical to testing compatibility with 'Object' and will succeed for all non-null values
+                //         Expression<Func<dynamic, dynamic>> e18 = x => d is dynamic; // ok, warning
+                Diagnostic(ErrorCode.WRN_IsDynamicIsConfusing, "d is dynamic").WithArguments("is", "dynamic", "Object").WithLocation(43, 55),
+                // (46,59): error CS8382: Invalid object creation
+                //         Expression<Func<dynamic, dynamic>> e21 = x => new dynamic();
+                Diagnostic(ErrorCode.ERR_InvalidObjectCreation, "dynamic").WithLocation(46, 59),
+                // (25,52): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<C>> e0 = () => new C { P = d };
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(25, 52),
+                // (27,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<C>> e2 = () => new C { D = { X = { Y = 1 }, Z = 1 } };
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "X").WithLocation(27, 54),
+                // (27,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<C>> e2 = () => new C { D = { X = { Y = 1 }, Z = 1 } };
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "Y").WithLocation(27, 60),
+                // (27,69): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<C>> e2 = () => new C { D = { X = { Y = 1 }, Z = 1 } };
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "Z").WithLocation(27, 69),
+                // (28,44): error CS1963: An expression tree may not contain a dynamic operation
+                // 		Expression<Func<C>> e3 = () => new C() { { d }, { d, d, d } };
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "{ d }").WithLocation(28, 44),
+                // (28,51): error CS1963: An expression tree may not contain a dynamic operation
+                // 		Expression<Func<C>> e3 = () => new C() { { d }, { d, d, d } };
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "{ d, d, d }").WithLocation(28, 51),
+                // (29,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e4 = x => x.goo();
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "x.goo()").WithLocation(29, 54),
+                // (29,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e4 = x => x.goo();
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "x.goo").WithLocation(29, 54),
+                // (30,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e5 = x => x[1];
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "x[1]").WithLocation(30, 54),
+                // (31,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e6 = x => x.y.z;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "x.y.z").WithLocation(31, 54),
+                // (31,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e6 = x => x.y.z;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "x.y").WithLocation(31, 54),
+                // (32,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e7 = x => x + 1;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "x + 1").WithLocation(32, 54),
+                // (33,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e8 = x => -x;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "-x").WithLocation(33, 54),
+                // (34,54): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e9 = x => f(d);
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "f(d)").WithLocation(34, 54),
+                // (36,55): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e11 = x => f((dynamic)1);
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "f((dynamic)1)").WithLocation(36, 55),
+                // (37,55): error CS1963: An expression tree may not contain a dynamic operation
+                //         Expression<Func<dynamic, dynamic>> e12 = x => f(d ?? null);
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "f(d ?? null)").WithLocation(37, 55),
                 // (38,55): error CS1963: An expression tree may not contain a dynamic operation
                 //         Expression<Func<dynamic, dynamic>> e13 = x => d ? 1 : 2;
                 Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(38, 55),
@@ -4399,13 +4490,24 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, parseOptions: TestOptions.Regular7_2, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithMscorlib45AndCSharp(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.DebugExe);
 
             CompileAndVerify(comp, expectedOutput:
 @"
 True
 True
 ").VerifyDiagnostics();
+
+            comp = CreateCompilationWithMscorlib45AndCSharp(source, parseOptions: TestOptions.Regular7_2, options: TestOptions.DebugExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (10,15): error CS8364: Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.
+                //         M1(in d, d = 2, in d);
+                Diagnostic(ErrorCode.ERR_InDynamicMethodArg, "d").WithLocation(10, 15),
+                // (10,28): error CS8364: Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.
+                //         M1(in d, d = 2, in d);
+                Diagnostic(ErrorCode.ERR_InDynamicMethodArg, "d").WithLocation(10, 28)
+                );
         }
 
         [WorkItem(22813, "https://github.com/dotnet/roslyn/issues/22813")]
@@ -4544,6 +4646,6905 @@ class C2 : C1
             var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
 
             CompileAndVerify(comp, expectedOutput: "int").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ResultIsDynamic_01(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source1 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1.Test(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    object Test(string name, object value);
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp1 = CreateCompilation(source1, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"i1.Test(""name"", value)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("System.Object I1.Test(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), operation.TargetMethod.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1).VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((I1 i1, dynamic value) => i1.Test(""name"", value));
+        Print(expr);
+    }
+
+    static Expression<Func<I1, dynamic, T>> GetExpression<T>(Expression<Func<I1, dynamic, T>> ex) => ex;
+    static void Print<T1, T2, T3>(Expression<Func<T1, T2, T3>> expr)
+    {
+        System.Console.Write(typeof(T3));
+        System.Console.Write("" "");
+        System.Console.Write(expr);
+    }
+}
+
+public interface I1
+{
+    object Test(string name, object value);
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe, parseOptions: parseOptions);
+            CompileAndVerify(comp2,
+                expectedOutput: @"System.Object (i1, value) => Convert(i1.Test(""name"", value)" + (ExecutionConditionUtil.IsMonoOrCoreClr ? ", Object)" : ")")).VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1.Test(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    object? Test(string name, object value);
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+            comp3.VerifyDiagnostics(
+                // (9,46): warning CS8604: Possible null reference argument for parameter 'c' in 'C JsonSerializer.Deserialize<C>(Stream c)'.
+                //         return JsonSerializer.Deserialize<C>(result);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "result").WithArguments("c", "C JsonSerializer.Deserialize<C>(Stream c)").WithLocation(9, 46)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ResultIsDynamic_02(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source1 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1.Test(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    int Test(string name, object value);
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp1 = CreateCompilation(source1, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"i1.Test(""name"", value)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("System.Int32 I1.Test(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), operation.TargetMethod.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1).VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((I1 i1, dynamic value) => i1.Test(""name"", value));
+        Print(expr);
+    }
+
+    static Expression<Func<I1, dynamic, T>> GetExpression<T>(Expression<Func<I1, dynamic, T>> ex) => ex;
+    static void Print<T1, T2, T3>(Expression<Func<T1, T2, T3>> expr)
+    {
+        System.Console.Write(typeof(T3));
+        System.Console.Write("" "");
+        System.Console.Write(expr);
+    }
+}
+
+public interface I1
+{
+    object Test(string name, object value);
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe, parseOptions: parseOptions);
+            CompileAndVerify(comp2,
+                expectedOutput: @"System.Object (i1, value) => Convert(i1.Test(""name"", value)" + (ExecutionConditionUtil.IsMonoOrCoreClr ? ", Object)" : ")")).VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1.Test(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    int? Test(string name, object value);
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+            comp3.VerifyDiagnostics(
+                // (9,46): warning CS8604: Possible null reference argument for parameter 'c' in 'C JsonSerializer.Deserialize<C>(Stream c)'.
+                //         return JsonSerializer.Deserialize<C>(result);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "result").WithArguments("c", "C JsonSerializer.Deserialize<C>(Stream c)").WithLocation(9, 46)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ResultIsDynamic_03(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source1 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1.Test(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    dynamic Test(string name, object value);
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp1 = CreateCompilation(source1, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"i1.Test(""name"", value)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("dynamic I1.Test(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), operation.TargetMethod.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1).VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((I1 i1, dynamic value) => i1.Test(""name"", value));
+        Print(expr);
+    }
+
+    static Expression<Func<I1, dynamic, T>> GetExpression<T>(Expression<Func<I1, dynamic, T>> ex) => ex;
+    static void Print<T1, T2, T3>(Expression<Func<T1, T2, T3>> expr)
+    {
+        System.Console.Write(typeof(T3));
+        System.Console.Write("" "");
+        System.Console.Write(expr);
+    }
+}
+
+public interface I1
+{
+    dynamic Test(string name, object value);
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe, parseOptions: parseOptions);
+            CompileAndVerify(comp2,
+                expectedOutput: @"System.Object (i1, value) => i1.Test(""name"", value)").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1.Test(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    dynamic? Test(string name, object value);
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+            comp3.VerifyDiagnostics(
+                // (9,46): warning CS8604: Possible null reference argument for parameter 'c' in 'C JsonSerializer.Deserialize<C>(Stream c)'.
+                //         return JsonSerializer.Deserialize<C>(result);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "result").WithArguments("c", "C JsonSerializer.Deserialize<C>(Stream c)").WithLocation(9, 46)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_Extension(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = new C().Test(""name"", d);
+        System.Console.Write(result);        
+    }
+}
+
+static class Extensions
+{
+    public static int Test(this C c, string name, object value) => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"new C().Test(""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.Test(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_01()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = Test(name: ""name"", d);
+        System.Console.Write(result);        
+    }
+
+    static int Test(string name, object value) => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(name: ""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.Test(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_02()
+        {
+            string source1 = @"
+#pragma warning disable //CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+
+unsafe public class C
+{
+    static void Main()
+    {
+        string name = ""name"";
+        dynamic d = 1;
+        var result = Test(&name, d);
+        System.Console.Write(result);        
+    }
+
+    static int Test(string* name, object value) => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe.WithAllowUnsafe(true), targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(&name, d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("System.Int32 C.Test(System.String* name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123", verify: Verification.Skipped).VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_03(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = Test(""name"", d);
+        System.Console.Write(result);        
+    }
+
+    static int Test(string name, object value, params System.Collections.Generic.List<int> list) => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.Test(System.String name, System.Object value, params System.Collections.Generic.List<System.Int32> list)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("System.Int32", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_ParamArray()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = Test(""name"", d);
+        System.Console.Write(result);        
+    }
+
+    static int Test(string name, object value, params int[] list) => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.Test(System.String name, System.Object value, params System.Int32[] list)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_VoidReturning()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var a = Test1(d);
+    }
+
+    static void Test1(int x) {}
+}
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp);
+
+            comp.VerifyDiagnostics(
+                // (7,13): error CS0815: Cannot assign void to an implicitly-typed variable
+                //         var a = Test1(d);
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, "a = Test1(d)").WithArguments("void").WithLocation(7, 13)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        Test1(d)++;
+        var a = Test1(d);
+        System.Console.WriteLine(a);        
+    }
+
+    static int _test1 = 0;    
+    static ref int Test1(int x) => ref _test1;
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 a", symbolInfo.Symbol.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "1").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_NoConversion()
+        {
+            string source = @"
+unsafe public class C
+{
+    public static void Main()
+    {
+        int v = 0;
+        _test1 = &v;
+
+        dynamic d = 1;
+        (*Test1(d))++;
+        var a = Test1(d);
+        System.Console.WriteLine(*a);        
+    }
+
+    static int* _test1;    
+    static int* Test1(int x) => _test1;
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe.WithAllowUnsafe(true), targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32* a", symbolInfo.Symbol.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "1", verify: Verification.Skipped).VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_LocalFunction([CombinatorialValues(0, 12, 13)] int version)
+        {
+            var parseOptions = version switch { 12 => TestOptions.Regular12, 13 => TestOptions.RegularNext, _ => TestOptions.RegularPreview };
+
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var e = test4(d);
+        System.Console.WriteLine(e);        
+
+        static int test4(int x) => x;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "e").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 e", symbolInfo.Symbol.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "1").VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ResultIsDynamic_Delegate(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source = @"
+public class C
+{
+    static C M(Test i1, dynamic value)
+    {
+        var result = i1(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+delegate object Test(string name, object value);
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T);
+}
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"i1(""name"", value)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("System.Object Test.Invoke(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), operation.TargetMethod.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_Delegate_01()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = Test(name: ""name"", d);
+        System.Console.Write(result);        
+    }
+
+    static D Test = (string name, object value) => 123;
+    delegate int D(string name, object value);
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(name: ""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.D.Invoke(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_Delegate_02()
+        {
+            string source1 = @"
+#pragma warning disable //CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+
+unsafe public class C
+{
+    static void Main()
+    {
+        string name = ""name"";
+        dynamic d = 1;
+        var result = Test(&name, d);
+        System.Console.Write(result);        
+    }
+
+    static D Test = (string* name, object value) => 123;
+    delegate int D(string* name, object value);
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe.WithAllowUnsafe(true), targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(&name, d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("System.Int32 C.D.Invoke(System.String* name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123", verify: Verification.Skipped).VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_Delegate_03(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = Test(""name"", d);
+        System.Console.Write(result);        
+    }
+
+    static D Test = (string name, object value, params System.Collections.Generic.List<int> list) => 123;
+    delegate int D(string name, object value, params System.Collections.Generic.List<int> list);
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.D.Invoke(System.String name, System.Object value, params System.Collections.Generic.List<System.Int32> list)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("System.Int32", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_ParamArray_Delegate()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = Test(""name"", d);
+        System.Console.Write(result);        
+    }
+
+    static D Test = (string name, object value, params int[] list) => 123;
+    delegate int D(string name, object value, params int[] list);
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.D.Invoke(System.String name, System.Object value, params System.Int32[] list)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_VoidReturning_Delegate()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var a = Test1(d);
+    }
+
+    static D Test1 = null;
+}
+
+delegate void D(int x);
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp);
+
+            comp.VerifyDiagnostics(
+                // (7,13): error CS0815: Cannot assign void to an implicitly-typed variable
+                //         var a = Test1(d);
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, "a = Test1(d)").WithArguments("void").WithLocation(7, 13)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Delegate()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        Test1(d)++;
+        var a = Test1(d);
+        System.Console.WriteLine(a);        
+    }
+
+    static int _test1 = 0;    
+    static D Test1 = (int x) => ref _test1;
+
+    delegate ref int D(int x);
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 a", symbolInfo.Symbol.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "1").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_NoConversion_Delegate()
+        {
+            string source = @"
+unsafe public class C
+{
+    public static void Main()
+    {
+        int v = 0;
+        _test1 = &v;
+
+        dynamic d = 1;
+        (*Test1(d))++;
+        var a = Test1(d);
+        System.Console.WriteLine(*a);        
+    }
+
+    static int* _test1;    
+    static D Test1 = (int x) => _test1;
+    delegate int* D(int x);
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe.WithAllowUnsafe(true), targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32* a", symbolInfo.Symbol.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "1", verify: Verification.Skipped).VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ResultIsDynamic_Property_01(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1[""name"", value];
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    object this[string name, object value] {get;}
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Object I1.this[System.String name, System.Object value] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), operation.Property.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp).VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((I1 i1, dynamic value) => i1[""name"", value]);
+        Print(expr);
+    }
+
+    static Expression<Func<I1, dynamic, T>> GetExpression<T>(Expression<Func<I1, dynamic, T>> ex) => ex;
+    static void Print<T1, T2, T3>(Expression<Func<T1, T2, T3>> expr)
+    {
+        System.Console.Write(typeof(T3));
+        System.Console.Write("" "");
+        System.Console.Write(expr);
+    }
+}
+
+public interface I1
+{
+    object this[string name, object value] {get;}
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe, parseOptions: parseOptions);
+            CompileAndVerify(comp2,
+                expectedOutput: @"System.Object (i1, value) => Convert(i1.get_Item(""name"", value)" + (ExecutionConditionUtil.IsMonoOrCoreClr ? ", Object)" : ")")).VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1[""name"", value];
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    object? this[string name, object value] {get;}
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+            comp3.VerifyDiagnostics(
+                // (9,46): warning CS8604: Possible null reference argument for parameter 'c' in 'C JsonSerializer.Deserialize<C>(Stream c)'.
+                //         return JsonSerializer.Deserialize<C>(result);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "result").WithArguments("c", "C JsonSerializer.Deserialize<C>(Stream c)").WithLocation(9, 46)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ResultIsDynamic_Property_02(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1[""name"", value];
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    int this[string name, object value] {get;}
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 I1.this[System.String name, System.Object value] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), operation.Property.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp).VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((I1 i1, dynamic value) => i1[""name"", value]);
+        Print(expr);
+    }
+
+    static Expression<Func<I1, dynamic, T>> GetExpression<T>(Expression<Func<I1, dynamic, T>> ex) => ex;
+    static void Print<T1, T2, T3>(Expression<Func<T1, T2, T3>> expr)
+    {
+        System.Console.Write(typeof(T3));
+        System.Console.Write("" "");
+        System.Console.Write(expr);
+    }
+}
+
+public interface I1
+{
+    int this[string name, object value] {get;}
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe, parseOptions: parseOptions);
+            CompileAndVerify(comp2,
+                expectedOutput: @"System.Object (i1, value) => Convert(i1.get_Item(""name"", value)" + (ExecutionConditionUtil.IsMonoOrCoreClr ? ", Object)" : ")")).VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1[""name"", value];
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    int? this[string name, object value] {get;}
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+            comp3.VerifyDiagnostics(
+                // (9,46): warning CS8604: Possible null reference argument for parameter 'c' in 'C JsonSerializer.Deserialize<C>(Stream c)'.
+                //         return JsonSerializer.Deserialize<C>(result);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "result").WithArguments("c", "C JsonSerializer.Deserialize<C>(Stream c)").WithLocation(9, 46)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_03()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1[""name"", value];
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    dynamic this[string name, object value] {get;}
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic I1.this[System.String name, System.Object value] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), operation.Property.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp).VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((I1 i1, dynamic value) => i1[""name"", value]);
+        Print(expr);
+    }
+
+    static Expression<Func<I1, dynamic, T>> GetExpression<T>(Expression<Func<I1, dynamic, T>> ex) => ex;
+    static void Print<T1, T2, T3>(Expression<Func<T1, T2, T3>> expr)
+    {
+        System.Console.Write(typeof(T3));
+        System.Console.Write("" "");
+        System.Console.Write(expr);
+    }
+}
+
+public interface I1
+{
+    dynamic this[string name, object value] {get;}
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            CompileAndVerify(comp2,
+                expectedOutput: @"System.Object (i1, value) => i1.get_Item(""name"", value)").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1[""name"", value];
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    dynamic? this[string name, object value] {get;}
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (9,46): warning CS8604: Possible null reference argument for parameter 'c' in 'C JsonSerializer.Deserialize<C>(Stream c)'.
+                //         return JsonSerializer.Deserialize<C>(result);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "result").WithArguments("c", "C JsonSerializer.Deserialize<C>(Stream c)").WithLocation(9, 46)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_Property_01()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = new C()[name: ""name"", d];
+        System.Console.Write(result);        
+    }
+
+    int this[string name, object value] => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // This is surprising, but this scenario used to successfully bind dynamically before (unlike a call).
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.String name, System.Object value] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), operation.Property.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_Property_02()
+        {
+            string source1 = @"
+#pragma warning disable //CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+
+unsafe public class C
+{
+    static void Main()
+    {
+        string name = ""name"";
+        dynamic d = 1;
+        var result = new C()[&name, d];
+        System.Console.Write(result);        
+    }
+
+    int this[string* name, object value] => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe.WithAllowUnsafe(true), targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.String* name, System.Object value] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            CompileAndVerify(comp1, expectedOutput: "123", verify: Verification.Skipped).VerifyDiagnostics();
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [CombinatorialData]
+        public void SingleCandidate_ArgumentsNotSupportedByDynamic_Property_03(bool testPreview)
+        {
+            var parseOptions = testPreview ? TestOptions.RegularPreview : TestOptions.RegularNext;
+
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = new C()[""name"", d];
+        System.Console.Write(result);        
+    }
+
+    int this[string name, object value, params System.Collections.Generic.List<int> list] => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: parseOptions);
+
+            // This is surprising, but this scenario used to successfully bind dynamically before (unlike a call).
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.String name, System.Object value, params System.Collections.Generic.List<System.Int32> list] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_ParamArray_Property()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = new C()[""name"", d];
+        System.Console.Write(result);        
+    }
+
+    int this[string name, object value, params int[] list] => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // This is surprising, but this scenario used to successfully bind dynamically before (unlike a call).
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.String name, System.Object value, params System.Int32[] list] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Property()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        c[d]++;
+        var a = c[d];
+        System.Console.WriteLine(a);        
+    }
+
+    int _test1 = 0;    
+    ref int this[int x] => ref _test1;
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 a", symbolInfo.Symbol.ToTestDisplayString());
+
+            TypeInfo typeInfo;
+
+            foreach (var elementAccess in tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>())
+            {
+                symbolInfo = model.GetSymbolInfo(elementAccess);
+                AssertEx.Equal("ref System.Int32 C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+                typeInfo = model.GetTypeInfo(elementAccess);
+                AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+                AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+                var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+                AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+                Assert.Equal(typeInfo.Type, propertyRef.Type);
+            }
+
+            var increment = tree.GetRoot().DescendantNodes().OfType<PostfixUnaryExpressionSyntax>().Single();
+            typeInfo = model.GetTypeInfo(increment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "1").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_NoConversion_Property()
+        {
+            string source = @"
+unsafe public class C
+{
+    public static void Main()
+    {
+        int v = 0;
+        var c = new C();
+        c._test1 = &v;
+
+        dynamic d = 1;
+        (*c[d])++;
+        var a = c[d];
+        System.Console.WriteLine(*a);        
+    }
+
+    int* _test1;    
+    int* this[int x] => _test1;
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe.WithAllowUnsafe(true), targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32* a", symbolInfo.Symbol.ToTestDisplayString());
+
+            TypeInfo typeInfo;
+
+            foreach (var elementAccess in tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>())
+            {
+                symbolInfo = model.GetSymbolInfo(elementAccess);
+                AssertEx.Equal("System.Int32* C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+                typeInfo = model.GetTypeInfo(elementAccess);
+                AssertEx.Equal("System.Int32*", typeInfo.Type.ToTestDisplayString());
+                AssertEx.Equal("System.Int32*", typeInfo.ConvertedType.ToTestDisplayString());
+
+                var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+                AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+                Assert.Equal(typeInfo.Type, propertyRef.Type);
+            }
+
+            CompileAndVerify(comp, expectedOutput: "1", verify: Verification.Skipped).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_01()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] = 2;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] = (int?)null;
+        Print(a);        
+    }
+
+    int? _test1 = 0;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_02()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] = 2;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] = (int?)null;
+        Print(a);        
+    }
+
+    int? _test1 = 0;    
+    dynamic? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_03()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        dynamic right = 2;
+        var a = c[d] = right;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        dynamic? right = (int?)null;
+        var a = c[d] = right;
+        Print(a);        
+    }
+
+    int? _test1 = 0;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (12,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(12, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_RightSideIsConvertedStatically()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        object o = null;
+        var c = new C();
+        var a = c[d] = o;
+        System.Console.Write(a);        
+    }
+
+    System.IO.Stream this[int x]
+    {
+        get => null;
+        set {}
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.IO.Stream C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.IO.Stream", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.IO.Stream", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.IO.Stream", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.IO.Stream", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Object", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.IO.Stream", typeInfo.ConvertedType.ToTestDisplayString());
+
+            comp.VerifyDiagnostics(
+                // (9,24): error CS0266: Cannot implicitly convert type 'object' to 'System.IO.Stream'. An explicit conversion exists (are you missing a cast?)
+                //         var a = c[d] = o;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "o").WithArguments("object", "System.IO.Stream").WithLocation(9, 24)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Property_Assignment()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] = 2;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    ref int this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref System.Int32 C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] = (int?)null;
+        Print(a);        
+    }
+
+    int? _test1 = 0;    
+    ref int? this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_CompoundAssignment_01()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] += 2;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("System.Int32 System.Int32.op_Addition(System.Int32 left, System.Int32 right)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var operation = (ICompoundAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] += (int?)null;
+        Print(a);        
+    }
+
+    int? _test1 = 0;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (10,17): warning CS0458: The result of the expression is always 'null' of type 'dynamic'
+                //         var a = c[d] += (int?)null;
+                Diagnostic(ErrorCode.WRN_AlwaysNull, "c[d] += (int?)null").WithArguments("dynamic").WithLocation(10, 17),
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72906")]
+        public void SingleCandidate_ResultIsDynamic_Property_CompoundAssignment_02()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] += 2;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("dynamic dynamic.op_Addition(dynamic left, System.Int32 right)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var operation = (ICompoundAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] += (int?)null;
+        Print(a);        
+    }
+
+    int? _test1 = 0;    
+    dynamic? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // Nullable analysis behavior is consistent with how dynamic operators are analyzed.
+            // See https://github.com/dotnet/roslyn/issues/72906, for example.
+            comp3.VerifyDiagnostics();
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72906")]
+        public void SingleCandidate_ResultIsDynamic_Property_CompoundAssignment_03()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] += d;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("dynamic dynamic.op_Addition(System.Int32 left, dynamic right)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var operation = (ICompoundAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "1 1").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        dynamic? right = null;
+        var c = new C();
+        var a = c[d] += right;
+        Print(a);        
+    }
+
+    int? _test1 = 0;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // Nullable analysis behavior is consistent with how dynamic operators are analyzed.
+            // See https://github.com/dotnet/roslyn/issues/72906, for example.
+            comp3.VerifyDiagnostics();
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_CompoundAssignment_OperatorIsBoundStatically()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        C2 right = new C2();
+        var a = c[d] += right;
+        Print(a);        
+    }
+
+    C2 this[int x]
+    {
+        get => new C2();
+        set {}
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2 {}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("?", typeInfo.Type.ToTestDisplayString());
+            Assert.True(typeInfo.Type.IsErrorType());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("C2 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("?", typeInfo.Type.ToTestDisplayString());
+            Assert.True(typeInfo.Type.IsErrorType());
+            AssertEx.Equal("?", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            Assert.Null(symbolInfo.Symbol);
+
+            var operation = (ICompoundAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("C2", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("?", operation.Type.ToTestDisplayString());
+            Assert.True(operation.Type.IsErrorType());
+            Assert.Null(operation.OperatorMethod);
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            comp.VerifyDiagnostics(
+                // (9,17): error CS0019: Operator '+=' cannot be applied to operands of type 'C2' and 'C2'
+                //         var a = c[d] += right;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "c[d] += right").WithArguments("+=", "C2", "C2").WithLocation(9, 17)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Property_CompoundAssignment()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] += 2;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    ref int this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref System.Int32 C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("System.Int32 System.Int32.op_Addition(System.Int32 left, System.Int32 right)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] += (int?)null;
+        Print(a);        
+    }
+
+    int? _test1 = 0;    
+    ref int? this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (10,17): warning CS0458: The result of the expression is always 'null' of type 'int?'
+                //         var a = c[d] += (int?)null;
+                Diagnostic(ErrorCode.WRN_AlwaysNull, "c[d] += (int?)null").WithArguments("int?").WithLocation(10, 17),
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_PostfixIncrement_01()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d]++;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 2;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (PostfixUnaryExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("System.Int32 System.Int32.op_Increment(System.Int32 value)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var operation = (IIncrementOrDecrementOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            CompileAndVerify(comp, expectedOutput: "2 3").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d]++;
+        Print(a);        
+    }
+
+    int? _test1 = 2;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_PostfixIncrement_02()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d]++;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 2;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (PostfixUnaryExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("dynamic dynamic.op_Increment(dynamic value)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var operation = (IIncrementOrDecrementOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            CompileAndVerify(comp, expectedOutput: "2 3").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d]++;
+        Print(a);        
+    }
+
+    int? _test1 = 2;    
+    dynamic? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_PostfixIncrement_OperatorIsBoundStatically()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d]++;
+        Print(a);        
+    }
+
+
+    C2 this[int x]
+    {
+        get => new C2();
+        set {}
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2 {}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("?", typeInfo.Type.ToTestDisplayString());
+            Assert.True(typeInfo.Type.IsErrorType());
+            Assert.Equal(CodeAnalysis.NullableFlowState.None, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("C2 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (PostfixUnaryExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("?", typeInfo.Type.ToTestDisplayString());
+            Assert.True(typeInfo.Type.IsErrorType());
+            Assert.Equal(typeInfo.Type, typeInfo.ConvertedType);
+            symbolInfo = model.GetSymbolInfo(assignment);
+            Assert.Null(symbolInfo.Symbol);
+
+            var operation = (IIncrementOrDecrementOperation)model.GetOperation(assignment);
+            AssertEx.Equal("C2", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("?", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            comp.VerifyDiagnostics(
+                // (8,17): error CS0023: Operator '++' cannot be applied to operand of type 'C2'
+                //         var a = c[d]++;
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "c[d]++").WithArguments("++", "C2").WithLocation(8, 17)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_PrefixIncrement_01()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = ++c[d];
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 2;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (PrefixUnaryExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("System.Int32 System.Int32.op_Increment(System.Int32 value)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var operation = (IIncrementOrDecrementOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            CompileAndVerify(comp, expectedOutput: "3 3").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = ++c[d];
+        Print(a);        
+    }
+
+    int? _test1 = 2;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_PrefixIncrement_02()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = ++c[d];
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 2;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (PrefixUnaryExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("dynamic dynamic.op_Increment(dynamic value)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var operation = (IIncrementOrDecrementOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            CompileAndVerify(comp, expectedOutput: "3 3").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = ++c[d];
+        Print(a);        
+    }
+
+    int? _test1 = 2;    
+    dynamic? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Property_PrefixIncrement()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = ++c[d];
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 2;    
+    ref int this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref System.Int32 C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (PrefixUnaryExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+            symbolInfo = model.GetSymbolInfo(assignment);
+            AssertEx.Equal("System.Int32 System.Int32.op_Increment(System.Int32 value)", symbolInfo.Symbol.ToTestDisplayString());
+
+            var operation = (IIncrementOrDecrementOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Type.ToTestDisplayString());
+            Assert.Null(operation.OperatorMethod);
+
+            CompileAndVerify(comp, expectedOutput: "3 3").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = ++c[d];
+        Print(a);        
+    }
+
+    int? _test1 = 2;    
+    ref int? this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_ConditionalAssignment_01()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= ""2"";
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    string _test1 = null!;    
+    string this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.String C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.String", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.String", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.String", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.String", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.String", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.String", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= (string?)null;
+        Print(a);        
+    }
+
+    string? _test1 = null;    
+    string? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_ConditionalAssignment_02()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= 2;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int? _test1 = null;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32? C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32?", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32?", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32?", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= (int?)null;
+        Print(a);        
+    }
+
+    int? _test1 = null;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_ConditionalAssignment_03()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= ""2"";
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    string _test1 = null!;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.String", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= (string?)null;
+        Print(a);        
+    }
+
+    string? _test1 = null;    
+    dynamic? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_ConditionalAssignment_04()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        dynamic right = ""2"";
+        var a = c[d] ??= right;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    string _test1 = null!;    
+    string this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.String C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.String", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.String", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.String", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.String", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.String", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        dynamic? right = null;
+        var a = c[d] ??= right;
+        Print(a);        
+    }
+
+    string? _test1 = null;    
+    string? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (12,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a);        
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("b", "void C.Print(dynamic b)").WithLocation(12, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72912")]
+        public void SingleCandidate_ResultIsDynamic_Property_ConditionalAssignment_RightSideIsConvertedStatically()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= ""2"";
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    C2? _test1 = null;    
+    C2? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+
+class C2 {}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("C2? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("C2? C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("C2?", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2?", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("?", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("?", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("C2?", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.String", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("?", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.String", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.String", typeInfo.ConvertedType.ToTestDisplayString());
+
+            // The unexpected nullability warning is pre-existing condition - https://github.com/dotnet/roslyn/issues/72912
+            comp.VerifyDiagnostics(
+                // (10,17): error CS0019: Operator '??=' cannot be applied to operands of type 'C2' and 'string'
+                //         var a = c[d] ??= "2";
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, @"c[d] ??= ""2""").WithArguments("??=", "C2", "string").WithLocation(10, 17),
+                // (10,26): warning CS8619: Nullability of reference types in value of type 'string' doesn't match target type 'C2'.
+                //         var a = c[d] ??= "2";
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, @"""2""").WithArguments("string", "C2").WithLocation(10, 26)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_ConditionalAssignment_Error()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= new C2();
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    C2 _test1;    
+    C2 this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+
+struct C2 {}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("? a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("C2 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("?", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("?", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("C2", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("?", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            comp.VerifyDiagnostics(
+                // (8,17): error CS0019: Operator '??=' cannot be applied to operands of type 'C2' and 'C2'
+                //         var a = c[d] ??= new C2();
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "c[d] ??= new C2()").WithArguments("??=", "C2", "C2").WithLocation(8, 17)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Property_ConditionalAssignment()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = c[d] ??= 2;
+        Print(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int? _test1 = null;    
+    ref int? this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+        System.Console.Write(b);        
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref System.Int32? C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32?", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32?", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32?", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2 2").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_MemberInitializer_Assignment_01()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = 2 };
+        System.Console.WriteLine(c[1]);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d) => new C() { [d] = 2 });
+        Print(expr);
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static Expression<Func<dynamic, C>> GetExpression(Expression<Func<dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,59): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = 2 });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = 2 });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 60)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_MemberInitializer_Assignment_02()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = 2 };
+        System.Console.WriteLine(c[1]);        
+    }
+
+    int _test1 = 0;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d) => new C() { [d] = 2 });
+        Print(expr);
+    }
+
+    int _test1 = 0;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static Expression<Func<dynamic, C>> GetExpression(Expression<Func<dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,59): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = 2 });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = 2 });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 60)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_MemberInitializer_Assignment_03()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        dynamic v = 2;
+        var c = new C() { [d] = v };
+        System.Console.WriteLine(c[1]);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d, dynamic v) => new C() { [d] = v });
+        Print(expr);
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static Expression<Func<dynamic, dynamic, C>> GetExpression(Expression<Func<dynamic, dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,70): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d, dynamic v) => new C() { [d] = v });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 70),
+                // (9,71): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d, dynamic v) => new C() { [d] = v });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 71),
+                // (9,76): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d, dynamic v) => new C() { [d] = v });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "v").WithLocation(9, 76)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_MemberInitializer_Assignment_RightSideIsConvertedStatically()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = ""2"" };
+        System.Console.WriteLine(c[1]);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.String", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            comp.VerifyDiagnostics(
+                // (7,33): error CS0029: Cannot implicitly convert type 'string' to 'int'
+                //         var c = new C() { [d] = "2" };
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""2""").WithArguments("string", "int").WithLocation(7, 33)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72916")]
+        public void SingleCandidate_RefReturning_Property_MemberInitializer_Assignment()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = 2 };
+        System.Console.WriteLine(c[1]);        
+    }
+
+    int _test1 = 0;    
+    ref int this[int x]
+    {
+        get => ref _test1;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref System.Int32 C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            // IInvalidOperation is pre-existing condition - https://github.com/dotnet/roslyn/issues/72916
+            var propertyRef = (IInvalidOperation)model.GetOperation(elementAccess);
+            //var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            //AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IAssignmentOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Int32", operation.Target.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Value.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", operation.Type.ToTestDisplayString());
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_MemberInitializer_ObjectInitializer_01()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = { F = 2 } };
+        System.Console.WriteLine(c[1].F);        
+    }
+
+    C2 _test1 = new C2();    
+    C2 this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+
+class C2
+{
+    public int F = 0;
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("C2 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IMemberInitializerOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+        Print(expr);
+    }
+
+    C2 _test1 = new C2();    
+    C2 this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static Expression<Func<dynamic, C>> GetExpression(Expression<Func<dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+
+class C2
+{
+    public int F = 0;
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,59): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 60),
+                // (9,67): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "F").WithLocation(9, 67)
+                );
+
+            string source3 = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = { F = 2 } };
+    }
+
+    C2 _test1 = new C2();    
+    C2 this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+
+class C2
+{
+}
+";
+
+            var comp3 = CreateCompilation(source3, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+            CompileAndVerify(comp3).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_MemberInitializer_ObjectInitializer_02()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = { F = 2 } };
+        System.Console.WriteLine(c[1].F);        
+    }
+
+    C2 _test1 = new C2();    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+
+class C2
+{
+    public int F = 0;
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IMemberInitializerOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+        Print(expr);
+    }
+
+    C2 _test1 = new C2();    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static Expression<Func<dynamic, C>> GetExpression(Expression<Func<dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+
+class C2
+{
+    public int F = 0;
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,59): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 60),
+                // (9,67): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "F").WithLocation(9, 67)
+                );
+
+            string source3 = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = { F = 2 } };
+    }
+
+    C2 _test1 = new C2();    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+
+class C2
+{
+}
+";
+
+            var comp3 = CreateCompilation(source3, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+            CompileAndVerify(comp3).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Property_MemberInitializer_ObjectInitializer()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = { F = 2 } };
+        System.Console.WriteLine(c[1].F);        
+    }
+
+    C2 _test1 = new C2();    
+    ref C2 this[int x]
+    {
+        get => ref _test1;
+    }
+}
+
+class C2
+{
+    public int F = 0;
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref C2 C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IMemberInitializerOperation)model.GetOperation(assignment);
+            AssertEx.Equal("C2", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+        Print(expr);
+    }
+
+    C2 _test1 = new C2();    
+    ref C2 this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static Expression<Func<dynamic, C>> GetExpression(Expression<Func<dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+
+class C2
+{
+    public int F = 0;
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,59): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,59): error CS8153: An expression tree lambda may not contain a call to a method, property, or indexer that returns by reference
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_RefReturningCallInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = { F = 2 } });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 60)
+                );
+
+            string source3 = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = { F = 2 } };
+    }
+
+    C2 _test1 = new C2();    
+    ref C2 this[int x]
+    {
+        get => ref _test1;
+    }
+}
+
+class C2
+{
+}
+";
+
+            var comp3 = CreateCompilation(source3, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (7,35): error CS0117: 'C2' does not contain a definition for 'F'
+                //         var c = new C() { [d] = { F = 2 } };
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "F").WithArguments("C2", "F").WithLocation(7, 35)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_MemberInitializer_CollectionInitializer_01()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = {2} };
+        System.Console.WriteLine(c[1][0]);        
+    }
+
+    System.Collections.Generic.List<int> _test1 = new System.Collections.Generic.List<int>();    
+    System.Collections.Generic.List<int> this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Collections.Generic.List<System.Int32> C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IMemberInitializerOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+        Print(expr);
+    }
+
+    System.Collections.Generic.List<int> _test1 = new System.Collections.Generic.List<int>();    
+    System.Collections.Generic.List<int> this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static Expression<Func<dynamic, C>> GetExpression(Expression<Func<dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,59): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 60),
+                // (9,66): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "2").WithLocation(9, 66)
+                );
+
+            string source3 = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = {2} };
+    }
+
+    C2 _test1 = new C2();    
+    C2 this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+
+class C2
+{
+}
+";
+
+            var comp3 = CreateCompilation(source3, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+            CompileAndVerify(comp3).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_MemberInitializer_CollectionInitializer_02()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = {2} };
+        System.Console.WriteLine(c[1][0]);        
+    }
+
+    System.Collections.Generic.List<int> _test1 = new System.Collections.Generic.List<int>();    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IMemberInitializerOperation)model.GetOperation(assignment);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+        Print(expr);
+    }
+
+    System.Collections.Generic.List<int> _test1 = new System.Collections.Generic.List<int>();    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static Expression<Func<dynamic, C>> GetExpression(Expression<Func<dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,59): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 60),
+                // (9,66): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "2").WithLocation(9, 66)
+                );
+
+            string source3 = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = {2} };
+    }
+
+    C2 _test1 = new C2();    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+
+class C2
+{
+}
+";
+
+            var comp3 = CreateCompilation(source3, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+            CompileAndVerify(comp3).VerifyDiagnostics();
+        }
+
+        [ConditionalFact(typeof(NoIOperationValidation))] // IOperation validation is suppressed due to https://github.com/dotnet/roslyn/issues/72931
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72931")]
+        public void SingleCandidate_RefReturning_Property_MemberInitializer_CollectionInitializer()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = {2} };
+        System.Console.WriteLine(c[1][0]);        
+    }
+
+    System.Collections.Generic.List<int> _test1 = new System.Collections.Generic.List<int>();    
+    ref System.Collections.Generic.List<int> this[int x]
+    {
+        get => ref _test1;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ImplicitElementAccessSyntax>().Single();
+            var symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref System.Collections.Generic.List<System.Int32> C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Collections.Generic.List<System.Int32>", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Collections.Generic.List<System.Int32>", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var assignment = (AssignmentExpressionSyntax)elementAccess.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("System.Collections.Generic.List<System.Int32>", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Collections.Generic.List<System.Int32>", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IMemberInitializerOperation)model.GetOperation(assignment);
+            AssertEx.Equal("System.Collections.Generic.List<System.Int32>", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "2").VerifyDiagnostics();
+
+            string source2 = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    static void Main()
+    {
+        var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+        Print(expr);
+    }
+
+    System.Collections.Generic.List<int> _test1 = new System.Collections.Generic.List<int>();    
+    ref System.Collections.Generic.List<int> this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static Expression<Func<dynamic, C>> GetExpression(Expression<Func<dynamic, C>> ex) => ex;
+    static void Print(Expression<Func<dynamic, C>> expr)
+    {
+        System.Console.Write(expr);
+    }
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(
+                // (9,59): error CS8074: An expression tree lambda may not contain a dictionary initializer.
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_DictionaryInitializerInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,59): error CS8153: An expression tree lambda may not contain a call to a method, property, or indexer that returns by reference
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_RefReturningCallInExpressionTree, "[d]").WithLocation(9, 59),
+                // (9,60): error CS1963: An expression tree may not contain a dynamic operation
+                //         var expr = GetExpression((dynamic d) => new C() { [d] = {2} });
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsDynamicOperation, "d").WithLocation(9, 60)
+                );
+
+            string source3 = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C() { [d] = {2} };
+    }
+
+    C2 _test1 = new C2();    
+    ref C2 this[int x]
+    {
+        get => ref _test1;
+    }
+}
+
+class C2
+{
+}
+";
+
+            var comp3 = CreateCompilation(source3, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+            comp3.VerifyDiagnostics(
+                // (7,33): error CS1922: Cannot initialize type 'C2' with a collection initializer because it does not implement 'System.Collections.IEnumerable'
+                //         var c = new C() { [d] = {2} };
+                Diagnostic(ErrorCode.ERR_CollectionInitRequiresIEnumerable, "{2}").WithArguments("C2").WithLocation(7, 33)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/33011")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Tuple_01()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = (2, 123);
+        System.Console.Write(a);
+        Print(a.Item1);
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").First();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("(dynamic, System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic (dynamic, System.Int32).Item1", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            var tupleTypeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: null, Conversion: null, Nested: [{ Method: null, Conversion: { IsIdentity: true }, Nested: [] }, _] });
+
+            var operation = (IDeconstructionAssignmentOperation)model.GetOperation(assignment);
+            Assert.Equal(tupleTypeInfo.Type, operation.Target.Type);
+            Assert.Equal(tupleTypeInfo.Type, operation.Value.Type);
+            Assert.Equal(typeInfo.Type, operation.Type);
+
+            var right = (TupleExpressionSyntax)assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var rightElement = right.Arguments[0].Expression;
+            typeInfo = model.GetTypeInfo(rightElement);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "(2, 123) 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = ((int?)null, 123);
+        Print(a.Item1);
+    }
+
+    int? _test1 = 0;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // Nullability is not tracked across deconstruction, this is a pre-existing condition - https://github.com/dotnet/roslyn/issues/33011 
+            comp3.VerifyDiagnostics();
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/33011")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Tuple_02()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = (2, 123);
+        System.Console.Write(a);
+        Print(a.Item1);
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").First();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("(dynamic, System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic (dynamic, System.Int32).Item1", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            var tupleTypeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(dynamic, System.Int32)", tupleTypeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", tupleTypeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: null, Conversion: null, Nested: [{ Method: null, Conversion: { IsIdentity: true }, Nested: [] }, _] });
+
+            var operation = (IDeconstructionAssignmentOperation)model.GetOperation(assignment);
+            Assert.Equal(tupleTypeInfo.Type, operation.Target.Type);
+            Assert.Equal(tupleTypeInfo.Type, operation.Value.Type);
+            Assert.Equal(typeInfo.Type, operation.Type);
+
+            var right = (TupleExpressionSyntax)assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var rightElement = right.Arguments[0].Expression;
+            typeInfo = model.GetTypeInfo(rightElement);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "(2, 123) 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = ((int?)null, 123);
+        Print(a.Item1);
+    }
+
+    int? _test1 = 0;    
+    dynamic? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // Nullability is not tracked across deconstruction, this is a pre-existing condition - https://github.com/dotnet/roslyn/issues/33011 
+            comp3.VerifyDiagnostics();
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/33011")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Tuple_03()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = ((dynamic)2, 123);
+        System.Console.Write(a);
+        Print(a.Item1);
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").First();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("(dynamic, System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic (dynamic, System.Int32).Item1", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            var tupleTypeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: null, Conversion: null, Nested: [{ Method: null, Conversion: { IsIdentity: true }, Nested: [] }, _] });
+
+            var operation = (IDeconstructionAssignmentOperation)model.GetOperation(assignment);
+            Assert.Equal(tupleTypeInfo.Type, operation.Target.Type);
+            Assert.Equal(tupleTypeInfo.Type, operation.Value.Type);
+            Assert.Equal(typeInfo.Type, operation.Type);
+
+            var right = (TupleExpressionSyntax)assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var rightElement = right.Arguments[0].Expression;
+            typeInfo = model.GetTypeInfo(rightElement);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "(2, 123) 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = ((dynamic?)null, 123);
+        Print(a.Item1);
+    }
+
+    int? _test1 = 0;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // Nullability is not tracked across deconstruction, this is a pre-existing condition - https://github.com/dotnet/roslyn/issues/33011 
+            comp3.VerifyDiagnostics();
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Tuple_RightSideIsConvertedStatically()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = (""2"", 123);
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            comp.VerifyDiagnostics(
+                // (8,30): error CS0029: Cannot implicitly convert type 'string' to 'int'
+                //         var a = (c[d], _) = ("2", 123);
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""2""").WithArguments("string", "int").WithLocation(8, 30)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Property_Assignment_Deconstruction_Tuple()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = (2, 123);
+        System.Console.Write(a);
+        Print(a.Item1);
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    ref int this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").First();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("(System.Int32, System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 (System.Int32, System.Int32).Item1", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref System.Int32 C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            var tupleTypeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: null, Conversion: null, Nested: [{ Method: null, Conversion: { IsIdentity: true }, Nested: [] }, _] });
+
+            var operation = (IDeconstructionAssignmentOperation)model.GetOperation(assignment);
+            Assert.Equal(tupleTypeInfo.Type, operation.Target.Type);
+            Assert.Equal(tupleTypeInfo.Type, operation.Value.Type);
+            Assert.Equal(typeInfo.Type, operation.Type);
+
+            var right = (TupleExpressionSyntax)assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var rightElement = right.Arguments[0].Expression;
+            typeInfo = model.GetTypeInfo(rightElement);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "(2, 123) 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = ((int?)null, 123);
+        Print(a.Item1);
+    }
+
+    int? _test1 = 0;    
+    ref int? this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a.Item1);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a.Item1").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/33011")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Method_01()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+        System.Console.Write(a);        
+        Print(a.Item1);
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out int x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").First();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("(dynamic, System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic (dynamic, System.Int32).Item1", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            var tupleTypeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: not null, Conversion: null, Nested: [{ Method: null, Conversion: { IsIdentity: true }, Nested: [] }, _] });
+
+            var operation = (IDeconstructionAssignmentOperation)model.GetOperation(assignment);
+            Assert.Equal(tupleTypeInfo.Type, operation.Target.Type);
+            Assert.Equal("C2", operation.Value.Type.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, operation.Type);
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "(2, 123) 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+        Print(a.Item1);
+    }
+
+    int? _test1 = 0;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out int? x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // Nullability is not tracked across deconstruction, this is a pre-existing condition - https://github.com/dotnet/roslyn/issues/33011 
+            comp3.VerifyDiagnostics();
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/33011")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72913")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Method_02()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+        System.Console.Write(a);        
+        Print(a.Item1);
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    dynamic this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out int x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").First();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("(dynamic, System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic (dynamic, System.Int32).Item1", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("dynamic C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            var tupleTypeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(dynamic, System.Int32)", tupleTypeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", tupleTypeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: not null, Conversion: null, Nested: [{ Method: null, Conversion: { IsBoxing: true }, Nested: [] }, _] });
+
+            var operation = (IDeconstructionAssignmentOperation)model.GetOperation(assignment);
+            Assert.Equal(tupleTypeInfo.Type, operation.Target.Type);
+            Assert.Equal("C2", operation.Value.Type.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, operation.Type);
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            // The meaningless warning is a pre-existing condition - https://github.com/dotnet/roslyn/issues/72913
+            CompileAndVerify(comp, expectedOutput: "(2, 123) 2").VerifyDiagnostics(
+                // (10,18): warning CS8624: Argument of type 'dynamic' cannot be used as an output of type 'int' for parameter 'x' in 'void C2.Deconstruct(out int x, out int y)' due to differences in the nullability of reference types.
+                //         var a = (c[d], _) = new C2();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "c[d]").WithArguments("dynamic", "int", "x", "void C2.Deconstruct(out int x, out int y)").WithLocation(10, 18)
+                );
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+        Print(a.Item1);
+    }
+
+    int? _test1 = 0;    
+    dynamic? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out int? x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // Nullability is not tracked across deconstruction, this is a pre-existing condition - https://github.com/dotnet/roslyn/issues/33011 
+            // The meaningless warning is a pre-existing condition - https://github.com/dotnet/roslyn/issues/72913
+            comp3.VerifyDiagnostics(
+                // (10,18): warning CS8624: Argument of type 'dynamic' cannot be used as an output of type 'int?' for parameter 'x' in 'void C2.Deconstruct(out int? x, out int y)' due to differences in the nullability of reference types.
+                //         var a = (c[d], _) = new C2();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "c[d]").WithArguments("dynamic", "int?", "x", "void C2.Deconstruct(out int? x, out int y)").WithLocation(10, 18)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72914")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Method_03()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+        System.Console.Write(a);        
+        Print(a.Item1);
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out dynamic x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // The unexpected error is a pre-existing condition - https://github.com/dotnet/roslyn/issues/72914
+            comp.VerifyDiagnostics(
+                // (10,18): error CS0266: Cannot implicitly convert type 'dynamic' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //         var a = (c[d], _) = new C2();
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "c[d]").WithArguments("dynamic", "int").WithLocation(10, 18)
+                );
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+        Print(a.Item1);
+    }
+
+    int? _test1 = 0;    
+    int? this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out dynamic? x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            // The unexpected error is a pre-existing condition - https://github.com/dotnet/roslyn/issues/72914
+            comp3.VerifyDiagnostics(
+                // (10,18): error CS0266: Cannot implicitly convert type 'dynamic' to 'int?'. An explicit conversion exists (are you missing a cast?)
+                //         var a = (c[d], _) = new C2();
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "c[d]").WithArguments("dynamic", "int?").WithLocation(10, 18)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Method_RightSideIsConvertedStatically()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out string x, out int y)
+    {
+        (x, y) = (""2"", 123);
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            comp.VerifyDiagnostics(
+                // (8,18): error CS0029: Cannot implicitly convert type 'string' to 'int'
+                //         var a = (c[d], _) = new C2();
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "c[d]").WithArguments("string", "int").WithLocation(8, 18)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_RefReturning_Property_Assignment_Deconstruction_Method()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+        System.Console.Write(a);        
+        Print(a.Item1);
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    ref int this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out int x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").First();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("(System.Int32, System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("System.Int32 (System.Int32, System.Int32).Item1", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("ref System.Int32 C.this[System.Int32 x] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var propertyRef = (IPropertyReferenceOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal(symbolInfo.Symbol.ToTestDisplayString(), propertyRef.Property.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, propertyRef.Type);
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            var tupleTypeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", tupleTypeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: not null, Conversion: null, Nested: [{ Method: null, Conversion: { IsIdentity: true }, Nested: [] }, _] });
+
+            var operation = (IDeconstructionAssignmentOperation)model.GetOperation(assignment);
+            Assert.Equal(tupleTypeInfo.Type, operation.Target.Type);
+            Assert.Equal("C2", operation.Value.Type.ToTestDisplayString());
+            Assert.Equal(typeInfo.Type, operation.Type);
+
+            var right = assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "(2, 123) 2").VerifyDiagnostics();
+
+            string source3 = @"
+#nullable enable
+
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = new C2();
+        Print(a.Item1);
+    }
+
+    int? _test1 = 0;    
+    ref int? this[int x]
+    {
+        get => ref _test1;
+    }
+
+    static void Print(dynamic b) 
+    {
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out int? x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+            var comp3 = CreateCompilation(source3, targetFramework: TargetFramework.StandardAndCSharp);
+
+            comp3.VerifyDiagnostics(
+                // (11,15): warning CS8604: Possible null reference argument for parameter 'b' in 'void C.Print(dynamic b)'.
+                //         Print(a.Item1);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a.Item1").WithArguments("b", "void C.Print(dynamic b)").WithLocation(11, 15)
+                );
+
+            tree = comp3.SyntaxTrees.Single();
+            node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Item1").Single();
+            model = comp3.GetSemanticModel(tree);
+
+            typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("System.Int32?", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, typeInfo.Nullability.FlowState);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Nested_01()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = ((c[d], _), _) = ((2, 123), 124);
+        System.Console.Write(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("((dynamic, System.Int32), System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            typeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            left = (TupleExpressionSyntax)left.Parent.Parent;
+            typeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("((System.Int32, System.Int32), System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("((System.Int32, System.Int32), System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("((dynamic, System.Int32), System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("((dynamic, System.Int32), System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: null, Conversion: null, Nested: [{ Method: null, Conversion: null, Nested: [{ Method: null, Conversion: { IsIdentity: true }, Nested: [] }, _] }, _] });
+
+            var right = (TupleExpressionSyntax)assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("((System.Int32, System.Int32), System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("((System.Int32, System.Int32), System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            right = (TupleExpressionSyntax)right.Arguments[0].Expression;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var rightElement = right.Arguments[0].Expression;
+            typeInfo = model.GetTypeInfo(rightElement);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "((2, 123), 124) 2").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Nested_02()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = ((c[d], _), _) = (new C2(), 124);
+        System.Console.Write(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+
+class C2
+{
+    public void Deconstruct(out int x, out int y)
+    {
+        (x, y) = (2, 123);
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("((dynamic, System.Int32), System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            typeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            left = (TupleExpressionSyntax)left.Parent.Parent;
+            typeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("((System.Int32, System.Int32), System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("((System.Int32, System.Int32), System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("((dynamic, System.Int32), System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("((dynamic, System.Int32), System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.True(model.GetDeconstructionInfo(assignment) is { Method: null, Conversion: null, Nested: [{ Method: not null, Conversion: null, Nested: [{ Method: null, Conversion: { IsIdentity: true }, Nested: [] }, _] }, _] });
+
+            var right = (TupleExpressionSyntax)assignment.Right;
+            typeInfo = model.GetTypeInfo(right);
+            AssertEx.Equal("(C2, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(C2, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var rightElement = right.Arguments[0].Expression;
+            typeInfo = model.GetTypeInfo(rightElement);
+            AssertEx.Equal("C2", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("C2", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "((2, 123), 124) 2").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_Assignment_Deconstruction_Conditional()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        Test(true);
+        System.Console.Write("" "");        
+        Test(false);
+    }
+
+    static void Test(bool b)
+    {
+        dynamic d = 1;
+        var c = new C();
+        var a = (c[d], _) = b ? (2, 123) : (3, 124);
+        System.Console.Write(a);        
+        System.Console.Write("" "");        
+        System.Console.Write(c._test1);        
+    }
+
+    int _test1 = 0;    
+    int this[int x]
+    {
+        get => _test1;
+        set => _test1 = value;
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "a").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("(dynamic, System.Int32) a", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.Int32 x] { get; set; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("System.Int32", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var left = (TupleExpressionSyntax)elementAccess.Parent.Parent;
+            typeInfo = model.GetTypeInfo(left);
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(System.Int32, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var assignment = (AssignmentExpressionSyntax)left.Parent;
+            typeInfo = model.GetTypeInfo(assignment);
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("(dynamic, System.Int32)", typeInfo.ConvertedType.ToTestDisplayString());
+
+            CompileAndVerify(comp, expectedOutput: "(2, 123) 2 (3, 124) 3").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_CSharp12_01()
+        {
+            string source1 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1.Test(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    object Test(string name, object value);
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp1 = CreateCompilation(source1, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"i1.Test(""name"", value)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("System.Object I1.Test(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IDynamicInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_CSharp12_02()
+        {
+            string source1 = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1.Test(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    int Test(string name, object value);
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp1 = CreateCompilation(source1, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"i1.Test(""name"", value)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("System.Int32 I1.Test(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IDynamicInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_Extension_CSharp12()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = new C().Test(""name"", d);
+        System.Console.Write(result);        
+    }
+}
+
+static class Extensions
+{
+    public static int Test(this C c, string name, object value) => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var model = comp1.GetSemanticModel(tree);
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            Assert.Equal(OperationKind.Invalid, model.GetOperation(call).Kind);
+
+            comp1.VerifyDiagnostics(
+                // (7,22): error CS1973: 'C' has no applicable method named 'Test' but appears to have an extension method by that name. Extension methods cannot be dynamically dispatched. Consider casting the dynamic arguments or calling the extension method without the extension method syntax.
+                //         var result = new C().Test("name", d);
+                Diagnostic(ErrorCode.ERR_BadArgTypeDynamicExtension, @"new C().Test(""name"", d)").WithArguments("C", "Test").WithLocation(7, 22)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_ParamArray_CSharp12()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = Test(""name"", d);
+        System.Console.Write(result);        
+    }
+
+    static int Test(string name, object value, params int[] list) => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.Test(System.String name, System.Object value, params System.Int32[] list)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IDynamicInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Delegate_CSharp12()
+        {
+            string source = @"
+public class C
+{
+    static C M(Test i1, dynamic value)
+    {
+        var result = i1(""name"", value);
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+delegate object Test(string name, object value);
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T);
+}
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"i1(""name"", value)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal("System.Object Test.Invoke(System.String name, System.Object value)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IDynamicInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_ParamArray_Delegate_CSharp12()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = Test(""name"", d);
+        System.Console.Write(result);        
+    }
+
+    static D Test = (string name, object value, params int[] list) => 123;
+    delegate int D(string name, object value, params int[] list);
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+            AssertEx.Equal(@"Test(""name"", d)", call.ToString());
+            symbolInfo = model.GetSymbolInfo(call);
+            AssertEx.Equal(@"System.Int32 C.D.Invoke(System.String name, System.Object value, params System.Int32[] list)", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(call);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IDynamicInvocationOperation)model.GetOperation(call);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_CSharp12_01()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1[""name"", value];
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    object this[string name, object value] {get;}
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Object I1.this[System.String name, System.Object value] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IDynamicIndexerAccessOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_Property_CSharp12_02()
+        {
+            string source = @"
+#nullable enable
+
+public class C
+{
+    public static C M(I1 i1, dynamic value)
+    {
+        var result = i1[""name"", value];
+        return JsonSerializer.Deserialize<C>(result);
+    }
+}
+
+public interface I1
+{
+    int this[string name, object value] {get;}
+}
+
+class JsonSerializer
+{
+    public static T Deserialize<T>(System.IO.Stream c) => default(T)!;
+}
+";
+
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            var tree = comp.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic? result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var typeInfo = model.GetTypeInfo(node);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal(CodeAnalysis.NullableFlowState.NotNull, typeInfo.Nullability.FlowState);
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 I1.this[System.String name, System.Object value] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IDynamicIndexerAccessOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/72750")]
+        public void SingleCandidate_ResultIsDynamic_ParamArray_Property_CSharp12()
+        {
+            string source1 = @"
+public class C
+{
+    static void Main()
+    {
+        dynamic d = 1;
+        var result = new C()[""name"", d];
+        System.Console.Write(result);        
+    }
+
+    int this[string name, object value, params int[] list] => 123;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.StandardAndCSharp, parseOptions: TestOptions.Regular12);
+
+            // This is surprising, but this scenario used to successfully bind dynamically before (unlike a call).
+            var tree = comp1.SyntaxTrees.Single();
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "result").Single();
+            var model = comp1.GetSemanticModel(tree);
+            var symbolInfo = model.GetSymbolInfo(node);
+            Assert.Equal("dynamic result", symbolInfo.Symbol.ToTestDisplayString());
+
+            var elementAccess = tree.GetRoot().DescendantNodes().OfType<ElementAccessExpressionSyntax>().Single();
+            symbolInfo = model.GetSymbolInfo(elementAccess);
+            AssertEx.Equal("System.Int32 C.this[System.String name, System.Object value, params System.Int32[] list] { get; }", symbolInfo.Symbol.ToTestDisplayString());
+            var typeInfo = model.GetTypeInfo(elementAccess);
+            AssertEx.Equal("dynamic", typeInfo.Type.ToTestDisplayString());
+            AssertEx.Equal("dynamic", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var operation = (IDynamicIndexerAccessOperation)model.GetOperation(elementAccess);
+            AssertEx.Equal("dynamic", operation.Type.ToTestDisplayString());
+
+            CompileAndVerify(comp1, expectedOutput: "123").VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -3192,7 +3192,7 @@ class C
             TestOperatorKinds(code);
         }
 
-        private void TestBoundTree(string source, System.Func<IEnumerable<KeyValuePair<TreeDumperNode, TreeDumperNode>>, IEnumerable<string>> query)
+        private static void TestBoundTree(string source, System.Func<IEnumerable<KeyValuePair<TreeDumperNode, TreeDumperNode>>, IEnumerable<string>> query)
         {
             // The mechanism of this test is: we build the bound tree for the code passed in and then extract
             // from it the nodes that describe the operators. We then compare the description of
@@ -3217,7 +3217,7 @@ class C
             AssertEx.Equal(expected, results);
         }
 
-        private void TestOperatorKinds(string source)
+        internal static void TestOperatorKinds(string source)
         {
             // The mechanism of this test is: we build the bound tree for the code passed in and then extract
             // from it the nodes that describe the operators. We then compare the description of
@@ -3231,7 +3231,7 @@ class C
                 select node.Value.ToString());
         }
 
-        private void TestCompoundAssignment(string source)
+        internal static void TestCompoundAssignment(string source)
         {
             TestBoundTree(source, edges =>
                 from edge in edges
@@ -3260,7 +3260,7 @@ class C
                                                })));
         }
 
-        private void TestTypes(string source)
+        internal static void TestTypes(string source)
         {
             TestBoundTree(source, edges =>
                 from edge in edges
@@ -3289,7 +3289,7 @@ class C
             return s + ">";
         }
 
-        private void TestDynamicMemberAccessCore(string source)
+        internal static void TestDynamicMemberAccessCore(string source)
         {
             TestBoundTree(source, edges =>
                 from edge in edges

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests_LateBound.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests_LateBound.cs
@@ -225,7 +225,7 @@ class C
 ";
             var semanticInfo = GetSemanticInfoForTest<ExpressionSyntax>(sourceCode1);
 
-            Assert.Equal("C", semanticInfo.Type.ToTestDisplayString());
+            Assert.True(semanticInfo.Type.IsDynamic());
             Assert.Equal("C C.Create(System.Int32 arg)", semanticInfo.Symbol.ToTestDisplayString());
             Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
             Assert.Equal(0, semanticInfo.CandidateSymbols.Length);
@@ -548,8 +548,8 @@ class C
 ";
             var semanticInfo = GetSemanticInfoForTest<ExpressionSyntax>(sourceCode);
 
-            Assert.False(semanticInfo.Type.IsDynamic());
-            Assert.False(semanticInfo.ConvertedType.IsDynamic());
+            Assert.True(semanticInfo.Type.IsDynamic());
+            Assert.True(semanticInfo.ConvertedType.IsDynamic());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);


### PR DESCRIPTION
Restore `dynamic` as result type of some operations involving `dynamic` arguments  (#72964)

Fixes #72750.

For C# 12 language version: behavior of the compiler in regards to deciding between whether binding should be static or dynamic is the same as behavior of C# 12 compiler. As a result, for affected scenarios, what used to have `dynamic` type in C# 12 compiler will have `dynamic` type when C# 12 language version is targeted.

For newer language versions: invocations statically bound in presence of dynamic arguments should have dynamic result if their dynamic binding succeeded in C# 12. Corresponding spec update - dotnet/csharplang#8027 at commit 8.

Related to #33011, #72906, #72912, #72913, #72914, #72916, #72931.