### PR TITLE
Pass along cancellation token in snippets

### DIFF
--- a/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/AbstractSnippetFunction.cs
+++ b/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/AbstractSnippetFunction.cs
@@ -27,18 +27,13 @@ internal abstract partial class AbstractSnippetFunction : IVsExpansionFunction
         _threadingContext = threadingContext;
     }
 
-    protected bool TryGetDocument([NotNullWhen(true)] out Document? document)
-    {
-        document = _subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges()?.WithFrozenPartialSemantics(CancellationToken.None);
-        return document != null;
-    }
+    protected Document? GetDocument(CancellationToken cancellationToken)
+        => _subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges()?.WithFrozenPartialSemantics(cancellationToken);
 
     private int GetDefaultValue(CancellationToken cancellationToken, out string value, out int hasDefaultValue)
     {
-        var (ExitCode, Value, HasDefaultValue) = _threadingContext.JoinableTaskFactory.Run(() => GetDefaultValueAsync(cancellationToken));
-        value = Value;
-        hasDefaultValue = HasDefaultValue;
-        return ExitCode;
+        (var exitCode, value, hasDefaultValue) = _threadingContext.JoinableTaskFactory.Run(() => GetDefaultValueAsync(cancellationToken));
+        return exitCode;
     }
 
     protected virtual Task<(int ExitCode, string Value, int HasDefaultValue)> GetDefaultValueAsync(CancellationToken cancellationToken)
@@ -48,10 +43,8 @@ internal abstract partial class AbstractSnippetFunction : IVsExpansionFunction
 
     private int GetCurrentValue(CancellationToken cancellationToken, out string value, out int hasCurrentValue)
     {
-        var (ExitCode, Value, HasCurrentValue) = _threadingContext.JoinableTaskFactory.Run(() => GetCurrentValueAsync(cancellationToken));
-        value = Value;
-        hasCurrentValue = HasCurrentValue;
-        return ExitCode;
+        (var exitCode, value, hasCurrentValue) = _threadingContext.JoinableTaskFactory.Run(() => GetCurrentValueAsync(cancellationToken));
+        return exitCode;
     }
 
     protected virtual Task<(int ExitCode, string Value, int HasCurrentValue)> GetCurrentValueAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/SnippetFunctionClassName.cs
+++ b/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/SnippetFunctionClassName.cs
@@ -28,29 +28,22 @@ internal class SnippetFunctionClassName : AbstractSnippetFunction
     {
         var hasDefaultValue = 0;
         var value = string.Empty;
-        if (!TryGetDocument(out var document))
-        {
+        var document = GetDocument(cancellationToken);
+        if (document is null)
             return (VSConstants.E_FAIL, value, hasDefaultValue);
-        }
 
         var surfaceBufferFieldSpan = new VsTextSpan[1];
         if (snippetExpansionClient.ExpansionSession.GetFieldSpan(FieldName, surfaceBufferFieldSpan) != VSConstants.S_OK)
-        {
             return (VSConstants.E_FAIL, value, hasDefaultValue);
-        }
 
         if (!snippetExpansionClient.TryGetSubjectBufferSpan(surfaceBufferFieldSpan[0], out var subjectBufferFieldSpan))
-        {
             return (VSConstants.E_FAIL, value, hasDefaultValue);
-        }
 
         var snippetFunctionService = document.Project.GetRequiredLanguageService<SnippetFunctionService>();
         value = await snippetFunctionService.GetContainingClassNameAsync(document, subjectBufferFieldSpan.Start.Position, cancellationToken).ConfigureAwait(false);
 
         if (!string.IsNullOrWhiteSpace(value))
-        {
             hasDefaultValue = 1;
-        }
 
         return (VSConstants.S_OK, value, hasDefaultValue);
     }

--- a/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/SnippetFunctionGenerateSwitchCases.cs
+++ b/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/SnippetFunctionGenerateSwitchCases.cs
@@ -41,10 +41,9 @@ internal class SnippetFunctionGenerateSwitchCases : AbstractSnippetFunction
 
     protected override async Task<(int ExitCode, string Value, int HasCurrentValue)> GetCurrentValueAsync(CancellationToken cancellationToken)
     {
-        if (!TryGetDocument(out var document))
-        {
+        var document = GetDocument(cancellationToken);
+        if (document is null)
             return (VSConstants.S_OK, string.Empty, HasCurrentValue: 0);
-        }
 
         // If the switch expression is invalid, still show the default case
         var hasCurrentValue = 1;
@@ -60,9 +59,7 @@ internal class SnippetFunctionGenerateSwitchCases : AbstractSnippetFunction
 
         var value = await snippetFunctionService.GetSwitchExpansionAsync(document, caseGenerationSpan.Value, switchExpressionSpan.Value, simplifierOptions, cancellationToken).ConfigureAwait(false);
         if (value == null)
-        {
             return (VSConstants.S_OK, snippetFunctionService.SwitchDefaultCaseForm, hasCurrentValue);
-        }
 
         return (VSConstants.S_OK, value, hasCurrentValue);
     }

--- a/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/SnippetFunctionSimpleTypeName.cs
+++ b/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/SnippetFunctionSimpleTypeName.cs
@@ -35,23 +35,18 @@ internal class SnippetFunctionSimpleTypeName : AbstractSnippetFunction
     {
         var value = _fullyQualifiedName;
         var hasDefaultValue = 1;
-        if (!TryGetDocument(out var document))
-        {
+        var document = GetDocument(cancellationToken);
+        if (document is null)
             return (VSConstants.E_FAIL, value, hasDefaultValue);
-        }
 
         if (!TryGetFieldSpan(out var fieldSpan))
-        {
             return (VSConstants.E_FAIL, value, hasDefaultValue);
-        }
 
         var simplifierOptions = await document.GetSimplifierOptionsAsync(snippetExpansionClient.EditorOptionsService.GlobalOptions, cancellationToken).ConfigureAwait(false);
 
         var simplifiedTypeName = await SnippetFunctionService.GetSimplifiedTypeNameAsync(document, fieldSpan.Value, _fullyQualifiedName, simplifierOptions, cancellationToken).ConfigureAwait(false);
         if (string.IsNullOrEmpty(simplifiedTypeName))
-        {
             return (VSConstants.E_FAIL, value, hasDefaultValue);
-        }
 
         return (VSConstants.S_OK, simplifiedTypeName!, hasDefaultValue);
     }


### PR DESCRIPTION
Thread through a cancellation token from a callee parameter instead of silently ignoring it.

Note that this will not have any product impact on cancellation in snippets, since a caller further up the chain still hard-codes `CancellationToken.None`.
https://github.com/dotnet/roslyn/blob/1401f9bf94295c3a0d06c9beea90b2e26be827a8/src/VisualStudio/Core/Def/Snippets/SnippetFunctions/AbstractSnippetFunction.IVsExpansionFunction.cs#L15-L19