### PR TITLE
Use 'nullable disabled' semantic model when computing FAR results

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesDocumentState.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesDocumentState.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols;
 /// <summary>
 /// Ephemeral information that find-references needs for a particular document when searching for a <em>specific</em>
 /// symbol.  Importantly, it contains the global aliases to that symbol within the current project.
+/// </summary>
 internal sealed class FindReferencesDocumentState(
     FindReferenceCache cache,
     HashSet<string>? globalAliases)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesDocumentState.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesDocumentState.cs
@@ -8,23 +8,24 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.FindSymbols;
 
-internal class FindReferencesDocumentState(
-    Document document,
-    SyntaxNode root,
+/// <summary>
+/// Ephemeral information that find-references needs for a particular document when searching for a <em>specific</em>
+/// symbol.  Importantly, it contains the global aliases to that symbol within the current project.
+internal sealed class FindReferencesDocumentState(
     FindReferenceCache cache,
     HashSet<string>? globalAliases)
 {
     private static readonly HashSet<string> s_empty = [];
 
-    public readonly Document Document = document;
-    public readonly SyntaxNode Root = root;
     public readonly FindReferenceCache Cache = cache;
     public readonly HashSet<string> GlobalAliases = globalAliases ?? s_empty;
 
-    public readonly Solution Solution = document.Project.Solution;
-    public readonly ISyntaxFactsService SyntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-    public readonly ISemanticFactsService SemanticFacts = document.GetRequiredLanguageService<ISemanticFactsService>();
+    public Document Document => this.Cache.Document;
+    public SyntaxNode Root => this.Cache.Root;
+    public SemanticModel SemanticModel => this.Cache.SemanticModel;
+    public SyntaxTree SyntaxTree => this.SemanticModel.SyntaxTree;
 
-    public SemanticModel SemanticModel => Cache.SemanticModel;
-    public SyntaxTree SyntaxTree => SemanticModel.SyntaxTree;
+    public Solution Solution => this.Document.Project.Solution;
+    public ISyntaxFactsService SyntaxFacts => this.Document.GetRequiredLanguageService<ISyntaxFactsService>();
+    public ISemanticFactsService SemanticFacts => this.Document.GetRequiredLanguageService<ISemanticFactsService>();
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesDocumentState.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesDocumentState.cs
@@ -10,7 +10,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols;
 
 internal class FindReferencesDocumentState(
     Document document,
-    SemanticModel semanticModel,
     SyntaxNode root,
     FindReferenceCache cache,
     HashSet<string>? globalAliases)
@@ -18,13 +17,14 @@ internal class FindReferencesDocumentState(
     private static readonly HashSet<string> s_empty = [];
 
     public readonly Document Document = document;
-    public readonly SemanticModel SemanticModel = semanticModel;
     public readonly SyntaxNode Root = root;
     public readonly FindReferenceCache Cache = cache;
     public readonly HashSet<string> GlobalAliases = globalAliases ?? s_empty;
 
     public readonly Solution Solution = document.Project.Solution;
-    public readonly SyntaxTree SyntaxTree = semanticModel.SyntaxTree;
     public readonly ISyntaxFactsService SyntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
     public readonly ISemanticFactsService SemanticFacts = document.GetRequiredLanguageService<ISemanticFactsService>();
+
+    public SemanticModel SemanticModel => Cache.SemanticModel;
+    public SyntaxTree SyntaxTree => SemanticModel.SyntaxTree;
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -262,7 +262,6 @@ internal partial class FindReferencesSearchEngine
             // the symbol being searched for).  As such, we're almost certainly going to have to do semantic checks
             // to now see if the candidate actually matches the symbol.  This will require syntax and semantics.  So
             // just grab those once here and hold onto them for the lifetime of this call.
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var cache = await FindReferenceCache.GetCacheAsync(document, cancellationToken).ConfigureAwait(false);
 
             foreach (var symbol in symbols)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -262,15 +262,14 @@ internal partial class FindReferencesSearchEngine
             // the symbol being searched for).  As such, we're almost certainly going to have to do semantic checks
             // to now see if the candidate actually matches the symbol.  This will require syntax and semantics.  So
             // just grab those once here and hold onto them for the lifetime of this call.
-            var model = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var cache = FindReferenceCache.GetCache(model);
+            var cache = await FindReferenceCache.GetCacheAsync(document, cancellationToken).ConfigureAwait(false);
 
             foreach (var symbol in symbols)
             {
                 var globalAliases = TryGet(symbolToGlobalAliases, symbol);
                 var state = new FindReferencesDocumentState(
-                    document, model, root, cache, globalAliases);
+                    document, root, cache, globalAliases);
                 await ProcessDocumentAsync(symbol, state).ConfigureAwait(false);
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -268,8 +268,8 @@ internal partial class FindReferencesSearchEngine
             foreach (var symbol in symbols)
             {
                 var globalAliases = TryGet(symbolToGlobalAliases, symbol);
-                var state = new FindReferencesDocumentState(
-                    document, root, cache, globalAliases);
+                var state = new FindReferencesDocumentState(cache, globalAliases);
+
                 await ProcessDocumentAsync(symbol, state).ConfigureAwait(false);
             }
         }
@@ -279,8 +279,7 @@ internal partial class FindReferencesSearchEngine
         }
 
         async Task ProcessDocumentAsync(
-            ISymbol symbol,
-            FindReferencesDocumentState state)
+            ISymbol symbol, FindReferencesDocumentState state)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
@@ -87,14 +87,13 @@ internal partial class FindReferencesSearchEngine
             // appropriate finders checking this document for hits.  We're likely going to need to perform syntax
             // and semantics checks in this file.  So just grab those once here and hold onto them for the lifetime
             // of this call.
-            var model = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var cache = FindReferenceCache.GetCache(model);
+            var cache = await FindReferenceCache.GetCacheAsync(document, cancellationToken).ConfigureAwait(false);
 
             foreach (var symbol in symbols)
             {
                 var globalAliases = GetGlobalAliasesSet(symbolToGlobalAliases, symbol);
-                var state = new FindReferencesDocumentState(document, model, root, cache, globalAliases);
+                var state = new FindReferencesDocumentState(document, root, cache, globalAliases);
 
                 await PerformSearchInDocumentWorkerAsync(symbol, document, state).ConfigureAwait(false);
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
@@ -87,20 +87,19 @@ internal partial class FindReferencesSearchEngine
             // appropriate finders checking this document for hits.  We're likely going to need to perform syntax
             // and semantics checks in this file.  So just grab those once here and hold onto them for the lifetime
             // of this call.
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var cache = await FindReferenceCache.GetCacheAsync(document, cancellationToken).ConfigureAwait(false);
 
             foreach (var symbol in symbols)
             {
                 var globalAliases = GetGlobalAliasesSet(symbolToGlobalAliases, symbol);
-                var state = new FindReferencesDocumentState(document, root, cache, globalAliases);
+                var state = new FindReferencesDocumentState(cache, globalAliases);
 
-                await PerformSearchInDocumentWorkerAsync(symbol, document, state).ConfigureAwait(false);
+                await PerformSearchInDocumentWorkerAsync(symbol, state).ConfigureAwait(false);
             }
         }
 
         async ValueTask PerformSearchInDocumentWorkerAsync(
-            ISymbol symbol, Document document, FindReferencesDocumentState state)
+            ISymbol symbol, FindReferencesDocumentState state)
         {
             // Always perform a normal search, looking for direct references to exactly that symbol.
             foreach (var finder in _finders)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
@@ -91,7 +91,7 @@ internal partial class FindReferencesSearchEngine
 
             foreach (var symbol in symbols)
             {
-                var globalAliases = GetGlobalAliasesSet(symbolToGlobalAliases, symbol);
+                var globalAliases = TryGet(symbolToGlobalAliases, symbol);
                 var state = new FindReferencesDocumentState(cache, globalAliases);
 
                 await PerformSearchInDocumentWorkerAsync(symbol, state).ConfigureAwait(false);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
@@ -41,6 +41,21 @@ internal static partial class DocumentExtensions
         return semanticModel ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.SyntaxTree_is_required_to_accomplish_the_task_but_is_not_supported_by_document_0, document.Name));
     }
 
+#if !CODE_STYLE
+
+    public static async ValueTask<SemanticModel> GetRequiredNullableDisabledSemanticModelAsync(this Document document, CancellationToken cancellationToken)
+    {
+        if (document.TryGetNullableDisabledSemanticModel(out var semanticModel))
+            return semanticModel;
+
+#pragma warning disable RSEXPERIMENTAL001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        semanticModel = await document.GetSemanticModelAsync(SemanticModelOptions.DisableNullableAnalysis, cancellationToken).ConfigureAwait(false);
+#pragma warning restore RSEXPERIMENTAL001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        return semanticModel ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.SyntaxTree_is_required_to_accomplish_the_task_but_is_not_supported_by_document_0, document.Name));
+    }
+
+#endif
+
     public static async ValueTask<SyntaxTree> GetRequiredSyntaxTreeAsync(this Document document, CancellationToken cancellationToken)
     {
         if (document.TryGetSyntaxTree(out var syntaxTree))


### PR DESCRIPTION
Traces show upwards of 15% of our time in nullability analysis for these features:

![image](https://github.com/dotnet/roslyn/assets/4564579/c2347d9a-d5ae-4520-b70c-d3ea2965e88c)
