### PR TITLE
Use 'nullable disabled' semantic model when computing doc highlights results

### DIFF
--- a/src/Features/CSharp/Portable/DocumentHighlighting/CSharpDocumentHighlightsService.cs
+++ b/src/Features/CSharp/Portable/DocumentHighlighting/CSharpDocumentHighlightsService.cs
@@ -24,10 +24,12 @@ namespace Microsoft.CodeAnalysis.CSharp.DocumentHighlighting;
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal class CSharpDocumentHighlightsService(
-    [ImportMany] IEnumerable<Lazy<IEmbeddedLanguageDocumentHighlighter, EmbeddedLanguageMetadata>> services) : AbstractDocumentHighlightsService(LanguageNames.CSharp,
-          CSharpEmbeddedLanguagesProvider.Info,
-          CSharpSyntaxKinds.Instance,
-          services)
+    [ImportMany] IEnumerable<Lazy<IEmbeddedLanguageDocumentHighlighter, EmbeddedLanguageMetadata>> services)
+    : AbstractDocumentHighlightsService(
+        LanguageNames.CSharp,
+        CSharpEmbeddedLanguagesProvider.Info,
+        CSharpSyntaxKinds.Instance,
+        services)
 {
     protected override async Task<ImmutableArray<Location>> GetAdditionalReferencesAsync(
         Document document, ISymbol symbol, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/DocumentHighlighting/CSharpDocumentHighlightsService.cs
+++ b/src/Features/CSharp/Portable/DocumentHighlighting/CSharpDocumentHighlightsService.cs
@@ -56,7 +56,9 @@ internal class CSharpDocumentHighlightsService(
 
                 if (type.IsVar)
                 {
-                    semanticModel ??= await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                    // Document highlights are not impacted by nullable analysis.  Get a semantic model with nullability
+                    // disabled to lower the amount of work we need to do here.
+                    semanticModel ??= await document.GetRequiredNullableDisabledSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
                     var boundSymbol = semanticModel.GetSymbolInfo(type, cancellationToken).Symbol;
                     boundSymbol = boundSymbol?.OriginalDefinition;

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -63,7 +63,9 @@ internal abstract partial class AbstractDocumentHighlightsService :
     private async Task<ImmutableArray<DocumentHighlights>> GetDocumentHighlightsInCurrentProcessAsync(
         Document document, int position, IImmutableSet<Document> documentsToSearch, HighlightingOptions options, CancellationToken cancellationToken)
     {
-        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        // Document highlights are not impacted by nullable analysis.  Get a semantic model with nullability disabled to
+        // lower the amount of work we need to do here.
+        var semanticModel = await document.GetRequiredNullableDisabledSemanticModelAsync(cancellationToken).ConfigureAwait(false);
         var result = TryGetEmbeddedLanguageHighlights(document, semanticModel, position, options, cancellationToken);
         if (!result.IsDefaultOrEmpty)
             return result;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/DocumentExtensions.cs
@@ -41,6 +41,21 @@ internal static partial class DocumentExtensions
         return semanticModel ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.SyntaxTree_is_required_to_accomplish_the_task_but_is_not_supported_by_document_0, document.Name));
     }
 
+#if !CODE_STYLE
+
+    public static async ValueTask<SemanticModel> GetRequiredNullableDisabledSemanticModelAsync(this Document document, CancellationToken cancellationToken)
+    {
+        if (document.TryGetNullableDisabledSemanticModel(out var semanticModel))
+            return semanticModel;
+
+#pragma warning disable RSEXPERIMENTAL001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        semanticModel = await document.GetSemanticModelAsync(SemanticModelOptions.DisableNullableAnalysis, cancellationToken).ConfigureAwait(false);
+#pragma warning restore RSEXPERIMENTAL001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        return semanticModel ?? throw new InvalidOperationException(string.Format(WorkspaceExtensionsResources.SyntaxTree_is_required_to_accomplish_the_task_but_is_not_supported_by_document_0, document.Name));
+    }
+
+#endif
+
     public static async ValueTask<SyntaxTree> GetRequiredSyntaxTreeAsync(this Document document, CancellationToken cancellationToken)
     {
         if (document.TryGetSyntaxTree(out var syntaxTree))


### PR DESCRIPTION
Will also ebnefit from https://github.com/dotnet/roslyn/pull/73078 as doc-highlights uses FAR.

traces show upwards of 15% of our time just in nullability analysis for these features:

![image](https://github.com/dotnet/roslyn/assets/4564579/80684c15-2181-478b-8bdb-0f56766e9e81)
