### PR TITLE
Visit binary operators in ref safety analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -258,13 +258,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? Visit(BoundNode? node)
         {
 #if DEBUG
-            VisitCore(node);
+            TrackVisit(node);
 #endif
             return base.Visit(node);
         }
 
 #if DEBUG
-        private void VisitCore(BoundNode? node)
+        protected override void BeforeVisitingSkippedBoundBinaryOperatorChildren(BoundBinaryOperator node)
+        {
+            TrackVisit(node);
+        }
+
+        protected override void BeforeVisitingSkippedBoundCallChildren(BoundCall node)
+        {
+            TrackVisit(node);
+        }
+
+        private void TrackVisit(BoundNode? node)
         {
             if (node is BoundValuePlaceholderBase placeholder)
             {
@@ -296,45 +306,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitFieldEqualsValue(BoundFieldEqualsValue node)
         {
             throw ExceptionUtilities.Unreachable();
-        }
-
-        // Unlike the base implementation, we want to visit all the nodes, not just the operands.
-        public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
-        {
-            if (node.Left.Kind != BoundKind.BinaryOperator)
-            {
-                return base.VisitBinaryOperator(node);
-            }
-
-            var binary = (BoundBinaryOperator)node.Left;
-
-            var operators = ArrayBuilder<BoundBinaryOperator>.GetInstance();
-
-            operators.Push(binary);
-
-            BoundExpression current = binary.Left;
-
-            while (current.Kind == BoundKind.BinaryOperator)
-            {
-                binary = (BoundBinaryOperator)current;
-                operators.Push(binary);
-                current = binary.Left;
-            }
-
-            this.Visit(current);
-
-            while (operators.TryPop(out var op))
-            {
-                this.Visit(op.Right);
-#if DEBUG
-                this.VisitCore(op);
-#endif
-            }
-
-            this.Visit(node.Right);
-
-            operators.Free();
-            return null;
         }
 
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
@@ -703,13 +674,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _localScopeDepth,
                     _diagnostics);
             }
-
-#if DEBUG
-            if (_visited is { } && _visited.Count <= MaxTrackVisited)
-            {
-                _visited.Add(node);
-            }
-#endif
         }
 
         private void GetInterpolatedStringPlaceholders(

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (_visited is { } && _visited.Count <= MaxTrackVisited)
             {
-                Debug.Assert(_visited.Contains(expr));
+                Debug.Assert(_visited.Contains(expr), $"Expected {expr} `{expr.Syntax}` to be visited.");
             }
         }
 #endif

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundTreeWalker.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundTreeWalker.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(recursionDepth)
         { }
 
-        public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
+        public sealed override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
         {
             if (node.Left.Kind != BoundKind.BinaryOperator)
             {
@@ -114,6 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var binary = (BoundBinaryOperator)node.Left;
 
+            BeforeVisitingSkippedBoundBinaryOperatorChildren(binary);
             rightOperands.Push(binary.Right);
 
             BoundExpression current = binary.Left;
@@ -121,6 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             while (current.Kind == BoundKind.BinaryOperator)
             {
                 binary = (BoundBinaryOperator)current;
+                BeforeVisitingSkippedBoundBinaryOperatorChildren(binary);
                 rightOperands.Push(binary.Right);
                 current = binary.Left;
             }
@@ -136,6 +138,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        protected virtual void BeforeVisitingSkippedBoundBinaryOperatorChildren(BoundBinaryOperator node)
+        {
+        }
+
         public sealed override BoundNode? VisitCall(BoundCall node)
         {
             if (node.ReceiverOpt is BoundCall receiver1)
@@ -147,9 +153,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 node = receiver1;
                 while (node.ReceiverOpt is BoundCall receiver2)
                 {
+                    BeforeVisitingSkippedBoundCallChildren(node);
                     calls.Push(node);
                     node = receiver2;
                 }
+
+                BeforeVisitingSkippedBoundCallChildren(node);
 
                 VisitReceiver(node);
 
@@ -168,6 +177,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return null;
+        }
+
+        protected virtual void BeforeVisitingSkippedBoundCallChildren(BoundCall node)
+        {
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundTreeWalker.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundTreeWalker.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(recursionDepth)
         { }
 
-        public sealed override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
+        public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
         {
             if (node.Left.Kind != BoundKind.BinaryOperator)
             {


### PR DESCRIPTION
Alternative to https://github.com/dotnet/roslyn/pull/72935.
Fixes https://github.com/dotnet/roslyn/issues/72873.