### PR TITLE
Change IReferenceFinder.DetermineDocumentsToSearchAsync to not return an ImmutableArray

### DIFF
--- a/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
+++ b/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -59,15 +60,20 @@ internal class DelegateInvokeMethodReferenceFinder : AbstractReferenceFinder<IMe
         return result.ToImmutableAndClear();
     }
 
-    protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected override Task DetermineDocumentsToSearchAsync<TData>(
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        return Task.FromResult(project.Documents.ToImmutableArray());
+        foreach (var document in project.Documents)
+            processResult(document, processResultData);
+
+        return Task.CompletedTask;
     }
 
     protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InfrastructureTests.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InfrastructureTests.cs
@@ -22,7 +22,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests
 
         protected override string LanguageName => LanguageNames.CSharp;
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/73099")]
         public async Task CanCloseSaveDialog()
         {
             await SetUpEditorAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -190,7 +190,7 @@ internal partial class FindReferencesSearchEngine
         using var _2 = PooledDictionary<Document, MetadataUnifyingSymbolHashSet>.GetInstance(out var documentToSymbols);
         try
         {
-            using var _3 = ArrayBuilder<Document>.GetInstance(out var documents);
+            using var _3 = ArrayBuilder<Document>.GetInstance(out var documentsBuffer);
 
             await AddGlobalAliasesAsync(project, allSymbols, symbolToGlobalAliases, cancellationToken).ConfigureAwait(false);
 
@@ -203,16 +203,16 @@ internal partial class FindReferencesSearchEngine
                     await finder.DetermineDocumentsToSearchAsync(
                         symbol, globalAliases, project, _documents,
                         static (doc, documents) => documents.Add(doc),
-                        documents,
+                        documentsBuffer,
                         _options, cancellationToken).ConfigureAwait(false);
 
-                    foreach (var document in documents)
+                    foreach (var document in documentsBuffer)
                     {
                         var docSymbols = GetSymbolSet(documentToSymbols, document);
                         docSymbols.Add(symbol);
                     }
 
-                    documents.Clear();
+                    documentsBuffer.Clear();
                 }
             }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -190,7 +190,7 @@ internal partial class FindReferencesSearchEngine
         using var _2 = PooledDictionary<Document, MetadataUnifyingSymbolHashSet>.GetInstance(out var documentToSymbols);
         try
         {
-            using var _3 = ArrayBuilder<Document>.GetInstance(out var documentsBuffer);
+            using var _3 = PooledHashSet<Document>.GetInstance(out var documentBuffers);
 
             await AddGlobalAliasesAsync(project, allSymbols, symbolToGlobalAliases, cancellationToken).ConfigureAwait(false);
 
@@ -203,16 +203,16 @@ internal partial class FindReferencesSearchEngine
                     await finder.DetermineDocumentsToSearchAsync(
                         symbol, globalAliases, project, _documents,
                         static (doc, documents) => documents.Add(doc),
-                        documentsBuffer,
+                        documentBuffers,
                         _options, cancellationToken).ConfigureAwait(false);
 
-                    foreach (var document in documentsBuffer)
+                    foreach (var document in documentBuffers)
                     {
                         var docSymbols = GetSymbolSet(documentToSymbols, document);
                         docSymbols.Add(symbol);
                     }
 
-                    documentsBuffer.Clear();
+                    documentBuffers.Clear();
                 }
             }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -190,7 +190,8 @@ internal partial class FindReferencesSearchEngine
         using var _2 = PooledDictionary<Document, MetadataUnifyingSymbolHashSet>.GetInstance(out var documentToSymbols);
         try
         {
-            using var _3 = PooledHashSet<Document>.GetInstance(out var documentBuffers);
+            // scratch hashset to place results in. Populated/inspected/cleared in inner loop.
+            using var _3 = PooledHashSet<Document>.GetInstance(out var foundDocuments);
 
             await AddGlobalAliasesAsync(project, allSymbols, symbolToGlobalAliases, cancellationToken).ConfigureAwait(false);
 
@@ -203,16 +204,16 @@ internal partial class FindReferencesSearchEngine
                     await finder.DetermineDocumentsToSearchAsync(
                         symbol, globalAliases, project, _documents,
                         static (doc, documents) => documents.Add(doc),
-                        documentBuffers,
+                        foundDocuments,
                         _options, cancellationToken).ConfigureAwait(false);
 
-                    foreach (var document in documentBuffers)
+                    foreach (var document in foundDocuments)
                     {
                         var docSymbols = GetSymbolSet(documentToSymbols, document);
                         docSymbols.Add(symbol);
                     }
 
-                    documentBuffers.Clear();
+                    foundDocuments.Clear();
                 }
             }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -30,8 +30,8 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
     public abstract ValueTask<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
         ISymbol symbol, Solution solution, FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
-    public abstract Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
-        ISymbol symbol, HashSet<string>? globalAliases, Project project, IImmutableSet<Document>? documents, FindReferencesSearchOptions options, CancellationToken cancellationToken);
+    public abstract Task DetermineDocumentsToSearchAsync<TData>(
+        ISymbol symbol, HashSet<string>? globalAliases, Project project, IImmutableSet<Document>? documents, Action<Document, TData> processResult, TData processResultData, FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
     public abstract ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
         ISymbol symbol, FindReferencesDocumentState state, FindReferencesSearchOptions options, CancellationToken cancellationToken);
@@ -81,11 +81,13 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
         return name.TryGetWithoutAttributeSuffix(syntaxFacts.IsCaseSensitive, out result);
     }
 
-    protected static async Task<ImmutableArray<Document>> FindDocumentsAsync<T>(
+    protected static async Task FindDocumentsAsync<T, TData>(
         Project project,
         IImmutableSet<Document>? scope,
         Func<Document, T, CancellationToken, ValueTask<bool>> predicateAsync,
         T value,
+        Action<Document, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         // special case for highlight references
@@ -93,31 +95,30 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
         {
             var document = scope.First();
             if (document.Project == project)
-                return scope.ToImmutableArray();
+                processResult(document, processResultData);
 
-            return [];
+            return;
         }
 
-        using var _ = ArrayBuilder<Document>.GetInstance(out var documents);
         foreach (var document in await project.GetAllRegularAndSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false))
         {
             if (scope != null && !scope.Contains(document))
                 continue;
 
             if (await predicateAsync(document, value, cancellationToken).ConfigureAwait(false))
-                documents.Add(document);
+                processResult(document, processResultData);
         }
-
-        return documents.ToImmutableAndClear();
     }
 
     /// <summary>
     /// Finds all the documents in the provided project that contain the requested string
     /// values
     /// </summary>
-    protected static Task<ImmutableArray<Document>> FindDocumentsAsync(
+    protected static Task FindDocumentsAsync<TData>(
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken,
         params string[] values)
     {
@@ -130,30 +131,32 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
             }
 
             return true;
-        }, values, cancellationToken);
+        }, values, processResult, processResultData, cancellationToken);
     }
 
     /// <summary>
     /// Finds all the documents in the provided project that contain a global attribute in them.
     /// </summary>
-    protected static Task<ImmutableArray<Document>> FindDocumentsWithGlobalSuppressMessageAttributeAsync(
-        Project project, IImmutableSet<Document>? documents, CancellationToken cancellationToken)
+    protected static Task FindDocumentsWithGlobalSuppressMessageAttributeAsync<TData>(
+        Project project, IImmutableSet<Document>? documents, Action<Document, TData> processResult, TData processResultData, CancellationToken cancellationToken)
     {
         return FindDocumentsWithPredicateAsync(
-            project, documents, static index => index.ContainsGlobalSuppressMessageAttribute, cancellationToken);
+            project, documents, static index => index.ContainsGlobalSuppressMessageAttribute, processResult, processResultData, cancellationToken);
     }
 
-    protected static Task<ImmutableArray<Document>> FindDocumentsAsync(
+    protected static Task FindDocumentsAsync<TData>(
         Project project,
         IImmutableSet<Document>? documents,
         PredefinedType predefinedType,
+        Action<Document, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         if (predefinedType == PredefinedType.None)
-            return SpecializedTasks.EmptyImmutableArray<Document>();
+            return Task.CompletedTask;
 
         return FindDocumentsWithPredicateAsync(
-            project, documents, static (index, predefinedType) => index.ContainsPredefinedType(predefinedType), predefinedType, cancellationToken);
+            project, documents, static (index, predefinedType) => index.ContainsPredefinedType(predefinedType), predefinedType, processResult, processResultData, cancellationToken);
     }
 
     protected static bool IdentifiersMatch(ISyntaxFactsService syntaxFacts, string name, SyntaxToken token)
@@ -327,35 +330,41 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
         return allAliasReferences.ToImmutableAndClear();
     }
 
-    protected static Task<ImmutableArray<Document>> FindDocumentsWithPredicateAsync<T>(
+    protected static Task FindDocumentsWithPredicateAsync<T, TData>(
         Project project,
         IImmutableSet<Document>? documents,
         Func<SyntaxTreeIndex, T, bool> predicate,
         T value,
+        Action<Document, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         return FindDocumentsAsync(project, documents, static async (d, t, c) =>
         {
             var info = await SyntaxTreeIndex.GetRequiredIndexAsync(d, c).ConfigureAwait(false);
             return t.predicate(info, t.value);
-        }, (predicate, value), cancellationToken);
+        }, (predicate, value), processResult, processResultData, cancellationToken);
     }
 
-    protected static Task<ImmutableArray<Document>> FindDocumentsWithPredicateAsync(
+    protected static Task FindDocumentsWithPredicateAsync<TData>(
         Project project,
         IImmutableSet<Document>? documents,
         Func<SyntaxTreeIndex, bool> predicate,
+        Action<Document, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         return FindDocumentsWithPredicateAsync(
             project, documents,
             static (info, predicate) => predicate(info),
             predicate,
+            processResult,
+            processResultData,
             cancellationToken);
     }
 
-    protected static Task<ImmutableArray<Document>> FindDocumentsWithForEachStatementsAsync(Project project, IImmutableSet<Document>? documents, CancellationToken cancellationToken)
-        => FindDocumentsWithPredicateAsync(project, documents, static index => index.ContainsForEachStatement, cancellationToken);
+    protected static Task FindDocumentsWithForEachStatementsAsync<TData>(Project project, IImmutableSet<Document>? documents, Action<Document, TData> processResult, TData processResultData, CancellationToken cancellationToken)
+        => FindDocumentsWithPredicateAsync(project, documents, static index => index.ContainsForEachStatement, processResult, processResultData, cancellationToken);
 
     /// <summary>
     /// If the `node` implicitly matches the `symbol`, then it will be added to `locations`.
@@ -824,8 +833,9 @@ internal abstract partial class AbstractReferenceFinder<TSymbol> : AbstractRefer
 {
     protected abstract bool CanFind(TSymbol symbol);
 
-    protected abstract Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected abstract Task DetermineDocumentsToSearchAsync<TData>(
         TSymbol symbol, HashSet<string>? globalAliases, Project project, IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult, TData processResultData,
         FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
     protected abstract ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
@@ -845,13 +855,15 @@ internal abstract partial class AbstractReferenceFinder<TSymbol> : AbstractRefer
             : SpecializedTasks.EmptyImmutableArray<string>();
     }
 
-    public sealed override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    public sealed override Task DetermineDocumentsToSearchAsync<TData>(
         ISymbol symbol, HashSet<string>? globalAliases, Project project,
-        IImmutableSet<Document>? documents, FindReferencesSearchOptions options, CancellationToken cancellationToken)
+        IImmutableSet<Document>? documents, Action<Document, TData> processResult,
+        TData processResultData, FindReferencesSearchOptions options, CancellationToken cancellationToken)
     {
-        return symbol is TSymbol typedSymbol && CanFind(typedSymbol)
-            ? DetermineDocumentsToSearchAsync(typedSymbol, globalAliases, project, documents, options, cancellationToken)
-            : SpecializedTasks.EmptyImmutableArray<Document>();
+        if (symbol is TSymbol typedSymbol && CanFind(typedSymbol))
+            return DetermineDocumentsToSearchAsync(typedSymbol, globalAliases, project, documents, processResult, processResultData, options, cancellationToken);
+
+        return Task.CompletedTask;
     }
 
     public sealed override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -24,6 +24,9 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
     public const string ContainingTypeInfoPropertyName = "ContainingTypeInfo";
     public const string ContainingMemberInfoPropertyName = "ContainingMemberInfo";
 
+    protected static readonly Action<Document, HashSet<Document>> StandardHashSetAddCallback =
+        static (doc, set) => set.Add(doc);
+
     public abstract Task<ImmutableArray<string>> DetermineGlobalAliasesAsync(
         ISymbol symbol, Project project, CancellationToken cancellationToken);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -19,11 +18,13 @@ internal sealed class ConstructorInitializerSymbolReferenceFinder : AbstractRefe
     protected override bool CanFind(IMethodSymbol symbol)
         => symbol.MethodKind == MethodKind.Constructor;
 
-    protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected override Task DetermineDocumentsToSearchAsync<TData>(
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
@@ -47,7 +48,7 @@ internal sealed class ConstructorInitializerSymbolReferenceFinder : AbstractRefe
             }
 
             return false;
-        }, symbol.ContainingType.Name, cancellationToken);
+        }, symbol.ContainingType.Name, processResult, processResultData, cancellationToken);
     }
 
     protected sealed override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 
@@ -15,15 +15,17 @@ internal sealed class DestructorSymbolReferenceFinder : AbstractReferenceFinder<
     protected override bool CanFind(IMethodSymbol symbol)
         => symbol.MethodKind == MethodKind.Destructor;
 
-    protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected override Task DetermineDocumentsToSearchAsync<TData>(
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        return SpecializedTasks.EmptyImmutableArray<Document>();
+        return Task.CompletedTask;
     }
 
     protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -33,17 +34,18 @@ internal class EventSymbolReferenceFinder : AbstractMethodOrPropertyOrEventSymbo
         return new(backingFields.Concat(associatedNamedTypes));
     }
 
-    protected sealed override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected sealed override async Task DetermineDocumentsToSearchAsync<TData>(
         IEventSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        var documentsWithName = await FindDocumentsAsync(project, documents, cancellationToken, symbol.Name).ConfigureAwait(false);
-        var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
-        return documentsWithName.Concat(documentsWithGlobalAttributes);
+        await FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
+        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
     protected sealed override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
@@ -47,12 +47,12 @@ internal sealed partial class ExplicitConversionSymbolReferenceFinder : Abstract
         var underlyingNamedType = GetUnderlyingNamedType(symbol.ReturnType);
         Contract.ThrowIfNull(underlyingNamedType);
 
-        using var _ = ArrayBuilder<Document>.GetInstance(out var result);
+        using var _ = PooledHashSet<Document>.GetInstance(out var result);
         await FindDocumentsAsync(project, documents, static (doc, result) => result.Add(doc), result, cancellationToken, underlyingNamedType.Name).ConfigureAwait(false);
         await FindDocumentsAsync(project, documents, underlyingNamedType.SpecialType.ToPredefinedType(), static (doc, result) => result.Add(doc), result, cancellationToken).ConfigureAwait(false);
 
         // Ignore any documents that don't also have an explicit cast in them.
-        foreach (var document in result.Distinct())
+        foreach (var document in result)
         {
             var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
             if (index.ContainsConversion)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -23,11 +24,13 @@ internal sealed partial class ExplicitConversionSymbolReferenceFinder : Abstract
     private static INamedTypeSymbol? GetUnderlyingNamedType(ITypeSymbol symbol)
         => UnderlyingNamedTypeVisitor.Instance.Visit(symbol);
 
-    protected sealed override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected sealed override async Task DetermineDocumentsToSearchAsync<TData>(
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
@@ -43,20 +46,18 @@ internal sealed partial class ExplicitConversionSymbolReferenceFinder : Abstract
 
         var underlyingNamedType = GetUnderlyingNamedType(symbol.ReturnType);
         Contract.ThrowIfNull(underlyingNamedType);
-        var documentsWithName = await FindDocumentsAsync(project, documents, cancellationToken, underlyingNamedType.Name).ConfigureAwait(false);
-        var documentsWithType = await FindDocumentsAsync(project, documents, underlyingNamedType.SpecialType.ToPredefinedType(), cancellationToken).ConfigureAwait(false);
 
         using var _ = ArrayBuilder<Document>.GetInstance(out var result);
+        await FindDocumentsAsync(project, documents, static (doc, result) => result.Add(doc), result, cancellationToken, underlyingNamedType.Name).ConfigureAwait(false);
+        await FindDocumentsAsync(project, documents, underlyingNamedType.SpecialType.ToPredefinedType(), static (doc, result) => result.Add(doc), result, cancellationToken).ConfigureAwait(false);
 
         // Ignore any documents that don't also have an explicit cast in them.
-        foreach (var document in documentsWithName.Concat(documentsWithType).Distinct())
+        foreach (var document in result.Distinct())
         {
             var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
             if (index.ContainsConversion)
-                result.Add(document);
+                processResult(document, processResultData);
         }
-
-        return result.ToImmutableAndClear();
     }
 
     protected sealed override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
@@ -48,8 +48,8 @@ internal sealed partial class ExplicitConversionSymbolReferenceFinder : Abstract
         Contract.ThrowIfNull(underlyingNamedType);
 
         using var _ = PooledHashSet<Document>.GetInstance(out var result);
-        await FindDocumentsAsync(project, documents, static (doc, result) => result.Add(doc), result, cancellationToken, underlyingNamedType.Name).ConfigureAwait(false);
-        await FindDocumentsAsync(project, documents, underlyingNamedType.SpecialType.ToPredefinedType(), static (doc, result) => result.Add(doc), result, cancellationToken).ConfigureAwait(false);
+        await FindDocumentsAsync(project, documents, StandardHashSetAddCallback, result, cancellationToken, underlyingNamedType.Name).ConfigureAwait(false);
+        await FindDocumentsAsync(project, documents, underlyingNamedType.SpecialType.ToPredefinedType(), StandardHashSetAddCallback, result, cancellationToken).ConfigureAwait(false);
 
         // Ignore any documents that don't also have an explicit cast in them.
         foreach (var document in result)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 
@@ -15,16 +15,18 @@ internal sealed class ExplicitInterfaceMethodReferenceFinder : AbstractReference
     protected override bool CanFind(IMethodSymbol symbol)
         => symbol.MethodKind == MethodKind.ExplicitInterfaceImplementation;
 
-    protected sealed override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected sealed override Task DetermineDocumentsToSearchAsync<TData>(
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         // An explicit method can't be referenced anywhere.
-        return SpecializedTasks.EmptyImmutableArray<Document>();
+        return Task.CompletedTask;
     }
 
     protected sealed override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 
@@ -26,17 +26,18 @@ internal sealed class FieldSymbolReferenceFinder : AbstractReferenceFinder<IFiel
             : new(ImmutableArray<ISymbol>.Empty);
     }
 
-    protected override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected override async Task DetermineDocumentsToSearchAsync<TData>(
         IFieldSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        var documentsWithName = await FindDocumentsAsync(project, documents, cancellationToken, symbol.Name).ConfigureAwait(false);
-        var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
-        return documentsWithName.Concat(documentsWithGlobalAttributes);
+        await FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
+        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
     protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -49,9 +50,10 @@ internal interface IReferenceFinder
     /// 
     /// Implementations of this method must be thread-safe.
     /// </summary>
-    Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    Task DetermineDocumentsToSearchAsync<TData>(
         ISymbol symbol, HashSet<string>? globalAliases,
         Project project, IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult, TData processResultData,
         FindReferencesSearchOptions options, CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -36,11 +37,13 @@ internal sealed class MethodTypeParameterSymbolReferenceFinder : AbstractTypePar
         return new([]);
     }
 
-    protected sealed override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected sealed override Task DetermineDocumentsToSearchAsync<TData>(
         ITypeParameterSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
@@ -55,7 +58,7 @@ internal sealed class MethodTypeParameterSymbolReferenceFinder : AbstractTypePar
         // Also, we only look for files that have the name of the owning type.  This helps filter
         // down the set considerably.
         Contract.ThrowIfNull(symbol.DeclaringMethod);
-        return FindDocumentsAsync(project, documents, cancellationToken, symbol.Name,
+        return FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name,
             GetMemberNameWithoutInterfaceName(symbol.DeclaringMethod.Name),
             symbol.DeclaringMethod.ContainingType.Name);
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 
@@ -17,31 +17,34 @@ internal sealed class OperatorSymbolReferenceFinder : AbstractMethodOrPropertyOr
     protected override bool CanFind(IMethodSymbol symbol)
         => symbol.MethodKind is MethodKind.UserDefinedOperator or MethodKind.BuiltinOperator;
 
-    protected sealed override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected sealed override async Task DetermineDocumentsToSearchAsync<TData>(
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         var op = symbol.GetPredefinedOperator();
-        var documentsWithOp = await FindDocumentsAsync(project, documents, op, cancellationToken).ConfigureAwait(false);
-        var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
-        return documentsWithOp.Concat(documentsWithGlobalAttributes);
+        await FindDocumentsAsync(project, documents, op, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
-    private static Task<ImmutableArray<Document>> FindDocumentsAsync(
+    private static Task FindDocumentsAsync<TData>(
         Project project,
         IImmutableSet<Document>? documents,
         PredefinedOperator op,
+        Action<Document, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         if (op == PredefinedOperator.None)
-            return SpecializedTasks.EmptyImmutableArray<Document>();
+            return Task.CompletedTask;
 
         return FindDocumentsWithPredicateAsync(
-            project, documents, static (index, op) => index.ContainsPredefinedOperator(op), op, cancellationToken);
+            project, documents, static (index, op) => index.ContainsPredefinedOperator(op), op, processResult, processResultData, cancellationToken);
     }
 
     protected sealed override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
@@ -20,11 +20,13 @@ internal sealed class ParameterSymbolReferenceFinder : AbstractReferenceFinder<I
     protected override bool CanFind(IParameterSymbol symbol)
         => true;
 
-    protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected override Task DetermineDocumentsToSearchAsync<TData>(
         IParameterSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
@@ -33,7 +35,7 @@ internal sealed class ParameterSymbolReferenceFinder : AbstractReferenceFinder<I
         // elsewhere as "paramName:" or "paramName:=".  We can narrow the search by
         // filtering down to matches of that form.  For now we just return any document
         // that references something with this name.
-        return FindDocumentsAsync(project, documents, cancellationToken, symbol.Name);
+        return FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name);
     }
 
     protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 
@@ -30,34 +29,35 @@ internal sealed class PropertyAccessorSymbolReferenceFinder : AbstractMethodOrPr
             : new(ImmutableArray.Create(symbol.AssociatedSymbol));
     }
 
-    protected override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected override async Task DetermineDocumentsToSearchAsync<TData>(
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         // First, find any documents with the full name of the accessor (i.e. get_Goo).
         // This will find explicit calls to the method (which can happen when C# references
         // a VB parameterized property).
-        var documentsWithName = await FindDocumentsAsync(project, documents, cancellationToken, symbol.Name).ConfigureAwait(false);
+        await FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
 
-        var propertyDocuments = ImmutableArray<Document>.Empty;
         if (symbol.AssociatedSymbol is IPropertySymbol property &&
             options.AssociatePropertyReferencesWithSpecificAccessor)
         {
             // we want to associate normal property references with the specific accessor being
             // referenced.  So we also need to include documents with our property's name. Just
             // defer to the Property finder to find these docs and combine them with the result.
-            propertyDocuments = await ReferenceFinders.Property.DetermineDocumentsToSearchAsync(
+            await ReferenceFinders.Property.DetermineDocumentsToSearchAsync(
                 property, globalAliases, project, documents,
+                processResult, processResultData,
                 options with { AssociatePropertyReferencesWithSpecificAccessor = false },
                 cancellationToken).ConfigureAwait(false);
         }
 
-        var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
-        return documentsWithName.Concat(propertyDocuments, documentsWithGlobalAttributes);
+        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
     protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -14,11 +15,13 @@ internal sealed class TypeParameterSymbolReferenceFinder : AbstractTypeParameter
     protected override bool CanFind(ITypeParameterSymbol symbol)
         => symbol.TypeParameterKind != TypeParameterKind.Method;
 
-    protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+    protected override Task DetermineDocumentsToSearchAsync<TData>(
         ITypeParameterSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
+        Action<Document, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
@@ -29,6 +32,6 @@ internal sealed class TypeParameterSymbolReferenceFinder : AbstractTypeParameter
         // parameter has a different name in different parts that we won't find it.  However,
         // this only happens in error situations.  It is not legal in C# to use a different
         // name for a type parameter in different parts.
-        return FindDocumentsAsync(project, documents, cancellationToken, symbol.Name, symbol.ContainingType.Name);
+        return FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name, symbol.ContainingType.Name);
     }
 }


### PR DESCRIPTION
Rather, this method now utilizes a callback to be invoked with results. This prevents quite a few intermediary array allocations during find references invocations.