### PR TITLE
Defer loading source-texts on the OOP side until actually needed. (part2)

### DIFF
--- a/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
@@ -243,6 +243,15 @@ internal sealed class SerializableSourceText
 
         internal override string? FilePath { get; }
 
+        /// <summary>
+        /// Documents should always hold onto instances of this text loader strongly.  In other words, they should load
+        /// from this, and then dump the contents into a RecoverableText object that then dumps the contents to a memory
+        /// mapped file within this process.  Doing that is pointless as the contents of this text are already in a
+        /// memory mapped file on the host side.
+        /// </summary>
+        internal override bool AlwaysHoldStrongly
+            => true;
+
         public override Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
             => _lazyTextAndVersion.GetValueAsync(cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
@@ -220,14 +220,20 @@ internal sealed class SerializableSourceText
     /// simply point to the segments in the memory-mapped-file the host has dumped its text into, and only actually
     /// realizing the real text values when they're needed.
     /// </summary>
-    private sealed class SerializableSourceTextLoader(
-        SerializableSourceText serializableSourceText,
-        string? filePath) : TextLoader
+    private sealed class SerializableSourceTextLoader : TextLoader
     {
-        public readonly SerializableSourceText SerializableSourceText = serializableSourceText;
+        public readonly SerializableSourceText SerializableSourceText;
         private readonly VersionStamp _version = VersionStamp.Create();
 
-        internal override string? FilePath { get; } = filePath;
+        public SerializableSourceTextLoader(
+            SerializableSourceText serializableSourceText,
+            string? filePath)
+        {
+            SerializableSourceText = serializableSourceText;
+            FilePath = filePath;
+        }
+
+        internal override string? FilePath { get; }
 
         /// <summary>
         /// Documents should always hold onto instances of this text loader strongly.  In other words, they should load

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -175,6 +175,11 @@ internal partial class TextDocumentState
         var service = solutionServices.GetRequiredService<IWorkspaceConfigurationService>();
         var options = service.Options;
 
+        // See if the client, the loader itself, or the options want us to hold onto this loader strongly.  If so, we
+        // wrap it directly in a LoadableTextAndVersionSource that will keep it alive, deferring to it to get the final
+        // source text.  If none of the above hold, we'll create a RecoverableTextAndVersion.  This will use the loaded
+        // the first time to get the text contents, but will then dump those contents to a memory-mapped-file afterwards
+        // so that it can be kept out of main memory, while still allowing us to preserve snapshot semantics.
         return mode == PreservationMode.PreserveIdentity || loader.AlwaysHoldStrongly || options.DisableRecoverableText
             ? new LoadableTextAndVersionSource(loader, cacheResult: true)
             : new RecoverableTextAndVersion(new LoadableTextAndVersionSource(loader, cacheResult: false), solutionServices);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -60,7 +60,9 @@ internal partial class TextDocumentState
                info.DocumentServiceProvider,
                info.Attributes,
                textAndVersionSource: info.TextLoader != null
-                ? CreateRecoverableText(info.TextLoader, solutionServices)
+                ? info.TextLoader.AlwaysHoldStrongly
+                    ? CreateStrongText(info.TextLoader)
+                    : CreateRecoverableText(info.TextLoader, solutionServices)
                 : CreateStrongText(TextAndVersion.Create(SourceText.From(string.Empty, encoding: null, loadTextOptions.ChecksumAlgorithm), VersionStamp.Default, info.FilePath)),
                loadTextOptions)
     {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
@@ -32,6 +32,16 @@ public abstract class TextLoader
     internal virtual string? FilePath => null;
 
     /// <summary>
+    /// <see langword="true"/> if the document that holds onto this loader should do so with a strong reference, versus
+    /// a reference that will take the contents of this loader and store them in a recoverable form.  This should be
+    /// used when the underlying data is already stored in a recoverable form somewhere else and it would be wasteful to
+    /// store another copy.  For example, a document that is backed by memory-mapped contents in another process does not
+    /// need to dump it's content to another memory-mapped file in the process it lives in.  It can always recover the 
+    /// text from the original process.
+    /// </summary>
+    internal virtual bool AlwaysHoldStrongly => false;
+
+    /// <summary>
     /// True if <see cref="LoadTextAndVersionAsync(LoadTextOptions, CancellationToken)"/> reloads <see cref="SourceText"/> from its original binary representation (e.g. file on disk).
     /// </summary>
     internal virtual bool CanReloadText

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
@@ -33,13 +33,15 @@ public abstract class TextLoader
 
     /// <summary>
     /// <see langword="true"/> if the document that holds onto this loader should do so with a strong reference, versus
-    /// a reference that will take the contents of this loader and store them in a recoverable form.  This should be
-    /// used when the underlying data is already stored in a recoverable form somewhere else and it would be wasteful to
-    /// store another copy.  For example, a document that is backed by memory-mapped contents in another process does not
-    /// need to dump it's content to another memory-mapped file in the process it lives in.  It can always recover the 
-    /// text from the original process.
+    /// a reference that will take the contents of this loader and store them in a recoverable form (e.g. a memory
+    /// mapped file within the <em>same</em> process).  This should be used when the underlying data is already stored
+    /// in a recoverable form somewhere else and it would be wasteful to store another copy.  For example, a document
+    /// that is backed by memory-mapped contents in <em>another</em> process does not need to dump it's content to
+    /// another memory-mapped file in the process it lives in.  It can always recover the text from the original
+    /// process.
     /// </summary>
-    internal virtual bool AlwaysHoldStrongly => false;
+    internal virtual bool AlwaysHoldStrongly
+        => false;
 
     /// <summary>
     /// True if <see cref="LoadTextAndVersionAsync(LoadTextOptions, CancellationToken)"/> reloads <see cref="SourceText"/> from its original binary representation (e.g. file on disk).

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -619,12 +619,11 @@ namespace Microsoft.CodeAnalysis.Remote
                         assetPath: document.Id, newDocumentChecksums.textChecksum, cancellationToken).ConfigureAwait(false);
                     var loader = serializableSourceText.ToTextLoader(document.FilePath);
 
-                    // We strongly want to use identity-preservation with these loaders.  By doing that we'll always use
-                    // this loader as the 'truth' of how to get teh source-text for a particular document.  When the
-                    // text is first needed it will be pulled from the memory mapped files on the host side.  Then, if
-                    // that text is ever dropped, we'll still be pointing at this same loader.  That will ensure that we
-                    // still read the data from the host side, without doing something silly (like dumping it to our own
-                    // memory mapped data on the OOP side).
+                    // The mode here doesn't actually matter. The text loaded created by ToTextLoader will already tell
+                    // the solution to use it as the source of truth for the document and to not then dump the contents
+                    // of it to a memory-mapped-file within this process (no point when it's already that way in the
+                    // shared memory-mapped-file we are pointing to in the host process).  But 'PreserveIdentity'
+                    // matches that as well so we use that mode here for clarity.
                     var mode = PreservationMode.PreserveIdentity;
 
                     document = document.Kind switch

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -618,13 +618,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     var serializableSourceText = await _assetProvider.GetAssetAsync<SerializableSourceText>(
                         assetPath: document.Id, newDocumentChecksums.textChecksum, cancellationToken).ConfigureAwait(false);
                     var loader = serializableSourceText.ToTextLoader(document.FilePath);
-
-                    // The mode here doesn't actually matter. The text loaded created by ToTextLoader will already tell
-                    // the solution to use it as the source of truth for the document and to not then dump the contents
-                    // of it to a memory-mapped-file within this process (no point when it's already that way in the
-                    // shared memory-mapped-file we are pointing to in the host process).  But 'PreserveIdentity'
-                    // matches that as well so we use that mode here for clarity.
-                    var mode = PreservationMode.PreserveIdentity;
+                    var mode = PreservationMode.PreserveValue;
 
                     document = document.Kind switch
                     {


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/73088.

Also update the OOP workspace so that if text is released for closed files, it can be retrieved from the same memory-mapped-file it was created from in the first place.  Before this, the OOP side was itself using the 'recoverable text' system as well for all docs.  So after reading docs, the docs would then go into new MMFs in the OOP process.  But that's pointless since the contents are already in an MMF from the original host process.  So we can just release our text knowing we can reload from that.

PR1: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=9445756&view=results
PR2: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=9445757&view=results