### PR TITLE
Remove unnecessary dump of skeleton references to memory mapped files

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.SkeletonReferenceCache.cs
@@ -251,7 +251,7 @@ internal partial class SolutionCompilationState
                         logger?.Log($"Successfully emitted a skeleton assembly for {compilation.AssemblyName}");
 
                         stream.Position = 0;
-                        var metadata = AssemblyMetadata.CreateFromStream(stream, leaveOpen: false);
+                        var metadata = AssemblyMetadata.CreateFromStream(stream, leaveOpen: true);
                         return metadata;
                     }
 


### PR DESCRIPTION
I notice this during some major cleanup i was doing of our memory-mapped-file subsystem.  When producign skeletons we dump them into memory mapped storage, only to do nothing with that storage except read the data back in again.  Because the storage object is not help onto (or any of hte info to reconstruct it later by any other party) the data in the MMF is effectively orphaned and will never be read in again.  

We can avoid this entirely with zero loss in functionality.  This should make life better for a project like roslyn as we're not pointlessly causing additional IO here.