### PR TITLE
Remove unused async entrypoints

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -214,7 +214,7 @@ internal sealed partial class VisualStudioMetadataReferenceManager : IWorkspaceS
                 storage = _temporaryStorageService.CreateTemporaryStreamStorage();
 
                 copyStream.Position = 0;
-                storage.WriteStream(copyStream);
+                storage.WriteStream(copyStream, CancellationToken.None);
             }
 
             // get stream that owns the underlying unmanaged memory.

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
@@ -44,7 +44,5 @@ internal interface ITemporaryTextStorageInternal : IDisposable
 internal interface ITemporaryStreamStorageInternal : IDisposable
 {
     Stream ReadStream(CancellationToken cancellationToken = default);
-    Task<Stream> ReadStreamAsync(CancellationToken cancellationToken = default);
     void WriteStream(Stream stream, CancellationToken cancellationToken = default);
-    Task WriteStreamAsync(Stream stream, CancellationToken cancellationToken = default);
 }

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -60,8 +60,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
 
             data.Position = 0;
-            temporaryStorage.WriteStreamAsync(data).Wait();
-            using var result = temporaryStorage.ReadStreamAsync().Result;
+            temporaryStorage.WriteStream(data, CancellationToken.None);
+            using var result = temporaryStorage.ReadStream(CancellationToken.None);
             Assert.Equal(data.Length, result.Length);
 
             for (var i = 0; i < SharedPools.ByteBufferSize; i++)
@@ -119,18 +119,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             // Nothing has been written yet
             Assert.Throws<InvalidOperationException>(() => storage.ReadStream(CancellationToken.None));
-            Assert.Throws<AggregateException>(() => storage.ReadStreamAsync().Result);
 
             // write a normal stream
             var stream = new MemoryStream();
             stream.Write([42], 0, 1);
             stream.Position = 0;
-            storage.WriteStreamAsync(stream).Wait();
+            storage.WriteStream(stream, CancellationToken.None);
 
             // Writing multiple times is not allowed
             // These should also throw before ever getting to the point where they would look at the null stream arg.
-            Assert.Throws<InvalidOperationException>(() => storage.WriteStream(null!));
-            Assert.Throws<AggregateException>(() => storage.WriteStreamAsync(null!).Wait());
+            Assert.Throws<InvalidOperationException>(() => storage.WriteStream(null!, CancellationToken.None));
         }
 
         [ConditionalFact(typeof(WindowsOnly))]
@@ -144,7 +142,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // 0 length streams are allowed
             using (var stream1 = new MemoryStream())
             {
-                storage.WriteStream(stream1);
+                storage.WriteStream(stream1, CancellationToken.None);
             }
 
             using (var stream2 = storage.ReadStream(CancellationToken.None))
@@ -176,7 +174,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
                     storage1.WriteStream(new MemoryStream(buffer.GetBuffer(), 0, 1024 * i - 1));
                     storage2.WriteStream(new MemoryStream(buffer.GetBuffer(), 0, 1024 * i));
-                    storage3.WriteStream(new MemoryStream(buffer.GetBuffer(), 0, 1024 * i + 1));
+                    storage3.WriteStream(new MemoryStream(buffer.GetBuffer(), 0, 1024 * i + 1), CancellationToken.None);
 
                     await Task.Yield();
 
@@ -220,12 +218,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     var s = service.CreateTemporaryStreamStorage();
                     storageHandles.Add(s);
                     data.Position = 0;
-                    s.WriteStreamAsync(data).Wait();
+                    s.WriteStream(data, CancellationToken.None);
                 }
 
                 for (var i = 0; i < 1024 * 5; i++)
                 {
-                    using var s = storageHandles[i].ReadStreamAsync().Result;
+                    using var s = storageHandles[i].ReadStream(CancellationToken.None);
                     Assert.Equal(1, s.ReadByte());
                     storageHandles[i].Dispose();
                 }
@@ -247,7 +245,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
 
             expected.Position = 0;
-            storage.WriteStream(expected);
+            storage.WriteStream(expected, CancellationToken.None);
 
             expected.Position = 0;
             using var stream = storage.ReadStream(CancellationToken.None);
@@ -274,7 +272,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
 
             expected.Position = 0;
-            storage.WriteStream(expected);
+            storage.WriteStream(expected, CancellationToken.None);
 
             expected.Position = 0;
             using var stream = storage.ReadStream(CancellationToken.None);
@@ -316,7 +314,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
 
             expected.Position = 0;
-            storage.WriteStream(expected);
+            storage.WriteStream(expected, CancellationToken.None);
 
             expected.Position = 0;
             using var stream = storage.ReadStream(CancellationToken.None);


### PR DESCRIPTION
These entrypoints were only used in tests.