### PR TITLE
Reduce allocations due to multiple levels of ImmutableArray<FinderLocations> created during find references invocations.

### DIFF
--- a/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
+++ b/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
@@ -95,10 +95,7 @@ internal class DelegateInvokeMethodReferenceFinder : AbstractReferenceFinder<IMe
             .Where(e => state.SemanticModel.GetSymbolInfo(e, cancellationToken).Symbol?.OriginalDefinition == methodSymbol);
 
         foreach (var node in invocations)
-        {
-            var finderLocation = CreateFinderLocation(node, state, cancellationToken);
-            processResult(finderLocation, processResultData);
-        }
+            processResult(CreateFinderLocation(node, state, cancellationToken), processResultData);
 
         foreach (var node in nodes)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -272,7 +272,7 @@ internal partial class FindReferencesSearchEngine
             // just grab those once here and hold onto them for the lifetime of this call.
             var cache = await FindReferenceCache.GetCacheAsync(document, cancellationToken).ConfigureAwait(false);
 
-            // scratch hashset to place results in. Populated/inspected/cleared in inner loop.
+            // scratch array to place results in. Populated/inspected/cleared in inner loop.
             using var _ = ArrayBuilder<FinderLocation>.GetInstance(out var foundReferenceLocations);
 
             foreach (var symbol in symbols)
@@ -304,9 +304,9 @@ internal partial class FindReferencesSearchEngine
                         symbol, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, foundReferenceLocations, _options, cancellationToken).ConfigureAwait(false);
                     foreach (var (_, location) in foundReferenceLocations)
                         await _progress.OnReferenceFoundAsync(group, symbol, location, cancellationToken).ConfigureAwait(false);
-                }
 
-                foundReferenceLocations.Clear();
+                    foundReferenceLocations.Clear();
+                }
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -203,7 +203,7 @@ internal partial class FindReferencesSearchEngine
                 {
                     await finder.DetermineDocumentsToSearchAsync(
                         symbol, globalAliases, project, _documents,
-                        static (doc, documents) => documents.Add(doc),
+                        StandardCallbacks<Document>.AddToHashSet,
                         foundDocuments,
                         _options, cancellationToken).ConfigureAwait(false);
 
@@ -272,12 +272,15 @@ internal partial class FindReferencesSearchEngine
             // just grab those once here and hold onto them for the lifetime of this call.
             var cache = await FindReferenceCache.GetCacheAsync(document, cancellationToken).ConfigureAwait(false);
 
+            // scratch hashset to place results in. Populated/inspected/cleared in inner loop.
+            using var _ = ArrayBuilder<FinderLocation>.GetInstance(out var foundReferenceLocations);
+
             foreach (var symbol in symbols)
             {
                 var globalAliases = TryGet(symbolToGlobalAliases, symbol);
                 var state = new FindReferencesDocumentState(cache, globalAliases);
 
-                await ProcessDocumentAsync(symbol, state).ConfigureAwait(false);
+                await ProcessDocumentAsync(symbol, state, foundReferenceLocations).ConfigureAwait(false);
             }
         }
         finally
@@ -286,7 +289,7 @@ internal partial class FindReferencesSearchEngine
         }
 
         async Task ProcessDocumentAsync(
-            ISymbol symbol, FindReferencesDocumentState state)
+            ISymbol symbol, FindReferencesDocumentState state, ArrayBuilder<FinderLocation> foundReferenceLocations)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -297,11 +300,13 @@ internal partial class FindReferencesSearchEngine
                 var group = _symbolToGroup[symbol];
                 foreach (var finder in _finders)
                 {
-                    var references = await finder.FindReferencesInDocumentAsync(
-                        symbol, state, _options, cancellationToken).ConfigureAwait(false);
-                    foreach (var (_, location) in references)
+                    await finder.FindReferencesInDocumentAsync(
+                        symbol, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, foundReferenceLocations, _options, cancellationToken).ConfigureAwait(false);
+                    foreach (var (_, location) in foundReferenceLocations)
                         await _progress.OnReferenceFoundAsync(group, symbol, location, cancellationToken).ConfigureAwait(false);
                 }
+
+                foundReferenceLocations.Clear();
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
@@ -4,10 +4,8 @@
 
 using System.Collections.Immutable;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder_GlobalSuppressions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder_GlobalSuppressions.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -51,28 +50,30 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
     ///     [assembly: SuppressMessage("RuleCategory", "RuleId', Scope = "member", Target = "~F:C.Field")]
     /// </summary>
     [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", OftenCompletesSynchronously = true)]
-    protected static async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentInsideGlobalSuppressionsAsync(
+    protected static async ValueTask FindReferencesInDocumentInsideGlobalSuppressionsAsync<TData>(
         ISymbol symbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         if (!ShouldFindReferencesInGlobalSuppressions(symbol, out var docCommentId))
-            return [];
+            return;
 
         // Check if we have any relevant global attributes in this document.
         var info = await SyntaxTreeIndex.GetRequiredIndexAsync(state.Document, cancellationToken).ConfigureAwait(false);
         if (!info.ContainsGlobalSuppressMessageAttribute)
-            return [];
+            return;
 
         var semanticModel = state.SemanticModel;
         var suppressMessageAttribute = semanticModel.Compilation.SuppressMessageAttributeType();
         if (suppressMessageAttribute == null)
-            return [];
+            return;
 
         // Check if we have any instances of the symbol documentation comment ID string literals within global attributes.
         // These string literals represent references to the symbol.
         if (!TryGetExpectedDocumentationCommentId(docCommentId, out var expectedDocCommentId))
-            return [];
+            return;
 
         var syntaxFacts = state.SyntaxFacts;
 
@@ -80,17 +81,16 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
         // perform semantic checks to ensure these are valid references to the symbol
         // and if so, add these locations to the computed references.
         var root = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-        using var _ = ArrayBuilder<FinderLocation>.GetInstance(out var locations);
         foreach (var token in root.DescendantTokens())
         {
             if (IsCandidate(state, token, expectedDocCommentId.Span, suppressMessageAttribute, cancellationToken, out var offsetOfReferenceInToken))
             {
                 var referenceLocation = CreateReferenceLocation(offsetOfReferenceInToken, token, root, state.Document, syntaxFacts);
-                locations.Add(new FinderLocation(token.GetRequiredParent(), referenceLocation));
+                processResult(new FinderLocation(token.GetRequiredParent(), referenceLocation), processResultData);
             }
         }
 
-        return locations.ToImmutableAndClear();
+        return;
 
         // Local functions
         static bool IsCandidate(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
@@ -51,9 +51,11 @@ internal sealed class ConstructorInitializerSymbolReferenceFinder : AbstractRefe
         }, symbol.ContainingType.Name, processResult, processResultData, cancellationToken);
     }
 
-    protected sealed override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    protected sealed override async ValueTask FindReferencesInDocumentAsync<TData>(
         IMethodSymbol methodSymbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
@@ -68,7 +70,9 @@ internal sealed class ConstructorInitializerSymbolReferenceFinder : AbstractRefe
             static (token, tuple) => TokensMatch(tuple.state, token, tuple.methodSymbol.ContainingType.Name, tuple.cancellationToken),
             (state, methodSymbol, cancellationToken));
 
-        return await FindReferencesInTokensAsync(methodSymbol, state, totalTokens, cancellationToken).ConfigureAwait(false);
+        await FindReferencesInTokensAsync(methodSymbol, state, totalTokens, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+
+        return;
 
         // local functions
         static bool TokensMatch(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -116,17 +115,6 @@ internal class ConstructorSymbolReferenceFinder : AbstractReferenceFinder<IMetho
             await AddReferencesInDocumentWorkerAsync(
                 methodSymbol, globalAlias, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
         }
-
-        // Nest, our containing type might itself have local aliases to it in this particular file.
-        // If so, see what the local aliases are and then search for constructor references to that.
-        using var _2 = ArrayBuilder<FinderLocation>.GetInstance(out var typeReferences);
-        await NamedTypeSymbolReferenceFinder.AddReferencesToTypeOrGlobalAliasToItAsync(
-            methodSymbol.ContainingType, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, typeReferences, cancellationToken).ConfigureAwait(false);
-
-        // REVIEW: This looks to go to quite a bit of work to populate aliasReferences, but never uses it?
-        using var _3 = ArrayBuilder<FinderLocation>.GetInstance(out var aliasReferences);
-        await FindLocalAliasReferencesAsync(
-            typeReferences, methodSymbol, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, aliasReferences, cancellationToken).ConfigureAwait(false);
 
         // Finally, look for constructor references to predefined types (like `new int()`),
         // implicit object references, and inside global suppression attributes.

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 
@@ -28,12 +29,14 @@ internal sealed class DestructorSymbolReferenceFinder : AbstractReferenceFinder<
         return Task.CompletedTask;
     }
 
-    protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    protected override ValueTask FindReferencesInDocumentAsync<TData>(
         IMethodSymbol methodSymbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        return new ValueTask<ImmutableArray<FinderLocation>>([]);
+        return ValueTaskFactory.CompletedTask;
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
@@ -48,12 +48,14 @@ internal class EventSymbolReferenceFinder : AbstractMethodOrPropertyOrEventSymbo
         await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
-    protected sealed override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    protected sealed override ValueTask FindReferencesInDocumentAsync<TData>(
         IEventSymbol symbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        return FindReferencesInDocumentUsingSymbolNameAsync(symbol, state, cancellationToken);
+        return FindReferencesInDocumentUsingSymbolNameAsync(symbol, state, processResult, processResultData, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 
@@ -29,13 +30,15 @@ internal sealed class ExplicitInterfaceMethodReferenceFinder : AbstractReference
         return Task.CompletedTask;
     }
 
-    protected sealed override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    protected sealed override ValueTask FindReferencesInDocumentAsync<TData>(
         IMethodSymbol symbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         // An explicit method can't be referenced anywhere.
-        return new([]);
+        return ValueTaskFactory.CompletedTask;
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -40,16 +40,17 @@ internal sealed class FieldSymbolReferenceFinder : AbstractReferenceFinder<IFiel
         await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
-    protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    protected override async ValueTask FindReferencesInDocumentAsync<TData>(
         IFieldSymbol symbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        var nameReferences = await FindReferencesInDocumentUsingSymbolNameAsync(
-            symbol, state, cancellationToken).ConfigureAwait(false);
-        var suppressionReferences = await FindReferencesInDocumentInsideGlobalSuppressionsAsync(
-            symbol, state, cancellationToken).ConfigureAwait(false);
-        return nameReferences.Concat(suppressionReferences);
+        await FindReferencesInDocumentUsingSymbolNameAsync(
+            symbol, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+        await FindReferencesInDocumentInsideGlobalSuppressionsAsync(
+            symbol, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
@@ -63,9 +63,11 @@ internal interface IReferenceFinder
     /// 
     /// Implementations of this method must be thread-safe.
     /// </summary>
-    ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    ValueTask FindReferencesInDocumentAsync<TData>(
         ISymbol symbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -120,7 +120,7 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
         await AddReferencesToTypeOrGlobalAliasToItAsync(
             namedType, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, initialReferences, cancellationToken).ConfigureAwait(false);
 
-        // call processResult on items in initialReferences
+        // The items in initialReferences need to be both reported and used later to calculate additional results.
         foreach (var location in initialReferences)
             processResult(location, processResultData);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders;
 
@@ -104,9 +105,11 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
             predefinedType == actualType;
     }
 
-    protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    protected override async ValueTask FindReferencesInDocumentAsync<TData>(
         INamedTypeSymbol namedType,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
@@ -115,31 +118,34 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
         // First find all references to this type, either with it's actual name, or through potential
         // global alises to it.
         await AddReferencesToTypeOrGlobalAliasToItAsync(
-            namedType, state, initialReferences, cancellationToken).ConfigureAwait(false);
+            namedType, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, initialReferences, cancellationToken).ConfigureAwait(false);
+
+        // call processResult on items in initialReferences
+        foreach (var location in initialReferences)
+            processResult(location, processResultData);
 
         // This named type may end up being locally aliased as well.  If so, now find all the references
         // to the local alias.
 
-        initialReferences.AddRange(await FindLocalAliasReferencesAsync(
-            initialReferences, state, cancellationToken).ConfigureAwait(false));
+        await FindLocalAliasReferencesAsync(
+            initialReferences, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
 
-        initialReferences.AddRange(await FindPredefinedTypeReferencesAsync(
-            namedType, state, cancellationToken).ConfigureAwait(false));
+        await FindPredefinedTypeReferencesAsync(
+            namedType, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
 
-        initialReferences.AddRange(await FindReferencesInDocumentInsideGlobalSuppressionsAsync(
-            namedType, state, cancellationToken).ConfigureAwait(false));
-
-        return initialReferences.ToImmutableAndClear();
+        await FindReferencesInDocumentInsideGlobalSuppressionsAsync(
+            namedType, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
-    internal static async ValueTask AddReferencesToTypeOrGlobalAliasToItAsync(
+    internal static async ValueTask AddReferencesToTypeOrGlobalAliasToItAsync<TData>(
         INamedTypeSymbol namedType,
         FindReferencesDocumentState state,
-        ArrayBuilder<FinderLocation> nonAliasReferences,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         await AddNonAliasReferencesAsync(
-            namedType, namedType.Name, state, nonAliasReferences, cancellationToken).ConfigureAwait(false);
+            namedType, namedType.Name, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
 
         foreach (var globalAlias in state.GlobalAliases)
         {
@@ -150,7 +156,7 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
                 continue;
 
             await AddNonAliasReferencesAsync(
-                namedType, globalAlias, state, nonAliasReferences, cancellationToken).ConfigureAwait(false);
+                namedType, globalAlias, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -159,24 +165,27 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
     /// only if it referenced though <paramref name="name"/> (which might be the actual name
     /// of the type, or a global alias to it).
     /// </summary>
-    private static async ValueTask AddNonAliasReferencesAsync(
+    private static async ValueTask AddNonAliasReferencesAsync<TData>(
         INamedTypeSymbol symbol,
         string name,
         FindReferencesDocumentState state,
-        ArrayBuilder<FinderLocation> nonAliasesReferences,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
-        nonAliasesReferences.AddRange(await FindOrdinaryReferencesAsync(
-            symbol, name, state, cancellationToken).ConfigureAwait(false));
+        await FindOrdinaryReferencesAsync(
+            symbol, name, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
 
-        nonAliasesReferences.AddRange(await FindAttributeReferencesAsync(
-            symbol, name, state, cancellationToken).ConfigureAwait(false));
+        await FindAttributeReferencesAsync(
+            symbol, name, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
-    private static ValueTask<ImmutableArray<FinderLocation>> FindOrdinaryReferencesAsync(
+    private static ValueTask FindOrdinaryReferencesAsync<TData>(
         INamedTypeSymbol namedType,
         string name,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         // Get the parent node that best matches what this token represents.  For example, if we have `new a.b()`
@@ -185,17 +194,19 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
         // associate with the type, but rather with the constructor itself.
 
         return FindReferencesInDocumentUsingIdentifierAsync(
-            namedType, name, state, cancellationToken);
+            namedType, name, state, processResult, processResultData, cancellationToken);
     }
 
-    private static ValueTask<ImmutableArray<FinderLocation>> FindPredefinedTypeReferencesAsync(
+    private static ValueTask FindPredefinedTypeReferencesAsync<TData>(
         INamedTypeSymbol symbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         var predefinedType = symbol.SpecialType.ToPredefinedType();
         if (predefinedType == PredefinedType.None)
-            return new([]);
+            return ValueTaskFactory.CompletedTask;
 
         var tokens = state.Root
             .DescendantTokens(descendIntoTrivia: true)
@@ -203,17 +214,19 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
                 static (token, tuple) => IsPotentialReference(tuple.predefinedType, tuple.state.SyntaxFacts, token),
                 (state, predefinedType));
 
-        return FindReferencesInTokensAsync(symbol, state, tokens, cancellationToken);
+        return FindReferencesInTokensAsync(symbol, state, tokens, processResult, processResultData, cancellationToken);
     }
 
-    private static ValueTask<ImmutableArray<FinderLocation>> FindAttributeReferencesAsync(
+    private static ValueTask FindAttributeReferencesAsync<TData>(
         INamedTypeSymbol namedType,
         string name,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         return TryGetNameWithoutAttributeSuffix(name, state.SyntaxFacts, out var nameWithoutSuffix)
-            ? FindReferencesInDocumentUsingIdentifierAsync(namedType, nameWithoutSuffix, state, cancellationToken)
-            : new([]);
+            ? FindReferencesInDocumentUsingIdentifierAsync(namedType, nameWithoutSuffix, state, processResult, processResultData, cancellationToken)
+            : ValueTaskFactory.CompletedTask;
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
@@ -50,24 +50,26 @@ internal class NamespaceSymbolReferenceFinder : AbstractReferenceFinder<INamespa
         await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
-    protected override async ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    protected override async ValueTask FindReferencesInDocumentAsync<TData>(
         INamespaceSymbol symbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        using var _ = ArrayBuilder<FinderLocation>.GetInstance(out var initialReferences);
-
         if (symbol.IsGlobalNamespace)
         {
             await AddGlobalNamespaceReferencesAsync(
-                symbol, state, initialReferences, cancellationToken).ConfigureAwait(false);
+                symbol, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
         }
         else
         {
+            using var _ = ArrayBuilder<FinderLocation>.GetInstance(out var initialReferences);
+
             var namespaceName = symbol.Name;
             await AddNamedReferencesAsync(
-                symbol, namespaceName, state, initialReferences, cancellationToken).ConfigureAwait(false);
+                symbol, namespaceName, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, initialReferences, cancellationToken).ConfigureAwait(false);
 
             foreach (var globalAlias in state.GlobalAliases)
             {
@@ -78,41 +80,45 @@ internal class NamespaceSymbolReferenceFinder : AbstractReferenceFinder<INamespa
                     continue;
 
                 await AddNamedReferencesAsync(
-                    symbol, globalAlias, state, initialReferences, cancellationToken).ConfigureAwait(false);
+                    symbol, globalAlias, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, initialReferences, cancellationToken).ConfigureAwait(false);
             }
 
-            initialReferences.AddRange(await FindLocalAliasReferencesAsync(
-                initialReferences, symbol, state, cancellationToken).ConfigureAwait(false));
+            // call processResult on items in initialReferences
+            foreach (var location in initialReferences)
+                processResult(location, processResultData);
 
-            initialReferences.AddRange(await FindReferencesInDocumentInsideGlobalSuppressionsAsync(
-                symbol, state, cancellationToken).ConfigureAwait(false));
+            await FindLocalAliasReferencesAsync(
+                initialReferences, symbol, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+
+            await FindReferencesInDocumentInsideGlobalSuppressionsAsync(
+                symbol, state, processResult, processResultData, cancellationToken).ConfigureAwait(false);
         }
-
-        return initialReferences.ToImmutableAndClear();
     }
 
     /// <summary>
     /// Finds references to <paramref name="symbol"/> in this <paramref name="state"/>, but only if it referenced
     /// though <paramref name="name"/> (which might be the actual name of the type, or a global alias to it).
     /// </summary>
-    private static async ValueTask AddNamedReferencesAsync(
+    private static async ValueTask AddNamedReferencesAsync<TData>(
         INamespaceSymbol symbol,
         string name,
         FindReferencesDocumentState state,
-        ArrayBuilder<FinderLocation> initialReferences,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         var tokens = await FindMatchingIdentifierTokensAsync(
             state, name, cancellationToken).ConfigureAwait(false);
 
-        initialReferences.AddRange(await FindReferencesInTokensAsync(
-            symbol, state, tokens, cancellationToken).ConfigureAwait(false));
+        await FindReferencesInTokensAsync(
+            symbol, state, tokens, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task AddGlobalNamespaceReferencesAsync(
+    private static async Task AddGlobalNamespaceReferencesAsync<TData>(
         INamespaceSymbol symbol,
         FindReferencesDocumentState state,
-        ArrayBuilder<FinderLocation> initialReferences,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         CancellationToken cancellationToken)
     {
         var tokens = state.Root
@@ -121,7 +127,7 @@ internal class NamespaceSymbolReferenceFinder : AbstractReferenceFinder<INamespa
                 static (token, state) => state.SyntaxFacts.IsGlobalNamespaceKeyword(token),
                 state);
 
-        initialReferences.AddRange(await FindReferencesInTokensAsync(
-            symbol, state, tokens, cancellationToken).ConfigureAwait(false));
+        await FindReferencesInTokensAsync(
+            symbol, state, tokens, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
@@ -83,7 +83,7 @@ internal class NamespaceSymbolReferenceFinder : AbstractReferenceFinder<INamespa
                     symbol, globalAlias, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, initialReferences, cancellationToken).ConfigureAwait(false);
             }
 
-            // call processResult on items in initialReferences
+            // The items in initialReferences need to be both reported and used later to calculate additional results.
             foreach (var location in initialReferences)
                 processResult(location, processResultData);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
@@ -38,13 +38,15 @@ internal sealed class ParameterSymbolReferenceFinder : AbstractReferenceFinder<I
         return FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name);
     }
 
-    protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+    protected override ValueTask FindReferencesInDocumentAsync<TData>(
         IParameterSymbol symbol,
         FindReferencesDocumentState state,
+        Action<FinderLocation, TData> processResult,
+        TData processResultData,
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        return FindReferencesInDocumentUsingIdentifierAsync(symbol, symbol.Name, state, cancellationToken);
+        return FindReferencesInDocumentUsingIdentifierAsync(symbol, symbol.Name, state, processResult, processResultData, cancellationToken);
     }
 
     protected override async ValueTask<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
@@ -78,7 +78,8 @@ internal sealed class PropertyAccessorSymbolReferenceFinder : AbstractMethodOrPr
         }
 
         await ReferenceFinders.Property.FindReferencesInDocumentAsync(
-            property, state,
+            property,
+            state,
             static (loc, data) =>
             {
                 var accessors = GetReferencedAccessorSymbols(
@@ -86,7 +87,7 @@ internal sealed class PropertyAccessorSymbolReferenceFinder : AbstractMethodOrPr
                 if (accessors.Contains(data.symbol))
                     data.processResult(loc, data.processResultData);
             },
-            (state, property, symbol, processResult, processResultData, cancellationToken),
+            (property, symbol, state, processResult, processResultData, cancellationToken),
             options with { AssociatePropertyReferencesWithSpecificAccessor = false },
             cancellationToken).ConfigureAwait(false);
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
@@ -145,7 +145,7 @@ internal sealed class PropertySymbolReferenceFinder : AbstractMethodOrPropertyOr
                 if (useResult)
                     data.processResult(loc, data.processResultData);
             },
-            processResultData: (options, state, symbol, cancellationToken, self: this, processResult, processResultData),
+            processResultData: (self: this, symbol, state, processResult, processResultData, options, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         if (IsForEachProperty(symbol))

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/StandardCallbacks.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/StandardCallbacks.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.FindSymbols;
+
+internal static class StandardCallbacks<T>
+{
+    public static readonly Action<T, HashSet<T>> AddToHashSet =
+        static (data, set) => set.Add(data);
+
+    public static readonly Action<T, ArrayBuilder<T>> AddToArrayBuilder =
+        static (data, builder) => builder.Add(data);
+}


### PR DESCRIPTION
This is very similar to this PR (https://github.com/dotnet/roslyn/pull/73093) that did the same thing for ImmutableArray<Document> in this context. The general idea is to pass an action that the caller can use to process a result, rather than many levels of functions creating and returning ImmutableArrays.