### PR TITLE
Simplify temporary storage subsystem.

### DIFF
--- a/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var text = SourceText.From("Hello, World!");
 
             // Create a temporary storage location
-            using var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage();
+            var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage();
             // Write text into it
             await temporaryStorage.WriteTextAsync(text);
 
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var text = SourceText.From("Hello, World!", Encoding.ASCII);
 
             // Create a temporary storage location
-            using var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage();
+            var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage();
             // Write text into it
             await temporaryStorage.WriteTextAsync(text);
 

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
@@ -209,18 +209,6 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
         /// </summary>
         public ImmutableArray<byte> ContentHash => _contentHash;
 
-        public void Dispose()
-        {
-            // Destructors of SafeHandle and FileStream in MemoryMappedFile
-            // will eventually release resources if this Dispose is not called
-            // explicitly
-            _memoryMappedInfo?.Dispose();
-
-            _memoryMappedInfo = null;
-            _encoding = null;
-            _contentHash = default;
-        }
-
         public SourceText ReadText(CancellationToken cancellationToken)
         {
             if (_memoryMappedInfo == null)

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
@@ -121,12 +121,9 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
     /// <returns>A <see cref="MemoryMappedInfo"/> describing the allocated block.</returns>
     private MemoryMappedInfo CreateTemporaryStorage(long size)
     {
+        // Larger blocks are allocated separately
         if (size >= SingleFileThreshold)
-        {
-            // Larger blocks are allocated separately
-            var mapName = CreateUniqueName(size);
-            return new MemoryMappedInfo(mapName, offset: 0, size: size);
-        }
+            return MemoryMappedInfo.CreateNew(CreateUniqueName(size), size: size);
 
         lock (_gate)
         {
@@ -182,7 +179,7 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
             _checksumAlgorithm = checksumAlgorithm;
             _encoding = encoding;
             _contentHash = contentHash;
-            _memoryMappedInfo = new MemoryMappedInfo(storageName, offset, size);
+            _memoryMappedInfo = MemoryMappedInfo.OpenExisting(storageName, offset, size);
         }
 
         // TODO: cleanup https://github.com/dotnet/roslyn/issues/43037
@@ -307,7 +304,7 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
         public TemporaryStreamStorage(TemporaryStorageService service, string storageName, long offset, long size)
         {
             _service = service;
-            _memoryMappedInfo = new MemoryMappedInfo(storageName, offset, size);
+            _memoryMappedInfo = MemoryMappedInfo.OpenExisting(storageName, offset, size);
         }
 
         // TODO: clean up https://github.com/dotnet/roslyn/issues/43037

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
@@ -36,7 +36,7 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
     /// <para>The value of 256k reduced the number of files dumped to separate memory mapped files by 60% compared to
     /// the next lower power-of-2 size for Roslyn.sln itself.</para>
     /// </remarks>
-    /// <seealso cref="_weakFileReference"/>
+    /// <seealso cref="_fileReference"/>
     private const long SingleFileThreshold = 256 * 1024;
 
     /// <summary>
@@ -47,7 +47,7 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
     /// Roslyn.sln a snapshot. This keeps the data safe, so that we can drop it from memory when not needed, but
     /// reconstitute the contents we originally had in the snapshot in case the original files change on disk.</para>
     /// </remarks>
-    /// <seealso cref="_weakFileReference"/>
+    /// <seealso cref="_fileReference"/>
     private const long MultiFileBlockSize = SingleFileThreshold * 32;
 
     private readonly IWorkspaceThreadingService? _workspaceThreadingService;
@@ -68,23 +68,23 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
     /// The most recent memory mapped file for creating multiple storage units. It will be used via bump-pointer
     /// allocation until space is no longer available in it.  Access should be synchronized on <see cref="_gate"/>
     /// </summary>
-    private ReferenceCountedDisposable<MemoryMappedFile>.WeakReference _weakFileReference;
+    private MemoryMappedFile? _fileReference;
 
     /// <summary>The name of the current memory mapped file for multiple storage units. Access should be synchronized on
     /// <see cref="_gate"/></summary>
-    /// <seealso cref="_weakFileReference"/>
+    /// <seealso cref="_fileReference"/>
     private string? _name;
 
     /// <summary>The total size of the current memory mapped file for multiple storage units. Access should be
     /// synchronized on <see cref="_gate"/></summary>
-    /// <seealso cref="_weakFileReference"/>
+    /// <seealso cref="_fileReference"/>
     private long _fileSize;
 
     /// <summary>
     /// The offset into the current memory mapped file where the next storage unit can be held. Access should be
     /// synchronized on <see cref="_gate"/>.
     /// </summary>
-    /// <seealso cref="_weakFileReference"/>
+    /// <seealso cref="_fileReference"/>
     private long _offset;
 
     [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
@@ -125,8 +125,7 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
         {
             // Larger blocks are allocated separately
             var mapName = CreateUniqueName(size);
-            var storage = MemoryMappedFile.CreateNew(mapName, size);
-            return new MemoryMappedInfo(new ReferenceCountedDisposable<MemoryMappedFile>(storage), mapName, offset: 0, size: size);
+            return new MemoryMappedInfo(mapName, offset: 0, size: size);
         }
 
         lock (_gate)
@@ -134,14 +133,13 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
             // Obtain a reference to the memory mapped file, creating one if necessary. If a reference counted
             // handle to a memory mapped file is obtained in this section, it must either be disposed before
             // returning or returned to the caller who will own it through the MemoryMappedInfo.
-            var reference = _weakFileReference.TryAddReference();
+            var reference = _fileReference;
             if (reference == null || _offset + size > _fileSize)
             {
                 var mapName = CreateUniqueName(MultiFileBlockSize);
-                var file = MemoryMappedFile.CreateNew(mapName, MultiFileBlockSize);
 
-                reference = new ReferenceCountedDisposable<MemoryMappedFile>(file);
-                _weakFileReference = new ReferenceCountedDisposable<MemoryMappedFile>.WeakReference(reference);
+                reference = MemoryMappedFile.CreateNew(mapName, MultiFileBlockSize);
+                _fileReference = reference;
                 _name = mapName;
                 _fileSize = MultiFileBlockSize;
                 _offset = size;
@@ -329,15 +327,6 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
         public string? Name => _memoryMappedInfo?.Name;
         public long Offset => _memoryMappedInfo!.Offset;
         public long Size => _memoryMappedInfo!.Size;
-
-        public void Dispose()
-        {
-            // Destructors of SafeHandle and FileStream in MemoryMappedFile
-            // will eventually release resources if this Dispose is not called
-            // explicitly
-            _memoryMappedInfo?.Dispose();
-            _memoryMappedInfo = null;
-        }
 
         Stream ITemporaryStreamStorageInternal.ReadStream(CancellationToken cancellationToken)
             => ReadStream(cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
@@ -41,7 +41,7 @@ internal interface ITemporaryTextStorageInternal : IDisposable
     Task WriteTextAsync(SourceText text, CancellationToken cancellationToken = default);
 }
 
-internal interface ITemporaryStreamStorageInternal : IDisposable
+internal interface ITemporaryStreamStorageInternal
 {
     Stream ReadStream(CancellationToken cancellationToken = default);
     void WriteStream(Stream stream, CancellationToken cancellationToken = default);

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
@@ -33,7 +33,7 @@ public interface ITemporaryStreamStorage : IDisposable
 /// <summary>
 /// TemporaryStorage can be used to read and write text to a temporary storage location.
 /// </summary>
-internal interface ITemporaryTextStorageInternal : IDisposable
+internal interface ITemporaryTextStorageInternal
 {
     SourceText ReadText(CancellationToken cancellationToken = default);
     Task<SourceText> ReadTextAsync(CancellationToken cancellationToken = default);

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectOptionsProcessor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectOptionsProcessor.cs
@@ -71,7 +71,6 @@ internal class ProjectSystemProjectOptionsProcessor : IDisposable
         // Dispose the existing stored command-line and then persist the new one so we can
         // recover it later.  Only bother persisting things if we have a non-empty string.
 
-        _commandLineStorage?.Dispose();
         _commandLineStorage = null;
         if (!arguments.IsEmpty)
         {
@@ -276,7 +275,6 @@ internal class ProjectSystemProjectOptionsProcessor : IDisposable
         lock (_gate)
         {
             DisposeOfRuleSetFile_NoLock();
-            _commandLineStorage?.Dispose();
         }
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -168,9 +168,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 for (var j = 1; j < 5; j++)
                 {
-                    using ITemporaryStreamStorageInternal storage1 = service.CreateTemporaryStreamStorage(),
-                                                  storage2 = service.CreateTemporaryStreamStorage();
-                    var storage3 = service.CreateTemporaryStreamStorage(); // let the finalizer run for this instance
+                    ITemporaryStreamStorageInternal
+                        storage1 = service.CreateTemporaryStreamStorage(),
+                        storage2 = service.CreateTemporaryStreamStorage(),
+                        storage3 = service.CreateTemporaryStreamStorage();
 
                     storage1.WriteStream(new MemoryStream(buffer.GetBuffer(), 0, 1024 * i - 1));
                     storage2.WriteStream(new MemoryStream(buffer.GetBuffer(), 0, 1024 * i));
@@ -225,7 +226,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 {
                     using var s = storageHandles[i].ReadStream(CancellationToken.None);
                     Assert.Equal(1, s.ReadByte());
-                    storageHandles[i].Dispose();
                 }
             }
         }

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -84,8 +84,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.NotSame(text, text2);
             Assert.Equal(text.ToString(), text2.ToString());
             Assert.Equal(text.Encoding, text2.Encoding);
-
-            temporaryStorage.Dispose();
         }
 
         [ConditionalFact(typeof(WindowsOnly))]


### PR DESCRIPTION
the major complexity here was that this system supported Disposable, but in all but one case that facility was never used.  And, in the one place where it was used, it's the place least likely to need/care about it.

This changes the temp-storage-system to just remove the disposal logic entirely from it.  Instead, the system just works through normal .net gc+finalization (which  MMFs already work properly with).  This means you might end up releasing the data slightly later then when you could do it manually.  but as *no one* was using the manual capability, this just makes the lifetimes much simpler as you no longer have to think about it at all.