### PR TITLE
Use a small subset of VS JSON converters for VS Code

### DIFF
--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/Converters/VSCodeInternalExtensionUtilities.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/Converters/VSCodeInternalExtensionUtilities.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.LanguageServer.Protocol
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Utilities to aid work with VS Code LSP Extensions.
+    /// </summary>
+    internal static class VSCodeInternalExtensionUtilities
+    {
+        /// <summary>
+        /// Adds <see cref="VSExtensionConverter{TBase, TExtension}"/> necessary to deserialize
+        /// JSON stream into objects which include VS Code-specific extensions.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="serializer"/> is used in parallel to execution of this method,
+        /// its access needs to be synchronized with this method call, to guarantee that
+        /// <see cref="JsonSerializer.Converters"/> collection is not modified when <paramref name="serializer"/> in use.
+        /// </remarks>
+        /// <param name="serializer">Instance of <see cref="JsonSerializer"/> which is guaranteed to not work in parallel to this method call.</param>
+        public static void AddVSCodeInternalExtensionConverters(this JsonSerializer serializer)
+        {
+            // Reading the number of converters before we start adding new ones
+            var existingConvertersCount = serializer.Converters.Count;
+
+            AddOrReplaceConverter<TextDocumentRegistrationOptions, VSInternalTextDocumentRegistrationOptions>();
+            AddOrReplaceConverter<TextDocumentClientCapabilities, VSInternalTextDocumentClientCapabilities>();
+
+            void AddOrReplaceConverter<TBase, TExtension>()
+                where TExtension : TBase
+            {
+                for (var i = 0; i < existingConvertersCount; i++)
+                {
+                    var existingConverterType = serializer.Converters[i].GetType();
+                    if (existingConverterType.IsGenericType &&
+                        existingConverterType.GetGenericTypeDefinition() == typeof(VSExtensionConverter<,>) &&
+                        existingConverterType.GenericTypeArguments[0] == typeof(TBase))
+                    {
+                        serializer.Converters.RemoveAt(i);
+                        existingConvertersCount--;
+                        break;
+                    }
+                }
+
+                serializer.Converters.Add(new VSExtensionConverter<TBase, TExtension>());
+            }
+        }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -39,6 +39,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             _lspServiceProvider = lspServiceProvider;
             _serverKind = serverKind;
 
+            VSCodeInternalExtensionUtilities.AddVSCodeInternalExtensionConverters(serializer);
+
             // Create services that require base dependencies (jsonrpc) or are more complex to create to the set manually.
             _baseServices = GetBaseServices(jsonRpc, logger, capabilitiesProvider, hostServices, serverKind, supportedLanguages);
 

--- a/src/Tools/ExternalAccess/Xaml/Internal/ClientCapabilityProvider.cs
+++ b/src/Tools/ExternalAccess/Xaml/Internal/ClientCapabilityProvider.cs
@@ -73,6 +73,12 @@ internal class ClientCapabilityProvider : IClientCapabilityProvider
                 return _clientCapabilities?.Workspace?.DidChangeConfiguration?.DynamicRegistration == true;
             case LSP.Methods.WorkspaceDidChangeWatchedFilesName:
                 return _clientCapabilities?.Workspace?.DidChangeWatchedFiles?.DynamicRegistration == true;
+            case LSP.VSInternalMethods.OnAutoInsertName:
+                if (_clientCapabilities.TextDocument is VSInternalTextDocumentClientCapabilities internalTextDocumentClientCapabilities)
+                {
+                    return internalTextDocumentClientCapabilities.OnAutoInsert?.DynamicRegistration == true;
+                }
+                return false;
             default:
                 throw new InvalidOperationException($"Unsupported dynamic registration method: {methodName}");
         }


### PR DESCRIPTION
Replaces PR #72960 to support VSInternalTextDocumentRegistrationOptions/ClientCapabilities for VS Code.