### PR TITLE
Fix example in cookbook

### DIFF
--- a/docs/features/incremental-generators.cookbook.md
+++ b/docs/features/incremental-generators.cookbook.md
@@ -191,7 +191,7 @@ public class FileTransformGenerator : IIncrementalGenerator
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var pipeline = context.AdditionalTextsProvider
-            .Where(static (text, cancellationToken) => text.Path.EndsWith(".xml"))
+            .Where(static (text) => text.Path.EndsWith(".xml"))
             .Select(static (text, cancellationToken) =>
             {
                 var name = Path.GetFileName(text.Path);


### PR DESCRIPTION
The example was using the overload of `Where` that takes a `CancellationToken` but that is only exposed internally. Change to use the public overload that does not.

Fixes #72919