### PR TITLE
Fix issue with frozen-partial snapshots having incomplete references.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.cs
@@ -529,18 +529,23 @@ namespace Microsoft.CodeAnalysis
 
                             if (creationPolicy.SkeletonReferenceCreationPolicy is SkeletonReferenceCreationPolicy.Create)
                             {
-                                // Client always wants an up to date metadata reference.  Produce one for this project reference.
-                                var metadataReference = await compilationState.GetMetadataReferenceAsync(projectReference, this.ProjectState, cancellationToken).ConfigureAwait(false);
+                                // Client always wants an up to date metadata reference.  Produce one for this project
+                                // reference.  Because the policy is to always 'Create' here, we include cross language
+                                // references, producing skeletons for them if necessary.
+                                var metadataReference = await compilationState.GetMetadataReferenceAsync(
+                                    projectReference, this.ProjectState, includeCrossLanguage: true, cancellationToken).ConfigureAwait(false);
                                 AddMetadataReference(projectReference, metadataReference);
                             }
                             else
                             {
                                 Contract.ThrowIfFalse(creationPolicy.SkeletonReferenceCreationPolicy is SkeletonReferenceCreationPolicy.CreateIfAbsent or SkeletonReferenceCreationPolicy.DoNotCreate);
 
-                                // If not asked to explicit create an up to date skeleton, attempt to get a partial
-                                // reference, or fallback to the last successful reference for this project if we can
-                                // find one. 
-                                var metadataReference = compilationState.GetPartialMetadataReference(projectReference, this.ProjectState);
+                                // Client does not want to force a skeleton reference to be created.  Try to get a
+                                // metadata reference cheaply in the case where this is a reference to the same
+                                // language.  If that fails, also attempt to get a reference to a skeleton assembly
+                                // produced from one of our prior stale compilations.
+                                var metadataReference = await compilationState.GetMetadataReferenceAsync(
+                                    projectReference, this.ProjectState, includeCrossLanguage: false, cancellationToken).ConfigureAwait(false);
                                 if (metadataReference is null)
                                 {
                                     var inProgressCompilationNotRef = staleCompilationWithGeneratedDocuments ?? compilationWithoutGeneratedDocuments;
@@ -552,7 +557,8 @@ namespace Microsoft.CodeAnalysis
                                 // create a real skeleton here.
                                 if (metadataReference is null && creationPolicy.SkeletonReferenceCreationPolicy is SkeletonReferenceCreationPolicy.CreateIfAbsent)
                                 {
-                                    metadataReference = await compilationState.GetMetadataReferenceAsync(projectReference, this.ProjectState, cancellationToken).ConfigureAwait(false);
+                                    metadataReference = await compilationState.GetMetadataReferenceAsync(
+                                        projectReference, this.ProjectState, includeCrossLanguage: true, cancellationToken).ConfigureAwait(false);
                                 }
 
                                 AddMetadataReference(projectReference, metadataReference);
@@ -645,32 +651,6 @@ namespace Microsoft.CodeAnalysis
                         this.ProjectState.AssemblyName,
                         this.ProjectState.CompilationOptions!);
                 }
-            }
-
-            /// <summary>
-            /// Attempts to get (without waiting) a metadata reference to a possibly in progress
-            /// compilation. Only actual compilation references are returned. Could potentially 
-            /// return null if nothing can be provided.
-            /// </summary>
-            public MetadataReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference)
-            {
-                if (ProjectState.LanguageServices == fromProject.LanguageServices)
-                {
-                    // if we have a compilation and its the correct language, use a simple compilation reference in any
-                    // state it happens to be in right now
-                    if (ReadState() is CompilationTrackerState compilationState)
-                        return compilationState.CompilationWithoutGeneratedDocuments.ToMetadataReference(projectReference.Aliases, projectReference.EmbedInteropTypes);
-                }
-                else
-                {
-                    // Cross project reference.  We need a skeleton reference.  Skeletons are too expensive to
-                    // generate on demand.  So just try to see if we can grab the last generated skeleton for that
-                    // project.
-                    var properties = new MetadataReferenceProperties(aliases: projectReference.Aliases, embedInteropTypes: projectReference.EmbedInteropTypes);
-                    return _skeletonReferenceCache.TryGetAlreadyBuiltMetadataReference(properties);
-                }
-
-                return null;
             }
 
             public Task<bool> HasSuccessfullyLoadedAsync(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.GeneratedFileReplacingCompilationTracker.cs
@@ -147,18 +147,6 @@ internal partial class SolutionCompilationState
                 await UnderlyingTracker.GetDependentChecksumAsync(compilationState, cancellationToken).ConfigureAwait(false),
                 (await _replacementDocumentStates.GetDocumentChecksumsAndIdsAsync(cancellationToken).ConfigureAwait(false)).Checksum);
 
-        public MetadataReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference)
-        {
-            // This method is used if you're forking a solution with partial semantics, and used to quickly produce references.
-            // So this method should only be called if:
-            //
-            // 1. Project A has a open source generated document, and this CompilationTracker represents A
-            // 2. Project B references that A, and is being frozen for partial semantics.
-            //
-            // We generally don't use partial semantics in a different project than the open file, so this isn't a scenario we need to support.
-            throw new NotImplementedException();
-        }
-
         public async ValueTask<TextDocumentStates<SourceGeneratedDocumentState>> GetSourceGeneratedDocumentStatesAsync(
             SolutionCompilationState compilationState, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.ICompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.ICompilationTracker.cs
@@ -49,7 +49,6 @@ internal partial class SolutionCompilationState
         Task<VersionStamp> GetDependentSemanticVersionAsync(SolutionCompilationState compilationState, CancellationToken cancellationToken);
         Task<Checksum> GetDependentChecksumAsync(SolutionCompilationState compilationState, CancellationToken cancellationToken);
 
-        MetadataReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference);
         ValueTask<TextDocumentStates<SourceGeneratedDocumentState>> GetSourceGeneratedDocumentStatesAsync(SolutionCompilationState compilationState, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<Diagnostic>> GetSourceGeneratorDiagnosticsAsync(SolutionCompilationState compilationState, CancellationToken cancellationToken);
         ValueTask<GeneratorDriverRunResult?> GetSourceGeneratorRunResultAsync(SolutionCompilationState solution, CancellationToken cancellationToken);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2216,7 +2216,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 {
                     if (solution.ContainsProject(referenced.ProjectId))
                     {
-                        var referencedMetadata = await solution.CompilationState.GetMetadataReferenceAsync(referenced, solution.GetProjectState(project.Id), CancellationToken.None);
+                        var referencedMetadata = await solution.CompilationState.GetMetadataReferenceAsync(
+                            referenced, solution.GetProjectState(project.Id), includeCrossLanguage: true, CancellationToken.None);
                         Assert.NotNull(referencedMetadata);
                         if (referencedMetadata is CompilationReference compilationReference)
                         {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2035575

Core issue is that when producing a frozen partial snapshot, we had uniform logic for producing P2P references, regardless of whether the P2P reference was to the same language or a different language.

For frozen partial, we don't want to produce the reference to a different language, as that would involve generating skeleton assemblies. This is enormously expensive as it is effectively running the compiler and emitting the metadata to an in-memory object we then read in as a reference.

However, for the same language, making a normal P2P reference is fine (and cheap).  In that case, we can just point directly at the compilation object directly, as the compilers support direct (same lang) p2p refs.

In the case of frozen-partial, because we already forked all compilation-trackers to not run generators or produce skeletons, asking for the compilation for the reference will not incur those costs (transitively).  So frozen partial will still be fast for the mainline case, while avoiding the massive expensvie of SGs and Skeletons at all levels.

--

This was breaking a cross project winforms case when the project config was changed.  Namely, after changing the project config, we would try to determine which were the designable types in the solution.  Finding a type X in P1, we would then try to walk its inheritance chain.  If that type X inherited from a type Y in P2, and we hadn't produced a viable P2P ref for that, we'd end up with error types, breaking the designable type detection rules.  

In the case here, while we had a P2P ref, because we simply snapped that P2P ref at the point it was at, we never did things like properly add all the metadata-references *that* project had, leading to a referenced compilation with sources in it, but no metadata.
