### PR TITLE
Require AddExplicitInterfaceImplementation for adding a type that implements member explicitly

### DIFF
--- a/src/Features/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -10453,7 +10453,7 @@ class C
             // should not contain RUDE_EDIT_INSERT_AROUND
             edits.VerifySemanticDiagnostics(
                 active,
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]
@@ -10484,7 +10484,7 @@ class C
 
             edits.VerifySemanticDiagnostics(
                 active,
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]
@@ -10667,7 +10667,7 @@ class C
             // should not contain RUDE_EDIT_INSERT_AROUND
             edits.VerifySemanticDiagnostics(
                 active,
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]
@@ -10758,7 +10758,7 @@ class C
 
             edits.VerifySemanticDiagnostics(
                 active,
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]
@@ -10786,7 +10786,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]

--- a/src/Features/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -6569,7 +6569,7 @@ class Test
                 capabilities: EditAndContinueCapabilities.Baseline);
 
             edits.VerifySemanticDiagnostics(
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         #endregion
@@ -9615,7 +9615,7 @@ class Test
                 capabilities: EditAndContinueCapabilities.Baseline);
 
             edits.VerifySemanticDiagnostics(
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]
@@ -9649,7 +9649,7 @@ class Test
                 capabilities: EditAndContinueCapabilities.Baseline);
 
             edits.VerifySemanticDiagnostics(
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]
@@ -11484,7 +11484,7 @@ class C
 
             edits.VerifySemanticDiagnostics(
                 targetFrameworks: [TargetFramework.Mscorlib40AndSystemCore],
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         #endregion
@@ -12079,7 +12079,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]
@@ -12431,7 +12431,7 @@ class C
 
             edits.VerifySemanticDiagnostics(
                 targetFrameworks: [TargetFramework.MinimalAsync],
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
         }
 
         [Fact]

--- a/src/Features/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -1968,70 +1968,132 @@ public interface I
         }
 
         [Fact]
-        public void Class_ImplementingInterface_Add()
+        public void Class_ImplementingInterface_Add_Implicit_NonVirtual()
         {
-            var src1 = @"
-using System;
+            var src1 = """
+                interface I
+                {
+                    void F();
+                }
+                """;
 
-public interface ISample
-{
-    string Get();
-}
+            var src2 = """
+                interface I
+                {
+                    void F();
+                }
 
-public interface IConflict
-{
-    string Get();
-}
+                class C : I
+                {
+                    public void F() {}
+                }
+                """;
 
-public class BaseClass : ISample
-{
-    public virtual string Get() => string.Empty;
-}
-";
-            var src2 = @"
-using System;
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C"))],
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+        }
 
-public interface ISample
-{
-    string Get();
-}
+        [Fact]
+        public void Class_ImplementingInterface_Add_Implicit_Virtual()
+        {
+            var src1 = """
+                interface I
+                {
+                    void F();
+                }
+                """;
 
-public interface IConflict
-{
-    string Get();
-}
+            var src2 = """
+                interface I
+                {
+                    void F();
+                }
 
-public class BaseClass : ISample
-{
-    public virtual string Get() => string.Empty;
-}
+                class C : I
+                {
+                    public virtual void F() {}
+                }
+                """;
 
-public class SubClass : BaseClass, IConflict
-{
-    public override string Get() => string.Empty;
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C"))],
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+        }
 
-    string IConflict.Get() => String.Empty;
-}
-";
+        [Fact]
+        public void Class_ImplementingInterface_Add_Implicit_Override()
+        {
+            var src1 = """
+                interface I
+                {
+                    void F();
+                }
+
+                class C : I
+                {
+                    public virtual void F() {}
+                }
+                """;
+
+            var src2 = """
+                interface I
+                {
+                    void F();
+                }
+
+                class C : I
+                {
+                    public virtual void F() {}
+                }
+
+                class D : C
+                {
+                    public override void F() {}
+                }
+                """;
+
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("D"))],
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
+        }
+
+        [Theory]
+        [InlineData("void F();", "void I.F() {}")]
+        [InlineData("int F { get; }", "int I.F { get; }")]
+        [InlineData("event System.Action F;", "event System.Action I.F { add {} remove {} }")]
+        public void Class_ImplementingInterface_Add_Explicit_NonVirtual(string memberDef, string explicitImpl)
+        {
+            var src1 = $$"""
+                interface I
+                {
+                    {{memberDef}}
+                }
+                """;
+
+            var src2 = $$"""
+                interface I
+                {
+                    {{memberDef}}
+                }
+
+                class C<T> : I
+                {
+                    {{explicitImpl}}
+                }
+                """;
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits(
-                @"Insert [public class SubClass : BaseClass, IConflict
-{
-    public override string Get() => string.Empty;
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C"))],
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
 
-    string IConflict.Get() => String.Empty;
-}]@219",
-                "Insert [: BaseClass, IConflict]@241",
-                "Insert [public override string Get() => string.Empty;]@272",
-                "Insert [string IConflict.Get() => String.Empty;]@325",
-                "Insert [()]@298",
-                "Insert [()]@345");
-
-            // Here we add a class implementing an interface and a method inside it with explicit interface specifier.
-            // We want to be sure that adding the method will not tirgger a rude edit as it happens if adding a single method with explicit interface specifier.
             edits.VerifySemanticDiagnostics(
+                [Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "class C<T>", GetResource("class"))],
                 capabilities: EditAndContinueCapabilities.NewTypeDefinition);
         }
 
@@ -2312,15 +2374,28 @@ class C<T>
         public void Type_Generic_InsertMembers_Reloadable()
         {
             var src1 = ReloadableAttributeSrc + @"
-[CreateNewOnMetadataUpdate]
-class C<T>
+interface IExplicit
 {
+    void F() {}
+}
+
+[CreateNewOnMetadataUpdate]
+class C<T> : IExplicit
+{
+    void IExplicit.F() {}
 }
 ";
             var src2 = ReloadableAttributeSrc + @"
-[CreateNewOnMetadataUpdate]
-class C<T>
+interface IExplicit
 {
+    void F() {}
+}
+
+[CreateNewOnMetadataUpdate]
+class C<T> : IExplicit
+{
+    void IExplicit.F() {}
+
     void M() {}
     int P1 { get; set; }
     int P2 { get => 1; set {} }
@@ -2337,6 +2412,10 @@ class C<T>
             var edits = GetTopEdits(src1, src2);
             edits.VerifySemantics(
                 [SemanticEdit(SemanticEditKind.Replace, c => c.GetMember("C"))],
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
+
+            edits.VerifySemanticDiagnostics(
+                [Diagnostic(RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime, "void M()", "CreateNewOnMetadataUpdateAttribute")],
                 capabilities: EditAndContinueCapabilities.NewTypeDefinition);
         }
 
@@ -7534,7 +7613,7 @@ class Test
 }";
             var edits = GetTopEdits(src1, src2);
             edits.VerifySemanticDiagnostics(
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
 
             VerifyPreserveLocalVariables(edits, preserveLocalVariables: false);
         }
@@ -9667,7 +9746,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.AddExplicitInterfaceImplementation);
 
             VerifyPreserveLocalVariables(edits, preserveLocalVariables: false);
         }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
@@ -65,6 +65,11 @@ internal enum EditAndContinueCapabilities
     /// Adding a static or instance field to an existing generic type.
     /// </summary>
     GenericAddFieldToExistingType = 1 << 9,
+
+    /// <summary>
+    /// The runtime supports adding to InterfaceImpl table.
+    /// </summary>
+    AddExplicitInterfaceImplementation = 1 << 10,
 }
 
 internal static class EditAndContinueCapabilitiesParser
@@ -87,6 +92,7 @@ internal static class EditAndContinueCapabilitiesParser
                 nameof(EditAndContinueCapabilities.GenericAddMethodToExistingType) => EditAndContinueCapabilities.GenericAddMethodToExistingType,
                 nameof(EditAndContinueCapabilities.GenericUpdateMethod) => EditAndContinueCapabilities.GenericUpdateMethod,
                 nameof(EditAndContinueCapabilities.GenericAddFieldToExistingType) => EditAndContinueCapabilities.GenericAddFieldToExistingType,
+                nameof(EditAndContinueCapabilities.AddExplicitInterfaceImplementation) => EditAndContinueCapabilities.AddExplicitInterfaceImplementation,
 
                 // To make it eaiser for  runtimes to specify more broad capabilities
                 "AddDefinitionToExistingType" => EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.AddStaticFieldToExistingType | EditAndContinueCapabilities.AddInstanceFieldToExistingType,
@@ -122,6 +128,9 @@ internal static class EditAndContinueCapabilitiesParser
 
         if (capabilities.HasFlag(EditAndContinueCapabilities.UpdateParameters))
             builder.Add(nameof(EditAndContinueCapabilities.UpdateParameters));
+
+        if (capabilities.HasFlag(EditAndContinueCapabilities.AddExplicitInterfaceImplementation))
+            builder.Add(nameof(EditAndContinueCapabilities.AddExplicitInterfaceImplementation));
 
         return builder.ToImmutable();
     }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilitiesGrantor.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilitiesGrantor.cs
@@ -20,6 +20,17 @@ internal sealed class EditAndContinueCapabilitiesGrantor(EditAndContinueCapabili
     }
 
     public bool GrantNewTypeDefinition(INamedTypeSymbol type)
-        => Grant(EditAndContinueCapabilities.NewTypeDefinition) &&
-           (!type.HasExplicitInterfaceImplementation() || Grant(EditAndContinueCapabilities.AddExplicitInterfaceImplementation));
+    {
+        if (!Grant(EditAndContinueCapabilities.NewTypeDefinition))
+        {
+            return false;
+        }
+
+        if (type.HasExplicitlyImplementedInterfaceMember() && !Grant(EditAndContinueCapabilities.AddExplicitInterfaceImplementation))
+        {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilitiesGrantor.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilitiesGrantor.cs
@@ -18,4 +18,8 @@ internal sealed class EditAndContinueCapabilitiesGrantor(EditAndContinueCapabili
         GrantedCapabilities |= capabilities;
         return (_availableCapabilities & capabilities) == capabilities;
     }
+
+    public bool GrantNewTypeDefinition(INamedTypeSymbol type)
+        => Grant(EditAndContinueCapabilities.NewTypeDefinition) &&
+           (!type.HasExplicitInterfaceImplementation() || Grant(EditAndContinueCapabilities.AddExplicitInterfaceImplementation));
 }

--- a/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
@@ -230,6 +230,6 @@ internal static partial class Extensions
     /// <summary>
     /// Returns true if any member of the type implements an interface member explicitly.
     /// </summary>
-    public static bool HasExplicitInterfaceImplementation(this INamedTypeSymbol type)
+    public static bool HasExplicitlyImplementedInterfaceMember(this INamedTypeSymbol type)
         => type.GetMembers().Any(static member => member.ExplicitInterfaceImplementations().Any());
 }

--- a/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
@@ -226,4 +226,10 @@ internal static partial class Extensions
 
     public static ISymbol PartialAsImplementation(this ISymbol symbol)
         => symbol is IMethodSymbol { PartialImplementationPart: { } impl } ? impl : symbol;
+
+    /// <summary>
+    /// Returns true if any member of the type implements an interface member explicitly.
+    /// </summary>
+    public static bool HasExplicitInterfaceImplementation(this INamedTypeSymbol type)
+        => type.GetMembers().Any(static member => member.ExplicitInterfaceImplementations().Any());
 }

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -61,7 +61,17 @@ internal sealed class WatchHotReloadService
     private readonly ImmutableArray<string> _capabilities;
 
     public WatchHotReloadService(HostWorkspaceServices services, ImmutableArray<string> capabilities)
-        => (_encService, _capabilities) = (services.GetRequiredService<IEditAndContinueWorkspaceService>().Service, capabilities);
+    {
+        _encService = services.GetRequiredService<IEditAndContinueWorkspaceService>().Service;
+        _capabilities = AddImplicitDotNetCapabilities(capabilities);
+    }
+
+    /// <summary>
+    /// Adds capabilities that are available by default on runtimes supported by dotnet-watch: .NET and Mono
+    /// and not on .NET Framework (they are not in <see cref="EditAndContinueCapabilities.Baseline"/>.
+    /// </summary>
+    private static ImmutableArray<string> AddImplicitDotNetCapabilities(ImmutableArray<string> capabilities)
+        => capabilities.Add(nameof(EditAndContinueCapabilities.AddExplicitInterfaceImplementation));
 
     /// <summary>
     /// Starts the watcher.

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -31,7 +31,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             EditAndContinueCapabilities.AddInstanceFieldToExistingType |
             EditAndContinueCapabilities.AddStaticFieldToExistingType |
             EditAndContinueCapabilities.AddMethodToExistingType |
-            EditAndContinueCapabilities.NewTypeDefinition;
+            EditAndContinueCapabilities.NewTypeDefinition |
+            EditAndContinueCapabilities.AddExplicitInterfaceImplementation;
 
         public const EditAndContinueCapabilities Net6RuntimeCapabilities =
             Net5RuntimeCapabilities |

--- a/src/Features/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -5137,7 +5137,7 @@ End Class
 
             edits.VerifySemanticDiagnostics(
                 active,
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
         <Fact>
@@ -5167,7 +5167,7 @@ End Class
 
             edits.VerifySemanticDiagnostics(
                 active,
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
         <Fact>
@@ -5284,7 +5284,7 @@ End Class
 
             edits.VerifySemanticDiagnostics(
                 active,
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
         <Fact>
@@ -5403,7 +5403,7 @@ End Class
 
             edits.VerifySemanticDiagnostics(
                 active,
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
         <Fact>
@@ -5432,7 +5432,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifySemanticDiagnostics(active,
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
         <Fact>
@@ -5515,7 +5515,7 @@ End Class
 
             ' No rude edit since the AS is within the nested function.
             edits.VerifySemanticDiagnostics(active,
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
         <Fact>

--- a/src/Features/VisualBasicTest/EditAndContinue/StatementEditingTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/StatementEditingTests.vb
@@ -5309,7 +5309,7 @@ End Class
             VerifySemanticDiagnostics(
                 editScript:=edits,
                 targetFrameworks:={TargetFramework.Mscorlib40AndSystemCore},
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
 #End Region
@@ -5419,7 +5419,7 @@ End Class
             VerifySemanticDiagnostics(
                 edits,
                 targetFrameworks:={TargetFramework.MinimalAsync},
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
         <Theory>

--- a/src/Features/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -4789,6 +4789,10 @@ End Structure
                 "Update [Function F() As Task(Of String)]@11 -> [Async Function F() As Task(Of String)]@11")
 
             edits.VerifySemanticDiagnostics(
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
+
+            edits.VerifySemanticDiagnostics(
+                {Diagnostic(RudeEditKind.MakeMethodAsyncNotSupportedByRuntime, "Async Function F()")},
                 capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
         End Sub
 
@@ -5268,7 +5272,7 @@ End Class"
                 "Update [Function F() As Task(Of String)]@11 -> [Iterator Function F() As Task(Of String)]@11")
 
             edits.VerifySemanticDiagnostics(
-                capabilities:=EditAndContinueCapabilities.NewTypeDefinition)
+                capabilities:=EditAndContinueCapabilities.NewTypeDefinition Or EditAndContinueCapabilities.AddExplicitInterfaceImplementation)
         End Sub
 
         <Fact>


### PR DESCRIPTION
Adding a new row to InterfaceImpl table may case AV on .NET Framework runtime. Report rude edit to prevent that from happening.
The rude edit is reported when `AddExplicitInterfaceImplementation` runtime capability is not present.

Contributes to fix of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1452066.
Debugger part: https://devdiv.visualstudio.com/DevDiv/_git/Concord/pullrequest/546202