### PR TITLE
Update obsoletion to be an error for a few types

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Host;
 
-[Obsolete("Roslyn no longer exports a mechanism to store arbitrary data in-memory.")]
+[Obsolete("Roslyn no longer exports a mechanism to store arbitrary data in-memory.", error: true)]
 public interface ITemporaryTextStorage : IDisposable
 {
     SourceText ReadText(CancellationToken cancellationToken = default);
@@ -21,7 +21,7 @@ public interface ITemporaryTextStorage : IDisposable
     Task WriteTextAsync(SourceText text, CancellationToken cancellationToken = default);
 }
 
-[Obsolete("Roslyn no longer exports a mechanism to store arbitrary data in-memory.")]
+[Obsolete("Roslyn no longer exports a mechanism to store arbitrary data in-memory.", error: true)]
 public interface ITemporaryStreamStorage : IDisposable
 {
     Stream ReadStream(CancellationToken cancellationToken = default);

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorageService.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Host;
 
-[Obsolete("API is no longer available")]
+[Obsolete("API is no longer available", error: true)]
 public interface ITemporaryStorageService : IWorkspaceService
 {
     ITemporaryStreamStorage CreateTemporaryStreamStorage(CancellationToken cancellationToken = default);


### PR DESCRIPTION
These types were obsoleted two years back in 17.4: https://github.com/dotnet/roslyn/pull/62998

We have legacy impls that literally do nothing (they just store the data in memory, and then return it when asked).  This PR upgrades these from an obsoletion warning to an error (as part of our policy of gradual deprecation).  Once this is out a while, we can then finally remove.  

No usages of these types at all inside MS, or searching with grep.app.  