### PR TITLE
[17.8] Update source build baseline

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -24,6 +24,11 @@
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/7.0*" />
   </IgnorePatterns>
   <Usages>
+    <Usage Id="Microsoft.Build" Version="17.3.4" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Framework" Version="17.3.4" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="17.3.4" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="17.3.4" />
+    <Usage Id="Microsoft.NET.StringTools" Version="17.3.4" />
     <Usage Id="System.Composition" Version="7.0.0" />
     <Usage Id="System.Composition.AttributedModel" Version="7.0.0" />
     <Usage Id="System.Composition.Convention" Version="7.0.0" />


### PR DESCRIPTION
Fixes 17.8 official builds. Example run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2438402&view=results

CI on PRs didn't catch this probably because these two PRs were merged in parallel:
- https://github.com/dotnet/roslyn/pull/73210
- https://github.com/dotnet/roslyn/pull/73113