### PR TITLE
Implement analyzer/fixer: remove unnecessary `Call` keyword from `Call` statement

### DIFF
--- a/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs
+++ b/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs
@@ -73,6 +73,7 @@ internal static class EnforceOnBuildValues
     public const EnforceOnBuild ConvertTypeOfToNameOf = /*IDE0082*/ EnforceOnBuild.Recommended;
     public const EnforceOnBuild UseNotPattern = /*IDE0083*/ EnforceOnBuild.Recommended;
     public const EnforceOnBuild UseIsNotExpression = /*IDE0084*/ EnforceOnBuild.Recommended;
+    public const EnforceOnBuild RemoveUnnecessaryCall = /*IDE0085*/ EnforceOnBuild.Recommended;
     public const EnforceOnBuild UseImplicitObjectCreation = /*IDE0090*/ EnforceOnBuild.Recommended;
     public const EnforceOnBuild RemoveRedundantEquality = /*IDE0100*/ EnforceOnBuild.Recommended;
     public const EnforceOnBuild RemoveUnnecessaryDiscardDesignation = /*IDE0110*/ EnforceOnBuild.Recommended;

--- a/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
@@ -146,6 +146,8 @@ internal static class IDEDiagnosticIds
     public const string UseNotPatternDiagnosticId = "IDE0083";
     public const string UseIsNotExpressionDiagnosticId = "IDE0084";
 
+    public const string RemoveUnnecessaryCallDiagnosticId = "IDE0085";
+
     public const string UseImplicitObjectCreationDiagnosticId = "IDE0090";
 
     public const string RemoveRedundantEqualityDiagnosticId = "IDE0100";

--- a/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -102,6 +102,7 @@ internal static class PredefinedCodeFixProviderNames
     public const string RemoveSharedFromModuleMembers = nameof(RemoveSharedFromModuleMembers);
     public const string RemoveUnnecessaryAttributeSuppressions = nameof(RemoveUnnecessaryAttributeSuppressions);
     public const string RemoveUnnecessaryByVal = nameof(RemoveUnnecessaryByVal);
+    public const string RemoveUnnecessaryCall = nameof(RemoveUnnecessaryCall);
     public const string RemoveUnnecessaryCast = nameof(RemoveUnnecessaryCast);
     public const string RemoveUnnecessaryDiscardDesignation = nameof(RemoveUnnecessaryDiscardDesignation);
     public const string RemoveUnnecessaryImports = nameof(RemoveUnnecessaryImports);

--- a/src/Analyzers/VisualBasic/Analyzers/RemoveUnnecessaryCall/VisualBasicRemoveUnnecessaryCallDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/RemoveUnnecessaryCall/VisualBasicRemoveUnnecessaryCallDiagnosticAnalyzer.vb
@@ -1,0 +1,99 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.CodeStyle
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryCall
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Friend NotInheritable Class VisualBasicRemoveUnnecessaryCallDiagnosticAnalyzer
+        Inherits AbstractBuiltInUnnecessaryCodeStyleDiagnosticAnalyzer
+
+        Public Sub New()
+            MyBase.New(
+                diagnosticId:=IDEDiagnosticIds.RemoveUnnecessaryCallDiagnosticId,
+                enforceOnBuild:=EnforceOnBuildValues.RemoveUnnecessaryCall,
+                [option]:=Nothing,
+                fadingOption:=Nothing,
+                title:=New LocalizableResourceString(NameOf(VisualBasicAnalyzersResources.Remove_Call), VisualBasicAnalyzersResources.ResourceManager, GetType(VisualBasicAnalyzersResources)))
+        End Sub
+
+        Protected Overrides Sub InitializeWorker(context As AnalysisContext)
+            context.RegisterSyntaxNodeAction(
+                Sub(syntaxContext As SyntaxNodeAnalysisContext)
+                    If ShouldSkipAnalysis(syntaxContext, notification:=Nothing) Then
+                        Return
+                    End If
+
+                    Dim callSyntax = DirectCast(syntaxContext.Node, CallStatementSyntax)
+                    Dim root = callSyntax.Invocation
+                    Dim rootAsInvocation = TryCast(root, InvocationExpressionSyntax)
+                    Dim rootAsMemberAccess As MemberAccessExpressionSyntax
+                    Dim rootAsConditionalAccess As ConditionalAccessExpressionSyntax
+                    If rootAsInvocation IsNot Nothing Then
+                        root = rootAsInvocation.Expression
+                    Else
+                        rootAsMemberAccess = TryCast(root, MemberAccessExpressionSyntax)
+                        If rootAsmemberAccess IsNot Nothing Then
+                            root = rootAsMemberAccess.Expression
+                        Else
+                            rootAsConditionalAccess = TryCast(root, ConditionalAccessExpressionSyntax)
+                            If rootAsConditionalAccess IsNot Nothing Then
+                                root = rootAsConditionalAccess.Expression
+                            Else
+                                Debug.Fail(
+                                    "Invocation expression node (type: " & root.GetTypeDisplayName() & ") is not " &
+                                    NameOf(InvocationExpressionSyntax) & ", " &
+                                    NameOf(MemberAccessExpressionSyntax) & ", or " &
+                                    NameOf(ConditionalAccessExpressionSyntax) & "."
+                                )
+                            End If
+                        End If
+                    End If
+                    While True
+                        rootAsMemberAccess = TryCast(root, MemberAccessExpressionSyntax)
+                        rootAsInvocation = TryCast(root, InvocationExpressionSyntax)
+                        rootAsConditionalAccess = TryCast(root, ConditionalAccessExpressionSyntax)
+                        If rootAsMemberAccess Is Nothing AndAlso
+                            rootAsInvocation Is Nothing AndAlso
+                            rootAsConditionalAccess Is Nothing Then
+                            Exit While
+                        End If
+                        root = If(
+                            rootAsMemberAccess?.Expression,
+                            If(
+                                rootAsInvocation?.Expression,
+                                rootAsConditionalAccess?.Expression
+                            )
+                        )
+                    End While
+
+                    ' Refer to ParseAssignmentOrInvocationStatement() calls in src\Compilers\VisualBasic\Portable\Parser\Parser.vb
+                    ' Adopt syntax kind types that wrap them.
+                    If Not root.IsKind(
+                        SyntaxKind.IdentifierName, ' Appended
+                        SyntaxKind.MyBaseExpression,
+                        SyntaxKind.MyClassExpression,
+                        SyntaxKind.MeExpression,
+                        SyntaxKind.GlobalName,
+                        SyntaxKind.PredefinedType,
+                        SyntaxKind.PredefinedCastExpression,
+                        SyntaxKind.DirectCastExpression,
+                        SyntaxKind.TryCastExpression,
+                        SyntaxKind.CTypeExpression,
+                        SyntaxKind.GetTypeExpression,
+                        SyntaxKind.GetXmlNamespaceExpression
+                    ) Then
+                        Return
+                    End If
+                    syntaxContext.ReportDiagnostic(Diagnostic.Create(Descriptor, callSyntax.CallKeyword.GetLocation(), additionalLocations:={callSyntax.GetLocation()}))
+                End Sub, SyntaxKind.CallStatement)
+        End Sub
+
+        Public Overrides Function GetAnalyzerCategory() As DiagnosticAnalyzerCategory
+            Return DiagnosticAnalyzerCategory.SemanticSpanAnalysis
+        End Function
+    End Class
+End Namespace

--- a/src/Analyzers/VisualBasic/Analyzers/VisualBasicAnalyzers.projitems
+++ b/src/Analyzers/VisualBasic/Analyzers/VisualBasicAnalyzers.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)QualifyMemberAccess\VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveRedundantEquality\VisualBasicRemoveRedundantEqualityDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryByVal\VisualBasicRemoveUnnecessaryByValDiagnosticAnalyzer.vb" />
+    <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCall\VisualBasicRemoveUnnecessaryCallDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCast\VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessarySuppressions\VisualBasicRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessarySuppressions\VisualBasicRemoveUnnecessaryAttributeSuppressionsDiagnosticAnalyzer.vb" />
@@ -66,5 +67,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(DefaultLanguageSourceExtension)' != '' AND '$(BuildingInsideVisualStudio)' != 'true'">
     <ExpectedCompile Include="$(MSBuildThisFileDirectory)**\*$(DefaultLanguageSourceExtension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCall\" />
   </ItemGroup>
 </Project>

--- a/src/Analyzers/VisualBasic/Analyzers/VisualBasicAnalyzersResources.resx
+++ b/src/Analyzers/VisualBasic/Analyzers/VisualBasicAnalyzersResources.resx
@@ -143,4 +143,8 @@
   <data name="Object_creation_can_be_simplified" xml:space="preserve">
     <value>Object creation can be simplified</value>
   </data>
+  <data name="Remove_Call" xml:space="preserve">
+    <value>'Call' keyword is unnecessary here and can be removed.</value>
+    <comment>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</comment>
+  </data>
 </root>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.cs.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Klíčové slovo ByVal není zapotřebí a dá se odebrat.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">Použít kontrolu „IsNot Nothing“</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.de.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Das ByVal-Schlüsselwort ist unnötig und kann entfernt werden.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">Prüfung "IsNot Nothing" verwenden</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.es.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">La palabra clave "ByVal" no es necesaria y se puede quitar.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">Usar comprobación "IsNot Nothing"</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.fr.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Le mot clé 'ByVal' est inutile et peut être supprimé.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">Utiliser la vérification 'IsNot Nothing'</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.it.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">La parola chiave 'ByVal' non è necessaria e può essere rimossa.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">Usa controllo 'IsNot Nothing'</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.ja.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'ByVal' キーワードは必要ありません。削除することができます。</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">IsNot Nothing' チェックを使用します</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.ko.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'ByVal' 키워드는 불필요하며 제거할 수 있습니다.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">IsNot Nothing' 검사 사용</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.pl.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Słowo kluczowe „ByVal” jest niepotrzebne i można je usunąć.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">Użyj sprawdzania „IsNot Nothing”</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.pt-BR.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">A palavra-chave 'ByVal' é desnecessária e pode ser removida.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">Usar a verificação 'IsNot Nothing'</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.ru.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Ключевое слово "ByVal" является необязательным и может быть удалено.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">Использовать флажок "IsNot Nothing"</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.tr.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'ByVal' anahtar sözcüğü gereksizdir ve kaldırılabilir.</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">IsNot Nothing' denetimi kullan</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.zh-Hans.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">"ByVal" 关键字是不必要的，可以删除。</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">使用 "IsNot Nothing" 检查</target>

--- a/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.zh-Hant.xlf
+++ b/src/Analyzers/VisualBasic/Analyzers/xlf/VisualBasicAnalyzersResources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'ByVal' 關鍵字非必要，可以移除。</target>
         <note>{locked: ByVal}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
       </trans-unit>
+      <trans-unit id="Remove_Call">
+        <source>'Call' keyword is unnecessary here and can be removed.</source>
+        <target state="new">'Call' keyword is unnecessary here and can be removed.</target>
+        <note>{locked: Call}This is a Visual Basic keyword and should not be localized or have its casing changed</note>
+      </trans-unit>
       <trans-unit id="Use_IsNot_Nothing_check">
         <source>Use 'IsNot Nothing' check</source>
         <target state="translated">使用 'IsNot Nothing' 檢查</target>

--- a/src/Analyzers/VisualBasic/CodeFixes/RemoveUnnecessaryCall/VisualBasicRemoveUnnecessaryCallCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/RemoveUnnecessaryCall/VisualBasicRemoveUnnecessaryCallCodeFixProvider.vb
@@ -1,0 +1,46 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.Composition
+Imports System.Diagnostics.CodeAnalysis
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeActions
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editing
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryCall
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.RemoveUnnecessaryCall), [Shared]>
+    Friend Class VisualBasicRemoveUnnecessaryCallCodeFixProvider
+        Inherits SyntaxEditorBasedCodeFixProvider
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+
+        Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String) =
+            ImmutableArray.Create(IDEDiagnosticIds.RemoveUnnecessaryCallDiagnosticId)
+
+        Public Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
+            For Each diagnostic In context.Diagnostics
+                RegisterCodeFix(context, VisualBasicAnalyzersResources.Remove_Call, NameOf(VisualBasicAnalyzersResources.Remove_Call), diagnostic)
+            Next
+
+            Return Task.CompletedTask
+        End Function
+
+        Protected Overrides Async Function FixAllAsync(document As Document, diagnostics As ImmutableArray(Of Diagnostic), editor As SyntaxEditor, fallbackOptions As CodeActionOptionsProvider, cancellationToken As CancellationToken) As Task
+            Dim root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
+            For Each diagnostic In diagnostics
+                Dim node = DirectCast(root.FindNode(diagnostic.AdditionalLocations(0).SourceSpan), CallStatementSyntax)
+                ' replace ExpressionSyntax with ExpressionStatementSyntax
+                editor.ReplaceNode(node, SyntaxFactory.ExpressionStatement(node.Invocation).WithTriviaFrom(node))
+            Next
+        End Function
+    End Class
+End Namespace

--- a/src/Analyzers/VisualBasic/CodeFixes/VisualBasicCodeFixes.projitems
+++ b/src/Analyzers/VisualBasic/CodeFixes/VisualBasicCodeFixes.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RemoveAsyncModifier\RemoveAsyncModifierHelpers.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveAsyncModifier\VisualBasicRemoveAsyncModifierCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryByVal\VisualBasicRemoveUnnecessaryByValCodeFixProvider.vb" />
+    <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCall\VisualBasicRemoveUnnecessaryCallCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCast\VisualBasicRemoveUnnecessaryCastCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryImports\VisualBasicRemoveUnnecessaryImportsCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryParentheses\VisualBasicRemoveUnnecessaryParenthesesCodeFixProvider.vb" />
@@ -64,5 +65,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(DefaultLanguageSourceExtension)' != '' AND '$(BuildingInsideVisualStudio)' != 'true'">
     <ExpectedCompile Include="$(MSBuildThisFileDirectory)**\*$(DefaultLanguageSourceExtension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCall\" />
   </ItemGroup>
 </Project>

--- a/src/Analyzers/VisualBasic/Tests/RemoveUnnecessaryCall/RemoveUnnecessaryCallTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/RemoveUnnecessaryCall/RemoveUnnecessaryCallTests.vb
@@ -1,0 +1,397 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports VerifyVB = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.VisualBasicCodeFixVerifier(Of
+    Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryCall.VisualBasicRemoveUnnecessaryCallDiagnosticAnalyzer,
+    Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryCall.VisualBasicRemoveUnnecessaryCallCodeFixProvider)
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.RemoveUnnecessaryCall
+    <Trait(Traits.Feature, Traits.Features.CodeActionsRemoveCall)>
+    Public Class RemoveUnnecessaryCallTests
+        Private Shared Function VerifyCodeFixAsync(source As String, fixedSource As String) As Task
+            Return New VerifyVB.Test With
+            {
+                .TestCode = source,
+                .FixedCode = fixedSource
+            }.RunAsync()
+        End Function
+
+        <Fact>
+        Public Function TestRemoveCall() As Task
+            Return VerifyCodeFixAsync(
+"Imports System
+Public Class Program
+    Public Sub MySub()
+        [|Call|] Console.WriteLine()
+    End Sub
+End Class
+",
+"Imports System
+Public Class Program
+    Public Sub MySub()
+        Console.WriteLine()
+    End Sub
+End Class
+")
+        End Function
+
+        <Fact>
+        Public Function TestRemoveCallLowerCase() As Task
+            Return VerifyCodeFixAsync(
+"Imports System
+Public Class Program
+    Public Sub MySub()
+        [|call|] Console.WriteLine()
+    End Sub
+End Class
+",
+"Imports System
+Public Class Program
+    Public Sub MySub()
+        Console.WriteLine()
+    End Sub
+End Class
+")
+        End Function
+        <Fact>
+        Public Function TestRemoveCallTrailingComment() As Task
+            Return VerifyCodeFixAsync(
+"Imports System
+Public Class Program
+    Public Sub MySub()
+        [|Call|] Console.WriteLine() ' comment
+    End Sub
+End Class
+",
+"Imports System
+Public Class Program
+    Public Sub MySub()
+        Console.WriteLine() ' comment
+    End Sub
+End Class
+")
+        End Function
+
+        <Fact>
+        Public Function TestRemoveCallFullQualifiedName() As Task
+            Return VerifyCodeFixAsync(
+"Public Class Program
+    Public Sub MySub()
+        [|Call|] System.Console.WriteLine()
+        [|Call|] Global.System.Console.WriteLine()
+    End Sub
+End Class
+",
+"Public Class Program
+    Public Sub MySub()
+        System.Console.WriteLine()
+        Global.System.Console.WriteLine()
+    End Sub
+End Class
+")
+        End Function
+
+        <Fact>
+        Public Function TestRemoveCallClassKeywords() As Task
+            Return VerifyCodeFixAsync(
+"Imports System
+Public Class Program
+    Public Sub MySub()
+        [|Call|] MyClass.A()
+        [|Call|] MyClass.A
+        [|Call|] C(Nothing)
+    End Sub
+    Public Shared Sub A()
+    End Sub
+    Public Overridable Sub B()
+    End Sub
+    Private Sub C(b As Action)
+        If b Is Nothing Then
+            [|Call|] Me.B()
+            [|Call|] Me.B
+        End If
+    End Sub
+End Class
+Public Class Program2
+    Inherits Program
+    Public Overrides Sub B()
+        [|Call|] MyBase.B()
+        [|Call|] MyBase.B
+    End Sub
+End Class
+",
+"Imports System
+Public Class Program
+    Public Sub MySub()
+        MyClass.A()
+        MyClass.A
+        C(Nothing)
+    End Sub
+    Public Shared Sub A()
+    End Sub
+    Public Overridable Sub B()
+    End Sub
+    Private Sub C(b As Action)
+        If b Is Nothing Then
+            Me.B()
+            Me.B
+        End If
+    End Sub
+End Class
+Public Class Program2
+    Inherits Program
+    Public Overrides Sub B()
+        MyBase.B()
+        MyBase.B
+    End Sub
+End Class
+")
+        End Function
+
+        <Fact>
+        Public Function TestRemoveCallTypeShared() As Task
+            Return VerifyCodeFixAsync(
+"Public Class Program
+    Public Sub MySub()
+        [|Call|] Decimal.Round(1.5D).A()
+        [|Call|] Decimal.Round(0.5D).A
+    End Sub
+End Class
+Module DecimalExt
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub A(x As Decimal)
+    End Sub
+End Module
+",
+"Public Class Program
+    Public Sub MySub()
+        Decimal.Round(1.5D).A()
+        Decimal.Round(0.5D).A
+    End Sub
+End Class
+Module DecimalExt
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub A(x As Decimal)
+    End Sub
+End Module
+")
+        End Function
+
+        <Fact>
+        Public Function TestRemoveCallTypeOperations() As Task
+            Return VerifyCodeFixAsync(
+"Public Class Program
+    Public Sub MySub()
+        Dim o As Object = """"
+        [|Call|] CStr(o).A
+        [|Call|] CType(o, String).A
+        [|Call|] DirectCast(o, String).A()
+        [|Call|] TryCast(o, String)?.A()
+        [|Call|] GetType(String).ToString().A()
+    End Sub
+End Class
+Module StringExt
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub A(x As String)
+    End Sub
+End Module
+",
+"Public Class Program
+    Public Sub MySub()
+        Dim o As Object = """"
+        CStr(o).A
+        CType(o, String).A
+        DirectCast(o, String).A()
+        TryCast(o, String)?.A()
+        GetType(String).ToString().A()
+    End Sub
+End Class
+Module StringExt
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub A(x As String)
+    End Sub
+End Module
+")
+        End Function
+
+        <Fact>
+        Public Function TestRemoveCallGetXmlNamespace() As Task
+            Return VerifyCodeFixAsync(
+"Imports System.Xml.Linq
+Imports <xmlns:ns=""http://example.com"">
+Public Class Program
+    Public Sub MySub()
+        [|Call|] GetXmlNamespace(ns).A
+        [|Call|] GetXmlNamespace(ns).A()
+    End Sub
+End Class
+Module StringExt
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub A(x As XNamespace)
+    End Sub
+End Module
+",
+"Imports System.Xml.Linq
+Imports <xmlns:ns=""http://example.com"">
+Public Class Program
+    Public Sub MySub()
+        GetXmlNamespace(ns).A
+        GetXmlNamespace(ns).A()
+    End Sub
+End Class
+Module StringExt
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub A(x As XNamespace)
+    End Sub
+End Module
+")
+        End Function
+
+        <Fact>
+        Public Function TestRemoveCallMethodChain() As Task
+            Return VerifyCodeFixAsync(
+"Imports System.Runtime.CompilerServices
+Public Class Program
+    Public Sub MySub()
+        Dim o As Object = """"
+        [|Call|] CStr(o).C.C().C.C().C()?.C.A
+        [|Call|] GetType(Integer).ToString().ToString.C.C?.C.C().C()?.C.A
+    End Sub
+End Class
+Module StringExt
+    <Extension>
+    Public Sub A(x As String)
+    End Sub
+    <Extension>
+    Public Function C(x As String) As String
+        Return x
+    End Function
+End Module
+",
+"Imports System.Runtime.CompilerServices
+Public Class Program
+    Public Sub MySub()
+        Dim o As Object = """"
+        CStr(o).C.C().C.C().C()?.C.A
+        GetType(Integer).ToString().ToString.C.C?.C.C().C()?.C.A
+    End Sub
+End Class
+Module StringExt
+    <Extension>
+    Public Sub A(x As String)
+    End Sub
+    <Extension>
+    Public Function C(x As String) As String
+        Return x
+    End Function
+End Module
+")
+        End Function
+
+        <Theory>
+        <InlineData(
+"' New Operator
+Imports System
+Public Class Program
+    Public Sub MySub()
+        Call New A().B
+        Call New A().B()
+    End SUb
+End Class
+Class A
+    Public Sub B()
+    End Sub
+End Class
+")>
+        <InlineData(
+"' Parens
+Imports System
+Public Class Program
+    Public Sub MySub()
+        Call (1 + 2).A()
+        Call (1 + 2).A
+    End SUb
+End Class
+Module IntExt
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub A(n As Integer)
+    End Sub
+End Module
+")>
+        <InlineData(
+"' If Operator
+Imports System
+Imports System.Runtime.CompilerServices
+Public Class Program
+    Public Sub MySub()
+        Call If(String.Empty.Length = 0, 1, 0).A()
+        Call If(String.Empty, ""null"").A
+    End SUb
+End Class
+Module IntExt
+    <Extension>
+    Public Sub A(n As Integer)
+    End Sub
+    <Extension>
+    Public Sub A(s As String)
+    End Sub
+End Module
+")>
+        <InlineData(
+"' Literal
+Imports System.Runtime.CompilerServices
+Public Class Program
+    Public Sub MySub()
+        Call 1.A
+        Call 2.A()
+        Call 1.5.A
+        Call 2.5.A()
+        Call """".A
+        Call """".A()
+        Call True.A
+        Call False.A()
+        Call #2024-01-01#.A
+        Call #01/01/2024#.A()
+        Call Nothing?.ToString()
+    End Sub
+End Class
+Module StringExt
+    <Extension>
+    Public Sub A(x As String)
+    End Sub
+    <Extension>
+    Public Sub A(x As Integer)
+    End Sub
+    <Extension>
+    Public Sub A(x As Double)
+    End Sub
+    <Extension>
+    Public Sub A(x As Boolean)
+    End Sub
+    <Extension>
+    Public Sub A(x As Date)
+    End Sub
+End Module
+"
+        )>
+        <InlineData(
+"'XML
+Imports System.Xml.Linq
+Public Class Program
+    Public Sub MySub()
+        Call <xml:Root/>.A
+        Call <xml:Root/>.A()
+    End Sub
+End Class
+Module XmlExt
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub A(x As XElement)
+    End Sub
+End Module
+")>
+        Public Function TestRemoveCallKeep(code As String) As Task
+            Return VerifyCodeFixAsync(code, code)
+        End Function
+    End Class
+End Namespace

--- a/src/Analyzers/VisualBasic/Tests/VisualBasicAnalyzers.UnitTests.projitems
+++ b/src/Analyzers/VisualBasic/Tests/VisualBasicAnalyzers.UnitTests.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RemoveAsyncModifier\RemoveAsyncModifierTests.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveRedundantEquality\RemoveRedundantEqualityTests.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryByVal\RemoveUnnecessaryByValTests.vb" />
+    <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCall\RemoveUnnecessaryCallTests.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UnsealClass\UnsealClassTests.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UpdateLegacySuppressions\UpdateLegacySuppressionsTests.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessarySuppressions\RemoveUnnecessarySuppressionsTests.vb" />
@@ -77,5 +78,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(DefaultLanguageSourceExtension)' != '' AND '$(BuildingInsideVisualStudio)' != 'true'">
     <ExpectedCompile Include="$(MSBuildThisFileDirectory)**\*$(DefaultLanguageSourceExtension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCall\" />
   </ItemGroup>
 </Project>

--- a/src/Compilers/Test/Core/Traits/Traits.cs
+++ b/src/Compilers/Test/Core/Traits/Traits.cs
@@ -149,6 +149,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsQualifyMemberAccess = "CodeActions.QualifyMemberAccess";
             public const string CodeActionsRemoveAsyncModifier = "CodeActions.RemoveAsyncModifier";
             public const string CodeActionsRemoveByVal = "CodeActions.RemoveByVal";
+            public const string CodeActionsRemoveCall = "CodeActions.RemoveCall";
             public const string CodeActionsRemoveDocCommentNode = "CodeActions.RemoveDocCommentNode";
             public const string CodeActionsRemoveInKeyword = "CodeActions.RemoveInKeyword";
             public const string CodeActionsRemoveUnnecessarySuppressions = "CodeActions.RemoveUnnecessarySuppressions";

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -626,8 +626,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
         }
 
         [Theory]
-        [InlineData(LanguageNames.CSharp, 49)]
-        [InlineData(LanguageNames.VisualBasic, 86)]
+        [InlineData(LanguageNames.CSharp, 50)]
+        [InlineData(LanguageNames.VisualBasic, 87)]
         public void VerifyAllCodeStyleFixersAreSupportedByCodeCleanup(string language, int numberOfUnsupportedDiagnosticIds)
         {
             var supportedDiagnostics = GetSupportedDiagnosticIdsForCodeCleanupService(language);

--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -655,6 +655,9 @@ dotnet_diagnostic.IDE0082.severity = %value%
 # IDE0084
 dotnet_diagnostic.IDE0084.severity = %value%
 
+# IDE0085
+dotnet_diagnostic.IDE0085.severity = %value%
+
 # IDE0100
 dotnet_diagnostic.IDE0100.severity = %value%
 
@@ -975,6 +978,7 @@ dotnet_diagnostic.JSON002.severity = %value%
                 ("IDE0081", null, null),
                 ("IDE0082", null, null),
                 ("IDE0084", "visual_basic_style_prefer_isnot_expression", "true"),
+                ("IDE0085", null, null),
                 ("IDE0100", null, null),
                 ("IDE0120", null, null),
                 ("IDE0140", "visual_basic_style_prefer_simplified_object_creation", "true"),


### PR DESCRIPTION
Fixes #71818

Mandatory:

- [x] Implement the same level as RemoveUnnecessaryByVal

Backlog:

- [ ] Support FixAll
- [ ] Support CodeCleanUp
- [ ] Assign a dedicated code style option name