### PR TITLE
Resolve extension members in all non-invocation contexts

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.IdentifierUsedAsValueFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.IdentifierUsedAsValueFinder.cs
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             /// <summary>
-            /// Follows the logic of <see cref="Binder.BindInstanceMemberAccess"/> and <see cref="Binder.BindMemberOfType"/>
+            /// Follows the logic of <see cref="Binder.BindMemberAccessWithBoundLeftInternal"/> and <see cref="Binder.BindMemberOfType"/>
             /// </summary>
             protected static bool TreatAsInstanceMemberAccess(
                 Binder enclosingBinder,

--- a/src/Compilers/CSharp/Portable/Binder/Binder.IdentifierUsedAsValueFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.IdentifierUsedAsValueFinder.cs
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             /// <summary>
-            /// Follows the logic of <see cref="Binder.BindMemberAccessWithBoundLeftInternal"/> and <see cref="Binder.BindMemberOfType"/>
+            /// Follows the logic of <see cref="Binder.BindMemberAccessWithBoundLeftCore"/> and <see cref="Binder.BindMemberOfType"/>
             /// </summary>
             protected static bool TreatAsInstanceMemberAccess(
                 Binder enclosingBinder,

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -475,9 +475,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var methodGroup = (BoundMethodGroup)expr;
                 CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 var resolution = this.ResolveMethodGroup(methodGroup, analyzedArguments: null, useSiteInfo: ref useSiteInfo, options: OverloadResolution.Options.None);
+                Debug.Assert(!resolution.IsNonMethodExtensionMember(out _), "A method group that resolves to a non-method extension member should have been resolved before getting here");
                 diagnostics.Add(expr.Syntax, useSiteInfo);
                 Symbol otherSymbol = null;
-                bool resolvedToUnusableSymbol = resolution.MethodGroup == null && !resolution.IsNonMethodExtensionMember(out _);
+                bool resolvedToUnusableSymbol = resolution.MethodGroup == null;
                 if (!expr.HasAnyErrors) diagnostics.AddRange(resolution.Diagnostics); // Suppress cascading.
                 hasResolutionErrors = resolution.HasAnyErrors;
                 if (hasResolutionErrors)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -406,11 +406,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression CheckValue(BoundExpression expr, BindValueKind valueKind, BindingDiagnosticBag diagnostics)
         {
-            if (RequiresAssignableVariable(valueKind))
-            {
-                expr = ResolveToExtensionMemberIfPossible(expr, diagnostics);
-            }
-
             switch (expr.Kind)
             {
                 case BoundKind.PropertyGroup:
@@ -482,7 +477,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var resolution = this.ResolveMethodGroup(methodGroup, analyzedArguments: null, useSiteInfo: ref useSiteInfo, options: OverloadResolution.Options.None);
                 diagnostics.Add(expr.Syntax, useSiteInfo);
                 Symbol otherSymbol = null;
-                bool resolvedToUnusableSymbol = resolution.MethodGroup == null && !resolution.IsExtensionMember(out _);
+                bool resolvedToUnusableSymbol = resolution.MethodGroup == null && !resolution.IsNonMethodExtensionMember(out _);
                 if (!expr.HasAnyErrors) diagnostics.AddRange(resolution.Diagnostics); // Suppress cascading.
                 hasResolutionErrors = resolution.HasAnyErrors;
                 if (hasResolutionErrors)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var methodGroup = (BoundMethodGroup)expr;
                 CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 var resolution = this.ResolveMethodGroup(methodGroup, analyzedArguments: null, useSiteInfo: ref useSiteInfo, options: OverloadResolution.Options.None);
-                Debug.Assert(!resolution.IsNonMethodExtensionMember(out _), "A method group that resolves to a non-method extension member should have been resolved before getting here");
+                Debug.Assert(!resolution.IsNonMethodExtensionMember(out _));
                 diagnostics.Add(expr.Syntax, useSiteInfo);
                 Symbol otherSymbol = null;
                 bool resolvedToUnusableSymbol = resolution.MethodGroup == null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var receiver = new BoundLiteral(node, ConstantValue.Null, awaiterType);
             var name = WellKnownMemberNames.IsCompleted;
-            var qualified = BindMemberAccessWithBoundLeftInternal(node, node, receiver, name, 0, default(SeparatedSyntaxList<TypeSyntax>), default(ImmutableArray<TypeWithAnnotations>), invoked: false, indexed: false, diagnostics);
+            var qualified = BindMemberAccessWithBoundLeftCore(node, node, receiver, name, 0, default(SeparatedSyntaxList<TypeSyntax>), default(ImmutableArray<TypeWithAnnotations>), invoked: false, indexed: false, diagnostics);
             if (qualified.HasAnyErrors)
             {
                 isCompletedProperty = null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var receiver = new BoundLiteral(node, ConstantValue.Null, awaiterType);
             var name = WellKnownMemberNames.IsCompleted;
-            var qualified = BindInstanceMemberAccess(node, node, receiver, name, 0, default(SeparatedSyntaxList<TypeSyntax>), default(ImmutableArray<TypeWithAnnotations>), invoked: false, indexed: false, diagnostics);
+            var qualified = BindMemberAccessWithBoundLeftInternal(node, node, receiver, name, 0, default(SeparatedSyntaxList<TypeSyntax>), default(ImmutableArray<TypeWithAnnotations>), invoked: false, indexed: false, diagnostics);
             if (qualified.HasAnyErrors)
             {
                 isCompletedProperty = null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1124,7 +1124,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!methodGroup.HasAnyErrors) diagnostics.AddRange(resolution.Diagnostics); // Suppress cascading.
 
-                if (resolution.HasAnyErrors) // PROTOTYPE(instance) should we do anything special about extensions in this path?
+                if (resolution.IsNonMethodExtensionMember(out Symbol? extensionMember))
+                {
+                    addMethods = [];
+                    result = false;
+                }
+                else if (resolution.HasAnyErrors)
                 {
                     addMethods = [];
                     result = false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1044,7 +1044,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BindingDiagnosticBag diagnostics,
                 out ImmutableArray<MethodSymbol> addMethods)
             {
-                var boundExpression = addMethodBinder.BindMemberAccessWithBoundLeftInternal(
+                var boundExpression = addMethodBinder.BindMemberAccessWithBoundLeftCore(
                     node, node, receiver, WellKnownMemberNames.CollectionInitializerAddMethodName, rightArity: 0,
                     typeArgumentsSyntax: default(SeparatedSyntaxList<TypeSyntax>),
                     typeArgumentsWithAnnotations: default(ImmutableArray<TypeWithAnnotations>),

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1044,11 +1044,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BindingDiagnosticBag diagnostics,
                 out ImmutableArray<MethodSymbol> addMethods)
             {
-                var boundExpression = addMethodBinder.BindInstanceMemberAccess(
+                var boundExpression = addMethodBinder.BindMemberAccessWithBoundLeftInternal(
                     node, node, receiver, WellKnownMemberNames.CollectionInitializerAddMethodName, rightArity: 0,
                     typeArgumentsSyntax: default(SeparatedSyntaxList<TypeSyntax>),
                     typeArgumentsWithAnnotations: default(ImmutableArray<TypeWithAnnotations>),
-                    invoked: true, indexed: false, diagnostics, searchExtensionMethodsIfNecessary: true);
+                    invoked: true, indexed: false, diagnostics, searchExtensionsIfNecessary: true);
 
                 // require the target member to be a method.
                 if (boundExpression.Kind == BoundKind.FieldAccess || boundExpression.Kind == BoundKind.PropertyAccess)
@@ -1124,7 +1124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!methodGroup.HasAnyErrors) diagnostics.AddRange(resolution.Diagnostics); // Suppress cascading.
 
-                if (resolution.HasAnyErrors)
+                if (resolution.HasAnyErrors) // PROTOTYPE(instance) should we do anything special about extensions in this path?
                 {
                     addMethods = [];
                     result = false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1126,6 +1126,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (resolution.IsNonMethodExtensionMember(out Symbol? extensionMember))
                 {
+                    ReportMakeInvocationExpressionBadMemberKind(syntax, WellKnownMemberNames.CollectionInitializerAddMethodName, methodGroup, diagnostics);
                     addMethods = [];
                     result = false;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 const string methodName = WellKnownMemberNames.DeconstructMethodName;
-                var memberAccess = BindMemberAccessWithBoundLeftInternal(
+                var memberAccess = BindMemberAccessWithBoundLeftCore(
                                         rightSyntax, receiverSyntax, receiver, methodName, rightArity: 0,
                                         typeArgumentsSyntax: default(SeparatedSyntaxList<TypeSyntax>),
                                         typeArgumentsWithAnnotations: default(ImmutableArray<TypeWithAnnotations>),

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 const string methodName = WellKnownMemberNames.DeconstructMethodName;
-                var memberAccess = BindInstanceMemberAccess(
+                var memberAccess = BindMemberAccessWithBoundLeftInternal(
                                         rightSyntax, receiverSyntax, receiver, methodName, rightArity: 0,
                                         typeArgumentsSyntax: default(SeparatedSyntaxList<TypeSyntax>),
                                         typeArgumentsWithAnnotations: default(ImmutableArray<TypeWithAnnotations>),

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -577,6 +577,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             BoundExpression result = bindExpressionInternal(node, diagnostics, invoked, indexed);
+
             if (IsEarlyAttributeBinder && result.Kind == BoundKind.MethodGroup && (!IsInsideNameof || EnclosingNameofArgument != node))
             {
                 return BadExpression(node, LookupResultKind.NotAValue);
@@ -7456,10 +7457,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
 
-                    BoundExpression result = MakeBoundMethodGroupAndCheckOmittedTypeArguments(boundLeft, rightName, typeArguments, lookupResult,
+                    return MakeBoundMethodGroupAndCheckOmittedTypeArguments(boundLeft, rightName, typeArguments, lookupResult,
                         flags: BoundMethodGroupFlags.SearchExtensionMethods, node, typeArgumentsSyntax, diagnostics);
-
-                    return result;
                 }
 
                 return null;
@@ -7628,10 +7627,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
 
-                    BoundExpression result = MakeBoundMethodGroupAndCheckOmittedTypeArguments(boundLeft, rightName, typeArgumentsWithAnnotations, lookupResult,
+                    return MakeBoundMethodGroupAndCheckOmittedTypeArguments(boundLeft, rightName, typeArgumentsWithAnnotations, lookupResult,
                         flags, node, typeArgumentsSyntax, diagnostics);
-
-                    return result;
                 }
 
                 this.BindMemberAccessReportError(node, right, rightName, boundLeft, lookupResult.Error, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7486,7 +7486,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var methodGroup = (BoundMethodGroup)expr;
                         CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                         var resolution = this.ResolveMethodGroup(methodGroup, analyzedArguments: null, useSiteInfo: ref useSiteInfo, options: OverloadResolution.Options.None);
-                        Debug.Assert(!resolution.IsNonMethodExtensionMember(out _), "A method group that resolves to a non-method extension member should have been resolved before getting here");
+                        Debug.Assert(!resolution.IsNonMethodExtensionMember(out _));
                         diagnostics.Add(expr.Syntax, useSiteInfo);
 
                         if (!expr.HasAnyErrors)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7521,14 +7521,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         //   or than any method from an extension type), then that's the member being accessed.
         //
         // - if the extension member lookup finds a method (classic extension method compatible with the receiver or method in extension type;
-        //   closer than any non-method extension member), we don't need to touch the result for the member access (it's a method group already).
-        //   This method group will be resolved specially in scenarios that can handle method group
-        //   (such as inferred local `var x = A.B;`, conversion to a delegate type `System.Action a = A.B;`).
-        //   It will be an error in other scenarios.
+        //   closer than any non-method extension member), then we return nothing and let the caller represent the failed member lookup with a BoundMethodGroup.
+        //   Note: Such method group will be resolved specially in scenarios that can handle method groups
+        //     (such as inferred local `var x = A.B;`, conversion to a delegate type `System.Action a = A.B;`).
+        //     It will be an error in other scenarios.
         //
         // - if the extension member lookup is ambiguous, then we'll use an error symbol as the result of the member access.
         //
-        // - if the extension member lookup finds nothing, then we don't need to touch the result for the member access.
+        // - if the extension member lookup finds nothing, then we return nothing and let the caller represent the failed member lookup with a BoundMethodGroup.
         internal BoundExpression? ResolveExtensionMemberAccessIfResultIsNonMethod(SyntaxNode syntax, BoundExpression receiver, string name,
           SeparatedSyntaxList<TypeSyntax> typeArgumentsSyntax, ImmutableArray<TypeWithAnnotations> typeArgumentsOpt,
             BindingDiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5353,7 +5353,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // SPEC VIOLATION:  Native compiler also allows initialization of field-like events in object initializers, so we allow it as well.
 
-                    boundMember = BindMemberAccessWithBoundLeftInternal(
+                    boundMember = BindMemberAccessWithBoundLeftCore(
                         node: memberName,
                         right: memberName,
                         boundLeft: implicitReceiver,
@@ -7291,7 +7291,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // CheckValue call will occur in ReplaceTypeOrValueReceiver.
                             // NOTE: This means that we won't get CheckValue diagnostics in error scenarios,
                             // but they would be cascading anyway.
-                            return BindMemberAccessWithBoundLeftInternal(node, right, boundLeft, rightName, rightArity, typeArgumentsSyntax, typeArguments, invoked, indexed, diagnostics);
+                            return BindMemberAccessWithBoundLeftCore(node, right, boundLeft, rightName, rightArity, typeArgumentsSyntax, typeArguments, invoked, indexed, diagnostics);
                         }
                     default:
                         {
@@ -7312,7 +7312,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // These checks occur later.
                                 boundLeft = CheckValue(boundLeft, BindValueKind.RValue, diagnostics);
                                 boundLeft = BindToNaturalType(boundLeft, diagnostics);
-                                return BindMemberAccessWithBoundLeftInternal(node, right, boundLeft, rightName, rightArity, typeArgumentsSyntax, typeArguments, invoked, indexed, diagnostics);
+                                return BindMemberAccessWithBoundLeftCore(node, right, boundLeft, rightName, rightArity, typeArgumentsSyntax, typeArguments, invoked, indexed, diagnostics);
                             }
                             break;
                         }
@@ -7435,7 +7435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (this.EnclosingNameofArgument == node)
                 {
                     // Support selecting an extension method from a type name in nameof(.)
-                    return BindMemberAccessWithBoundLeftInternal(node, right, boundLeft, rightName, rightArity, typeArgumentsSyntax, typeArguments, invoked, indexed, diagnostics);
+                    return BindMemberAccessWithBoundLeftCore(node, right, boundLeft, rightName, rightArity, typeArgumentsSyntax, typeArguments, invoked, indexed, diagnostics);
                 }
                 else
                 {
@@ -7543,7 +7543,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundExpression BindMemberAccessWithBoundLeftInternal(
+        private BoundExpression BindMemberAccessWithBoundLeftCore(
             SyntaxNode node,
             SyntaxNode right,
             BoundExpression boundLeft,
@@ -7602,11 +7602,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (!invoked)
                     {
-                        var extensionResult = ResolveToNonMethodExtensionMemberIfPossible(result, diagnostics);
-                        if (extensionResult is not BoundMethodGroup)
-                        {
-                            return extensionResult;
-                        }
+                        result = ResolveToNonMethodExtensionMemberIfPossible(result, diagnostics);
                     }
 
                     return result;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         parameterNamesAndLocationsBuilder.Clear();
                     }
 
-                    var call = MakeInvocationExpression(part.Syntax, implicitBuilderReceiver, methodName, arguments, diagnostics, names: parameterNamesAndLocations, searchExtensionMethodsIfNecessary: false);
+                    var call = MakeInvocationExpression(part.Syntax, implicitBuilderReceiver, methodName, arguments, diagnostics, names: parameterNamesAndLocations, searchExtensionsIfNecessary: false);
                     builderAppendCalls.Add(call);
                     positionInfo.Add((isLiteral, hasAlignment, hasFormat));
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -2403,7 +2403,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Check that the method group contains something applicable. Otherwise error.
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             var resolution = ResolveMethodGroup(methodGroup, analyzedArguments: null, useSiteInfo: ref useSiteInfo, options: OverloadResolution.Options.None);
-            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _), "A method group that resolves to a non-method extension member should have been resolved getting here");
+            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _));
 
             // PROTOTYPE we probably want this error for extension members too
             diagnostics.Add(methodGroup.Syntax, useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -721,7 +721,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                          (analyzedArguments.HasDynamicArgument ? OverloadResolution.Options.DynamicResolution : OverloadResolution.Options.None));
             diagnostics.Add(expression, useSiteInfo);
 
-            if (resolution.IsExtensionMember(out Symbol extensionMember))
+            if (resolution.IsNonMethodExtensionMember(out Symbol extensionMember))
             {
                 diagnostics.AddRange(resolution.Diagnostics);
                 var extensionMemberAccess = GetExtensionMemberAccess(expression, methodGroup.ReceiverOpt, extensionMember,
@@ -729,6 +729,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 Debug.Assert(extensionMemberAccess.Kind != BoundKind.MethodGroup);
 
+                extensionMemberAccess = CheckValue(extensionMemberAccess, BindValueKind.RValue, diagnostics);
                 var extensionMemberInvocation = BindInvocationExpression(syntax, expression, methodName, extensionMemberAccess, analyzedArguments, diagnostics);
                 anyApplicableCandidates = !extensionMemberInvocation.HasAnyErrors;
                 return extensionMemberInvocation;
@@ -2372,7 +2373,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             CheckFeatureAvailability(node, MessageID.IDS_FeatureNameof, diagnostics);
             var argument = node.ArgumentList.Arguments[0].Expression;
             var boundArgument = BindExpression(argument, diagnostics);
-            boundArgument = ResolveToExtensionMemberIfPossible(boundArgument, diagnostics);
 
             bool syntaxIsOk = CheckSyntaxForNameofArgument(argument, out string name, boundArgument.HasAnyErrors ? BindingDiagnosticBag.Discarded : diagnostics);
             if (!boundArgument.HasAnyErrors && syntaxIsOk && boundArgument.Kind == BoundKind.MethodGroup)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(names.IsDefault || names.Length == args.Length);
 
             receiver = BindToNaturalType(receiver, diagnostics);
-            var boundExpression = BindMemberAccessWithBoundLeftInternal(node, node, receiver, methodName, typeArgs.NullToEmpty().Length, typeArgsSyntax, typeArgs, invoked: true, indexed: false, diagnostics, searchExtensionsIfNecessary);
+            var boundExpression = BindMemberAccessWithBoundLeftCore(node, node, receiver, methodName, typeArgs.NullToEmpty().Length, typeArgsSyntax, typeArgs, invoked: true, indexed: false, diagnostics, searchExtensionsIfNecessary);
 
             // The other consumers of this helper (await and collection initializers) require the target member to be a method.
             if (!allowFieldsAndProperties && (boundExpression.Kind == BoundKind.FieldAccess || boundExpression.Kind == BoundKind.PropertyAccess))

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -1546,7 +1546,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundImplicitReceiver implicitReceiver = new BoundImplicitReceiver(memberName, inputType);
             string name = memberName.Identifier.ValueText;
 
-            BoundExpression boundMember = BindInstanceMemberAccess(
+            BoundExpression boundMember = BindMemberAccessWithBoundLeftInternal(
                 node: memberName,
                 right: memberName,
                 boundLeft: implicitReceiver,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -1546,7 +1546,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundImplicitReceiver implicitReceiver = new BoundImplicitReceiver(memberName, inputType);
             string name = memberName.Identifier.ValueText;
 
-            BoundExpression boundMember = BindMemberAccessWithBoundLeftInternal(
+            BoundExpression boundMember = BindMemberAccessWithBoundLeftCore(
                 node: memberName,
                 right: memberName,
                 boundLeft: implicitReceiver,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -928,6 +928,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(receiver.Type is object || ultimateReceiver.Type is null);
             if ((object?)ultimateReceiver.Type == null)
             {
+                Debug.Assert(ultimateReceiver.Kind != BoundKind.MethodGroup || ultimateReceiver.HasAnyErrors);
+
                 if (ultimateReceiver.HasAnyErrors || node.HasErrors)
                 {
                     // report no additional errors
@@ -952,25 +954,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Could not find an implementation of the query pattern for source type '{0}'.  '{1}' not found.
                     diagnostics.Add(ErrorCode.ERR_QueryNoProvider, node.Location, MessageID.IDS_AnonMethod.Localize(), methodName);
-                }
-                else if (ultimateReceiver.Kind == BoundKind.MethodGroup)
-                {
-                    var methodGroup = (BoundMethodGroup)ultimateReceiver;
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-                    // PROTOTYPE we'll want extension types to contribute
-                    var resolution = this.ResolveMethodGroup(methodGroup, analyzedArguments: null, useSiteInfo: ref useSiteInfo, options: OverloadResolution.Options.None);
-                    diagnostics.Add(node, useSiteInfo);
-                    diagnostics.AddRange(resolution.Diagnostics);
-                    if (resolution.HasAnyErrors)
-                    {
-                        receiver = this.BindMemberAccessBadResult(methodGroup);
-                    }
-                    else
-                    {
-                        Debug.Assert(!resolution.IsEmpty);
-                        diagnostics.Add(ErrorCode.ERR_QueryNoProvider, node.Location, MessageID.IDS_SK_METHOD.Localize(), methodName);
-                    }
-                    resolution.Free();
                 }
 
                 receiver = new BoundBadExpression(receiver.Syntax, LookupResultKind.NotAValue, ImmutableArray<Symbol?>.Empty, ImmutableArray.Create(receiver), CreateErrorType());

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -4022,7 +4022,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = null;
                 isExpanded = false;
 
-                var boundAccess = BindInstanceMemberAccess(
+                var boundAccess = BindMemberAccessWithBoundLeftInternal(
                        syntaxNode,
                        syntaxNode,
                        receiver,
@@ -4046,8 +4046,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 //       containing method can be invoked in normal form which allows
                 //       us to skip some work during the lookup.
 
+                // PROTOTYPE(instance) We may have a delegate type value here instead of a method group.
+                //                     We need to decide whether to handle or block.
                 var analyzedArguments = AnalyzedArguments.GetInstance();
-                // PROTOTYPE we'll likely want extension types to contribute
                 var patternMethodCall = BindMethodGroupInvocation(
                     syntaxNode,
                     syntaxNode,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -896,7 +896,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = value.Kind switch
             {
                 BoundKind.UnboundLambda => BindToInferredDelegateType(value, diagnostics),
-                BoundKind.MethodGroup => BindToExtensionMemberOrInferredDelegateType((BoundMethodGroup)value, diagnostics),
+                BoundKind.MethodGroup => BindToInferredDelegateType(value, diagnostics),
                 _ => BindToNaturalType(value, diagnostics)
             };
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -4022,7 +4022,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = null;
                 isExpanded = false;
 
-                var boundAccess = BindMemberAccessWithBoundLeftInternal(
+                var boundAccess = BindMemberAccessWithBoundLeftCore(
                        syntaxNode,
                        syntaxNode,
                        receiver,

--- a/src/Compilers/CSharp/Portable/Binder/MethodGroupResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/MethodGroupResolution.cs
@@ -92,9 +92,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 #nullable enable
         /// <summary>
         /// Indicates that we have a viable result that is a non-method extension member.
-        /// PROTOTYPE consider renaming the method to IsNonMethodExtensionMember
         /// </summary>
-        public bool IsExtensionMember([NotNullWhen(true)] out Symbol? extensionMember)
+        public bool IsNonMethodExtensionMember([NotNullWhen(true)] out Symbol? extensionMember)
         {
             bool isExtensionMember = ResultKind == LookupResultKind.Viable && MethodGroup is null;
             extensionMember = isExtensionMember ? OtherSymbol : null;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -105,21 +105,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal readonly ImmutableArray<(BoundValuePlaceholder? placeholder, BoundExpression? conversion)> DeconstructConversionInfo;
         }
 
-        private class ExtensionMemberUncommonData : NestedUncommonData
-        {
-            internal readonly Symbol ExtensionMember;
-
-            internal ExtensionMemberUncommonData(Symbol extensionMember, ImmutableArray<Conversion> nestedConversions)
-                : base(nestedConversions)
-            {
-                Debug.Assert(extensionMember is not null);
-                Debug.Assert(nestedConversions.Length == 1);
-                Debug.Assert(nestedConversions[0].Kind != ConversionKind.ExtensionMember);
-
-                ExtensionMember = extensionMember;
-            }
-        }
-
         private sealed class CollectionExpressionUncommonData : NestedUncommonData
         {
             internal CollectionExpressionUncommonData(
@@ -184,13 +169,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 isArrayIndex: false,
                 conversionResult: default,
                 conversionMethod: conversionMethod);
-        }
-
-        // For extension member conversion
-        internal Conversion(Symbol extensionMember, Conversion nestedConversion)
-        {
-            this._kind = ConversionKind.ExtensionMember;
-            _uncommonData = new ExtensionMemberUncommonData(extensionMember, nestedConversions: ImmutableArray.Create(nestedConversion));
         }
 
         internal Conversion(ConversionKind kind, ImmutableArray<Conversion> nestedConversions)
@@ -561,26 +539,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var uncommonData = (DeconstructionUncommonData?)_uncommonData;
                 return uncommonData == null ? default : uncommonData.DeconstructConversionInfo;
             }
-        }
-
-        internal bool IsExtensionMemberConversion([NotNullWhen(true)] out Symbol? extensionMember, out Conversion nestedConversion)
-        {
-            if (Kind != ConversionKind.ExtensionMember)
-            {
-                extensionMember = null;
-                nestedConversion = default;
-                return false;
-            }
-
-            var uncommonData = (ExtensionMemberUncommonData?)_uncommonData;
-
-            Debug.Assert(uncommonData is not null);
-            extensionMember = uncommonData.ExtensionMember;
-
-            Debug.Assert(uncommonData._nestedConversionsOpt.Length == 1);
-            nestedConversion = uncommonData._nestedConversionsOpt[0];
-
-            return true;
         }
 
         internal CollectionExpressionTypeKind GetCollectionExpressionTypeKind(out TypeSymbol? elementType, out MethodSymbol? constructor, out bool isExpanded)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -67,6 +67,5 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         InterpolatedStringHandler, // A conversion from an interpolated string literal to a type attributed with InterpolatedStringBuilderAttribute
         InlineArray, // A conversion from an inline array to Span/ReadOnlySpan
-        ExtensionMember, // The ExtensionMember conversion is not part of the language, it is an implementation detail
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
@@ -53,7 +53,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ObjectCreation:
                 case InlineArray:
                 case CollectionExpression:
-                case ExtensionMember:
                     return true;
 
                 case ExplicitNumeric:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var resolution = ResolveDelegateOrFunctionPointerMethodGroup(_binder, source, methodSymbol, isFunctionPointer, callingConventionInfo, ref useSiteInfo);
-            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _), "A method group that resolves to a non-method extension member should have been resolved getting here");
+            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _));
 
             var conversion = (resolution.IsEmpty || resolution.HasAnyErrors) ?
                 Conversion.NoConversion :
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 resolution = binder.ResolveMethodGroup(source, analyzedArguments: null, ref useSiteInfo, options: OverloadResolution.Options.IsMethodGroupConversion);
             }
 
-            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _), "A method group that resolves to a non-method extension member should have been resolved getting here");
+            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _));
             return resolution;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -46,11 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Must be a bona fide delegate type, not an expression tree type.
             if (!destination.IsDelegateType())
             {
-                if (tryGetExtensionMemberConversion(source, destination, ref useSiteInfo, out var extensionMemberConversion))
-                {
-                    return extensionMemberConversion;
-                }
-
                 return Conversion.NoConversion;
             }
 
@@ -107,44 +102,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var resolution = ResolveDelegateOrFunctionPointerMethodGroup(_binder, source, methodSymbol, isFunctionPointer, callingConventionInfo, ref useSiteInfo);
-            if (resolution.IsExtensionMember(out var extensionMember))
-            {
-                var nestedConversion = ClassifyConversionFromExpressionType(extensionMember.GetTypeOrReturnType().Type, destination, isChecked: false, ref useSiteInfo);
-                if (nestedConversion.Kind != ConversionKind.NoConversion)
-                {
-                    return new Conversion(extensionMember, nestedConversion);
-                }
-            }
+            Debug.Assert(!resolution.IsNonMethodExtensionMember(extensionMember: out _));
 
             var conversion = (resolution.IsEmpty || resolution.HasAnyErrors) ?
                 Conversion.NoConversion :
                 ToConversion(resolution.OverloadResolutionResult, resolution.MethodGroup, methodSymbol.ParameterCount);
             resolution.Free();
             return conversion;
-
-            bool tryGetExtensionMemberConversion(BoundMethodGroup source, TypeSymbol destination,
-                ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, out Conversion extensionMemberConversion)
-            {
-                if (source is not { Methods: [], SearchExtensionMethods: true })
-                {
-                    extensionMemberConversion = default;
-                    return false;
-                }
-
-                MethodGroupResolution resolution = _binder.ResolveMethodGroup(source, analyzedArguments: null, ref useSiteInfo, options: OverloadResolution.Options.None);
-                if (resolution.IsExtensionMember(out Symbol? extensionMember) && extensionMember is not NamedTypeSymbol)
-                {
-                    var nestedConversion = ClassifyConversionFromExpressionType(extensionMember.GetTypeOrReturnType().Type, destination, isChecked: false, ref useSiteInfo);
-                    if (nestedConversion.Kind != ConversionKind.NoConversion)
-                    {
-                        extensionMemberConversion = new Conversion(extensionMember, nestedConversion);
-                        return true;
-                    }
-                }
-
-                extensionMemberConversion = default;
-                return false;
-            }
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1492,6 +1492,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 returnType: null,
                 callingConventionInfo: in callingConventionInfo);
 
+            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _), "A method group that resolves to a non-method extension member should have been resolved getting here");
+
             TypeWithAnnotations type = default;
 
             // The resolution could be empty (e.g. if there are no methods in the BoundMethodGroup).

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1492,7 +1492,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 returnType: null,
                 callingConventionInfo: in callingConventionInfo);
 
-            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _), "A method group that resolves to a non-method extension member should have been resolved getting here");
+            Debug.Assert(!resolution.IsNonMethodExtensionMember(out _));
 
             TypeWithAnnotations type = default;
 

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -37487,7 +37487,6 @@ public class MyCollection : IEnumerable<int>
     IEnumerator IEnumerable.GetEnumerator() => throw null;
 }
 """;
-        // PROTOTYPE(instance) We need to decide whether to allow this and adjust HasCollectionExpressionApplicableAddMethod and other downstream logic accordingly
         var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
         comp.VerifyEmitDiagnostics(
             // (4,18): error CS0118: 'Add' is a property but is used like a method

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -38454,7 +38454,7 @@ implicit extension E for object
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70, options: TestOptions.DebugExe);
         comp.VerifyEmitDiagnostics();
-        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran")).VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -33423,7 +33423,7 @@ implicit extension E for object
             Diagnostic(ErrorCode.ERR_AssignmentInitOnly, "new object().Property").WithArguments("E.Property").WithLocation(1, 1));
     }
 
-    [Fact]
+    [ConditionalFact(typeof(NoUsedAssembliesValidation))] // PROTOTYPE(instance) enable and execute once we can lower/emit for non-static scenarios
     public void PropertyAccess_InitOnlyProperty_Instance_ObjectInitializer()
     {
         var src = """

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -37468,7 +37468,7 @@ public class MyCollection : IEnumerable<int>
     }
 
     [Fact]
-    public void ResolveAll_CollectionExpression_ExtensionAddDelegateTypeField()
+    public void ResolveAll_CollectionExpression_ExtensionAddDelegateTypeProperty()
     {
         var source = """
 using System.Collections;
@@ -37478,7 +37478,7 @@ MyCollection c = [42];
 
 public implicit extension E for MyCollection
 {
-    public System.Action<int> Add = (int i) => { System.Console.Write("ran"); };
+    public System.Action<int> Add => (int i) => { };
 }
 
 public class MyCollection : IEnumerable<int>
@@ -37490,9 +37490,9 @@ public class MyCollection : IEnumerable<int>
         // PROTOTYPE(instance) We need to decide whether to allow this and adjust HasCollectionExpressionApplicableAddMethod and other downstream logic accordingly
         var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
         comp.VerifyEmitDiagnostics(
-            // (8,31): error CS9313: 'E.Add': cannot declare instance members with state in extension types.
-            //     public System.Action<int> Add = (int i) => { System.Console.Write("ran"); };
-            Diagnostic(ErrorCode.ERR_StateInExtension, "Add").WithArguments("E.Add").WithLocation(8, 31));
+            // (4,18): error CS0118: 'Add' is a property but is used like a method
+            // MyCollection c = [42];
+            Diagnostic(ErrorCode.ERR_BadSKknown, "[42]").WithArguments("Add", "property", "method").WithLocation(4, 18));
     }
 
     [Fact]


### PR DESCRIPTION
When we bind a member access expression there are two cases:
1. the expression is considered "invoked" (syntactically part of an `invocation_expression`), in which case the extension member lookup will filter out non-invocable members,
2. the expression is not considered "invoked", so if member lookup failed, we can go ahead and use normal extension member lookup (ie. not filtering out non-invocable members) to resolve the expression to a non-method extension member.

This PR implements the second case.

It also removes previous logic we had for resolving to a non-method extension member during a conversion. That logic relied on an incorrect understanding of the spec (that conversions to a delegate type would cause the expression to be treated as "invoked", so we had to wait until processing the conversion to perform the extension member lookup). 

So the following scenario becomes an error:
```
var x = (System.Action)D.f; // binds to field, so error: string cannot convert to Action
System.Action a = D.f; // ditto

class D { }
 
implicit extension E1 for D
{
    public static string f = null;
}
 
implicit extension E2 for object
{
    public static void f() { }
}
```

----

Here are the relevant sections of the spec that justify this understanding:

The [Member Lookup](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#125-member-lookup) has concept of a member being "invoked":
> "If the simple_name or member_access occurs as the primary_expression of an invocation_expression, the member is said to be invoked."
> "Next, if the member is invoked, all non-invocable members are removed from the set."

But in [Method group conversions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#108-method-group-conversions), although treat the conversion as an invocation:
> A single method M is selected corresponding to a method invocation of the form `E(A)` ... [using arguments constructed from the parameter types of delegate type]

The method group conversion only kicks in when we have already determined that we have a method group:
> "An implicit conversion exists from a method group ([§12.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#122-expression-classifications)) to a compatible delegate type ([§20.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/delegates.md#204-delegate-compatibility)). If D is a delegate type, and E is an expression that is classified as a method group, ..."

In short, a conversion to a delegate type does not cause the expression to be treated as "invoked", although we process it somewhat like an invocation.

Relates to test plan https://github.com/dotnet/roslyn/issues/66722