### PR TITLE
Populate the CurrentBlockAnalysisData's _reachingWrites when creating an OperationTreeAnalysis.

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -196,12 +196,12 @@ internal static partial class SymbolUsageAnalysis
                     if (write.Kind != OperationKind.FlowCaptureReference)
                     {
                         Debug.Assert(symbolOpt != null);
-                        OnWriteReferenceFound(symbolOpt, write, ValueUsageInfo.Write);
-
                         if (isUsedCompoundAssignment)
                         {
                             OnReadReferenceFound(symbolOpt);
                         }
+
+                        OnWriteReferenceFound(symbolOpt, write, ValueUsageInfo.Write);
                     }
                     else
                     {


### PR DESCRIPTION
Populate the CurrentBlockAnalysisData's _reachingWrites when creating an OperationTreeAnalysis.

This is similar to what FlowGraphAnalysisData does upon inspecting a new block.

Inspection of the lightbulb speedometer test demonstrated that a significant portion of CPU (~8%) in our OOP was spent in AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer. Looking at the code a bit indicated that the expensive calls to create/invoke the ControlFlowGraph weren't being short-circuited properly in the trivial cases I tried locally.

When a read operation is encountered, the code looks at all writes that are still unread. For each of these, it updates the map to indicate that the write has now been read. However, this wasn't working for parameters as the _reachingWrites collection didn't account for them.

As the image below indicates, of the 8% of CPU over 7% is accountable to the CFG. With that short-circuited more commonly now, we should save quite a bit of CPU during execution of this analyzer.

![image](https://github.com/dotnet/roslyn/assets/6785178/849b808c-b8a6-4297-8d13-46518b2a4614)