### PR TITLE
Fix need for redundant enter when rename suggestions are not available

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -186,7 +186,7 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
         Assumes.NotNull(_dropDownPopup);
         if ((e.Key is Key.Escape or Key.Space or Key.Enter)
             && (_dropDownPopup.IsOpen // Handle these keystrokes when dropdown is present
-            || _smartRenameViewModel.IsUsingResultPanel && this.TextSelectionLength < this.Text.Length)) // Or when panel is present and text is not yet selected
+            || _smartRenameViewModel.IsSuggestionsPanelExpanded && this.TextSelectionLength < this.Text.Length)) // Or when panel is present and text is not yet selected
         {
             _dropDownPopup.IsOpen = false;
             SelectAllText();

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -164,6 +164,7 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
 
     private void InnerTextBox_GotFocus(object sender, RoutedEventArgs e)
     {
+        e.Handled = true; // Prevent selecting all the text
         if (!_smartRenameViewModel.IsUsingDropdown)
         {
             return;
@@ -185,8 +186,7 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
     {
         Assumes.NotNull(_dropDownPopup);
         if ((e.Key is Key.Escape or Key.Space or Key.Enter)
-            && (_dropDownPopup.IsOpen // Handle these keystrokes when dropdown is present
-            || _smartRenameViewModel.IsSuggestionsPanelExpanded && this.TextSelectionLength < this.Text.Length)) // Or when panel is present and text is not yet selected
+            && _dropDownPopup.IsOpen) // Handle these keystrokes when dropdown is present
         {
             _dropDownPopup.IsOpen = false;
             SelectAllText();

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -174,8 +174,12 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
                 SuggestedNames.Add(name);
             }
 
-            // Changing the list may have changed the text in the text box. We need to restore it.
-            BaseViewModel.IdentifierText = textInputBackup;
+            if (IsUsingDropdown)
+            {
+                // Changing the list may have changed the text in the text box. We need to restore it.
+                // This has a side effect of selecting all the text in the text box.
+                BaseViewModel.IdentifierText = textInputBackup;
+            }
 
             return;
         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -174,12 +174,8 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
                 SuggestedNames.Add(name);
             }
 
-            if (IsUsingDropdown)
-            {
-                // Changing the list may have changed the text in the text box. We need to restore it.
-                // This has a side effect of selecting all the text in the text box.
-                BaseViewModel.IdentifierText = textInputBackup;
-            }
+            // Changing the list may have changed the text in the text box. We need to restore it.
+            BaseViewModel.IdentifierText = textInputBackup;
 
             return;
         }


### PR DESCRIPTION
# Context
In the current AI rename experience, developer needs to hit Enter twice to complete the rename. 

Rename is completed only when user pressed enter and there is no popup with suggestions. Before suggestions were acquired automatically, first enter would close the popup and second enter would complete the rename.

When suggestions are acquired automatically, there is no popup but a list of suggestions. First enter "confirms" selection from the list and selects all text in the textbox. Second enter completes the rename. (We are deciding whether this is a good UX or if we'd like to change it).

# Problem

The bug was that we required two enters even if the suggestions were hidden. i.e. user opted out from automatic rename suggestions, and we still required the first enter to "confirm"

_in the gif, I'm hitting enter twice. first enter selects the content of the text box_
![smart rename double enter bug](https://github.com/dotnet/roslyn/assets/1673956/31971daf-c51f-40f4-a0aa-413b28a632f4)

# Solution

When suggestions are not visible, don't require second enter
_in the gif, I'm hitting enter just once_
![smart rename double enter fixed](https://github.com/dotnet/roslyn/assets/1673956/02602662-29f3-4daa-9565-c809f4b58821)

# Notes on commit 1
Currently, we keep two enter behavior when suggestions are visible

_in the gif, I'm hitting enter twice. first enter selects the content of the text box_
![smart rename double enter expected](https://github.com/dotnet/roslyn/assets/1673956/46dab102-abcd-44c1-ab93-821e4cb09b4e)

# Notes on commit 2
I really don't like the double enter behavior, and the fact that the rename text box content gets selected when suggestions arrive. I made changes in commit 2 to address these. With commit 2, the only time user hits enter twice is when the _dropdown_ is visible (Smart Rename is ON, Automatically getting suggestions is OFF)

_in the gif, I'm hitting enter once. when suggestions arrive, there is no select-all that'd cause me to overwrite what I typed so far_
![smart rename selection and enter fixed](https://github.com/dotnet/roslyn/assets/1673956/6e4a60ae-615a-4459-be4b-bf0e0a63ab66)

_in the gif, I'm hitting enter twice because dropdown is used (Automatically getting suggestions is OFF). But notice there is no select-all_
![smart rename dropdown still needs double enter but selection fixed](https://github.com/dotnet/roslyn/assets/1673956/a310dd8c-6b7c-4ff3-b566-76ab5b4bba66)


