### PR TITLE
Restore parallel processing options for Find-References.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -23,8 +23,6 @@ using Reference = (SymbolGroup group, ISymbol symbol, ReferenceLocation location
 
 internal partial class FindReferencesSearchEngine
 {
-    private static readonly ObjectPool<MetadataUnifyingSymbolHashSet> s_metadataUnifyingSymbolHashSetPool = new(() => []);
-
     private readonly Solution _solution;
     private readonly IImmutableSet<Document>? _documents;
     private readonly ImmutableArray<IReferenceFinder> _finders;
@@ -32,11 +30,6 @@ internal partial class FindReferencesSearchEngine
     private readonly IStreamingFindReferencesProgress _progress;
     private readonly FindReferencesSearchOptions _options;
 
-    /// <summary>
-    /// Scheduler to run our tasks on.  If we're in <see cref="FindReferencesSearchOptions.Explicit"/> mode, we'll
-    /// run all our tasks concurrently.  Otherwise, we will run them serially using <see cref="s_exclusiveScheduler"/>
-    /// </summary>
-    private readonly TaskScheduler _scheduler;
     private static readonly TaskScheduler s_exclusiveScheduler = new ConcurrentExclusiveSchedulerPair().ExclusiveScheduler;
 
     /// <summary>
@@ -60,13 +53,22 @@ internal partial class FindReferencesSearchEngine
         _options = options;
 
         _progressTracker = progress.ProgressTracker;
-
-        // If we're an explicit invocation, just defer to the threadpool to execute all our work in parallel to get
-        // things done as quickly as possible.  If we're running implicitly, then use a
-        // ConcurrentExclusiveSchedulerPair's exclusive scheduler as that's the most built-in way in the TPL to get
-        // will run things serially.
-        _scheduler = _options.Explicit ? TaskScheduler.Default : s_exclusiveScheduler;
     }
+
+    /// <summary>
+    /// Options to control the parallelism of the search.   If we're in <see
+    /// cref="FindReferencesSearchOptions.Explicit"/> mode, we'll run all our tasks concurrently.  Otherwise, we will
+    /// run them serially using <see cref="s_exclusiveScheduler"/>
+    /// </summary>
+    private ParallelOptions GetParallelOptions(CancellationToken cancellationToken)
+        => new()
+        {
+            CancellationToken = cancellationToken,
+            // If we're an explicit invocation, just defer to the threadpool to execute all our work in parallel to get
+            // things done as quickly as possible.  If we're running implicitly, then use a exclusive scheduler as
+            // that's the most built-in way in the TPL to get will run things serially.
+            TaskScheduler = _options.Explicit ? null : s_exclusiveScheduler,
+        };
 
     public Task FindReferencesAsync(ISymbol symbol, CancellationToken cancellationToken)
         => FindReferencesAsync([symbol], cancellationToken);
@@ -112,17 +114,12 @@ internal partial class FindReferencesSearchEngine
         // set of documents to search, we only bother with those.
         var projectsToSearch = await GetProjectsToSearchAsync(allSymbols, cancellationToken).ConfigureAwait(false);
 
-        // We need to process projects in order when updating our symbol set.  Say we have three projects (A, B
-        // and C), we cannot necessarily find inherited symbols in C until we have searched B.  Importantly,
-        // while we're processing each project linearly to update the symbol set we're searching for, we still
-        // then process the projects in parallel once we know the set of symbols we're searching for in that
-        // project.
         await _progressTracker.AddItemsAsync(projectsToSearch.Length, cancellationToken).ConfigureAwait(false);
 
         // Pull off and start searching each project as soon as we can once we've done the inheritance cascade into it.
         await RoslynParallel.ForEachAsync(
             GetProjectsAndSymbolsToSearchAsync(symbolSet, projectsToSearch, cancellationToken),
-            cancellationToken,
+            GetParallelOptions(cancellationToken),
             async (tuple, cancellationToken) => await ProcessProjectAsync(
                 tuple.project, tuple.allSymbols, onReferenceFound, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
     }
@@ -132,6 +129,11 @@ internal partial class FindReferencesSearchEngine
         ImmutableArray<Project> projectsToSearch,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // We need to process projects in order when updating our symbol set.  Say we have three projects (A, B
+        // and C), we cannot necessarily find inherited symbols in C until we have searched B.  Importantly,
+        // while we're processing each project linearly to update the symbol set we're searching for, we still
+        // then process the projects in parallel once we know the set of symbols we're searching for in that
+        // project.
         var dependencyGraph = _solution.GetProjectDependencyGraph();
         foreach (var projectId in dependencyGraph.GetTopologicallySortedProjects(cancellationToken))
         {
@@ -152,9 +154,6 @@ internal partial class FindReferencesSearchEngine
             yield return (currentProject, allSymbols);
         }
     }
-
-    public Task CreateWorkAsync(Func<Task> createWorkAsync, CancellationToken cancellationToken)
-        => Task.Factory.StartNew(createWorkAsync, cancellationToken, TaskCreationOptions.None, _scheduler).Unwrap();
 
     /// <summary>
     /// Notify the caller of the engine about the definitions we've found that we're looking for.  We'll only notify
@@ -231,10 +230,7 @@ internal partial class FindReferencesSearchEngine
                         _options, cancellationToken).ConfigureAwait(false);
 
                     foreach (var document in foundDocuments)
-                    {
-                        var docSymbols = GetSymbolSet(documentToSymbols, document);
-                        docSymbols.Add(symbol);
-                    }
+                        GetSymbolSet(documentToSymbols, document).Add(symbol);
 
                     foundDocuments.Clear();
                 }
@@ -242,17 +238,14 @@ internal partial class FindReferencesSearchEngine
 
             await RoslynParallel.ForEachAsync(
                 documentToSymbols,
-                cancellationToken,
+                GetParallelOptions(cancellationToken),
                 (kvp, cancellationToken) =>
                     ProcessDocumentAsync(kvp.Key, kvp.Value, symbolToGlobalAliases, onReferenceFound, cancellationToken)).ConfigureAwait(false);
         }
         finally
         {
             foreach (var (_, symbols) in documentToSymbols)
-            {
-                symbols.Clear();
-                s_metadataUnifyingSymbolHashSetPool.Free(symbols);
-            }
+                MetadataUnifyingSymbolHashSet.ClearAndFree(symbols);
 
             FreeGlobalAliases(symbolToGlobalAliases);
 
@@ -260,7 +253,7 @@ internal partial class FindReferencesSearchEngine
         }
 
         static MetadataUnifyingSymbolHashSet GetSymbolSet<T>(PooledDictionary<T, MetadataUnifyingSymbolHashSet> dictionary, T key) where T : notnull
-            => dictionary.GetOrAdd(key, static _ => s_metadataUnifyingSymbolHashSetPool.Allocate());
+            => dictionary.GetOrAdd(key, static _ => MetadataUnifyingSymbolHashSet.AllocateFromPool());
     }
 
     private static PooledHashSet<U>? TryGet<T, U>(Dictionary<T, PooledHashSet<U>> dictionary, T key) where T : notnull
@@ -296,13 +289,13 @@ internal partial class FindReferencesSearchEngine
 
         await RoslynParallel.ForEachAsync(
             symbols,
-            cancellationToken,
+            GetParallelOptions(cancellationToken),
             async (symbol, cancellationToken) =>
             {
                 // symbolToGlobalAliases is safe to read in parallel.  It is created fully before this point and is no
                 // longer mutated.
-                var globalAliases = TryGet(symbolToGlobalAliases, symbol);
-                var state = new FindReferencesDocumentState(cache, globalAliases);
+                var state = new FindReferencesDocumentState(
+                    cache, TryGet(symbolToGlobalAliases, symbol));
 
                 await ProcessDocumentAsync(symbol, state, onReferenceFound).ConfigureAwait(false);
             }).ConfigureAwait(false);
@@ -349,10 +342,7 @@ internal partial class FindReferencesSearchEngine
                 var aliases = await finder.DetermineGlobalAliasesAsync(
                     symbol, project, cancellationToken).ConfigureAwait(false);
                 if (aliases.Length > 0)
-                {
-                    var globalAliases = GetGlobalAliasesSet(symbolToGlobalAliases, symbol);
-                    globalAliases.AddRange(aliases);
-                }
+                    GetGlobalAliasesSet(symbolToGlobalAliases, symbol).AddRange(aliases);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -67,7 +67,7 @@ internal partial class FindReferencesSearchEngine
             // If we're an explicit invocation, just defer to the threadpool to execute all our work in parallel to get
             // things done as quickly as possible.  If we're running implicitly, then use a exclusive scheduler as
             // that's the most built-in way in the TPL to get will run things serially.
-            TaskScheduler = _options.Explicit ? null : s_exclusiveScheduler,
+            TaskScheduler = _options.Explicit ? TaskScheduler.Default : s_exclusiveScheduler,
         };
 
     public Task FindReferencesAsync(ISymbol symbol, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -260,15 +260,7 @@ internal partial class FindReferencesSearchEngine
         }
 
         static MetadataUnifyingSymbolHashSet GetSymbolSet<T>(PooledDictionary<T, MetadataUnifyingSymbolHashSet> dictionary, T key) where T : notnull
-        {
-            if (!dictionary.TryGetValue(key, out var set))
-            {
-                set = s_metadataUnifyingSymbolHashSetPool.Allocate();
-                dictionary.Add(key, set);
-            }
-
-            return set;
-        }
+            => dictionary.GetOrAdd(key, static _ => s_metadataUnifyingSymbolHashSetPool.Allocate());
     }
 
     private static PooledHashSet<U>? TryGet<T, U>(Dictionary<T, PooledHashSet<U>> dictionary, T key) where T : notnull
@@ -366,15 +358,7 @@ internal partial class FindReferencesSearchEngine
     }
 
     private static PooledHashSet<string> GetGlobalAliasesSet<T>(PooledDictionary<T, PooledHashSet<string>> dictionary, T key) where T : notnull
-    {
-        if (!dictionary.TryGetValue(key, out var set))
-        {
-            set = PooledHashSet<string>.GetInstance();
-            dictionary.Add(key, set);
-        }
-
-        return set;
-    }
+        => dictionary.GetOrAdd(key, static _ => PooledHashSet<string>.GetInstance());
 
     private static void FreeGlobalAliases(PooledDictionary<ISymbol, PooledHashSet<string>> symbolToGlobalAliases)
     {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
@@ -91,8 +91,8 @@ internal partial class FindReferencesSearchEngine
 
             foreach (var symbol in symbols)
             {
-                var globalAliases = TryGet(symbolToGlobalAliases, symbol);
-                var state = new FindReferencesDocumentState(cache, globalAliases);
+                var state = new FindReferencesDocumentState(
+                    cache, TryGet(symbolToGlobalAliases, symbol));
 
                 await PerformSearchInDocumentWorkerAsync(symbol, state).ConfigureAwait(false);
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/MetadataUnifyingSymbolHashSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/MetadataUnifyingSymbolHashSet.cs
@@ -3,12 +3,24 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FindSymbols;
 
 internal sealed class MetadataUnifyingSymbolHashSet : HashSet<ISymbol>
 {
+    private static readonly ObjectPool<MetadataUnifyingSymbolHashSet> s_metadataUnifyingSymbolHashSetPool = new(() => []);
+
     public MetadataUnifyingSymbolHashSet() : base(MetadataUnifyingEquivalenceComparer.Instance)
     {
+    }
+
+    public static MetadataUnifyingSymbolHashSet AllocateFromPool()
+        => s_metadataUnifyingSymbolHashSetPool.Allocate();
+
+    public static void ClearAndFree(MetadataUnifyingSymbolHashSet set)
+    {
+        set.Clear();
+        s_metadataUnifyingSymbolHashSetPool.Free(set);
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/RoslynParallel.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/RoslynParallel.cs
@@ -19,8 +19,11 @@ internal static class RoslynParallel
         CancellationToken cancellationToken,
         Func<TSource, CancellationToken, ValueTask> body)
     {
-        return ForEachAsync(source, new ParallelOptions() { CancellationToken = cancellationToken }, body);
+        return ForEachAsync(source, GetParallelOptions(cancellationToken), body);
     }
+
+    private static ParallelOptions GetParallelOptions(CancellationToken cancellationToken)
+        => new() { TaskScheduler = TaskScheduler.Default, CancellationToken = cancellationToken };
 
     public static async Task ForEachAsync<TSource>(
         IEnumerable<TSource> source,
@@ -53,7 +56,7 @@ internal static class RoslynParallel
         CancellationToken cancellationToken,
         Func<TSource, CancellationToken, ValueTask> body)
     {
-        return ForEachAsync(source, new ParallelOptions() { CancellationToken = cancellationToken }, body);
+        return ForEachAsync(source, GetParallelOptions(cancellationToken), body);
     }
 
     public static async Task ForEachAsync<TSource>(

--- a/src/Workspaces/Core/Portable/Shared/Utilities/RoslynParallel.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/RoslynParallel.cs
@@ -10,59 +10,78 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities;
 
+#pragma warning disable CA1068 // CancellationToken parameters must come last
+
 internal static class RoslynParallel
 {
-#pragma warning disable CA1068 // CancellationToken parameters must come last
-    public static async Task ForEachAsync<TSource>(
-#pragma warning restore CA1068 // CancellationToken parameters must come last
+    public static Task ForEachAsync<TSource>(
         IEnumerable<TSource> source,
         CancellationToken cancellationToken,
         Func<TSource, CancellationToken, ValueTask> body)
     {
+        return ForEachAsync(source, new ParallelOptions() { CancellationToken = cancellationToken }, body);
+    }
+
+    public static async Task ForEachAsync<TSource>(
+        IEnumerable<TSource> source,
+        ParallelOptions parallelOptions,
+        Func<TSource, CancellationToken, ValueTask> body)
+    {
+        var cancellationToken = parallelOptions.CancellationToken;
         if (cancellationToken.IsCancellationRequested)
             return;
 
 #if NET
-        await Parallel.ForEachAsync(source, cancellationToken, body).ConfigureAwait(false);
+        await Parallel.ForEachAsync(source, parallelOptions, body).ConfigureAwait(false);
 #else
         using var _ = ArrayBuilder<Task>.GetInstance(out var tasks);
 
         foreach (var item in source)
         {
-            tasks.Add(Task.Run(async () =>
-            {
-                await body(item, cancellationToken).ConfigureAwait(false);
-            }, cancellationToken));
+            tasks.Add(CreateWorkAsync(
+                parallelOptions.TaskScheduler,
+                async () => await body(item, cancellationToken).ConfigureAwait(false),
+                cancellationToken));
         }
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 #endif
     }
 
-#pragma warning disable CA1068 // CancellationToken parameters must come last
-    public static async Task ForEachAsync<TSource>(
-#pragma warning restore CA1068 // CancellationToken parameters must come last
+    public static Task ForEachAsync<TSource>(
         IAsyncEnumerable<TSource> source,
         CancellationToken cancellationToken,
         Func<TSource, CancellationToken, ValueTask> body)
     {
+        return ForEachAsync(source, new ParallelOptions() { CancellationToken = cancellationToken }, body);
+    }
+
+    public static async Task ForEachAsync<TSource>(
+        IAsyncEnumerable<TSource> source,
+        ParallelOptions parallelOptions,
+        Func<TSource, CancellationToken, ValueTask> body)
+    {
+        var cancellationToken = parallelOptions.CancellationToken;
         if (cancellationToken.IsCancellationRequested)
             return;
 
 #if NET
-        await Parallel.ForEachAsync(source, cancellationToken, body).ConfigureAwait(false);
+        await Parallel.ForEachAsync(source, parallelOptions, body).ConfigureAwait(false);
 #else
         using var _ = ArrayBuilder<Task>.GetInstance(out var tasks);
 
         await foreach (var item in source)
         {
-            tasks.Add(Task.Run(async () =>
-            {
-                await body(item, cancellationToken).ConfigureAwait(false);
-            }, cancellationToken));
+            tasks.Add(CreateWorkAsync(
+                parallelOptions.TaskScheduler,
+                async () => await body(item, cancellationToken).ConfigureAwait(false),
+                cancellationToken));
         }
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 #endif
     }
+
+    public static Task CreateWorkAsync(TaskScheduler scheduler, Func<Task> createWorkAsync, CancellationToken cancellationToken)
+        => scheduler is null ? createWorkAsync() : Task.Factory.StartNew(createWorkAsync, cancellationToken, TaskCreationOptions.None, scheduler).Unwrap();
 }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/RoslynParallel.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/RoslynParallel.cs
@@ -83,5 +83,5 @@ internal static class RoslynParallel
     }
 
     public static Task CreateWorkAsync(TaskScheduler scheduler, Func<Task> createWorkAsync, CancellationToken cancellationToken)
-        => scheduler is null ? createWorkAsync() : Task.Factory.StartNew(createWorkAsync, cancellationToken, TaskCreationOptions.None, scheduler).Unwrap();
+        => Task.Factory.StartNew(createWorkAsync, cancellationToken, TaskCreationOptions.None, scheduler).Unwrap();
 }


### PR DESCRIPTION
Dropped this accidentally in the recent refactorings.