### PR TITLE
Avoid setting `hasAnyCodeStyleOption` for analyzers with no `CodeStyleOption2<T>`

### DIFF
--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
@@ -86,7 +86,7 @@ internal abstract partial class AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
         foreach (var (descriptor, option) in supportedDiagnosticsWithOptions)
         {
-            Debug.Assert(option != null == descriptor.CustomTags.Contains(WellKnownDiagnosticTags.CustomSeverityConfigurable));
+            Debug.Assert(option is { Definition.DefaultValue: ICodeStyleOption } == descriptor.CustomTags.Contains(WellKnownDiagnosticTags.CustomSeverityConfigurable));
             AddDiagnosticIdToOptionMapping(descriptor.Id, option);
         }
     }

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -21,7 +21,7 @@ internal abstract class AbstractFileHeaderDiagnosticAnalyzer : AbstractBuiltInCo
     private static readonly DiagnosticDescriptor s_missingHeaderDescriptor = CreateDescriptorForFileHeader(s_missingHeaderTitle, s_missingHeaderMessage);
 
     private static DiagnosticDescriptor CreateDescriptorForFileHeader(LocalizableString title, LocalizableString message)
-        => CreateDescriptorWithId(IDEDiagnosticIds.FileHeaderMismatch, EnforceOnBuildValues.FileHeaderMismatch, hasAnyCodeStyleOption: true, title, message);
+        => CreateDescriptorWithId(IDEDiagnosticIds.FileHeaderMismatch, EnforceOnBuildValues.FileHeaderMismatch, hasAnyCodeStyleOption: false, title, message);
 
     protected AbstractFileHeaderDiagnosticAnalyzer()
         : base(ImmutableDictionary<DiagnosticDescriptor, IOption2>.Empty

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -28,7 +28,7 @@ internal abstract class AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer<TSynt
     // ruleset editor or solution explorer. Setting messageFormat to empty string ensures that we won't display
     // this diagnostic in the preview pane header.
     private static readonly DiagnosticDescriptor s_fixableIdDescriptor = CreateDescriptorWithId(
-        RemoveUnnecessaryImportsConstants.DiagnosticFixableId, EnforceOnBuild.Never, hasAnyCodeStyleOption: true, "", "", isConfigurable: false);
+        RemoveUnnecessaryImportsConstants.DiagnosticFixableId, EnforceOnBuild.Never, hasAnyCodeStyleOption: false, "", "", isConfigurable: false);
 
 #pragma warning disable RS0030 // Do not used banned APIs - Special diagnostic with 'Warning' default severity.
     private static readonly DiagnosticDescriptor s_enableGenerateDocumentationFileIdDescriptor = new(


### PR DESCRIPTION
Fixes #72162
Fixes #72876