### PR TITLE
Nullable annotate InMethodyBinder

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -181,6 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (usage == NodeUsage.MethodBody)
                     {
                         method = method ?? GetMethodSymbol(methodDecl, resultBinder);
+                        Debug.Assert(method is not null);
                         resultBinder = new InMethodBinder(method, resultBinder);
                     }
 
@@ -247,6 +248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultBinder = VisitCore(parent.Parent);
 
                     SourceMemberMethodSymbol method = GetMethodSymbol(parent, resultBinder);
+                    Debug.Assert(method is not null);
                     resultBinder = new InMethodBinder(method, resultBinder);
 
                     resultBinder = resultBinder.WithUnsafeRegionIfNecessary(parent.Modifiers);
@@ -490,8 +492,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+#nullable enable
             // Get the correct methods symbol within container that corresponds to the given method syntax.
-            private SourceMemberMethodSymbol GetMethodSymbol(BaseMethodDeclarationSyntax baseMethodDeclarationSyntax, Binder outerBinder)
+            private SourceMemberMethodSymbol? GetMethodSymbol(BaseMethodDeclarationSyntax baseMethodDeclarationSyntax, Binder outerBinder)
             {
                 if (baseMethodDeclarationSyntax == _memberDeclarationOpt)
                 {
@@ -507,6 +510,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 string methodName = GetMethodName(baseMethodDeclarationSyntax, outerBinder);
                 return (SourceMemberMethodSymbol)GetMemberSymbol(methodName, baseMethodDeclarationSyntax.FullSpan, container, SymbolKind.Method);
             }
+
+#nullable disable
 
             private SourcePropertySymbol GetPropertySymbol(BasePropertyDeclarationSyntax basePropertyDeclarationSyntax, Binder outerBinder)
             {

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -21,9 +19,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal sealed class InMethodBinder : LocalScopeBinder
     {
-        private MultiDictionary<string, ParameterSymbol> _lazyParameterMap;
+        private MultiDictionary<string, ParameterSymbol>? _lazyParameterMap;
         private readonly MethodSymbol _methodSymbol;
-        private SmallDictionary<string, Symbol> _lazyDefinitionMap;
+        private SmallDictionary<string, Symbol>? _lazyDefinitionMap;
 
 #if DEBUG
         /// <summary>
@@ -34,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// MethodCompiler.BindMethodBody adds keys with flag == 1 before binding a method body.
         /// Binder.BindIdentifier adds or updates keys with flag == 2.
         /// </summary>
-        public ConcurrentDictionary<IdentifierNameSyntax, int> IdentifierMap;
+        public ConcurrentDictionary<IdentifierNameSyntax, int>? IdentifierMap;
 #endif
 
         public InMethodBinder(MethodSymbol owner, Binder enclosing)
@@ -56,12 +54,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override SourceLocalSymbol LookupLocal(SyntaxToken nameToken)
+        protected override SourceLocalSymbol? LookupLocal(SyntaxToken nameToken)
         {
             return null;
         }
 
-        protected override LocalFunctionSymbol LookupLocalFunction(SyntaxToken nameToken)
+        protected override LocalFunctionSymbol? LookupLocalFunction(SyntaxToken nameToken)
         {
             return null;
         }
@@ -102,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal override GeneratedLabelSymbol BreakLabel
+        internal override GeneratedLabelSymbol? BreakLabel
         {
             get
             {
@@ -110,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal override GeneratedLabelSymbol ContinueLabel
+        internal override GeneratedLabelSymbol? ContinueLabel
         {
             get
             {
@@ -143,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal static TypeWithAnnotations GetIteratorElementTypeFromReturnType(CSharpCompilation compilation,
-            RefKind refKind, TypeSymbol returnType, Location errorLocation, BindingDiagnosticBag diagnostics)
+            RefKind refKind, TypeSymbol returnType, Location? errorLocation, BindingDiagnosticBag? diagnostics)
         {
             if (refKind == RefKind.None && returnType.Kind == SymbolKind.NamedType)
             {
@@ -239,7 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static bool ReportConflictWithParameter(Symbol parameter, Symbol newSymbol, string name, Location newLocation, BindingDiagnosticBag diagnostics)
+        private static bool ReportConflictWithParameter(Symbol parameter, Symbol? newSymbol, string name, Location newLocation, BindingDiagnosticBag diagnostics)
         {
 #if DEBUG
             var locations = parameter.Locations;
@@ -251,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SymbolKind parameterKind = parameter.Kind;
 
             // Quirk of the way we represent lambda parameters.                
-            SymbolKind newSymbolKind = (object)newSymbol == null ? SymbolKind.Parameter : newSymbol.Kind;
+            SymbolKind newSymbolKind = newSymbol is null ? SymbolKind.Parameter : newSymbol.Kind;
 
             if (newSymbolKind == SymbolKind.ErrorType)
             {
@@ -269,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return true;
 
                     case SymbolKind.Method:
-                        if (((MethodSymbol)newSymbol).MethodKind == MethodKind.LocalFunction)
+                        if (((MethodSymbol)newSymbol!).MethodKind == MethodKind.LocalFunction)
                         {
                             goto case SymbolKind.Parameter;
                         }
@@ -297,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return true;
 
                     case SymbolKind.Method:
-                        if (((MethodSymbol)newSymbol).MethodKind == MethodKind.LocalFunction)
+                        if (((MethodSymbol)newSymbol!).MethodKind == MethodKind.LocalFunction)
                         {
                             goto case SymbolKind.Parameter;
                         }
@@ -340,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _lazyDefinitionMap = map;
             }
 
-            Symbol existingDeclaration;
+            Symbol? existingDeclaration;
             if (map.TryGetValue(name, out existingDeclaration))
             {
                 return ReportConflictWithParameter(existingDeclaration, symbol, name, location, diagnostics);


### PR DESCRIPTION
This is in response to #73022 where there is a null reference exception during binder. The cause is, very likely, a `null` symbol being passed into the binder. It's not possible to fully root cause this at the moment but adding asserts and NRT annotations to help us track it down in the future.