### PR TITLE
Fix sorting of extensions from more specific to less

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// A specific location for binding.
     /// </summary>
     [Flags]
-    internal enum BinderFlags : uint
+    internal enum BinderFlags : ulong
     {
         None, // No specific location
         SuppressConstraintChecks = 1 << 0,
@@ -116,7 +116,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Indicates the binder is used during collection expression conversion
         /// to verify applicable methods are available.
         /// </summary>
-        CollectionExpressionConversionValidation = 1u << 31,
+        CollectionExpressionConversionValidation = 1ul << 31,
+
+        /// <summary>
+        /// PROTOTYPE(static) we currently disallow resolving extensions in using directives
+        /// </summary>
+        InUsingDirective = 1ul << 32,
 
         // Groups
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -11000,7 +11000,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var type = receiver.Type;
                         Debug.Assert(type is not null);
                         // Note: extension methods are not allowed to extend an extension type
-                        if (type.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
+                        if (type.GetExtendedTypeNoUseSiteDiagnostics(null) is { } extendedType)
                         {
                             type = extendedType;
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Flags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Flags.cs
@@ -109,5 +109,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? this
                 : new Binder(this, (this.Flags & ~removed) | added);
         }
+
+        /// <summary>
+        /// PROTOTYPE(static) we currently disallow resolving extensions in using directives
+        /// </summary>
+        internal bool InUsingDirective
+        {
+            get { return this.Flags.Includes(BinderFlags.InUsingDirective); }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -193,15 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 type = extendedType;
             }
 
-            GetCompatibleExtensions(this, type, compatibleExtensions, originalBinder, basesBeingResolved);
-
-            // Sort extensions from more specific to less specific
-            var tempUseSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(useSiteInfo);
-            compatibleExtensions.Sort((x, y) => isMoreSpecificExtension(x, y) ? -1 : 1); // Note: captures tempUseSiteInfo
-            if (tempUseSiteInfo.AccumulatesDiagnostics)
-            {
-                useSiteInfo.MergeAndClear(ref tempUseSiteInfo);
-            }
+            GetCompatibleExtensions(this, type, compatibleExtensions, originalBinder, basesBeingResolved, ref useSiteInfo);
 
             // PROTOTYPE test use-site diagnostics
             var tempResult = LookupResult.GetInstance();
@@ -218,31 +210,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             tempResult.Free();
             compatibleExtensions.Free();
-            return;
-
-            bool isMoreSpecificExtension(NamedTypeSymbol extension, NamedTypeSymbol other)
-            {
-                if (extension.ExtendedTypeNoUseSiteDiagnostics is not { } extendedType
-                    || other.ExtendedTypeNoUseSiteDiagnostics is not { } otherExtendedType)
-                {
-                    // We wouldn't have gathered these members if we didn't have an extended type for them.
-                    throw ExceptionUtilities.Unreachable();
-                }
-
-                if (extendedType.Equals(otherExtendedType, TypeCompareKind.AllIgnoreOptions))
-                {
-                    return false;
-                }
-
-                // PROTOTYPE(static) revise if we allow extension lookup on type parameters
-                Debug.Assert(!extendedType.IsTypeParameter());
-                Debug.Assert(!otherExtendedType.IsTypeParameter());
-                return DerivesOrImplements(baseTypeOrImplementedInterface: otherExtendedType, derivedType: extendedType, null, this.Compilation, ref tempUseSiteInfo);
-            }
         }
 
+        // Note: we return the compatible extensions in order:
+        // for any given pair, if one is more specific it will precede the other in the list
         private static void GetCompatibleExtensions(Binder binder, TypeSymbol type, ArrayBuilder<NamedTypeSymbol> compatibleExtensions,
-            Binder originalBinder, ConsList<TypeSymbol>? basesBeingResolved)
+            Binder originalBinder, ConsList<TypeSymbol>? basesBeingResolved, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (type.IsErrorType())
             {
@@ -252,47 +225,59 @@ namespace Microsoft.CodeAnalysis.CSharp
             var extensions = ArrayBuilder<NamedTypeSymbol>.GetInstance();
             binder.GetImplicitExtensionTypes(extensions, originalBinder);
 
-            foreach (var extension in extensions)
+#if !DEBUG
+            // In DEBUG mode, we prefer to exercise the code below even in the absence of extensions
+            if (extensions.Count == 0)
             {
-                if (basesBeingResolved?.Contains(extension) == true)
-                {
-                    continue;
-                }
+                return;
+            }
+#endif
 
-                addSubstitutedIfCompatible(extension, type, compatibleExtensions);
+            PooledHashSet<NamedTypeSymbol>? visited = null;
+            var baseType = type;
+            do
+            {
+                addCompatibleExtensions(binder, extensions, baseType, compatibleExtensions, basesBeingResolved);
+                baseType = baseType.GetNextBaseTypeNoUseSiteDiagnostics(basesBeingResolved, originalBinder.Compilation, ref visited);
+            }
+            while (baseType is not null);
+
+            if (type is NamedTypeSymbol namedType)
+            {
+                foreach (var implementedInterface in GetBaseInterfaces(namedType, basesBeingResolved, ref useSiteInfo))
+                {
+                    addCompatibleExtensions(binder, extensions, implementedInterface, compatibleExtensions, basesBeingResolved);
+                }
             }
 
+            visited?.Free();
             extensions.Free();
             return;
 
-            static void addSubstitutedIfCompatible(NamedTypeSymbol extension, TypeSymbol type, ArrayBuilder<NamedTypeSymbol> compatibleExtensions)
+            static void addCompatibleExtensions(Binder binder, ArrayBuilder<NamedTypeSymbol> extensions, TypeSymbol type,
+                ArrayBuilder<NamedTypeSymbol> compatibleExtensions, ConsList<TypeSymbol>? basesBeingResolved)
             {
                 Debug.Assert(!type.IsExtension);
-                if (extension.ExtendedTypeNoUseSiteDiagnostics is null)
+                foreach (var extension in extensions)
                 {
-                    return;
-                }
-
-                var baseType = type;
-                do
-                {
-                    if (TypeUnification.CanImplicitlyExtend(extension, baseType, out AbstractTypeParameterMap? map))
+                    Debug.Assert(extension.IsDefinition);
+                    if (basesBeingResolved?.ContainsReference(extension) == true || extension.ExtendedTypeNoUseSiteDiagnostics is null)
                     {
-                        var substitutedExtension = map is not null ? (NamedTypeSymbol)map.SubstituteType(extension).Type : extension;
-                        compatibleExtensions.Add(substitutedExtension);
-                        break;
+                        continue;
                     }
 
-                    baseType = baseType.BaseTypeNoUseSiteDiagnostics;
-                }
-                while (baseType is not null);
-
-                foreach (var implementedInterface in type.AllInterfacesNoUseSiteDiagnostics)
-                {
-                    if (TypeUnification.CanImplicitlyExtend(extension, implementedInterface, out AbstractTypeParameterMap? map))
+                    if (TypeUnification.CanImplicitlyExtend(extension, type, out AbstractTypeParameterMap? map))
                     {
                         var substitutedExtension = map is not null ? (NamedTypeSymbol)map.SubstituteType(extension).Type : extension;
-                        compatibleExtensions.Add(substitutedExtension);
+
+                        // PROTOTYPE(static) we should warn for nullability issues
+                        var constraintsOk = substitutedExtension.CheckConstraints(
+                              new ConstraintsHelper.CheckConstraintsArgs(binder.Compilation, binder.Conversions, includeNullability: false, Location.None, BindingDiagnosticBag.Discarded));
+
+                        if (constraintsOk)
+                        {
+                            compatibleExtensions.Add(substitutedExtension);
+                        }
                     }
                 }
             }
@@ -2389,9 +2374,10 @@ symIsHidden:;
             }
 
             var compatibleExtensions = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+            var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
             foreach (var scope in new ExtensionScopes(this))
             {
-                GetCompatibleExtensions(scope.Binder, type, compatibleExtensions, originalBinder, basesBeingResolved: null);
+                GetCompatibleExtensions(scope.Binder, type, compatibleExtensions, originalBinder, basesBeingResolved: null, ref discardedUseSiteInfo);
 
                 foreach (NamedTypeSymbol extension in compatibleExtensions)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var compatibleExtensions = ArrayBuilder<NamedTypeSymbol>.GetInstance();
 
-            if (type.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
+            if (type.GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved) is { } extendedType)
             {
                 type = extendedType;
             }
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var extension in extensions)
                 {
                     Debug.Assert(extension.IsDefinition);
-                    if (basesBeingResolved?.ContainsReference(extension) == true || extension.ExtendedTypeNoUseSiteDiagnostics is null)
+                    if (extension.GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved) is null)
                     {
                         continue;
                     }
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var extension = (NamedTypeSymbol)type;
                     this.LookupMembersInExtension(result, extension, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteInfo);
 
-                    if (extension.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
+                    if (extension.GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved) is { } extendedType)
                     {
                         // any viable non-methods [non-indexers] found here will hide viable methods [indexers] (with the same name) in any further base classes
                         // short circuit looking up in extended type if we already have a viable result and we won't be adding on more
@@ -1528,7 +1528,7 @@ symIsHidden:;
             {
                 var sym = hiddenSymbols[i];
 
-                if (sym.ContainingType.ExtendedTypeNoUseSiteDiagnostics is not { } symExtendedType)
+                if (sym.ContainingType.GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved) is not { } symExtendedType)
                 {
                     // We wouldn't have gathered these members if we didn't have an extended type for them.
                     throw ExceptionUtilities.Unreachable();
@@ -1539,7 +1539,7 @@ symIsHidden:;
                 {
                     var hidingSym = hidingSymbols[j];
 
-                    if (hidingSym.ContainingType.ExtendedTypeNoUseSiteDiagnostics is not { } hidingSymExtendedType)
+                    if (hidingSym.ContainingType.GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved) is not { } hidingSymExtendedType)
                     {
                         // We wouldn't have gathered these members if we didn't have an extended type for them.
                         throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -2192,7 +2192,7 @@ symIsHidden:;
             {
                 AddMemberLookupSymbolsInfoWithoutInheritance(result, type, options, originalBinder, accessThroughType: type);
 
-                if (type.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
+                if (type.GetExtendedTypeNoUseSiteDiagnostics(null) is { } extendedType)
                 {
                     AddMemberLookupSymbolsInfoInType(result, extendedType, options, originalBinder, accessThroughType: type);
                 }
@@ -2368,7 +2368,7 @@ symIsHidden:;
         internal void AddImplicitExtensionMemberLookupSymbolsInfoForType(LookupSymbolsInfo result, TypeSymbol type, LookupOptions options, Binder originalBinder)
         {
             var accessThroughType = type;
-            if (type.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
+            if (type.GetExtendedTypeNoUseSiteDiagnostics(null) is { } extendedType)
             {
                 type = extendedType;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -875,7 +875,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.LookupSymbolsSimpleName(result, qualifierOpt, identifierValueText, 0, basesBeingResolved, options, diagnose: true, useSiteInfo: ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
 
-            if (result.Kind != LookupResultKind.Viable && qualifierOpt is TypeSymbol typeSymbol)
+            // PROTOTYPE(static) we currently disallow resolving extensions in using directives
+            if (result.Kind != LookupResultKind.Viable && qualifierOpt is TypeSymbol typeSymbol && !InUsingDirective)
             {
                 Debug.Assert(result.Kind != LookupResultKind.Ambiguous);
                 this.LookupExtensionTypeMembersIfNeeded(result, typeSymbol, identifierValueText, arity: 0, basesBeingResolved, options, ref useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
@@ -23,14 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return this.Flags.Includes(BinderFlags.UnsafeRegion); }
         }
 
-        /// <summary>
-        /// PROTOTYPE(static) we currently disallow resolving extensions in using directives
-        /// </summary>
-        internal bool InUsingDirective
-        {
-            get { return this.Flags.Includes(BinderFlags.InUsingDirective); }
-        }
-
         /// <returns>True if a diagnostic was reported</returns>
         internal bool ReportUnsafeIfNotAllowed(SyntaxNode node, BindingDiagnosticBag diagnostics, TypeSymbol sizeOfTypeOpt = null)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
@@ -23,6 +23,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return this.Flags.Includes(BinderFlags.UnsafeRegion); }
         }
 
+        /// <summary>
+        /// PROTOTYPE(static) we currently disallow resolving extensions in using directives
+        /// </summary>
+        internal bool InUsingDirective
+        {
+            get { return this.Flags.Includes(BinderFlags.InUsingDirective); }
+        }
+
         /// <returns>True if a diagnostic was reported</returns>
         internal bool ReportUnsafeIfNotAllowed(SyntaxNode node, BindingDiagnosticBag diagnostics, TypeSymbol sizeOfTypeOpt = null)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1484,7 +1484,7 @@ outerDefault:
 
                 if (result.Result.IsValid || result.HasUseSiteDiagnosticToReport)
                 {
-                    if (result.Member.ContainingType.ExtendedTypeNoUseSiteDiagnostics is not { } extendedType)
+                    if (result.Member.ContainingType.GetExtendedTypeNoUseSiteDiagnostics(null) is not { } extendedType)
                     {
                         continue;
                     }
@@ -1548,7 +1548,7 @@ outerDefault:
                 }
                 else if (currentType.IsExtension)
                 {
-                    if (currentType.ExtendedTypeNoUseSiteDiagnostics is { } extendedType)
+                    if (currentType.GetExtendedTypeNoUseSiteDiagnostics(null) is { } extendedType)
                     {
                         if (extendedType.Equals(type, TypeCompareKind.ConsiderEverything))
                         {
@@ -1607,7 +1607,7 @@ outerDefault:
                     continue;
                 }
 
-                if (result.Member.ContainingType.ExtendedTypeNoUseSiteDiagnostics is not { } currentExtendedType)
+                if (result.Member.ContainingType.GetExtendedTypeNoUseSiteDiagnostics(null) is not { } currentExtendedType)
                 {
                     continue;
                 }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -655,7 +655,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!_globalHasErrors)
             {
                 var extensionMarker = new SynthesizedExtensionMarker(sourceExtension,
-                    sourceExtension.ExtendedTypeNoUseSiteDiagnostics,
+                    sourceExtension.GetExtendedTypeNoUseSiteDiagnostics(null),
                     _diagnostics);
 
 #if DEBUG

--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var syntax = usingDirective.NamespaceOrType;
-            var flags = BinderFlags.SuppressConstraintChecks | BinderFlags.SuppressObsoleteChecks;
+            var flags = BinderFlags.SuppressConstraintChecks | BinderFlags.SuppressObsoleteChecks | BinderFlags.InUsingDirective;
             if (usingDirective.UnsafeKeyword != default)
             {
                 this.CheckUnsafeModifier(DeclarationModifiers.Unsafe, usingDirective.UnsafeKeyword.GetLocation(), diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override bool IsExtension => false;
             internal sealed override bool IsExplicitExtension => false;
 
-            internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+            internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
             internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
                 => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override bool IsExtension => false;
             internal sealed override bool IsExplicitExtension => false;
 
-            internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+            internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
             internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
                 => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -487,7 +487,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal sealed override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -560,7 +560,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionTypeSymbol.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal override ObsoleteAttributeData ObsoleteAttributeData => throw ExceptionUtilities.Unreachable();
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -670,14 +670,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved)
         {
-            get
-            {
-                // Cycles are handled in `DecodeExtensionType` (where a bad extended type,
-                // such as one that is an extension type, would be replaced with an error type)
-                return GetDeclaredExtensionUnderlyingType();
-            }
+            // PROTOTYPE(static) consider handling basesBeingResolved through GetDeclaredExtensionUnderlyingType
+            // Cycles are handled in `DecodeExtensionType` (where a bad extended type,
+            // such as one that is an extension type, would be replaced with an error type)
+            return GetDeclaredExtensionUnderlyingType();
         }
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal sealed override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -405,20 +405,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         internal sealed override bool IsExtension => _underlyingType.IsExtension;
         internal sealed override bool IsExplicitExtension => _underlyingType.IsExplicitExtension;
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved)
         {
-            get
+            if (ReferenceEquals(_lazyExtendedType, ErrorTypeSymbol.UnknownResultType))
             {
-                if (ReferenceEquals(_lazyExtendedType, ErrorTypeSymbol.UnknownResultType))
-                {
-                    // Cycles are handled in `GetDeclaredExtensionUnderlyingType` (where a bad extended type,
-                    // such as one that is an extension type, would be replaced with an error type)
-                    TypeSymbol? extendedType = GetDeclaredExtensionUnderlyingType();
-                    Interlocked.CompareExchange(ref _lazyExtendedType, extendedType, ErrorTypeSymbol.UnknownResultType);
-                }
-
-                return _lazyExtendedType;
+                // PROTOTYPE(static) consider handling basesBeingResolved through GetDeclaredExtensionUnderlyingType
+                // Cycles are handled in `GetDeclaredExtensionUnderlyingType` (where a bad extended type,
+                // such as one that is an extension type, would be replaced with an error type)
+                TypeSymbol? extendedType = GetDeclaredExtensionUnderlyingType();
+                Interlocked.CompareExchange(ref _lazyExtendedType, extendedType, ErrorTypeSymbol.UnknownResultType);
             }
+
+            return _lazyExtendedType;
         }
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -180,7 +180,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #nullable enable
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override void CheckUnderlyingType(BindingDiagnosticBag diagnostics)
         {
-            var underlyingType = this.ExtendedTypeNoUseSiteDiagnostics;
+            var underlyingType = this.GetExtendedTypeNoUseSiteDiagnostics(null);
 
             if (underlyingType is null)
                 return;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -112,11 +112,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 var diagnostics = BindingDiagnosticBag.GetInstance();
                 TypeSymbol? acyclicBase = makeAcyclicUnderlyingType(basesBeingResolved, diagnostics);
-                if (basesBeingResolved is not null)
-                {
-                    return acyclicBase;
-                }
-
                 if (ReferenceEquals(Interlocked.CompareExchange(ref _lazyExtensionUnderlyingType, acyclicBase, ErrorTypeSymbol.UnknownResultType),
                         ErrorTypeSymbol.UnknownResultType))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1834,7 +1834,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var baseType = BaseTypeNoUseSiteDiagnostics;
             var interfaces = GetInterfacesToEmit();
-            var extendedType = ExtendedTypeNoUseSiteDiagnostics;
+            var extendedType = GetExtendedTypeNoUseSiteDiagnostics(null);
 
             if (compilation.ShouldEmitNativeIntegerAttributes())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.AliasesAndUsings.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.AliasesAndUsings.cs
@@ -732,7 +732,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 continue;
                             }
 
-                            var flags = BinderFlags.SuppressConstraintChecks;
+                            var flags = BinderFlags.SuppressConstraintChecks | BinderFlags.InUsingDirective;
                             if (usingDirective.UnsafeKeyword != default)
                             {
                                 var unsafeKeywordLocation = usingDirective.UnsafeKeyword.GetLocation();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -484,8 +484,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => _underlyingType.IsExtension;
         internal sealed override bool IsExplicitExtension => _underlyingType.IsExplicitExtension;
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
-            => _unbound ? null : Map.SubstituteType(OriginalDefinition.ExtendedTypeNoUseSiteDiagnostics).Type;
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved)
+        {
+            return _unbound ? null : Map.SubstituteType(OriginalDefinition.ExtendedTypeNoUseSiteDiagnostics).Type;
+        }
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw new InvalidOperationException("PROTOTYPE"); // PROTOTYPE

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -486,7 +486,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved)
         {
-            return _unbound ? null : Map.SubstituteType(OriginalDefinition.ExtendedTypeNoUseSiteDiagnostics).Type;
+            return _unbound ? null : Map.SubstituteType(OriginalDefinition.GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved)).Type;
         }
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListEnumeratorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListEnumeratorTypeSymbol.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         public override ImmutableArray<Symbol> GetMembers() => _members;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
@@ -945,7 +945,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -721,7 +721,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal sealed override bool HasInlineArrayAttribute(out int length)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2491,7 +2491,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract bool IsExtension { get; }
         internal abstract bool IsExplicitExtension { get; }
 
-        internal abstract TypeSymbol? ExtendedTypeNoUseSiteDiagnostics { get; }
+        internal TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
+            => GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved: null);
+
+        internal abstract TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved);
 
         // PROTOTYPE restore base extension logic
         internal ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics => [];

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2491,9 +2491,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract bool IsExtension { get; }
         internal abstract bool IsExplicitExtension { get; }
 
-        internal TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
-            => GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved: null);
-
         internal abstract TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved);
 
         // PROTOTYPE restore base extension logic

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            var extensionUnderlyingType = extension.ExtendedTypeNoUseSiteDiagnostics;
+            var extensionUnderlyingType = extension.GetExtendedTypeNoUseSiteDiagnostics(null);
             Debug.Assert(extensionUnderlyingType is not null);
             if (SourceExtensionTypeSymbol.CheckUnderspecifiedGenericExtension(extensionUnderlyingType, extension.TypeParameters,
                     BindingDiagnosticBag.Discarded, Location.None, extension))

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -39319,17 +39319,16 @@ implicit extension E for C<MyInterface>
     public interface Interface { }
 }
 """;
-        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70, options: TestOptions.DebugExe);
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
         comp.VerifyEmitDiagnostics(
             // (1,36): error CS0426: The type name 'Interface' does not exist in the type 'C<E.Interface>'
             // using MyInterface = C<E.Interface>.Interface;
             Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Interface").WithArguments("Interface", "C<E.Interface>").WithLocation(1, 36));
-        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
-        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "MyNested.M");
-        Assert.Equal("void E.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        var qualifiedName = GetSyntax<QualifiedNameSyntax>(tree, "C<E.Interface>.Interface");
+        Assert.Null(model.GetSymbolInfo(qualifiedName).Symbol);
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -48,7 +48,7 @@ public class ExtensionTypeTests : CompilingTestBase
         Assert.True(type is T, $"Found type '{type.GetType()}'");
         Assert.False(type.IsExtension);
         Assert.False(type.IsExplicitExtension);
-        Assert.Null(type.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(type.GetExtendedTypeNoUseSiteDiagnostics(null));
         Assert.Empty(type.BaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(type.AllBaseExtensionsNoUseSiteDiagnostics);
     }
@@ -87,7 +87,7 @@ public class ExtensionTypeTests : CompilingTestBase
         Assert.False(namedType.IsInterfaceType());
         Assert.False(namedType.IsAbstract);
 
-        if (namedType.ExtendedTypeNoUseSiteDiagnostics is { } underlyingType)
+        if (namedType.GetExtendedTypeNoUseSiteDiagnostics(null) is { } underlyingType)
         {
             // PROTOTYPE consider whether we want to expose invalid underlying types
             // in context of public APIs
@@ -209,7 +209,7 @@ explicit extension R2 for UnderlyingClass : R { }
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: isExplicit);
             }
 
-            Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
 
@@ -334,7 +334,7 @@ class C<T>
             var c = module.GlobalNamespace.GetTypeMember("C");
             var r = c.GetTypeMember("R");
             Assert.Equal(1, r.Arity);
-            var underlyingType = (NamedTypeSymbol)r.ExtendedTypeNoUseSiteDiagnostics;
+            var underlyingType = (NamedTypeSymbol)r.GetExtendedTypeNoUseSiteDiagnostics(null);
             Assert.Equal("UnderlyingClass<T, U>", underlyingType.ToTestDisplayString());
             Assert.Equal(2, underlyingType.TypeArguments().Length);
             Assert.Same(c.TypeArguments().Single(), underlyingType.TypeArguments()[0]);
@@ -831,7 +831,7 @@ static explicit extension R for UnderlyingClass
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         AssertEx.Equal(new[]
@@ -1998,7 +1998,7 @@ explicit extension R for UnderlyingStruct
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: true);
             }
 
-            Assert.Equal("UnderlyingStruct", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("UnderlyingStruct", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
@@ -2040,7 +2040,7 @@ interface I { }
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: isExplicit);
             }
 
-            Assert.Equal("T", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("T", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
@@ -2082,7 +2082,7 @@ enum E { }
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: isExplicit);
             }
 
-            Assert.Equal("E", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("E", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
@@ -2110,7 +2110,7 @@ explicit extension R for object
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("System.Object", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("System.Object", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(r.GetMembers());
@@ -2150,7 +2150,7 @@ explicit extension R<U> for C<U>
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: true);
             }
 
-            Assert.Equal("C<U>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<U>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
@@ -2191,7 +2191,7 @@ explicit extension R for (int, int)
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: true);
             }
 
-            Assert.Equal("(System.Int32, System.Int32)", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
@@ -2232,7 +2232,7 @@ explicit extension R for int[]
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: true);
             }
 
-            Assert.Equal("System.Int32[]", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("System.Int32[]", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
@@ -2409,7 +2409,7 @@ static explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.True(r.IsStatic);
         comp.VerifyDiagnostics();
     }
@@ -2426,7 +2426,7 @@ static explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.True(r.IsStatic);
         comp.VerifyDiagnostics();
     }
@@ -2443,7 +2443,7 @@ explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.False(r.IsStatic);
         comp.VerifyDiagnostics(
             // (2,26): error CS9306: Instance extension 'R' cannot extend type 'UnderlyingClass' because it is static.
@@ -2493,7 +2493,7 @@ public static explicit extension R4 for C : R1 { }
             );
 
         var r1 = (PENamedTypeSymbol)comp.GlobalNamespace.GetTypeMember("R1");
-        var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("C", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
     }
@@ -2543,7 +2543,7 @@ public explicit extension E2 for C : E1 { }
         var e1 = (RetargetingNamedTypeSymbol)e2.BaseExtensionsNoUseSiteDiagnostics.Single();
         Assert.Equal("E1", e1.Name);
         AssertEx.Equal("error CS8090: There is an error in a referenced assembly 'first, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.",
-            ((ErrorTypeSymbol)e1.ExtendedTypeNoUseSiteDiagnostics).ErrorInfo.ToString());
+            ((ErrorTypeSymbol)e1.GetExtendedTypeNoUseSiteDiagnostics(null)).ErrorInfo.ToString());
     }
 
     [Theory, CombinatorialData]
@@ -2618,7 +2618,7 @@ public explicit extension E4 for E0 : E2 { }
         var e2 = (RetargetingNamedTypeSymbol)comp.GlobalNamespace.GetTypeMember("E2");
 
         AssertEx.Equal("error CS8090: There is an error in a referenced assembly 'first, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.",
-            ((ErrorTypeSymbol)e2.ExtendedTypeNoUseSiteDiagnostics).ErrorInfo.ToString());
+            ((ErrorTypeSymbol)e2.GetExtendedTypeNoUseSiteDiagnostics(null)).ErrorInfo.ToString());
 
         AssertEx.Equal("error CS8090: There is an error in a referenced assembly 'first, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.",
             ((ErrorTypeSymbol)e2.BaseExtensionsNoUseSiteDiagnostics.Single()).ErrorInfo.ToString());
@@ -2636,7 +2636,7 @@ explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.False(r.IsSealed);
         comp.VerifyDiagnostics();
     }
@@ -2654,7 +2654,7 @@ file explicit extension R for UnderlyingClass
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R@<tree 0>", r.ToTestDisplayString());
-        Assert.Equal("UnderlyingClass@<tree 0>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass@<tree 0>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -2673,7 +2673,7 @@ explicit extension R for UnderlyingClass
             Diagnostic(ErrorCode.ERR_FileTypeUnderlying, "R").WithArguments("UnderlyingClass", "R").WithLocation(2, 20)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass@<tree 0>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass@<tree 0>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -2696,7 +2696,7 @@ explicit extension R for Outer.UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
-        Assert.Equal("Outer@<tree 0>.UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("Outer@<tree 0>.UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -2718,7 +2718,7 @@ partial explicit extension R for Outer.UnderlyingClass { }
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
-        Assert.Equal("Outer@<tree 0>.UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("Outer@<tree 0>.UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -2754,10 +2754,10 @@ implicit extension R2 for UnderlyingClass2 { } // 5
             );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        Assert.Equal("UnderlyingClass1", r1.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass1", r1.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        Assert.Equal("UnderlyingClass1", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass1", r2.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3057,7 +3057,7 @@ explicit extension R for { }
             );
 
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
     }
 
     [Theory, CombinatorialData]
@@ -3092,7 +3092,7 @@ explicit extension R3 for System.IntPtr : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("nint", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("nint", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         }
@@ -3134,7 +3134,7 @@ explicit extension R3 for System.IntPtr : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("nint", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("nint", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         }
@@ -3178,7 +3178,7 @@ explicit extension R3 for C<System.IntPtr> : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("C<nint>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<nint>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         }
@@ -3220,7 +3220,7 @@ explicit extension R3 for C<object> : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("C<dynamic>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<dynamic>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         }
@@ -3277,7 +3277,7 @@ explicit extension R3 for C<object> : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("C<System.Object?>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
+            Assert.Equal("C<System.Object?>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString(includeNonNullable: true));
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         }
@@ -3334,7 +3334,7 @@ explicit extension R3 for C<object> : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("C<System.Object!>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
+            Assert.Equal("C<System.Object!>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString(includeNonNullable: true));
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         }
@@ -3394,7 +3394,7 @@ explicit extension R4 for (int a, int other) : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("(System.Int32 a, System.Int32 b)", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("(System.Int32 a, System.Int32 b)", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
         }
@@ -3419,7 +3419,7 @@ unsafe explicit extension R for int*
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(r.GetExtendedTypeNoUseSiteDiagnostics(null));
         Assert.Empty(r.GetMembers());
     }
 
@@ -3439,7 +3439,7 @@ explicit extension R for ref int
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("System.Int32", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("System.Int32", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3492,7 +3492,7 @@ implicit extension R2 for int* // 3, 4
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(r.GetExtendedTypeNoUseSiteDiagnostics(null));
     }
 
     [Fact]
@@ -3512,7 +3512,7 @@ unsafe explicit extension R for delegate*<void>
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(r.GetExtendedTypeNoUseSiteDiagnostics(null));
         Assert.Empty(r.GetMembers());
     }
 
@@ -3532,7 +3532,7 @@ explicit extension R for dynamic
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(r.GetExtendedTypeNoUseSiteDiagnostics(null));
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
     }
@@ -3609,7 +3609,7 @@ partial explicit extension R { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3625,7 +3625,7 @@ partial explicit extension R for UnderlyingClass { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3644,7 +3644,7 @@ partial explicit extension R for UnderlyingClass2 { }
             Diagnostic(ErrorCode.ERR_PartialMultipleUnderlyingTypes, "R").WithArguments("R").WithLocation(3, 28)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3665,7 +3665,7 @@ partial explicit extension R for UnderlyingClass3 { }
             Diagnostic(ErrorCode.ERR_PartialMultipleUnderlyingTypes, "R").WithArguments("R").WithLocation(4, 28)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3688,7 +3688,7 @@ partial explicit extension R for UnderlyingClass3 { }
             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ErrorType").WithArguments("ErrorType").WithLocation(4, 34)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3711,7 +3711,7 @@ partial explicit extension R for UnderlyingClass3 { }
             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ErrorType").WithArguments("ErrorType").WithLocation(3, 34)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("ErrorType", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("ErrorType", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3729,7 +3729,7 @@ partial explicit extension R for C<object> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<System.Object>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<System.Object>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3749,8 +3749,8 @@ partial explicit extension R for C<dynamic> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("C<>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
+        Assert.True(r.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
     }
 
     [Fact]
@@ -3770,8 +3770,8 @@ partial explicit extension R for C<(int y, int b)> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("C<>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
+        Assert.True(r.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
     }
 
     [Fact]
@@ -3789,8 +3789,8 @@ partial explicit extension R for object? { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("System.Object", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
-        Assert.False(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("System.Object", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString(includeNonNullable: true));
+        Assert.False(r.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
     }
 
     [Fact]
@@ -3812,8 +3812,8 @@ partial explicit extension R for C<object?> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("C<>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
+        Assert.True(r.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
     }
 
     [Fact]
@@ -3833,7 +3833,7 @@ partial explicit extension R for C<object?> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<System.Object?>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<System.Object?>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3852,7 +3852,7 @@ partial explicit extension R for C<object> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<System.Object?>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<System.Object?>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3886,8 +3886,8 @@ partial explicit extension R for C<
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<, >", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("C<, >", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
+        Assert.True(r.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
     }
 
     [Fact]
@@ -3910,7 +3910,7 @@ partial explicit extension R for UnderlyingClass { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("Error", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("Error", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -3930,7 +3930,7 @@ partial explicit extension R for Error { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Theory, CombinatorialData]
@@ -3950,7 +3950,7 @@ partial {{keyword}} extension R { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(r.GetExtendedTypeNoUseSiteDiagnostics(null));
     }
 
     [ConditionalFact(typeof(NoBaseExtensions))]
@@ -4127,7 +4127,7 @@ explicit extension R for error
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        var underlyingType = r.ExtendedTypeNoUseSiteDiagnostics;
+        var underlyingType = r.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("error", underlyingType.ToTestDisplayString());
         Assert.True(underlyingType.IsErrorType());
     }
@@ -4148,7 +4148,7 @@ explicit extension R for C<error>
             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "error").WithArguments("error").WithLocation(2, 28)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        var underlyingType = r.ExtendedTypeNoUseSiteDiagnostics;
+        var underlyingType = r.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("C<error>", underlyingType.ToTestDisplayString());
     }
 
@@ -4195,7 +4195,7 @@ explicit extension R for R { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(r.GetExtendedTypeNoUseSiteDiagnostics(null));
     }
 
     [ConditionalFact(typeof(NoBaseExtensions))]
@@ -4229,7 +4229,7 @@ explicit extension R for R[] { }
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("R[]", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R[]", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -4241,7 +4241,7 @@ explicit extension R for (R, R) { }
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("(R, R)", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("(R, R)", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -4254,7 +4254,7 @@ explicit extension R for S<R> { }
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("S<R>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("S<R>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -4271,8 +4271,8 @@ explicit extension R for S<R> { }
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("S<R>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.Equal("R", r.ExtendedTypeNoUseSiteDiagnostics.GetMember("field").GetTypeOrReturnType().ToTestDisplayString());
+        Assert.Equal("S<R>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
+        Assert.Equal("R", r.GetExtendedTypeNoUseSiteDiagnostics(null).GetMember("field").GetTypeOrReturnType().ToTestDisplayString());
     }
 
     [Fact]
@@ -4287,7 +4287,7 @@ explicit extension R for C<R> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<R>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<R>", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [ConditionalFact(typeof(NoBaseExtensions))]
@@ -4416,13 +4416,13 @@ explicit extension R2 for object : R
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.True(r.IsExtension);
-        Assert.Equal("R2.Nested", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R2.Nested", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         Assert.True(r2.IsExtension);
-        Assert.Equal("System.Object", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("System.Object", r2.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(new[] { "R" }, r2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
         Assert.True(r2.BaseExtensionsNoUseSiteDiagnostics.Single().IsErrorType());
         Assert.Equal(new[] { "R" }, r2.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
@@ -4464,7 +4464,7 @@ public explicit extension R1 for R2 { }
 
         var r1 = comp5.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
-        var r2FromR1 = (ExtendedErrorTypeSymbol)r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r2FromR1 = (ExtendedErrorTypeSymbol)r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("R2", r2FromR1.ToTestDisplayString());
         AssertEx.Equal("error CS9322: Extension marker method on type 'R1' is malformed.", r2FromR1.ErrorInfo.ToString());
 
@@ -4496,7 +4496,7 @@ public explicit extension R9 for R2 { }
 
         r1 = comp6.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<RetargetingNamedTypeSymbol>(r1, isExplicit: true);
-        r2FromR1 = (ExtendedErrorTypeSymbol)r1.ExtendedTypeNoUseSiteDiagnostics;
+        r2FromR1 = (ExtendedErrorTypeSymbol)r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.True(r2FromR1.IsErrorType());
         AssertEx.Equal("error CS8090: There is an error in a referenced assembly 'second, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.",
             r2FromR1.ErrorInfo.ToString());
@@ -4516,13 +4516,13 @@ explicit extension R2 for R2.Nested[] : R
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.True(r.IsExtension);
-        Assert.Equal("R2.Nested[]", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R2.Nested[]", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         Assert.True(r2.IsExtension);
-        Assert.Equal("R2.Nested[]", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R2.Nested[]", r2.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(new[] { "R" }, r2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
         Assert.Equal(new[] { "R" }, r2.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
@@ -4540,12 +4540,12 @@ explicit extension R2 for (R2.Nested, int) : R
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("(R2.Nested, System.Int32)", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("(R2.Nested, System.Int32)", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(r.AllBaseExtensionsNoUseSiteDiagnostics);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        Assert.Equal("(R2.Nested, System.Int32)", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("(R2.Nested, System.Int32)", r2.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(new[] { "R" }, r2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
         Assert.Equal(new[] { "R" }, r2.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
@@ -4568,7 +4568,7 @@ explicit extension E2 for E2 : E2 { }
             );
         var e2 = comp.GlobalNamespace.GetTypeMember("E2");
         Assert.True(e2.IsExtension);
-        Assert.Null(e2.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(e2.GetExtendedTypeNoUseSiteDiagnostics(null));
         Assert.Equal("E2", e2.BaseExtensionsNoUseSiteDiagnostics.Single().ToTestDisplayString());
     }
 
@@ -4606,7 +4606,7 @@ public explicit extension R1 for R2.Nested2
 
         var r1 = comp1.GlobalNamespace.GetTypeMember("R1");
         Assert.True(r1.IsExtension);
-        Assert.Equal("R2.Nested2", r1.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R2.Nested2", r1.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -4679,12 +4679,12 @@ public explicit extension R3 for object : R1 { }
             );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("R2", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        var r2ExtendedType = r2.ExtendedTypeNoUseSiteDiagnostics;
+        var r2ExtendedType = r2.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("R1", r2ExtendedType.ToTestDisplayString());
         Assert.True(r2ExtendedType.IsErrorType());
     }
@@ -4967,12 +4967,12 @@ partial explicit extension R4 for C : R2 { }
         static void validate(ModuleSymbol module)
         {
             var r3 = module.GlobalNamespace.GetTypeMember("R3");
-            Assert.Equal("C", r3.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C", r3.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Equal(new[] { "R1", "R2" }, r3.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
             Assert.Equal(new[] { "R1", "R2" }, r3.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
 
             var r4 = module.GlobalNamespace.GetTypeMember("R4");
-            Assert.Equal("C", r4.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C", r4.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Equal(new[] { "R1", "R2" }, r4.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
             Assert.Equal(new[] { "R1", "R2" }, r4.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
         }
@@ -5006,13 +5006,13 @@ class D<U>
 
             var r3 = d.GetTypeMember("R3");
             Assert.Equal(1, r3.Arity);
-            Assert.Equal("C<U, V>", r3.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<U, V>", r3.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Equal(new[] { "D<U>.R1<U, V>", "D<U>.R2<U, V>" }, r3.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
             Assert.Equal(new[] { "D<U>.R1<U, V>", "D<U>.R2<U, V>" }, r3.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
 
             var r4 = d.GetTypeMember("R4");
             Assert.Equal(1, r4.Arity);
-            Assert.Equal("C<U, V>", r4.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<U, V>", r4.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
             Assert.Equal(new[] { "D<U>.R1<U, V>", "D<U>.R2<U, V>" }, r4.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
             Assert.Equal(new[] { "D<U>.R1<U, V>", "D<U>.R2<U, V>" }, r4.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
 
@@ -5041,7 +5041,7 @@ explicit extension R for C : error
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         var baseExtensions = r.BaseExtensionsNoUseSiteDiagnostics;
         Assert.Equal(new[] { "error" }, baseExtensions.ToTestDisplayStrings());
         Assert.True(baseExtensions.Single().IsErrorType());
@@ -5141,7 +5141,7 @@ explicit extension R for UnderlyingClass : R1 { }
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(new[] { "R1@<tree 0>" }, r.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
         Assert.Equal(new[] { "R1@<tree 0>" }, r.AllBaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
@@ -5163,7 +5163,7 @@ explicit extension R for UnderlyingClass : R1, R2 { }
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(new[] { "R1", "R2@<tree 0>" }, r.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -5186,7 +5186,7 @@ explicit extension R for UnderlyingClass : R1, R2 { }
             Diagnostic(ErrorCode.ERR_FileTypeBase, "R").WithArguments("R2", "R").WithLocation(4, 20)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(new[] { "R1@<tree 0>", "R2@<tree 0>" }, r.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -5550,12 +5550,12 @@ explicit extension R4<U> for C<U> : R3<U> { }
         comp.VerifyDiagnostics();
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        Assert.Equal("U", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.Equal("U", r2.BaseExtensionsNoUseSiteDiagnostics.Single().ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("U", r2.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
+        Assert.Equal("U", r2.BaseExtensionsNoUseSiteDiagnostics.Single().GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
 
         var r4 = comp.GlobalNamespace.GetTypeMember("R4");
-        Assert.Equal("C<U>", r4.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.Equal("C<U>", r4.BaseExtensionsNoUseSiteDiagnostics.Single().ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<U>", r4.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
+        Assert.Equal("C<U>", r4.BaseExtensionsNoUseSiteDiagnostics.Single().GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [ConditionalFact(typeof(NoBaseExtensions))]
@@ -5706,7 +5706,7 @@ partial explicit extension R
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.False(r.IsStatic);
     }
 
@@ -5726,7 +5726,7 @@ explicit extension R for C { }
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("C", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -5746,7 +5746,7 @@ unsafe explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.False(r.IsStatic);
     }
 
@@ -5763,7 +5763,7 @@ unsafe explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.False(r.IsStatic);
         comp.VerifyDiagnostics();
     }
@@ -5788,7 +5788,7 @@ explicit extension DerivedExtension for UnderlyingClass : BaseExtension
         var r = comp.GlobalNamespace.GetTypeMember("DerivedExtension").GetTypeMember("R");
         Assert.Equal("DerivedExtension.R", r.ToTestDisplayString());
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass2", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass2", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         // PROTOTYPE verify hiding in usages/lookups
     }
 
@@ -6081,7 +6081,7 @@ internal internal explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(Accessibility.Internal, r.DeclaredAccessibility);
     }
 
@@ -6105,7 +6105,7 @@ public internal explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(Accessibility.Public, r.DeclaredAccessibility);
     }
 
@@ -6129,7 +6129,7 @@ internal public explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(Accessibility.Public, r.DeclaredAccessibility);
     }
 
@@ -6150,7 +6150,7 @@ abstract explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
     }
 
     [Fact]
@@ -6739,7 +6739,7 @@ explicit extension E2 for int : E1 { }
 
         var e1 = comp2.GlobalNamespace.GetTypeMember("E1");
         VerifyExtension<RetargetingNamedTypeSymbol>(e1, isExplicit: isExplicit);
-        Assert.Equal("System.Int32", e1.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("System.Int32", e1.GetExtendedTypeNoUseSiteDiagnostics(null).ToTestDisplayString());
         Assert.Equal(new[] { "E0" }, e1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -6755,7 +6755,7 @@ class C { }
         var comp2 = CreateCompilation("", references: new[] { comp1.ToMetadataReference() }, targetFramework: TargetFramework.Mscorlib46);
         var c = comp2.GlobalNamespace.GetTypeMember("C");
         VerifyNotExtension<RetargetingNamedTypeSymbol>(c);
-        Assert.Null(c.ExtendedTypeNoUseSiteDiagnostics);
+        Assert.Null(c.GetExtendedTypeNoUseSiteDiagnostics(null));
         Assert.Empty(c.BaseExtensionsNoUseSiteDiagnostics);
     }
 
@@ -7158,7 +7158,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
 
@@ -7283,7 +7283,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
 
@@ -7328,7 +7328,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1ExtendedType = (ExtendedErrorTypeSymbol)r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = (ExtendedErrorTypeSymbol)r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
         AssertEx.Equal("error CS9322: Extension marker method on type 'R1' is malformed.", r1ExtendedType.ErrorInfo.ToString());
@@ -7673,7 +7673,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1Underyling = r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1Underyling = r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("dynamic", r1Underyling.ToTestDisplayString());
         Assert.True(r1Underyling.IsErrorType());
         Assert.Empty(r1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
@@ -7728,7 +7728,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1Underyling = (ExtendedErrorTypeSymbol)r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1Underyling = (ExtendedErrorTypeSymbol)r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("R0", r1Underyling.ToTestDisplayString());
         Assert.True(r1Underyling.IsErrorType());
         AssertEx.Equal("error CS9322: Extension marker method on type 'R1' is malformed.", r1Underyling.ErrorInfo.ToString());
@@ -7776,7 +7776,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
-        var r1Underyling = r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1Underyling = r1.GetExtendedTypeNoUseSiteDiagnostics(null);
         Assert.Equal("R1", r1Underyling.ToTestDisplayString());
         Assert.True(r1Underyling.IsErrorType());
         Assert.Empty(r1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
@@ -8263,7 +8263,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r1.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
 
         if (new NoBaseExtensions().ShouldSkip) return;
 
@@ -8305,7 +8305,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r1.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
 
         if (new NoBaseExtensions().ShouldSkip) return;
 
@@ -8347,7 +8347,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
-        Assert.False(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.False(r1.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -8380,7 +8380,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r1.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -8423,7 +8423,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r1.GetExtendedTypeNoUseSiteDiagnostics(null).IsErrorType());
 
         if (new NoBaseExtensions().ShouldSkip) return;
 

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -4172,13 +4172,12 @@ class C2 : C<UseSiteError> { }
 """;
         var comp = CreateCompilation(src, new[] { comp2.EmitToImageReference() }, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics(
-            // (2, 27): error CS0012: The type 'MissingBase' is defined in an assembly that is not referenced.You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            // (2,27): error CS0012: The type 'MissingBase' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
             // explicit extension R1 for UseSiteError { }
             Diagnostic(ErrorCode.ERR_NoTypeDef, "UseSiteError").WithArguments("MissingBase", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 27),
             // (4,12): error CS0012: The type 'MissingBase' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
             // class C1 : UseSiteError { }
-            Diagnostic(ErrorCode.ERR_NoTypeDef, "UseSiteError").WithArguments("MissingBase", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 12)
-            );
+            Diagnostic(ErrorCode.ERR_NoTypeDef, "UseSiteError").WithArguments("MissingBase", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 12));
     }
 
     [Fact]
@@ -11632,7 +11631,7 @@ _ = object.Type.M();
 {{(e1BeforeE2 ? e2 : e1)}}
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
-        if (e1BeforeE2)
+        if (!e1BeforeE2)
         {
             comp.VerifyEmitDiagnostics(
                 // (1,8): error CS0121: The call is ambiguous between the following methods or properties: 'E2.Method()' and 'E1.Method()'
@@ -14221,7 +14220,7 @@ class C { }
 {{(e1BeforeE2 ? e2 : e1)}}
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
-        if (e1BeforeE2)
+        if (!e1BeforeE2)
         {
             comp.VerifyDiagnostics(
                 // (1,9): error CS0121: The call is ambiguous between the following methods or properties: 'E2.Method()' and 'E1.Method()'
@@ -28243,9 +28242,9 @@ implicit extension E2 for C
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyEmitDiagnostics(
-            // (1,9): error CS0121: The call is ambiguous between the following methods or properties: 'E2.Method()' and 'E1.Method()'
+            // (1,9): error CS0121: The call is ambiguous between the following methods or properties: 'E1.Method()' and 'E2.Method()'
             // var x = C.Method;
-            Diagnostic(ErrorCode.ERR_AmbigCall, "C.Method").WithArguments("E2.Method()", "E1.Method()").WithLocation(1, 9)
+            Diagnostic(ErrorCode.ERR_AmbigCall, "C.Method").WithArguments("E1.Method()", "E2.Method()").WithLocation(1, 9)
             );
 
         var tree = comp.SyntaxTrees.Single();
@@ -30570,16 +30569,16 @@ implicit extension E2 for I2
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyEmitDiagnostics(
-            // (1,25): error CS0121: The call is ambiguous between the following methods or properties: 'E2.M()' and 'E1Base.M()'
+            // (1,25): error CS0121: The call is ambiguous between the following methods or properties: 'E1Base.M()' and 'E2.M()'
             // System.Console.Write(I3.M());
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E2.M()", "E1Base.M()").WithLocation(1, 25));
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E1Base.M()", "E2.M()").WithLocation(1, 25));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "I3.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
 
-        Assert.Equal(["System.String E2.M()", "System.String E1Base.M()"],
+        Assert.Equal(["System.String E1Base.M()", "System.String E2.M()"],
             model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
 
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE need to fix the semantic model
@@ -30814,15 +30813,15 @@ implicit extension E<T> for I<T>
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics(
-            // (1,24): error CS0229: Ambiguity between 'E<string>.M' and 'E<int>.M'
+            // (1,24): error CS0229: Ambiguity between 'E<int>.M' and 'E<string>.M'
             // System.Console.Write(C.M);
-            Diagnostic(ErrorCode.ERR_AmbigMember, "M").WithArguments("E<string>.M", "E<int>.M").WithLocation(1, 24));
+            Diagnostic(ErrorCode.ERR_AmbigMember, "M").WithArguments("E<int>.M", "E<string>.M").WithLocation(1, 24));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        Assert.Equal(["System.String E<System.String>.M", "System.String E<System.Int32>.M"],
+        Assert.Equal(["System.String E<System.Int32>.M", "System.String E<System.String>.M"],
             model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
         Assert.Empty(model.GetMemberGroup(memberAccess));
 
@@ -30860,9 +30859,9 @@ implicit extension E<T> for I<T>
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyEmitDiagnostics(
-            // (1,9): error CS0121: The call is ambiguous between the following methods or properties: 'E<string>.M()' and 'E<int>.M()'
+            // (1,9): error CS0121: The call is ambiguous between the following methods or properties: 'E<int>.M()' and 'E<string>.M()'
             // var x = C.M;
-            Diagnostic(ErrorCode.ERR_AmbigCall, "C.M").WithArguments("E<string>.M()", "E<int>.M()").WithLocation(1, 9));
+            Diagnostic(ErrorCode.ERR_AmbigCall, "C.M").WithArguments("E<int>.M()", "E<string>.M()").WithLocation(1, 9));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
@@ -30889,16 +30888,16 @@ implicit extension E<T> for I<T>
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics(
-            // (1,3): error CS0121: The call is ambiguous between the following methods or properties: 'E<string>.M()' and 'E<int>.M()'
+            // (1,3): error CS0121: The call is ambiguous between the following methods or properties: 'E<int>.M()' and 'E<string>.M()'
             // C.M();
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E<string>.M()", "E<int>.M()").WithLocation(1, 3));
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E<int>.M()", "E<string>.M()").WithLocation(1, 3));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
 
-        Assert.Equal(["void E<System.String>.M()", "void E<System.Int32>.M()"],
+        Assert.Equal(["void E<System.Int32>.M()", "void E<System.String>.M()"],
             model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
 
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE need to fix the semantic model
@@ -30920,16 +30919,16 @@ implicit extension E<T> for I<T>
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics(
-            // (1,3): error CS0121: The call is ambiguous between the following methods or properties: 'E<string>.M<int>()' and 'E<int>.M<int>()'
+            // (1,3): error CS0121: The call is ambiguous between the following methods or properties: 'E<int>.M<int>()' and 'E<string>.M<int>()'
             // C.M<int>();
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M<int>").WithArguments("E<string>.M<int>()", "E<int>.M<int>()").WithLocation(1, 3));
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M<int>").WithArguments("E<int>.M<int>()", "E<string>.M<int>()").WithLocation(1, 3));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M<int>");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
 
-        Assert.Equal(["void E<System.String>.M<System.Int32>()", "void E<System.Int32>.M<System.Int32>()"],
+        Assert.Equal(["void E<System.Int32>.M<System.Int32>()", "void E<System.String>.M<System.Int32>()"],
             model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
 
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE need to fix the semantic model
@@ -31129,7 +31128,7 @@ System.Console.Write(object.M());
 {{(e1BeforeE2 ? e2 : e1)}}
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
-        if (e1BeforeE2)
+        if (!e1BeforeE2)
         {
             comp.VerifyEmitDiagnostics(
                 // (1,29): error CS0121: The call is ambiguous between the following methods or properties: 'E2.M()' and 'E1.M()'
@@ -31335,9 +31334,8 @@ class C : I1, I2 { }
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        // PROTOTYPE(static) the sorting mechanism for more specific extension members to hide less specific ones is insufficient and needs to be revised
-        //Assert.Equal(["System.String E1.M", "System.String E2.M"],
-        //    model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Equal(["System.String E1.M", "System.String E2.M"],
+            model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE need to fix the semantic model
     }
 
@@ -31385,38 +31383,18 @@ class C : I1, I2 { }
 {{segments[third]}}
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
-        bool isE3beforeE4 = segmentIndex(2) < segmentIndex(1);
-        if (isE3beforeE4)
-        {
-            comp.VerifyEmitDiagnostics(
-                // (1,24): error CS0121: The call is ambiguous between the following methods or properties: 'E3.M()' and 'E4.M()'
-                // System.Console.Write(C.M());
-                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E3.M()", "E4.M()").WithLocation(1, 24));
-        }
-        else
-        {
-            comp.VerifyEmitDiagnostics(
-                // (1,24): error CS0121: The call is ambiguous between the following methods or properties: 'E4.M()' and 'E3.M()'
-                // System.Console.Write(C.M());
-                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E4.M()", "E3.M()").WithLocation(1, 24));
-        }
+        comp.VerifyEmitDiagnostics(
+            // (1,24): error CS0121: The call is ambiguous between the following methods or properties: 'E3.M()' and 'E4.M()'
+            // System.Console.Write(C.M());
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E3.M()", "E4.M()").WithLocation(1, 24));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        if (isE3beforeE4)
-        {
-            Assert.Equal(["System.String E3.M()", "System.String E4.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
-        }
-        else
-        {
-            Assert.Equal(["System.String E4.M()", "System.String E3.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
-        }
+        Assert.Equal(["System.String E3.M()", "System.String E4.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
 
         Assert.Empty(model.GetMemberGroup(memberAccess)); // PROTOTYPE need to fix the semantic model
-
-        int segmentIndex(int segment) => first == segment ? 0 : (second == segment ? 1 : 2);
     }
 
     [Theory, ClassData(typeof(ThreePermutationGenerator))]
@@ -31509,7 +31487,7 @@ class C { }
 """;
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         bool isE1beforeE2 = segmentIndex(0) < segmentIndex(1);
-        if (isE1beforeE2)
+        if (!isE1beforeE2)
         {
             comp.VerifyEmitDiagnostics(
                 // (1,24): error CS0121: The call is ambiguous between the following methods or properties: 'E2.M()' and 'E1.M()'
@@ -31528,7 +31506,7 @@ class C { }
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        if (isE1beforeE2)
+        if (!isE1beforeE2)
         {
             Assert.Equal(["System.String E2.M()", "System.String E1.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
         }
@@ -35273,40 +35251,29 @@ implicit extension E for IBase
     {
         var source = """
 // we'll lookup here
+int.StaticMethod();
+
 public implicit extension E<T> for T where T : struct
 {
     public static int StaticField = 0;
     public static int StaticProperty => 0;
-    public static void StaticMethod() { }
+    public static void StaticMethod() { System.Console.Write("ran"); }
     public class Nested { }
     public static event System.Action StaticEvent { add { } remove { } }
 }
 """;
         var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
-        // PROTOTYPE should warn about hiding
-        comp.VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
 
         var o = ((Compilation)comp).GetSpecialType(SpecialType.System_Object);
         AssertSetStrictlyEqual(objectSymbols, model.LookupSymbols(position: 0, o).ToTestDisplayStrings());
-
-        string[] eStaticSymbols = [
-            .. objectStaticSymbols,
-            "System.Int32 E<System.Object>.StaticProperty { get; }",
-            "void E<System.Object>.StaticMethod()",
-            "E<System.Object>.Nested",
-            "event System.Action E<System.Object>.StaticEvent",
-            "System.Int32 E<System.Object>.StaticField"];
-
-        // PROTOTYPE(instance) We'll want LookupSymbols to return extension type members too
         AssertSetStrictlyEqual(objectSymbols, model.LookupSymbols(position: 0, o, includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(eStaticSymbols, model.LookupStaticMembers(position: 0, o).ToTestDisplayStrings());
-
-        AssertSetStrictlyEqual(["E<System.Object>.Nested"], model.LookupNamespacesAndTypes(position: 0, o).ToTestDisplayStrings());
-        AssertSetStrictlyEqual(eStaticSymbols, model.LookupStaticMembers(position: 0, o).ToTestDisplayStrings());
+        AssertSetStrictlyEqual([], model.LookupNamespacesAndTypes(position: 0, o).ToTestDisplayStrings());
+        AssertSetStrictlyEqual(objectStaticSymbols, model.LookupStaticMembers(position: 0, o).ToTestDisplayStrings());
 
         var n = ((Compilation)comp).GetSpecialType(SpecialType.System_Nullable_T);
         string[] nullableInstanceSymbols = [
@@ -35331,20 +35298,21 @@ public implicit extension E<T> for T where T : struct
 
         AssertSetStrictlyEqual([.. nullableInstanceSymbols, .. nullableStaticSymbols], model.LookupSymbols(position: 0, n).ToTestDisplayStrings());
 
-        // PROTOTYPE(instance) We'll want LookupSymbols to return extension type members too
         AssertSetStrictlyEqual([.. nullableInstanceSymbols, .. nullableStaticSymbols],
             model.LookupSymbols(position: 0, n, includeReducedExtensionMethods: true).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual([
-            .. nullableStaticSymbols,
-            "System.Int32 E<T?>.StaticProperty { get; }",
-            "void E<T?>.StaticMethod()",
-            "E<T?>.Nested",
-            "event System.Action E<T?>.StaticEvent",
-            "System.Int32 E<T?>.StaticField"],
-            model.LookupStaticMembers(position: 0, n).ToTestDisplayStrings());
+        AssertSetStrictlyEqual(objectStaticSymbols, model.LookupStaticMembers(position: 0, n).ToTestDisplayStrings());
+        AssertSetStrictlyEqual([], model.LookupNamespacesAndTypes(position: 0, n).ToTestDisplayStrings());
 
-        AssertSetStrictlyEqual(["E<T?>.Nested"], model.LookupNamespacesAndTypes(position: 0, n).ToTestDisplayStrings());
+        var int32 = ((Compilation)comp).GetSpecialType(SpecialType.System_Int32);
+        AssertSetStrictlyEqual([
+            .. objectStaticSymbols,
+            "System.Int32 E<System.Int32>.StaticProperty { get; }",
+            "void E<System.Int32>.StaticMethod()",
+            "E<System.Int32>.Nested",
+            "event System.Action E<System.Int32>.StaticEvent",
+            "System.Int32 E<System.Int32>.StaticField"],
+            model.LookupStaticMembers(position: 0, int32).Where(m => m.ContainingType.Name != "Int32").ToTestDisplayStrings());
     }
 
     [Fact]
@@ -38763,5 +38731,635 @@ implicit extension E for object
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
         Assert.Equal("void E.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
         Assert.Equal([], model.GetMemberGroup(memberAccess).ToTestDisplayStrings()); // PROTOTYPE need to fix the semantic model
+    }
+
+    [Theory, ClassData(typeof(ThreePermutationGenerator))]
+    public void PreferMoreSpecific_Static_FieldAndLessSpecificFieldAndEmpty(int first, int second, int third)
+    {
+        string[] segments = [
+            """
+            implicit extension E1 for I1
+            {
+                public static string M = "ran";
+            }
+            """,
+            """
+            implicit extension E2 for I2 { }
+            """,
+            """
+            implicit extension E3 for I1Base
+            {
+                public static string M = null;
+            }
+            implicit extension E4 for I2Base { }
+            """];
+
+        var src = $$"""
+System.Console.Write(C.M);
+
+interface I1Base { }
+interface I1 : I1Base { }
+interface I2Base { }
+interface I2 : I2Base { }
+
+class C : I1, I2 { }
+
+{{segments[first]}}
+
+{{segments[second]}}
+
+{{segments[third]}}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
+        Assert.Equal("System.String E1.M", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Empty(model.GetMemberGroup(memberAccess));
+    }
+
+    [Theory, ClassData(typeof(ThreePermutationGenerator))]
+    public void PreferMoreSpecific_Static_InterfaceAppearsTwice(int first, int second, int third)
+    {
+        string[] segments = [
+            """
+            implicit extension E1<T> for I1<T>
+            {
+                public static string M => null;
+            }
+            """,
+            """
+            implicit extension E2 for I2 { }
+            """,
+            """
+            implicit extension E3 for C { }
+            """];
+
+        var src = $$"""
+System.Console.Write(C.M);
+
+interface I1<T> { }
+interface I2 : I1<string> { }
+
+class C : I1<int>, I2 { }
+
+{{segments[first]}}
+
+{{segments[second]}}
+
+{{segments[third]}}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+        comp.VerifyEmitDiagnostics(
+            // (1,24): error CS0229: Ambiguity between 'E1<int>.M' and 'E1<string>.M'
+            // System.Console.Write(C.M);
+            Diagnostic(ErrorCode.ERR_AmbigMember, "M").WithArguments("E1<int>.M", "E1<string>.M").WithLocation(1, 24));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+        Assert.Equal(["System.String E1<System.Int32>.M { get; }", "System.String E1<System.String>.M { get; }"],
+            model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Empty(model.GetMemberGroup(memberAccess));
+    }
+
+    [Theory, ClassData(typeof(ThreePermutationGenerator))]
+    public void PreferMoreSpecific_Static_InterfaceAppearsTwice_02(int first, int second, int third)
+    {
+        string[] segments = [
+            """
+            implicit extension E1<T> for I1<T>
+            {
+                public static string M => null;
+            }
+            """,
+            """
+            implicit extension E2 for Base { }
+            """,
+            """
+            implicit extension E3 for C { }
+            """];
+
+        var src = $$"""
+System.Console.Write(C.M);
+
+interface I1<T> { }
+class Base : I1<string> { }
+class C : Base, I1<int> { }
+
+{{segments[first]}}
+
+{{segments[second]}}
+
+{{segments[third]}}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+        comp.VerifyEmitDiagnostics(
+            // (1,24): error CS0229: Ambiguity between 'E1<string>.M' and 'E1<int>.M'
+            // System.Console.Write(C.M);
+            Diagnostic(ErrorCode.ERR_AmbigMember, "M").WithArguments("E1<string>.M", "E1<int>.M").WithLocation(1, 24));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+        Assert.Equal(["System.String E1<System.String>.M { get; }", "System.String E1<System.Int32>.M { get; }"],
+            model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Empty(model.GetMemberGroup(memberAccess));
+    }
+
+    [Theory, ClassData(typeof(ThreePermutationGenerator))]
+    public void PreferMoreSpecific_Static_InterfaceAppearsTwice_03(int first, int second, int third)
+    {
+        string[] segments = [
+            """
+            implicit extension E1<T> for I1<T>
+            {
+                public static string M => null;
+            }
+            """,
+            """
+            implicit extension E2 for Base
+            {
+                public static string M => null;
+            }
+            """,
+            """
+            implicit extension E3 for C { }
+            """];
+
+        var src = $$"""
+System.Console.Write(C.M);
+
+interface I1<T> { }
+class Base : I1<string> { }
+class C : Base, I1<int> { }
+
+{{segments[first]}}
+
+{{segments[second]}}
+
+{{segments[third]}}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+        comp.VerifyEmitDiagnostics(
+            // (1,24): error CS0229: Ambiguity between 'E1<int>.M' and 'E2.M'
+            // System.Console.Write(C.M);
+            Diagnostic(ErrorCode.ERR_AmbigMember, "M").WithArguments("E1<int>.M", "E2.M").WithLocation(1, 24));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
+        Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+        Assert.Equal(["System.String E1<System.Int32>.M { get; }", "System.String E2.M { get; }"],
+            model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Empty(model.GetMemberGroup(memberAccess));
+    }
+
+    [Theory, ClassData(typeof(ThreePermutationGenerator))]
+    public void PreferMoreSpecific_Static_InterfaceAppearsTwice_04(int first, int second, int third)
+    {
+        string[] segments = [
+            """
+            implicit extension E1<T> for I1<T>
+            {
+                public static string M => "ran";
+            }
+            """,
+            """
+            implicit extension E2 for I2 { }
+            """,
+            """
+            implicit extension E3 for C { }
+            """];
+
+        var src = $$"""
+System.Console.Write(C.M);
+
+interface I1<T> { }
+interface I2 : I1<int> { }
+
+class C : I1<int>, I2 { }
+
+{{segments[first]}}
+
+{{segments[second]}}
+
+{{segments[third]}}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "C.M");
+        Assert.Equal("System.String E1<System.Int32>.M { get; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        Assert.Equal([], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        Assert.Empty(model.GetMemberGroup(memberAccess));
+    }
+
+    [Fact]
+    public void Lookup_ExtensionTypeMembers_ForT_Static_Unconstrained()
+    {
+        var source = """
+// we'll lookup here
+int.StaticMethod();
+
+public implicit extension E<T> for T
+{
+    public static void StaticMethod() { System.Console.Write("ran"); }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+
+        var int32 = ((Compilation)comp).GetSpecialType(SpecialType.System_Int32);
+        AssertSetStrictlyEqual([
+            .. objectStaticSymbols,
+            "void E<System.Int32>.StaticMethod()",
+            "void E<System.ValueType>.StaticMethod()",
+            "void E<System.Object>.StaticMethod()",
+            "void E<System.IConvertible>.StaticMethod()",
+            "void E<System.IComparable>.StaticMethod()",
+            "void E<System.IComparable<System.Int32>>.StaticMethod()",
+            "void E<System.IEquatable<System.Int32>>.StaticMethod()",
+            "void E<System.ISpanFormattable>.StaticMethod()",
+            "void E<System.IFormattable>.StaticMethod()"],
+            model.LookupStaticMembers(position: 0, int32).Where(m => m.ContainingType.Name != "Int32").ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void Lookup_ExtensionTypeMembers_ForT_Static_BrokenConstraint()
+    {
+        var source = """
+object.StaticMethod();
+
+public implicit extension E<T> for T where T : struct
+{
+    public static void StaticMethod() { }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+        comp.VerifyEmitDiagnostics(
+            // (1,8): error CS0117: 'object' does not contain a definition for 'StaticMethod'
+            // object.StaticMethod();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "StaticMethod").WithArguments("object", "StaticMethod").WithLocation(1, 8));
+    }
+
+    [Fact]
+    public void Lookup_ExtensionTypeMembers_ForT_Instance_BrokenConstraint_Nullability()
+    {
+        var source = """
+#nullable enable
+bool b = true;
+var o = b ? null : new object();
+o.Method();
+
+public implicit extension E<T> for T where T : notnull
+{
+    public void Method() { }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+        comp.VerifyEmitDiagnostics(
+            // (4,1): warning CS8602: Dereference of a possibly null reference.
+            // o.Method();
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(4, 1));
+        // PROTOTYPE(instance) Execute when adding support for emitting non-static members
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "o.Method");
+        // PROTOTYPE(static) Updated nullability information should be reflected in the symbol
+        Assert.Equal("void E<System.Object>.Method()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString(includeNonNullable: true));
+    }
+
+    [Fact(Skip = "PROTOTYPE(static) hit assertion in NullableWalker")]
+    public void Lookup_ExtensionTypeMembers_Static_BrokenConstraint_Nullability()
+    {
+        var source = """
+#nullable enable
+C<object?>.StaticMethod();
+
+class C<T> { }
+
+public implicit extension E<T> for C<T> where T : notnull
+{
+    public static void StaticMethod() { System.Console.Write("ran"); }
+}
+""";
+        // PROTOTYPE(static) we should warn for nullability issues
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+        //comp.VerifyDiagnostics();
+        //CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Lookup_ExtensionTypeMembers_ForT_Static_NullableReferenceType()
+    {
+        var source = """
+#nullable enable
+object?.StaticMethod();
+
+public implicit extension E<T> for T
+{
+    public static void StaticMethod() { }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+        comp.VerifyEmitDiagnostics(
+            // (2,8): error CS1001: Identifier expected
+            // object?.StaticMethod();
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, ".").WithLocation(2, 8),
+            // (2,8): error CS1003: Syntax error, ',' expected
+            // object?.StaticMethod();
+            Diagnostic(ErrorCode.ERR_SyntaxError, ".").WithArguments(",").WithLocation(2, 8));
+    }
+
+    [Fact]
+    public void Lookup_ExtensionTypeMembers_ForT_Static_NullableReferenceTypeParenthesized()
+    {
+        var source = """
+#nullable enable
+(object?).StaticMethod();
+
+public implicit extension E<T> for T
+{
+    public static void StaticMethod() { }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+        comp.VerifyEmitDiagnostics(
+            // (2,10): error CS1525: Invalid expression term '.'
+            // (object?).StaticMethod();
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ".").WithArguments(".").WithLocation(2, 10));
+    }
+
+    [Fact]
+    public void UsingStatic_07()
+    {
+        var source = """
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal interface AnyEnum { }
+}
+""";
+        // In `GetInterfaceInfo` we call `SourceNamedTypeSymbol.BaseTypeNoUseSiteDiagnostics` which forces resolution on `ContainingType.BaseTypeNoUseSiteDiagnostics`
+        // This means that any lookup on `AnyEnum` causes the `using` directives to be resolved
+        var comp = CreateCompilationWithMscorlib45(source);
+        comp.VerifyDiagnostics(
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using static MyNamespace.AnyClass.AnyEnum.Val;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(1, 1),
+            // (1,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+            // using static MyNamespace.AnyClass.AnyEnum.Val;
+            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(1, 43),
+            // (5,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+            // internal class AnyClass : AnyBaseClass
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(5, 27) );
+    }
+
+    [Fact]
+    public void UsingStatic_WithExtension_NoNestedType()
+    {
+        var source = """
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal interface AnyEnum { }
+}
+
+implicit extension E for AnyClass.AnyEnum { }
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+
+        comp.VerifyDiagnostics(
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using static MyNamespace.AnyClass.AnyEnum.Val;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(1, 1),
+            // (1,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+            // using static MyNamespace.AnyClass.AnyEnum.Val;
+            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(1, 43),
+            // (5,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+            // internal class AnyClass : AnyBaseClass
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(5, 27) );
+    }
+
+    [Fact]
+    public void UsingStatic()
+    {
+        var source = """
+using static AnyClass.AnyEnum.Val;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal interface AnyEnum { }
+}
+
+implicit extension E for AnyClass.AnyEnum
+{
+    public class Val { }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+
+        comp.VerifyDiagnostics(
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using static AnyClass.AnyEnum.Val;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static AnyClass.AnyEnum.Val;").WithLocation(1, 1),
+            // (1,31): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+            // using static AnyClass.AnyEnum.Val;
+            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "AnyClass.AnyEnum").WithLocation(1, 31),
+            // (3,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+            // internal class AnyClass : AnyBaseClass
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(3, 27));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var qualifiedName = GetSyntax<QualifiedNameSyntax>(tree, "AnyClass.AnyEnum.Val");
+        Assert.Equal("E.Val", model.GetSymbolInfo(qualifiedName).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void UsingStatic_WithoutErrorBaseType()
+    {
+        var source = """
+using static C.Interface.Nested;
+
+internal class C
+{
+    internal interface Interface { }
+}
+
+implicit extension E for C.Interface
+{
+    public class Nested { }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+
+        comp.VerifyDiagnostics(
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using static C.Interface.Nested;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static C.Interface.Nested;").WithLocation(1, 1),
+            // (1,26): error CS0426: The type name 'Nested' does not exist in the type 'C.Interface'
+            // using static C.Interface.Nested;
+            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Nested").WithArguments("Nested", "C.Interface").WithLocation(1, 26));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var qualifiedName = GetSyntax<QualifiedNameSyntax>(tree, "C.Interface.Nested");
+        Assert.Equal("E.Nested", model.GetSymbolInfo(qualifiedName).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void AliasDirective()
+    {
+        var source = """
+using MyNested = C.Interface.Nested;
+
+MyNested.M();
+
+internal class C
+{
+    internal interface Interface { }
+}
+
+implicit extension E for C.Interface
+{
+    public class Nested { public static void M() { System.Console.Write("ran"); } }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var qualifiedName = GetSyntax<QualifiedNameSyntax>(tree, "C.Interface.Nested");
+        Assert.Equal("E.Nested", model.GetSymbolInfo(qualifiedName).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void UsingStatic_FromOuterScope()
+    {
+        var source = """
+internal class C
+{
+    internal interface Interface { }
+}
+
+implicit extension E for C.Interface
+{
+    public class Nested { }
+}
+
+namespace N
+{
+    using static C.Interface.Nested;
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+
+        comp.VerifyDiagnostics(
+            // (13,5): hidden CS8019: Unnecessary using directive.
+            //     using static C.Interface.Nested;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static C.Interface.Nested;").WithLocation(13, 5),
+            // (13,30): error CS0426: The type name 'Nested' does not exist in the type 'C.Interface'
+            //     using static C.Interface.Nested;
+            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Nested").WithArguments("Nested", "C.Interface").WithLocation(13, 30));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var qualifiedName = GetSyntax<QualifiedNameSyntax>(tree, "C.Interface.Nested");
+        Assert.Equal("E.Nested", model.GetSymbolInfo(qualifiedName).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void AliasDirective_FromOuterScope()
+    {
+        var source = """
+internal class C
+{
+    internal interface Interface { }
+}
+
+implicit extension E for C.Interface
+{
+    public class Nested { public static void M() { System.Console.Write("ran"); } }
+}
+
+namespace N
+{
+    using MyNested = C.Interface.Nested;
+
+    class D
+    {
+        public static void Main()
+        {
+            MyNested.M();
+        }
+    }
+}
+""";
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("ran"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var qualifiedName = GetSyntax<QualifiedNameSyntax>(tree, "C.Interface.Nested");
+        Assert.Equal("E.Nested", model.GetSymbolInfo(qualifiedName).Symbol.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void UsingStatic_ExistingInterfacesScenario()
+    {
+        var source = """
+interface IBase
+{
+    class Val { }
+}
+
+namespace N
+{
+    using static Interface.INested.Val; // error
+
+    internal interface Interface : IBase
+    {
+        internal interface INested : Interface
+        {
+            void M(Interface.INested.Val x); // okay
+        }
+    }
+}
+""";
+        var comp = CreateCompilationWithMscorlib45(source);
+
+        comp.VerifyDiagnostics(
+            // (8,5): hidden CS8019: Unnecessary using directive.
+            //     using static Interface.INested.Val; // error
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static Interface.INested.Val;").WithLocation(8, 5),
+            // (8,36): error CS0426: The type name 'Val' does not exist in the type 'Interface.INested'
+            //     using static Interface.INested.Val; // error
+            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "N.Interface.INested").WithLocation(8, 36));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var qualifiedName = GetSyntaxes<QualifiedNameSyntax>(tree, "Interface.INested.Val").ToArray();
+        Assert.Equal("IBase.Val", model.GetSymbolInfo(qualifiedName[0]).Symbol.ToTestDisplayString());
+        Assert.Equal("IBase.Val", model.GetSymbolInfo(qualifiedName[1]).Symbol.ToTestDisplayString());
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -335,7 +335,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 #nullable enable
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
-        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
+
+        internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
+
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();
 #nullable disable
         internal override bool IsInterpolatedStringHandlerType => false;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -360,7 +360,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
         internal override TypeSymbol GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();
-        internal override TypeSymbol ExtendedTypeNoUseSiteDiagnostics => throw ExceptionUtilities.Unreachable();
+
+        internal override TypeSymbol GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved)
+            => throw ExceptionUtilities.Unreachable();
 
         [Conditional("DEBUG")]
         internal static void VerifyTypeParameters(Symbol container, ImmutableArray<TypeParameterSymbol> typeParameters)


### PR DESCRIPTION
This PR also disallows resolution of extension members in `using` directives, as they cause multiple cycles.
This PR also adds a constraint check when substituting compatible extensions.
There's also a subtle change, as we now may continue to add a compatible extension as we walk up the base/interface hierarchy after that extension was found compatible at one level (marked with a GitHub comment).

Relates to test plan https://github.com/dotnet/roslyn/issues/66722