### PR TITLE
Fix failures in C# LSP inline completion (snippets)

### DIFF
--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalHover.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalHover.cs
@@ -10,6 +10,7 @@ namespace Roslyn.LanguageServer.Protocol
     /// <summary>
     /// Extension to Hover which adds additional data for colorization.
     /// </summary>
+    [DataContract]
     internal class VSInternalHover : Hover
     {
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionContext.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionContext.cs
@@ -12,6 +12,7 @@ namespace Roslyn.LanguageServer.Protocol
     /// Context for inline completion request.
     /// See https://github.com/microsoft/vscode/blob/075ba020e8493f40dba89891b1a08453f2c067e9/src/vscode-dts/vscode.proposed.inlineCompletions.d.ts#L27.
     /// </summary>
+    [DataContract]
     internal class VSInternalInlineCompletionContext
     {
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionItem.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionItem.cs
@@ -13,6 +13,7 @@ namespace Roslyn.LanguageServer.Protocol
     ///
     /// See https://github.com/microsoft/vscode/blob/075ba020e8493f40dba89891b1a08453f2c067e9/src/vscode-dts/vscode.proposed.inlineCompletions.d.ts#L78.
     /// </summary>
+    [DataContract]
     internal class VSInternalInlineCompletionItem
     {
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionList.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionList.cs
@@ -12,6 +12,7 @@ namespace Roslyn.LanguageServer.Protocol
     ///
     /// See https://github.com/microsoft/vscode/blob/075ba020e8493f40dba89891b1a08453f2c067e9/src/vscode-dts/vscode.proposed.inlineCompletions.d.ts#L72.
     /// </summary>
+    [DataContract]
     internal class VSInternalInlineCompletionList
     {
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionRequest.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalInlineCompletionRequest.cs
@@ -12,6 +12,7 @@ namespace Roslyn.LanguageServer.Protocol
     ///
     /// See https://github.com/microsoft/vscode/blob/075ba020e8493f40dba89891b1a08453f2c067e9/src/vscode-dts/vscode.proposed.inlineCompletions.d.ts#L24.
     /// </summary>
+    [DataContract]
     internal class VSInternalInlineCompletionRequest : ITextDocumentParams
     {
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalReferenceParams.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalReferenceParams.cs
@@ -10,6 +10,7 @@ namespace Roslyn.LanguageServer.Protocol
     /// <summary>
     /// Class which represents extensions of <see cref="ReferenceParams"/> passed as parameter of find reference requests.
     /// </summary>
+    [DataContract]
     internal class VSInternalReferenceParams : ReferenceParams
     {
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalSelectedCompletionInfo.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalSelectedCompletionInfo.cs
@@ -12,6 +12,7 @@ namespace Roslyn.LanguageServer.Protocol
     ///
     /// See https://github.com/microsoft/vscode/blob/075ba020e8493f40dba89891b1a08453f2c067e9/src/vscode-dts/vscode.proposed.inlineCompletions.d.ts#L48.
     /// </summary>
+    [DataContract]
     internal class VSInternalSelectedCompletionInfo
     {
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalTextDocumentClientCapabilities.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Internal/VSInternalTextDocumentClientCapabilities.cs
@@ -10,6 +10,7 @@ namespace Roslyn.LanguageServer.Protocol
     /// <summary>
     /// Text document capabilities specific to Visual Studio.
     /// </summary>
+    [DataContract]
     internal class VSInternalTextDocumentClientCapabilities : TextDocumentClientCapabilities
     {
         /// <summary>


### PR DESCRIPTION
These failures were happening due to serialization failing on the types being passed over the wire due to missing DataContract attributes. I did a pass through all VSInternal types defined in CLaSP and made sure that we matched which ones had the DataContract attribute to match what the VSLanguageServerClient repo does.

Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2049118