### PR TITLE
Load projects referenced through ProjectReference with ReferenceOutputAssembly=false to MSBuildWorkspace

### DIFF
--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/Extensions.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/Extensions.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public static IEnumerable<ProjectFileReference> GetProjectReferences(this MSB.Execution.ProjectInstance executedProject)
             => executedProject
                 .GetItems(ItemNames.ProjectReference)
-                .Where(i => i.ReferenceOutputAssemblyIsTrue())
                 .Select(CreateProjectFileReference);
 
         public static ImmutableArray<PackageReference> GetPackageReferences(this MSB.Execution.ProjectInstance executedProject)
@@ -55,7 +54,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// Create a <see cref="ProjectFileReference"/> from a ProjectReference node in the MSBuild file.
         /// </summary>
         private static ProjectFileReference CreateProjectFileReference(MSB.Execution.ProjectItemInstance reference)
-            => new(reference.EvaluatedInclude, reference.GetAliases());
+            => new(reference.EvaluatedInclude, reference.GetAliases(), reference.ReferenceOutputAssemblyIsTrue());
 
         public static ImmutableArray<string> GetAliases(this MSB.Framework.ITaskItem item)
         {

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFileReference.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFileReference.cs
@@ -27,12 +27,19 @@ namespace Microsoft.CodeAnalysis.MSBuild
         [DataMember(Order = 1)]
         public ImmutableArray<string> Aliases { get; }
 
-        public ProjectFileReference(string path, ImmutableArray<string> aliases)
+        /// <summary>
+        /// The value of <see cref="MetadataNames.ReferenceOutputAssembly"/>.
+        /// </summary>
+        [DataMember(Order = 2)]
+        public bool ReferenceOutputAssembly { get; }
+
+        public ProjectFileReference(string path, ImmutableArray<string> aliases, bool referenceOutputAssembly)
         {
             Debug.Assert(!aliases.IsDefault);
 
-            this.Path = path;
-            this.Aliases = aliases;
+            Path = path;
+            Aliases = aliases;
+            ReferenceOutputAssembly = referenceOutputAssembly;
         }
     }
 }

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
@@ -647,7 +647,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
             var project = this.CurrentSolution.GetProject(projectReference.ProjectId);
             if (project?.FilePath is not null)
             {
-                _applyChangesProjectFile.AddProjectReferenceAsync(project.Name, new ProjectFileReference(project.FilePath, projectReference.Aliases), CancellationToken.None).Wait();
+                // Only "ReferenceOutputAssembly=true" project references are represented in the workspace:
+                var reference = new ProjectFileReference(project.FilePath, projectReference.Aliases, referenceOutputAssembly: true);
+                _applyChangesProjectFile.AddProjectReferenceAsync(project.Name, reference, CancellationToken.None).Wait();
             }
 
             this.OnProjectReferenceAdded(projectId, projectReference);

--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
@@ -2432,7 +2432,7 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]
-        public async Task TestProjectReferenceWithReferenceOutputAssemblyFalse()
+        public async Task TestProjectReferenceWithReferenceOutputAssemblyFalse_SolutionRoot()
         {
             var files = GetProjectReferenceSolutionFiles();
             files = VisitProjectReferences(
@@ -2449,6 +2449,29 @@ class C1
             {
                 Assert.Empty(project.ProjectReferences);
             }
+        }
+
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]
+        public async Task TestProjectReferenceWithReferenceOutputAssemblyFalse_ProjectRoot()
+        {
+            var files = GetProjectReferenceSolutionFiles();
+            files = VisitProjectReferences(
+                files,
+                r => r.Add(new XElement(XName.Get("ReferenceOutputAssembly", MSBuildNamespace), "false")));
+
+            CreateFiles(files);
+
+            var referencingProjectPath = GetSolutionFileName(@"CSharpProject\CSharpProject_ProjectReference.csproj");
+            var referencedProjectPath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
+
+            using var workspace = CreateMSBuildWorkspace();
+            var project = await workspace.OpenProjectAsync(referencingProjectPath);
+
+            Assert.Empty(project.ProjectReferences);
+
+            // Project referenced through ProjectReference with ReferenceOutputAssembly=false
+            // should be present in the solution.
+            Assert.NotNull(project.Solution.GetProjectsByName("CSharpProject").SingleOrDefault());
         }
 
         private static FileSet VisitProjectReferences(FileSet files, Action<XElement> visitProjectReference)


### PR DESCRIPTION
These projects are currently not included in the solution, which breaks dotnet-watch.