### PR TITLE
Fetch storage instance once when searching

### DIFF
--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -239,6 +239,7 @@ internal abstract class AbstractChangeSignatureService : ILanguageService
                 streamingProgress,
                 FindReferencesSearchOptions.Default,
                 cancellationToken).ConfigureAwait(false);
+            await using var _ = engine.ConfigureAwait(false);
 
             await engine.FindReferencesAsync(symbol, cancellationToken).ConfigureAwait(false);
             return streamingProgress.GetReferencedSymbols();

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -232,12 +232,13 @@ internal abstract class AbstractChangeSignatureService : ILanguageService
         {
             var streamingProgress = new StreamingProgressCollector();
 
-            var engine = new FindReferencesSearchEngine(
+            var engine = await FindReferencesSearchEngine.CreateAsync(
                 solution,
                 documents: null,
                 ReferenceFinders.DefaultReferenceFinders.Add(DelegateInvokeMethodReferenceFinder.DelegateInvokeMethod),
                 streamingProgress,
-                FindReferencesSearchOptions.Default);
+                FindReferencesSearchOptions.Default,
+                cancellationToken).ConfigureAwait(false);
 
             await engine.FindReferencesAsync(symbol, cancellationToken).ConfigureAwait(false);
             return streamingProgress.GetReferencedSymbols();

--- a/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
+++ b/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
@@ -61,13 +61,13 @@ internal class DelegateInvokeMethodReferenceFinder : AbstractReferenceFinder<IMe
     }
 
     protected override Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         foreach (var document in project.Documents)

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -263,9 +263,7 @@ internal static partial class ExtensionMethodImportCompletionHelper
             var syntaxFacts = project.Services.GetRequiredService<ISyntaxFactsService>();
             var builder = new ExtensionMethodImportCompletionCacheEntry.Builder(checksum, project.Language, syntaxFacts.StringComparer);
 
-            var solution = project.Solution;
-            var storageService = solution.Services.GetPersistentStorageService();
-            var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
+            var storage = await project.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
             await using var _ = storage.ConfigureAwait(false);
 
             foreach (var document in project.Documents)

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -481,9 +481,7 @@ internal abstract partial class AbstractConvertTupleToStructCodeRefactoringProvi
 
     private static async Task AddDocumentsToUpdateForProjectAsync(Project project, ArrayBuilder<DocumentToUpdate> result, ImmutableArray<string> tupleFieldNames, CancellationToken cancellationToken)
     {
-        var solution = project.Solution;
-        var storageService = solution.Services.GetPersistentStorageService();
-        var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
+        var storage = await project.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
         await using var _ = storage.ConfigureAwait(false);
 
         foreach (var document in project.Documents)

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
@@ -170,9 +170,7 @@ internal static class UnitTestingSearchHelpers
         UnitTestingSearchQuery query,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var solution = project.Solution;
-        var storageService = solution.Services.GetPersistentStorageService();
-        var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
+        var storage = await project.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
         await using var _ = storage.ConfigureAwait(false);
 
         var (container, symbolName, symbolArity) = ExtractQueryData(query);

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.CachedIndexMap.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.CachedIndexMap.cs
@@ -56,6 +56,11 @@ internal abstract partial class AbstractNavigateToSearchService
             if (cancellationToken.IsCancellationRequested)
                 return SpecializedTasks.Null<TopLevelSyntaxTreeIndex>();
 
+            // It's ok for the async lazy to capture '_storage' here.  The _storage is only disposed when this type is
+            // GC'ed.  So the lifetime of it is always longer than of the _map itself.  In other words, if we were alive
+            // in order to grab items from the map, we clearly could not be GCed, and thus the storage would still be
+            // not-disposed.
+
             // Add the async lazy to compute the index for this document.  Or, return the existing cached one if already
             // present.  This ensures that subsequent searches that are run while the solution is still loading are fast
             // and avoid the cost of loading from the persistence service every time.

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.CachedIndexMap.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.CachedIndexMap.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Storage;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.NavigateTo;
+
+internal abstract partial class AbstractNavigateToSearchService
+{
+    private sealed class CachedIndexMap
+    {
+        private readonly SemaphoreSlim _gate = new(initialCount: 1);
+
+        /// <summary>
+        /// Cached map from document key to the (potentially stale) syntax tree index for it we use prior to the full
+        /// solution becoming available.
+        /// </summary>
+        private readonly ConcurrentDictionary<DocumentKey, AsyncLazy<TopLevelSyntaxTreeIndex?>> _map = new();
+
+        /// <summary>
+        /// String table we use to dedupe common values while deserializing <see cref="SyntaxTreeIndex"/>s.
+        /// </summary>
+        private readonly StringTable _stringTable = new();
+
+        private IChecksummedPersistentStorage? _storage;
+
+        public async ValueTask InitializeAsync(
+            IChecksummedPersistentStorageService storageService, SolutionKey solutionKey, CancellationToken cancellationToken)
+        {
+            using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_storage != null)
+                    return;
+
+                _storage = await storageService.GetStorageAsync(solutionKey, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        ~CachedIndexMap()
+        {
+            var storage = Interlocked.Exchange(ref _storage, null);
+            storage?.Dispose();
+        }
+
+        public Task<TopLevelSyntaxTreeIndex?> GetIndexAsync(DocumentKey documentKey, CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfNull(_storage);
+
+            if (cancellationToken.IsCancellationRequested)
+                return SpecializedTasks.Null<TopLevelSyntaxTreeIndex>();
+
+            // Add the async lazy to compute the index for this document.  Or, return the existing cached one if already
+            // present.  This ensures that subsequent searches that are run while the solution is still loading are fast
+            // and avoid the cost of loading from the persistence service every time.
+            //
+            // Pass in null for the checksum as we want to search stale index values regardless if the documents don't
+            // match on disk anymore.
+            var asyncLazy = _map.GetOrAdd(
+                documentKey,
+                documentKey => AsyncLazy.Create(static (tuple, c) =>
+                    TopLevelSyntaxTreeIndex.LoadAsync(tuple._storage, tuple.documentKey, checksum: null, tuple._stringTable, c),
+                    arg: (_storage, _stringTable, documentKey)));
+            return asyncLazy.GetValueAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.GeneratedDocumentSearch.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.GeneratedDocumentSearch.cs
@@ -68,9 +68,7 @@ internal abstract partial class AbstractNavigateToSearchService
         if (projects.Length == 0)
             return;
 
-        var solution = projects[0].Solution;
-        var storageService = solution.Services.GetPersistentStorageService();
-        var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
+        var storage = await projects[0].GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
         await using var _ = storage.ConfigureAwait(false);
 
         var (patternName, patternContainerOpt) = PatternMatcher.GetNameAndContainer(pattern);

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PatternMatching;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
@@ -38,6 +39,7 @@ internal abstract partial class AbstractNavigateToSearchService
         ];
 
     private static async ValueTask SearchSingleDocumentAsync(
+        IChecksummedPersistentStorage storage,
         Document document,
         string patternName,
         string? patternContainer,
@@ -50,13 +52,13 @@ internal abstract partial class AbstractNavigateToSearchService
 
         // Get the index for the file we're searching, as well as for its linked siblings.  We'll use the latter to add
         // the information to a symbol about all the project TFMs is can be found in.
-        var index = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
+        var index = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(document, storage, cancellationToken).ConfigureAwait(false);
         using var _ = ArrayBuilder<(TopLevelSyntaxTreeIndex, ProjectId)>.GetInstance(out var linkedIndices);
 
         foreach (var linkedDocumentId in document.GetLinkedDocumentIds())
         {
             var linkedDocument = document.Project.Solution.GetRequiredDocument(linkedDocumentId);
-            var linkedIndex = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(linkedDocument, cancellationToken).ConfigureAwait(false);
+            var linkedIndex = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(linkedDocument, storage, cancellationToken).ConfigureAwait(false);
             linkedIndices.Add((linkedIndex, linkedDocumentId.ProjectId));
         }
 

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.NormalSearch.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.NormalSearch.cs
@@ -49,9 +49,7 @@ internal abstract partial class AbstractNavigateToSearchService
     public static async Task SearchDocumentInCurrentProcessAsync(
         Document document, string searchPattern, IImmutableSet<string> kinds, Func<ImmutableArray<RoslynNavigateToItem>, Task> onItemsFound, CancellationToken cancellationToken)
     {
-        var solution = document.Project.Solution;
-        var storageService = solution.Services.GetPersistentStorageService();
-        var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
+        var storage = await document.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
         await using var _ = storage.ConfigureAwait(false);
 
         var (patternName, patternContainerOpt) = PatternMatcher.GetNameAndContainer(searchPattern);
@@ -128,11 +126,8 @@ internal abstract partial class AbstractNavigateToSearchService
 
         using var _1 = GetPooledHashSet(priorityDocuments.Select(d => d.Project), out var highPriProjects);
 
-        var solution = projects.First().Solution;
-
-        var storageService = solution.Services.GetPersistentStorageService();
-        var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
-        await using var _2 = storage.ConfigureAwait(false);
+        var storage = await projects[0].GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
+        await using var _ = storage.ConfigureAwait(false);
 
         // Process each project on its own.  That way we can tell the client when we are done searching it.  Put the
         // projects with priority documents ahead of those without so we can get results for those faster.

--- a/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
@@ -144,8 +144,7 @@ namespace IdeCoreBenchmarks
             var start = DateTime.Now;
 
             var solution = _workspace.CurrentSolution;
-            var storageService = solution.Services.GetPersistentStorageService();
-            var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), CancellationToken.None).ConfigureAwait(false);
+            var storage = await solution.GetPersistentStorageAsync(CancellationToken.None).ConfigureAwait(false);
             await using var _ = storage.ConfigureAwait(false);
 
             foreach (var project in solution.Projects)
@@ -170,8 +169,7 @@ namespace IdeCoreBenchmarks
             var start = DateTime.Now;
 
             var solution = _workspace.CurrentSolution;
-            var storageService = solution.Services.GetPersistentStorageService();
-            var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), CancellationToken.None).ConfigureAwait(false);
+            var storage = await solution.GetPersistentStorageAsync(CancellationToken.None).ConfigureAwait(false);
             await using var _ = storage.ConfigureAwait(false);
 
             foreach (var project in _workspace.CurrentSolution.Projects)

--- a/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
@@ -885,10 +885,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             await using (var storage = await GetStorageAsync(solution))
             {
-                var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, default);
-                await index.SaveAsync(document, _storageService!);
+                var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, storage, CancellationToken.None);
+                await index.GetTestAccessor().SaveAsync(document, storage);
 
-                var index2 = await SyntaxTreeIndex.LoadAsync(_storageService!, DocumentKey.ToDocumentKey(document), checksum: null, new StringTable(), default);
+                var index2 = await SyntaxTreeIndex.LoadAsync(storage, DocumentKey.ToDocumentKey(document), checksum: null, new StringTable(), default);
                 Assert.NotNull(index2);
             }
         }
@@ -905,10 +905,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             await using (var storage = await GetStorageAsync(solution))
             {
-                var index = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(document, default);
-                await index.SaveAsync(document, _storageService!);
+                var index = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(document, storage, CancellationToken.None);
+                await index.GetTestAccessor().SaveAsync(document, storage);
 
-                var index2 = await TopLevelSyntaxTreeIndex.LoadAsync(_storageService!, DocumentKey.ToDocumentKey(document), checksum: null, new StringTable(), default);
+                var index2 = await TopLevelSyntaxTreeIndex.LoadAsync(storage, DocumentKey.ToDocumentKey(document), checksum: null, new StringTable(), default);
                 Assert.NotNull(index2);
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindLiterals/FindLiteralsSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindLiterals/FindLiteralsSearchEngine.cs
@@ -17,7 +17,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols;
 
-internal class FindLiteralsSearchEngine
+internal sealed class FindLiteralsSearchEngine : IAsyncDisposable
 {
     private enum SearchKind
     {
@@ -77,10 +77,8 @@ internal class FindLiteralsSearchEngine
         }
     }
 
-    ~FindLiteralsSearchEngine()
-    {
-        _storage.Dispose();
-    }
+    public ValueTask DisposeAsync()
+        => _storage.DisposeAsync();
 
     public static async Task<FindLiteralsSearchEngine> CreateAsync(
         Solution solution,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindLiterals/FindLiteralsSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindLiterals/FindLiteralsSearchEngine.cs
@@ -86,8 +86,7 @@ internal sealed class FindLiteralsSearchEngine : IAsyncDisposable
         object value,
         CancellationToken cancellationToken)
     {
-        var storageService = solution.Services.GetPersistentStorageService();
-        var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
+        var storage = await solution.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
         return new(solution, progress, value, storage);
     }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
@@ -45,8 +45,7 @@ internal static partial class DependentTypeFinder
 
         private static async Task<ProjectIndex> CreateIndexAsync(Project project, CancellationToken cancellationToken)
         {
-            var storageService = project.Solution.Services.GetPersistentStorageService();
-            var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(project.Solution), cancellationToken).ConfigureAwait(false);
+            var storage = await project.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
             await using var _ = storage.ConfigureAwait(false);
 
             var classesThatMayDeriveFromSystemObject = new MultiDictionary<DocumentId, DeclaredSymbolInfo>();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
@@ -32,12 +32,12 @@ internal sealed class FindReferenceCache
         if (!s_cache.TryGetValue(document, out var cache))
         {
             // Extracted into local function to prevent captures.
-            cache = await GetOrAddCache(document, storage, cancellationToken).ConfigureAwait(false);
+            cache = await GetOrAddCacheAsync(document, storage, cancellationToken).ConfigureAwait(false);
         }
 
         return cache;
 
-        static async ValueTask<FindReferenceCache> GetOrAddCache(Document document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        static async ValueTask<FindReferenceCache> GetOrAddCacheAsync(Document document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
         {
             var cache = await ComputeCacheAsync(document, storage, cancellationToken).ConfigureAwait(false);
             return s_cache.GetValue(document, _ => cache);
@@ -56,6 +56,8 @@ internal sealed class FindReferenceCache
             // any unicode escapes in it, then we do simple string matching to find the tokens.
             var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, storage, cancellationToken).ConfigureAwait(false);
 
+            // Do not capture 'storage' inside FindReferenceCache.  The cache entry lives longer than the lifetime of
+            // the storage itself.
             return new(document, text, model, root, index);
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
@@ -64,7 +64,7 @@ internal partial class FindReferencesSearchEngine
             CancellationToken cancellationToken)
         {
             var solution = engine._solution;
-            var options = engine._options;
+            var options = engine.Options;
 
             // Start by mapping the initial symbol to the appropriate source symbol in originating project if possible.
             var searchSymbols = await MapToAppropriateSymbolsAsync(solution, symbols, cancellationToken).ConfigureAwait(false);
@@ -202,7 +202,7 @@ internal partial class FindReferencesSearchEngine
 
             foreach (var finder in engine._finders)
             {
-                var cascaded = await finder.DetermineCascadedSymbolsAsync(symbol, solution, engine._options, cancellationToken).ConfigureAwait(false);
+                var cascaded = await finder.DetermineCascadedSymbolsAsync(symbol, solution, engine.Options, cancellationToken).ConfigureAwait(false);
                 foreach (var cascade in cascaded)
                     await TryMapAndAddLinkedSymbolsAsync(cascade).ConfigureAwait(false);
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -72,8 +72,7 @@ internal partial class FindReferencesSearchEngine : IAsyncDisposable
         FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        var storageService = solution.Services.GetPersistentStorageService();
-        var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
+        var storage = await solution.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
         return new(solution, documents, finders, progress, options, storage);
     }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols;
 
 using Reference = (SymbolGroup group, ISymbol symbol, ReferenceLocation location);
 
-internal partial class FindReferencesSearchEngine
+internal partial class FindReferencesSearchEngine : IAsyncDisposable
 {
     private readonly Solution _solution;
     private readonly IImmutableSet<Document>? _documents;
@@ -61,10 +61,8 @@ internal partial class FindReferencesSearchEngine
         _progressTracker = progress.ProgressTracker;
     }
 
-    ~FindReferencesSearchEngine()
-    {
-        this.Storage.Dispose();
-    }
+    public ValueTask DisposeAsync()
+        => this.Storage.DisposeAsync();
 
     public static async Task<FindReferencesSearchEngine> CreateAsync(
         Solution solution,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
@@ -23,7 +23,7 @@ internal partial class FindReferencesSearchEngine
         // Caller needs to pass unidirectional cascading to make this search efficient.  If we only have
         // unidirectional cascading, then we only need to check the potential matches we find in the file against
         // the starting symbol.
-        Debug.Assert(_options.UnidirectionalHierarchyCascade);
+        Debug.Assert(Options.UnidirectionalHierarchyCascade);
 
         var unifiedSymbols = new MetadataUnifyingSymbolHashSet
         {
@@ -87,7 +87,7 @@ internal partial class FindReferencesSearchEngine
             // appropriate finders checking this document for hits.  We're likely going to need to perform syntax
             // and semantics checks in this file.  So just grab those once here and hold onto them for the lifetime
             // of this call.
-            var cache = await FindReferenceCache.GetCacheAsync(document, cancellationToken).ConfigureAwait(false);
+            var cache = await FindReferenceCache.GetCacheAsync(document, this.Storage, cancellationToken).ConfigureAwait(false);
 
             foreach (var symbol in symbols)
             {
@@ -114,7 +114,7 @@ internal partial class FindReferencesSearchEngine
             foreach (var finder in _finders)
             {
                 await finder.FindReferencesInDocumentAsync(
-                    symbol, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, referencesForFinder, _options, cancellationToken).ConfigureAwait(false);
+                    symbol, state, StandardCallbacks<FinderLocation>.AddToArrayBuilder, referencesForFinder, Options, cancellationToken).ConfigureAwait(false);
             }
 
             if (referencesForFinder.Count > 0)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMemberScopedReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMemberScopedReferenceFinder.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -25,13 +26,13 @@ internal abstract class AbstractMemberScopedReferenceFinder<TSymbol> : AbstractR
         => true;
 
     protected sealed override Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         TSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         var location = symbol.Locations.FirstOrDefault();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -19,18 +20,18 @@ internal sealed class ConstructorInitializerSymbolReferenceFinder : AbstractRefe
         => symbol.MethodKind == MethodKind.Constructor;
 
     protected override Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        return FindDocumentsAsync(project, documents, static async (document, name, cancellationToken) =>
+        return FindDocumentsAsync(searchEngine, project, documents, static async (document, name, storage, cancellationToken) =>
         {
-            var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
+            var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, storage, cancellationToken).ConfigureAwait(false);
             if (index.ContainsBaseConstructorInitializer)
                 return true;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
@@ -17,13 +17,13 @@ internal sealed class DestructorSymbolReferenceFinder : AbstractReferenceFinder<
         => symbol.MethodKind == MethodKind.Destructor;
 
     protected override Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         return Task.CompletedTask;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
@@ -36,17 +36,17 @@ internal class EventSymbolReferenceFinder : AbstractMethodOrPropertyOrEventSymbo
     }
 
     protected sealed override async Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IEventSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        await FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
-        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+        await FindDocumentsAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
+        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
     protected sealed override ValueTask FindReferencesInDocumentAsync<TData>(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
@@ -51,7 +51,7 @@ internal sealed partial class ExplicitConversionSymbolReferenceFinder : Abstract
         await FindDocumentsAsync(searchEngine, project, documents, underlyingNamedType.SpecialType.ToPredefinedType(), StandardCallbacks<Document>.AddToHashSet, result, cancellationToken).ConfigureAwait(false);
 
         // Ignore any documents that don't also have an explicit cast in them.
-        await FindDocumentsWithPredicateAsync(searchEngine, project, documents, index => index.ContainsConversion, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+        await FindDocumentsWithPredicateAsync(searchEngine, project, documents, static index => index.ContainsConversion, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
     protected sealed override ValueTask FindReferencesInDocumentAsync<TData>(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
@@ -17,13 +17,13 @@ internal sealed class ExplicitInterfaceMethodReferenceFinder : AbstractReference
         => symbol.MethodKind == MethodKind.ExplicitInterfaceImplementation;
 
     protected sealed override Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         // An explicit method can't be referenced anywhere.

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -28,17 +28,17 @@ internal sealed class FieldSymbolReferenceFinder : AbstractReferenceFinder<IFiel
     }
 
     protected override async Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IFieldSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        await FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
-        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+        await FindDocumentsAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
+        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
     protected override ValueTask FindReferencesInDocumentAsync<TData>(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
@@ -25,7 +25,7 @@ internal interface IReferenceFinder
     /// in a search for <c>A.X</c> because they both end in <c>X</c>.
     /// </summary>
     Task<ImmutableArray<string>> DetermineGlobalAliasesAsync(
-        ISymbol symbol, Project project, CancellationToken cancellationToken);
+        FindReferencesSearchEngine searchEngine, ISymbol symbol, Project project, CancellationToken cancellationToken);
 
     /// <summary>
     /// Called by the find references search engine when a new symbol definition is found.
@@ -51,10 +51,11 @@ internal interface IReferenceFinder
     /// Implementations of this method must be thread-safe.
     /// </summary>
     Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         ISymbol symbol, HashSet<string>? globalAliases,
         Project project, IImmutableSet<Document>? documents,
         Action<Document, TData> processResult, TData processResultData,
-        FindReferencesSearchOptions options, CancellationToken cancellationToken);
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Called by the find references search engine to determine the set of reference locations

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
@@ -38,13 +38,13 @@ internal sealed class MethodTypeParameterSymbolReferenceFinder : AbstractTypePar
     }
 
     protected sealed override Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         ITypeParameterSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         // Type parameters are only found in documents that have both their name, and the name
@@ -58,7 +58,7 @@ internal sealed class MethodTypeParameterSymbolReferenceFinder : AbstractTypePar
         // Also, we only look for files that have the name of the owning type.  This helps filter
         // down the set considerably.
         Contract.ThrowIfNull(symbol.DeclaringMethod);
-        return FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name,
+        return FindDocumentsAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken, symbol.Name,
             GetMemberNameWithoutInterfaceName(symbol.DeclaringMethod.Name),
             symbol.DeclaringMethod.ContainingType.Name);
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
@@ -19,21 +19,22 @@ internal sealed class OperatorSymbolReferenceFinder : AbstractMethodOrPropertyOr
         => symbol.MethodKind is MethodKind.UserDefinedOperator or MethodKind.BuiltinOperator;
 
     protected sealed override async Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IMethodSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         var op = symbol.GetPredefinedOperator();
-        await FindDocumentsAsync(project, documents, op, processResult, processResultData, cancellationToken).ConfigureAwait(false);
-        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+        await FindDocumentsAsync(searchEngine, project, documents, op, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
     private static Task FindDocumentsAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         Project project,
         IImmutableSet<Document>? documents,
         PredefinedOperator op,
@@ -45,7 +46,7 @@ internal sealed class OperatorSymbolReferenceFinder : AbstractMethodOrPropertyOr
             return Task.CompletedTask;
 
         return FindDocumentsWithPredicateAsync(
-            project, documents, static (index, op) => index.ContainsPredefinedOperator(op), op, processResult, processResultData, cancellationToken);
+            searchEngine, project, documents, static (index, op) => index.ContainsPredefinedOperator(op), op, processResult, processResultData, cancellationToken);
     }
 
     protected sealed override ValueTask FindReferencesInDocumentAsync<TData>(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
@@ -22,13 +22,13 @@ internal sealed class ParameterSymbolReferenceFinder : AbstractReferenceFinder<I
         => true;
 
     protected override Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IParameterSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         // TODO(cyrusn): We can be smarter with parameters.  They will either be found
@@ -36,7 +36,7 @@ internal sealed class ParameterSymbolReferenceFinder : AbstractReferenceFinder<I
         // elsewhere as "paramName:" or "paramName:=".  We can narrow the search by
         // filtering down to matches of that form.  For now we just return any document
         // that references something with this name.
-        return FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name);
+        return FindDocumentsAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken, symbol.Name);
     }
 
     protected override ValueTask FindReferencesInDocumentAsync<TData>(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
@@ -93,27 +93,27 @@ internal sealed class PropertySymbolReferenceFinder : AbstractMethodOrPropertyOr
     }
 
     protected sealed override async Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         IPropertySymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
-        await FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
+        await FindDocumentsAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken, symbol.Name).ConfigureAwait(false);
 
         if (IsForEachProperty(symbol))
-            await FindDocumentsWithForEachStatementsAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+            await FindDocumentsWithForEachStatementsAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
 
         if (symbol.IsIndexer)
-            await FindDocumentWithExplicitOrImplicitElementAccessExpressionsAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+            await FindDocumentWithExplicitOrImplicitElementAccessExpressionsAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
 
         if (symbol.IsIndexer)
-            await FindDocumentWithIndexerMemberCrefAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+            await FindDocumentWithIndexerMemberCrefAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
 
-        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
+        await FindDocumentsWithGlobalSuppressMessageAttributeAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken).ConfigureAwait(false);
     }
 
     private static bool IsForEachProperty(IPropertySymbol symbol)
@@ -161,17 +161,17 @@ internal sealed class PropertySymbolReferenceFinder : AbstractMethodOrPropertyOr
     }
 
     private static Task FindDocumentWithExplicitOrImplicitElementAccessExpressionsAsync<TData>(
-        Project project, IImmutableSet<Document>? documents, Action<Document, TData> processResult, TData processResultData, CancellationToken cancellationToken)
+        FindReferencesSearchEngine searchEngine, Project project, IImmutableSet<Document>? documents, Action<Document, TData> processResult, TData processResultData, CancellationToken cancellationToken)
     {
         return FindDocumentsWithPredicateAsync(
-            project, documents, static index => index.ContainsExplicitOrImplicitElementAccessExpression, processResult, processResultData, cancellationToken);
+            searchEngine, project, documents, static index => index.ContainsExplicitOrImplicitElementAccessExpression, processResult, processResultData, cancellationToken);
     }
 
     private static Task FindDocumentWithIndexerMemberCrefAsync<TData>(
-        Project project, IImmutableSet<Document>? documents, Action<Document, TData> processResult, TData processResultData, CancellationToken cancellationToken)
+        FindReferencesSearchEngine searchEngine, Project project, IImmutableSet<Document>? documents, Action<Document, TData> processResult, TData processResultData, CancellationToken cancellationToken)
     {
         return FindDocumentsWithPredicateAsync(
-            project, documents, static index => index.ContainsIndexerMemberCref, processResult, processResultData, cancellationToken);
+            searchEngine, project, documents, static index => index.ContainsIndexerMemberCref, processResult, processResultData, cancellationToken);
     }
 
     private static void FindIndexerReferences<TData>(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
@@ -16,13 +16,13 @@ internal sealed class TypeParameterSymbolReferenceFinder : AbstractTypeParameter
         => symbol.TypeParameterKind != TypeParameterKind.Method;
 
     protected override Task DetermineDocumentsToSearchAsync<TData>(
+        FindReferencesSearchEngine searchEngine,
         ITypeParameterSymbol symbol,
         HashSet<string>? globalAliases,
         Project project,
         IImmutableSet<Document>? documents,
         Action<Document, TData> processResult,
         TData processResultData,
-        FindReferencesSearchOptions options,
         CancellationToken cancellationToken)
     {
         // Type parameters are only found in documents that have both their name, and the
@@ -32,6 +32,6 @@ internal sealed class TypeParameterSymbolReferenceFinder : AbstractTypeParameter
         // parameter has a different name in different parts that we won't find it.  However,
         // this only happens in error situations.  It is not legal in C# to use a different
         // name for a type parameter in different parts.
-        return FindDocumentsAsync(project, documents, processResult, processResultData, cancellationToken, symbol.Name, symbol.ContainingType.Name);
+        return FindDocumentsAsync(searchEngine, project, documents, processResult, processResultData, cancellationToken, symbol.Name, symbol.ContainingType.Name);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex.cs
@@ -92,15 +92,6 @@ internal abstract partial class AbstractSyntaxIndex<TIndex>
             return index;
         }
 
-        //var disposeStorage = storage is null;
-        //try
-        //{
-        //    if (storage is null)
-        //    {
-        //        var storageService = project.LanguageServices.SolutionServices.GetPersistentStorageService();
-        //        storage = await storageService.GetStorageAsync(solutionKey, cancellationToken).ConfigureAwait(false);
-        //    }
-
         // What we have in memory isn't valid.  Try to load from the persistence service.
         index = await LoadAsync(storage, solutionKey, project, document, textChecksum, textAndDirectivesChecksum, read, cancellationToken).ConfigureAwait(false);
         if (index != null || loadOnly)
@@ -113,12 +104,6 @@ internal abstract partial class AbstractSyntaxIndex<TIndex>
         await index.SaveAsync(storage, solutionKey, project, document, cancellationToken).ConfigureAwait(false);
 
         return index;
-        //}
-        //finally
-        //{
-        //    if (disposeStorage)
-        //        storage?.Dispose();
-        //}
     }
 
     private static async Task<TIndex> CreateIndexAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -163,12 +163,8 @@ internal partial class AbstractSyntaxIndex<TIndex>
     {
         public async Task<bool> SaveAsync(
             Document document,
-            IChecksummedPersistentStorageService storageService)
+            IChecksummedPersistentStorage storage)
         {
-            var solutionKey = SolutionKey.ToSolutionKey(document.Project.Solution);
-            var storage = await storageService.GetStorageAsync(solutionKey, CancellationToken.None).ConfigureAwait(false);
-            await using var _ = storage.ConfigureAwait(false);
-
             return await index.SaveAsync(
                 storage,
                 SolutionKey.ToSolutionKey(document.Project.Solution),

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindLiteralReferences.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindLiteralReferences.cs
@@ -48,6 +48,8 @@ public static partial class SymbolFinder
         CancellationToken cancellationToken)
     {
         var engine = await FindLiteralsSearchEngine.CreateAsync(solution, progress, value, cancellationToken).ConfigureAwait(false);
+        await using var _ = engine.ConfigureAwait(false);
+
         await engine.FindReferencesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindLiteralReferences.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindLiteralReferences.cs
@@ -42,12 +42,12 @@ public static partial class SymbolFinder
         }
     }
 
-    internal static Task FindLiteralReferencesInCurrentProcessAsync(
+    internal static async Task FindLiteralReferencesInCurrentProcessAsync(
         object value, Solution solution,
         IStreamingFindLiteralReferencesProgress progress,
         CancellationToken cancellationToken)
     {
-        var engine = new FindLiteralsSearchEngine(solution, progress, value);
-        return engine.FindReferencesAsync(cancellationToken);
+        var engine = await FindLiteralsSearchEngine.CreateAsync(solution, progress, value, cancellationToken).ConfigureAwait(false);
+        await engine.FindReferencesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Current.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Current.cs
@@ -80,6 +80,7 @@ public static partial class SymbolFinder
 
         var engine = await FindReferencesSearchEngine.CreateAsync(
             solution, documents, finders, progress, options, cancellationToken).ConfigureAwait(false);
+        await using var _ = engine.ConfigureAwait(false);
         await engine.FindReferencesAsync(symbol, cancellationToken).ConfigureAwait(false);
     }
 
@@ -99,6 +100,7 @@ public static partial class SymbolFinder
         var finders = ReferenceFinders.DefaultReferenceFinders;
         var engine = await FindReferencesSearchEngine.CreateAsync(
             solution, documents, finders, progress, options, cancellationToken).ConfigureAwait(false);
+        await using var _ = engine.ConfigureAwait(false);
         await engine.FindReferencesInDocumentsAsync(symbol, documents, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Current.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Current.cs
@@ -67,7 +67,7 @@ public static partial class SymbolFinder
         }
     }
 
-    internal static Task FindReferencesInCurrentProcessAsync(
+    internal static async Task FindReferencesInCurrentProcessAsync(
         ISymbol symbol,
         Solution solution,
         IStreamingFindReferencesProgress progress,
@@ -77,12 +77,13 @@ public static partial class SymbolFinder
     {
         var finders = ReferenceFinders.DefaultReferenceFinders;
         progress ??= NoOpStreamingFindReferencesProgress.Instance;
-        var engine = new FindReferencesSearchEngine(
-            solution, documents, finders, progress, options);
-        return engine.FindReferencesAsync(symbol, cancellationToken);
+
+        var engine = await FindReferencesSearchEngine.CreateAsync(
+            solution, documents, finders, progress, options, cancellationToken).ConfigureAwait(false);
+        await engine.FindReferencesAsync(symbol, cancellationToken).ConfigureAwait(false);
     }
 
-    internal static Task FindReferencesInDocumentsInCurrentProcessAsync(
+    internal static async Task FindReferencesInDocumentsInCurrentProcessAsync(
         ISymbol symbol,
         Solution solution,
         IStreamingFindReferencesProgress progress,
@@ -96,8 +97,8 @@ public static partial class SymbolFinder
         options = options with { UnidirectionalHierarchyCascade = true };
 
         var finders = ReferenceFinders.DefaultReferenceFinders;
-        var engine = new FindReferencesSearchEngine(
-            solution, documents, finders, progress, options);
-        return engine.FindReferencesInDocumentsAsync(symbol, documents, cancellationToken);
+        var engine = await FindReferencesSearchEngine.CreateAsync(
+            solution, documents, finders, progress, options, cancellationToken).ConfigureAwait(false);
+        await engine.FindReferencesInDocumentsAsync(symbol, documents, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindRenamableReferences.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindRenamableReferences.cs
@@ -28,6 +28,7 @@ public static partial class SymbolFinder
                 streamingProgress,
                 FindReferencesSearchOptions.Default,
                 cancellationToken).ConfigureAwait(false);
+            await using var _ = engine.ConfigureAwait(false);
 
             await engine.FindReferencesAsync(symbols, cancellationToken).ConfigureAwait(false);
             return streamingProgress.GetReferencedSymbols();

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindRenamableReferences.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindRenamableReferences.cs
@@ -21,12 +21,13 @@ public static partial class SymbolFinder
         {
             var streamingProgress = new StreamingProgressCollector();
 
-            var engine = new FindReferencesSearchEngine(
+            var engine = await FindReferencesSearchEngine.CreateAsync(
                 solution,
                 documents: null,
                 ReferenceFinders.DefaultRenameReferenceFinders,
                 streamingProgress,
-                FindReferencesSearchOptions.Default);
+                FindReferencesSearchOptions.Default,
+                cancellationToken).ConfigureAwait(false);
 
             await engine.FindReferencesAsync(symbols, cancellationToken).ConfigureAwait(false);
             return streamingProgress.GetReferencedSymbols();

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -27,8 +27,7 @@ internal partial class SymbolTreeInfo
     /// of source and metadata SymbolTreeInfos.
     /// </summary>
     private static async Task<SymbolTreeInfo> LoadOrCreateAsync(
-        SolutionServices services,
-        SolutionKey solutionKey,
+        IChecksummedPersistentStorage storage,
         Checksum checksum,
         Func<Checksum, ValueTask<SymbolTreeInfo>> createAsync,
         string keySuffix,
@@ -36,12 +35,6 @@ internal partial class SymbolTreeInfo
     {
         using (Logger.LogBlock(FunctionId.SymbolTreeInfo_TryLoadOrCreate, cancellationToken))
         {
-            // Ok, we can use persistence.  First try to load from the persistence service. The data in the
-            // persistence store must match the checksum passed in.
-            var storageService = services.GetPersistentStorageService();
-            var storage = await storageService.GetStorageAsync(solutionKey, cancellationToken).ConfigureAwait(false);
-            await using var _ = storage.ConfigureAwait(false);
-
             var read = await LoadAsync(storage, checksum, checksumMustMatch: true, keySuffix, cancellationToken).ConfigureAwait(false);
             if (read != null)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Storage;
 
 namespace Microsoft.CodeAnalysis.FindSymbols;
@@ -30,21 +31,21 @@ internal sealed partial class SyntaxTreeIndex : AbstractSyntaxIndex<SyntaxTreeIn
         _globalAliasInfo = globalAliasInfo;
     }
 
-    public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-        => GetRequiredIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken);
+    public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Document document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetRequiredIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, storage, cancellationToken);
 
-    public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
-        => GetRequiredIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, cancellationToken);
+    public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetRequiredIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, storage, cancellationToken);
 
-    public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-        => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken);
+    public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, storage, cancellationToken);
 
-    public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
-        => GetIndexAsync(solutionKey, project, document, loadOnly: false, cancellationToken);
+    public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetIndexAsync(solutionKey, project, document, loadOnly: false, storage, cancellationToken);
 
-    public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-        => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, loadOnly, cancellationToken);
+    public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, loadOnly, storage, cancellationToken);
 
-    public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, bool loadOnly, CancellationToken cancellationToken)
-        => GetIndexAsync(solutionKey, project, document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+    public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, bool loadOnly, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetIndexAsync(solutionKey, project, document, loadOnly, ReadIndex, CreateIndex, storage, cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -14,9 +14,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols;
 internal sealed partial class SyntaxTreeIndex
 {
     public static Task<SyntaxTreeIndex?> LoadAsync(
-        IChecksummedPersistentStorageService storageService, DocumentKey documentKey, Checksum? checksum, StringTable stringTable, CancellationToken cancellationToken)
+        IChecksummedPersistentStorage storage, DocumentKey documentKey, Checksum? checksum, StringTable stringTable, CancellationToken cancellationToken)
     {
-        return LoadAsync(storageService, documentKey, checksum, stringTable, ReadIndex, cancellationToken);
+        return LoadAsync(storage, documentKey, checksum, stringTable, ReadIndex, cancellationToken);
     }
 
     public override void WriteTo(ObjectWriter writer)

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Storage;
 using Roslyn.Utilities;
 
@@ -44,21 +45,27 @@ internal sealed partial class TopLevelSyntaxTreeIndex : AbstractSyntaxIndex<TopL
     public bool ContainsExtensionMethod
         => _extensionMethodInfo.ContainsExtensionMethod;
 
-    public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-        => GetRequiredIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken);
+    //public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
+    //    => GetRequiredIndexAsync(document, storage: null, cancellationToken);
 
-    public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
-        => GetRequiredIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, cancellationToken);
+    public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetRequiredIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, storage, cancellationToken);
 
-    public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-        => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken);
+    //public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
+    //    => GetRequiredIndexAsync(solutionKey, project, document, storage: null, cancellationToken);
 
-    public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
-        => GetIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, cancellationToken);
+    public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetRequiredIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, storage, cancellationToken);
 
-    public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-        => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, loadOnly, cancellationToken);
+    public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, storage, cancellationToken);
 
-    public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, bool loadOnly, CancellationToken cancellationToken)
-        => GetIndexAsync(solutionKey, project, document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+    public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, storage, cancellationToken);
+
+    public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, loadOnly, storage, cancellationToken);
+
+    public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, bool loadOnly, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => GetIndexAsync(solutionKey, project, document, loadOnly, ReadIndex, CreateIndex, storage, cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
@@ -45,14 +45,8 @@ internal sealed partial class TopLevelSyntaxTreeIndex : AbstractSyntaxIndex<TopL
     public bool ContainsExtensionMethod
         => _extensionMethodInfo.ContainsExtensionMethod;
 
-    //public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-    //    => GetRequiredIndexAsync(document, storage: null, cancellationToken);
-
     public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
         => GetRequiredIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, storage, cancellationToken);
-
-    //public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
-    //    => GetRequiredIndexAsync(solutionKey, project, document, storage: null, cancellationToken);
 
     public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
         => GetRequiredIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, storage, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex_Persistence.cs
@@ -13,9 +13,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols;
 internal sealed partial class TopLevelSyntaxTreeIndex
 {
     public static Task<TopLevelSyntaxTreeIndex?> LoadAsync(
-        IChecksummedPersistentStorageService storageService, DocumentKey documentKey, Checksum? checksum, StringTable stringTable, CancellationToken cancellationToken)
+        IChecksummedPersistentStorage storage, DocumentKey documentKey, Checksum? checksum, StringTable stringTable, CancellationToken cancellationToken)
     {
-        return LoadAsync(storageService, documentKey, checksum, stringTable, ReadIndex, cancellationToken);
+        return LoadAsync(storage, documentKey, checksum, stringTable, ReadIndex, cancellationToken);
     }
 
     public override void WriteTo(ObjectWriter writer)

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -738,8 +738,7 @@ internal static partial class ConflictResolver
                 return;
 
             var solution = _renameLocationSet.Solution;
-            var storageService = _renameLocationSet.Solution.Services.GetPersistentStorageService();
-            var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), _cancellationToken).ConfigureAwait(false);
+            var storage = await solution.GetPersistentStorageAsync(_cancellationToken).ConfigureAwait(false);
             await using var _ = storage.ConfigureAwait(false);
 
             try

--- a/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
@@ -79,12 +79,12 @@ internal static class RenameUtilities
             SymbolKind.Parameter;
     }
 
-    internal static IEnumerable<Document> GetDocumentsAffectedByRename(ISymbol symbol, Solution solution, IEnumerable<RenameLocation> renameLocations)
+    internal static ImmutableArray<Document> GetDocumentsAffectedByRename(ISymbol symbol, Solution solution, IEnumerable<RenameLocation> renameLocations)
     {
         if (IsSymbolDefinedInsideMethod(symbol))
         {
             // if the symbol was declared inside of a method, don't check for conflicts in non-renamed documents.
-            return renameLocations.Select(l => solution.GetRequiredDocument(l.DocumentId));
+            return renameLocations.SelectAsArray(l => solution.GetRequiredDocument(l.DocumentId));
         }
         else
         {
@@ -99,7 +99,7 @@ internal static class RenameUtilities
             {
                 var isSubset = renameLocations.Select(l => l.DocumentId.ProjectId).Distinct().Except(projectIdsOfRenameSymbolDeclaration).IsEmpty();
                 Contract.ThrowIfFalse(isSubset);
-                return projectIdsOfRenameSymbolDeclaration.SelectMany(p => solution.GetRequiredProject(p).Documents);
+                return projectIdsOfRenameSymbolDeclaration.SelectManyAsArray(p => solution.GetRequiredProject(p).Documents);
             }
             else
             {
@@ -107,7 +107,7 @@ internal static class RenameUtilities
                 // the rename symbol.  Other projects should not be affected by the rename.
                 var relevantProjects = projectIdsOfRenameSymbolDeclaration.Concat(projectIdsOfRenameSymbolDeclaration.SelectMany(p =>
                    solution.GetProjectDependencyGraph().GetProjectsThatDirectlyDependOnThisProject(p))).Distinct();
-                return relevantProjects.SelectMany(p => solution.GetRequiredProject(p).Documents);
+                return relevantProjects.SelectManyAsArray(p => solution.GetRequiredProject(p).Documents);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.Utilities;
 
@@ -13,15 +14,15 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions;
 
 internal static partial class DocumentExtensions
 {
-    public static async ValueTask<SyntaxTreeIndex> GetSyntaxTreeIndexAsync(this Document document, CancellationToken cancellationToken)
+    public static async ValueTask<SyntaxTreeIndex> GetSyntaxTreeIndexAsync(this Document document, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
     {
-        var result = await SyntaxTreeIndex.GetIndexAsync(document, loadOnly: false, cancellationToken).ConfigureAwait(false);
+        var result = await SyntaxTreeIndex.GetIndexAsync(document, loadOnly: false, storage, cancellationToken).ConfigureAwait(false);
         Contract.ThrowIfNull(result);
         return result;
     }
 
-    public static ValueTask<SyntaxTreeIndex?> GetSyntaxTreeIndexAsync(this Document document, bool loadOnly, CancellationToken cancellationToken)
-        => SyntaxTreeIndex.GetIndexAsync(document, loadOnly, cancellationToken);
+    public static ValueTask<SyntaxTreeIndex?> GetSyntaxTreeIndexAsync(this Document document, bool loadOnly, IChecksummedPersistentStorage storage, CancellationToken cancellationToken)
+        => SyntaxTreeIndex.GetIndexAsync(document, loadOnly, storage, cancellationToken);
 
     /// <summary>
     /// Returns the semantic model for this document that may be produced from partial semantics. The semantic model

--- a/src/Workspaces/Core/Portable/Storage/PersistentStorageExtensions.cs
+++ b/src/Workspaces/Core/Portable/Storage/PersistentStorageExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 
 #if !DOTNET_BUILD_FROM_SOURCE
@@ -12,6 +14,18 @@ namespace Microsoft.CodeAnalysis.Storage;
 
 internal static class PersistentStorageExtensions
 {
+    public static async Task<IChecksummedPersistentStorage> GetPersistentStorageAsync(this Solution solution, CancellationToken cancellationToken)
+    {
+        var storageService = solution.Services.GetPersistentStorageService();
+        return await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
+    }
+
+    public static Task<IChecksummedPersistentStorage> GetPersistentStorageAsync(this Project project, CancellationToken cancellationToken)
+        => GetPersistentStorageAsync(project.Solution, cancellationToken);
+
+    public static Task<IChecksummedPersistentStorage> GetPersistentStorageAsync(this Document document, CancellationToken cancellationToken)
+        => GetPersistentStorageAsync(document.Project.Solution, cancellationToken);
+
     public static IChecksummedPersistentStorageService GetPersistentStorageService(this SolutionServices services)
     {
         var workspaceConfiguration = services.GetService<IWorkspaceConfigurationService>();

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -451,8 +451,7 @@ public partial class Project
         if (!this.SupportsCompilation)
             return false;
 
-        var storageService = this.Solution.Services.GetPersistentStorageService();
-        var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(this.Solution), cancellationToken).ConfigureAwait(false);
+        var storage = await this.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
         await using var _ = storage.ConfigureAwait(false);
 
         var results = await Task.WhenAll(this.Documents.Select(d => predicateAsync(d, storage))).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
@@ -113,13 +113,8 @@ namespace Microsoft.CodeAnalysis.Remote
         private static async Task CacheClassificationsAsync(
             Document document, ClassificationType type, ClassificationOptions options, CancellationToken cancellationToken)
         {
-            var solution = document.Project.Solution;
-            var persistenceService = solution.Services.GetPersistentStorageService();
-
-            var storage = await persistenceService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
-            await using var _1 = storage.ConfigureAwait(false);
-            if (storage == null)
-                return;
+            var storage = await document.GetPersistentStorageAsync(cancellationToken).ConfigureAwait(false);
+            await using var _ = storage.ConfigureAwait(false);
 
             var classificationService = document.GetLanguageService<IClassificationService>();
             if (classificationService == null)


### PR DESCRIPTION
Traces show high contention and high costs both grabbing the lock for the storage instance, and then often cancelling out, potentially on thousands of concurrent requests as we search all the documents in a solution.

This moves us to a model where we grab the storage instance once up front, and pass that along to the helpers that need it, which can then read/write from that instance easily.

![image](https://github.com/dotnet/roslyn/assets/4564579/ca33cc5d-ad4f-4f3b-9d35-a2e663750292)
