### PR TITLE
Replay updates

### DIFF
--- a/src/Tools/Replay/README.md
+++ b/src/Tools/Replay/README.md
@@ -24,3 +24,40 @@ e:\code\roslyn\src\Tools\Replay> dotnet run --framework net472 e:\code\example\m
 This runs all of the compilation events in the binary log against the compiler and outputs the results to `e:\temp`.
 
 [binary-log]: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Binary-Log.md
+
+## Example Usage
+
+### dotnet trace
+
+To profile with `dotnet trace` first run with the `-w` option to get the PID of the compiler server. Then start up `dotnet trace` against that PID and have replay continue
+
+Console 1
+
+```cmd
+e:\code\roslyn\src\Tools\Replay> dotnet run --framework net472 e:\code\example\msbuild.binlog -w
+Binary Log: E:\code\example\msbuild.binlog
+Client Directory: E:\code\roslyn\artifacts\bin\Replay\Release\net8.0\
+Output Directory: E:\code\roslyn\src\Tools\Replay\output
+Pipe Name: 0254ccf8-294e-4b8f-a606-70f105b9e4a1
+Parallel: 6
+
+Starting server
+Process Id: 48752
+Press any key to continue
+```
+
+Console 2
+
+```cmd
+e:\users\jaredpar> dotnet trace collect --profile gc-verbose -p 48752
+
+Provider Name                           Keywords            Level               Enabled By
+Microsoft-Windows-DotNETRuntime         0x0000000000008003  Verbose(5)          --profile
+
+Process        : C:\Program Files\dotnet\dotnet.exe
+Output File    : C:\Users\jaredpar\dotnet.exe_20240502_083035.nettrace
+
+[00:00:01:13]   Recording trace 379.5907 (MB)
+```
+
+Then go back to Console 1 and press any key to continue. The trace will automatically stop once the replay operation is complete.

--- a/src/Tools/Replay/Replay.cs
+++ b/src/Tools/Replay/Replay.cs
@@ -56,7 +56,7 @@ static ReplayOptions ParseOptions(string[] args)
 
     if (string.IsNullOrEmpty(outputDirectory))
     {
-        outputDirectory = Path.Combine(Environment.CurrentDirectory, "output");
+        outputDirectory = Path.Combine(Path.GetTempPath(), "replay");
     }
 
     return new ReplayOptions(


### PR DESCRIPTION
Two changes to the replay tool:

1. Add a better usage sample to the README.md
2. Change the default output path to `%TEMP%`

The previous default output path was under the current directory. That is problematic because source files can be written out during build. Those then get picked up by subsequent builds of Replay and lead to a multitude of compilation errors.