### PR TITLE
Improve analyzer consistency check message

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
@@ -749,5 +749,6 @@ public class Generator : ISourceGenerator
         public void AddDependencyLocation(string fullPath) { }
         public bool IsHostAssembly(Assembly assembly) => false;
         public Assembly LoadFromPath(string fullPath) => throw new Exception();
+        public string? GetOriginalDependencyLocation(AssemblyName assembly) => throw new Exception();
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -20,6 +20,13 @@ namespace Microsoft.CodeAnalysis
         /// process. Either part of the compiler itself or the process hosting the compiler.
         /// </summary>
         bool IsHostAssembly(Assembly assembly);
+
+        /// <summary>
+        /// For a given <see cref="AssemblyName"/> return the location it was originally added 
+        /// from. This will return null for any value that was not directly added through the 
+        /// loader.
+        /// </summary>
+        string? GetOriginalDependencyLocation(AssemblyName assembly);
     }
 
     /// <summary>
@@ -234,6 +241,9 @@ namespace Microsoft.CodeAnalysis
                 return null;
             }
         }
+
+        public string? GetOriginalDependencyLocation(AssemblyName assemblyName) =>
+            GetBestPath(assemblyName).BestOriginalPath;
 
         /// <summary>
         /// Return the best (original, real) path information for loading an assembly with the specified <see cref="AssemblyName"/>.

--- a/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
+++ b/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
@@ -128,7 +128,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 var loadedAssemblyMvid = loadedAssembly.ManifestModule.ModuleVersionId;
                 if (resolvedPathMvid != loadedAssemblyMvid)
                 {
-                    var message = $"analyzer assembly '{resolvedPath}' has MVID '{resolvedPathMvid}' but loaded assembly '{loadedAssembly.Location}' has MVID '{loadedAssemblyMvid}'";
+                    var loadedAssemblyLocation = loader.GetOriginalDependencyLocation(loadedAssembly.GetName()) ?? loadedAssembly.Location;
+                    var message = $"analyzer assembly '{resolvedPath}' has MVID '{resolvedPathMvid}' but loaded assembly '{loadedAssemblyLocation}' has MVID '{loadedAssemblyMvid}'";
                     errorMessages ??= new List<string>();
                     errorMessages.Add(message);
                     logger.LogError(message);

--- a/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 ImmutableArray.Create(new CommandLineAnalyzerReference(mvidAlpha2.Path)),
                 assemblyLoader,
                 Logger,
-                out List<string> errorMessages);
+                out List<string>? errorMessages);
             Assert.False(result);
             Assert.NotNull(errorMessages);
 

--- a/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
             // Both the original and failed paths need to appear in the message, not the shadow copy 
             // paths
-            var errorMessage = errorMessages.Single();
+            var errorMessage = errorMessages!.Single();
             Assert.Contains(mvidAlpha1.Path, errorMessage);
             Assert.Contains(mvidAlpha2.Path, errorMessage);
         }

--- a/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
@@ -154,8 +154,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 directory.Path,
                 ImmutableArray.Create(new CommandLineAnalyzerReference(mvidAlpha2.Path)),
                 assemblyLoader,
-                Logger);
+                Logger,
+                out List<string> errorMessages);
             Assert.False(result);
+            Assert.NotNull(errorMessages);
+
+            // Both the original and failed paths need to appear in the message, not the shadow copy 
+            // paths
+            var errorMessage = errorMessages.Single();
+            Assert.Contains(mvidAlpha1.Path, errorMessage);
+            Assert.Contains(mvidAlpha2.Path, errorMessage);
         }
 
         /// <summary>
@@ -242,5 +250,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public void AddDependencyLocation(string fullPath) { }
         public bool IsHostAssembly(Assembly assembly) => false;
         public Assembly LoadFromPath(string fullPath) => throw new Exception();
+        public string? GetOriginalDependencyLocation(AssemblyName assembly) => throw new Exception();
     }
 }


### PR DESCRIPTION
This changes the message when analyzer consistency checks fail to use the original location for both the requested load and the initial load. Previously the initial load was showing the shadow copy path. That is _much_ less actionable by customers.

Before

> CompilerServer: server failed - server rejected the request due to
analyzer / generator issues 'analyzer assembly 'e:\nuget\packages\microsoft.extensions.logging.abstractions\6.0.0\analyzers\dotnet\roslyn3.11\cs\Microsoft.Extensions.Logging.Generators.dll' has MVID '411719f3-42a9-4e21-8529-264aea08538c' but loaded assembly 'C:\Users\jaredpar\AppData\Local\Temp\VBCSCompiler\AnalyzerAssemblyLoader\ae4813f7a72847839648de6bc4d9dffd\26\Microsoft.Extensions.Logging.Generators.dll' has MVID '620a3d95-9a61-4671-81a7-5380bd2e5574'

After

> CompilerServer: server failed - server rejected the request due to analyzer / generator issues 'analyzer assembly 'e:\nuget\packages\microsoft.extensions.logging.abstractions\6.0.0\analyzers\dotnet\roslyn3.11\cs\Microsoft.Extensions.Logging.Generators.dll' has MVID '411719f3-42a9-4e21-8529-264aea08538c' but loaded assembly 'e:\nuget\.nuget\packages\microsoft.extensions.logging.abstractions\6.0.0\analyzers\dotnet\roslyn4.0\cs\Microsoft.Extensions.Logging.Generators.dll' has MVID '620a3d95-9a61-4671-81a7-5380bd2e5574'