### PR TITLE
Always use DiagnosticHelper.Create for diagnostics with options

### DIFF
--- a/src/Analyzers/Core/Analyzers/MatchFolderAndNamespace/AbstractMatchFolderAndNamespaceDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/MatchFolderAndNamespace/AbstractMatchFolderAndNamespaceDiagnosticAnalyzer.cs
@@ -79,9 +79,11 @@ internal abstract class AbstractMatchFolderAndNamespaceDiagnosticAnalyzer<TSynta
             var nameSyntax = GetSyntaxFacts().GetNameOfBaseNamespaceDeclaration(namespaceDecl);
             RoslynDebug.AssertNotNull(nameSyntax);
 
-            context.ReportDiagnostic(Diagnostic.Create(
+            context.ReportDiagnostic(DiagnosticHelper.Create(
                 Descriptor,
                 nameSyntax.GetLocation(),
+                option.Notification,
+                context.Options,
                 additionalLocations: null,
                 properties: ImmutableDictionary<string, string?>.Empty.Add(MatchFolderAndNamespaceConstants.TargetNamespace, targetNamespace),
                 messageArgs: new[] { currentNamespace, targetNamespace }));

--- a/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -71,8 +71,13 @@ internal abstract class AbstractOrderModifiersDiagnosticAnalyzer : AbstractBuilt
                 // If the severity is hidden, put the marker on all the modifiers so that the
                 // user can bring up the fix anywhere in the modifier list.
                 context.ReportDiagnostic(
-                    Diagnostic.Create(Descriptor, context.Tree.GetLocation(
-                        TextSpan.FromBounds(modifiers.First().SpanStart, modifiers.Last().Span.End))));
+                    DiagnosticHelper.Create(
+                        Descriptor,
+                        context.Tree.GetLocation(TextSpan.FromBounds(modifiers.First().SpanStart, modifiers.Last().Span.End)),
+                        notificationOption,
+                        context.Options,
+                        additionalLocations: null,
+                        properties: null));
             }
             else
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/39142, fixes #73261

`IDE0073` was also affected but got fixed by https://github.com/dotnet/roslyn/pull/73263

Repro repo on which I tested this PR: https://github.com/js6pak/BrokenCodeStyleAnalyzersRepro
8.0.1xx and this PR should report `IDE0036`, `IDE0073` and `IDE0130` while 8.0.2xx won't report anything.

Even though I think I found all the affected diagnostics, there might be more I missed and this silent breakage when you use `Diagnostic.Create` directly on `CustomSeverityConfigurable` diagnostics definitely feels wrong, maybe it should throw if you don't use `DiagnosticHelper`?