### PR TITLE
Expose a few things to Razor

### DIFF
--- a/src/Tools/ExternalAccess/Razor/ChecksumWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/ChecksumWrapper.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
+internal readonly struct ChecksumWrapper(Checksum checksum) : IEquatable<ChecksumWrapper>
+{
+    private readonly Checksum _value = checksum;
+
+    public override int GetHashCode()
+    {
+        return _value.GetHashCode();
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is ChecksumWrapper wrapper)
+        {
+            return Equals(wrapper);
+        }
+        return false;
+    }
+
+    public bool Equals(ChecksumWrapper other)
+    {
+        return _value.Equals(other._value);
+    }
+
+    public override string ToString()
+        => _value.ToString();
+}

--- a/src/Tools/ExternalAccess/Razor/RazorUri.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorUri.cs
@@ -14,7 +14,4 @@ internal static class RazorUri
 
     public static string GetDocumentFilePathFromUri(Uri uri)
         => ProtocolConversions.GetDocumentFilePathFromUri(uri);
-
-    public static Uri CreateUri(this TextDocument document)
-        => document.GetURI();
 }

--- a/src/Tools/ExternalAccess/Razor/SolutionExtensions.cs
+++ b/src/Tools/ExternalAccess/Razor/SolutionExtensions.cs
@@ -14,4 +14,7 @@ internal static class SolutionExtensions
 
     public static ImmutableArray<DocumentId> GetDocumentIds(this Solution solution, Uri documentUri)
         => LanguageServer.Extensions.GetDocumentIds(solution, documentUri);
+
+    public static int GetWorkspaceVersion(this Solution solution)
+        => solution.WorkspaceVersion;
 }

--- a/src/Tools/ExternalAccess/Razor/TextDocumentExtensions.cs
+++ b/src/Tools/ExternalAccess/Razor/TextDocumentExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
+internal static class TextDocumentExtensions
+{
+    public static Uri CreateUri(this TextDocument document)
+        => document.GetURI();
+
+    public static async Task<ChecksumWrapper> GetChecksumAsync(this TextDocument document, CancellationToken cancellationToken)
+        => new ChecksumWrapper(await document.State.GetChecksumAsync(cancellationToken).ConfigureAwait(false));
+}


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/9519

Razor needs to be able to reason about a solution workspace version and a document checksum, in order to know when to regenerate Html documents (for cohosting)