### PR TITLE
Have code action tests run in OOP mode by default

### DIFF
--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 bool retainNonFixableDiagnostics = false,
                 bool includeDiagnosticsOutsideSelection = false,
                 string title = null,
-                TestHost testHost = TestHost.InProcess,
+                TestHost testHost = TestHost.OutOfProcess,
                 string workspaceKind = null,
                 bool includeNonLocalDocumentDiagnostics = false,
                 bool treatPositionIndicatorsAsCode = false)
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             object fixProviderData = null,
             ParseOptions parseOptions = null,
             string title = null,
-            TestHost testHost = TestHost.InProcess)
+            TestHost testHost = TestHost.OutOfProcess)
         {
             return TestInRegularAndScript1Async(
                 initialMarkup, expectedMarkup,
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             OptionsCollectionAlias globalOptions = null,
             object fixProviderData = null,
             CodeActionPriority? priority = null,
-            TestHost testHost = TestHost.InProcess)
+            TestHost testHost = TestHost.OutOfProcess)
         {
             return TestAsync(
                 initialMarkup,

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             EditorTestWorkspace workspace, TestParameters parameters)
         {
             var (analyzer, _) = GetOrCreateDiagnosticProviderAndFixer(workspace, parameters);
-            AddAnalyzerToWorkspace(workspace, analyzer, parameters);
+            AddAnalyzerToWorkspace(workspace, analyzer);
 
             var document = GetDocumentAndSelectSpan(workspace, out var span);
             var allDiagnostics = await DiagnosticProviderTestUtilities.GetAllDiagnosticsAsync(workspace, document, span, includeNonLocalDocumentDiagnostics: parameters.includeNonLocalDocumentDiagnostics);
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             EditorTestWorkspace workspace, TestParameters parameters)
         {
             var (analyzer, fixer) = GetOrCreateDiagnosticProviderAndFixer(workspace, parameters);
-            AddAnalyzerToWorkspace(workspace, analyzer, parameters);
+            AddAnalyzerToWorkspace(workspace, analyzer);
 
             GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
 

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Remote.Testing;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -102,24 +103,22 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
         protected static void AddAnalyzerToWorkspace(Workspace workspace, DiagnosticAnalyzer analyzer, TestParameters parameters)
         {
-            AnalyzerReference[] analyzeReferences;
+            AnalyzerReference[] analyzerReferences;
             if (analyzer != null)
             {
-                Contract.ThrowIfTrue(parameters.testHost == TestHost.OutOfProcess, $"Out-of-proc testing is not supported since {analyzer} can't be serialized.");
-
-                analyzeReferences = new[] { new AnalyzerImageReference(ImmutableArray.Create(analyzer)) };
+                var analyzerImageReference = new AnalyzerImageReference(ImmutableArray.Create(analyzer));
+                analyzerReferences = [analyzerImageReference];
+                SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerImageReference);
             }
             else
             {
                 // create a serializable analyzer reference:
-                analyzeReferences = new[]
-                {
+                analyzerReferences = [
                     new AnalyzerFileReference(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp).GetType().Assembly.Location, TestAnalyzerAssemblyLoader.LoadFromFile),
-                    new AnalyzerFileReference(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.VisualBasic).GetType().Assembly.Location, TestAnalyzerAssemblyLoader.LoadFromFile)
-                };
+                    new AnalyzerFileReference(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.VisualBasic).GetType().Assembly.Location, TestAnalyzerAssemblyLoader.LoadFromFile)];
             }
 
-            workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(analyzeReferences));
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(analyzerReferences));
         }
 
         protected static Document GetDocumentAndSelectSpan(EditorTestWorkspace workspace, out TextSpan span)

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         internal override Task<CodeRefactoring> GetCodeRefactoringAsync(EditorTestWorkspace workspace, TestParameters parameters)
             => throw new NotImplementedException("No refactoring provided in diagnostic test");
 
-        protected static void AddAnalyzerToWorkspace(Workspace workspace, DiagnosticAnalyzer analyzer, TestParameters parameters)
+        protected static void AddAnalyzerToWorkspace(Workspace workspace, DiagnosticAnalyzer analyzer)
         {
             AnalyzerReference[] analyzerReferences;
             if (analyzer != null)

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -108,7 +108,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             {
                 var analyzerImageReference = new AnalyzerImageReference(ImmutableArray.Create(analyzer));
                 analyzerReferences = [analyzerImageReference];
-                SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerImageReference);
             }
             else
             {

--- a/src/Features/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/Features/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
             string? equivalenceKey = null,
             LanguageVersion languageVersion = LanguageVersion.CSharp9,
             OptionsCollection? options = null,
-            TestHost testHost = TestHost.InProcess,
+            TestHost testHost = TestHost.OutOfProcess,
             string[]? actions = null)
         {
             if (index != 0)

--- a/src/Features/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/Features/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -445,8 +445,8 @@ class Class
                     var parameters = new TestParameters();
                     using var workspace = CreateWorkspaceFromOptions(source, parameters);
 
-                    var analyzerReference = new AnalyzerImageReference(ImmutableArray.Create<DiagnosticAnalyzer>(new CSharpCompilerDiagnosticAnalyzer()));
-                    workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
+                    var analyzerReference = new AnalyzerImageReference([new CSharpCompilerDiagnosticAnalyzer()]);
+                    workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences([analyzerReference]));
 
                     var diagnosticService = Assert.IsType<DiagnosticAnalyzerService>(workspace.ExportProvider.GetExportedValue<IDiagnosticAnalyzerService>());
                     var incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace);

--- a/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 bool retainNonFixableDiagnostics = false,
                 bool includeDiagnosticsOutsideSelection = false,
                 string title = null,
-                TestHost testHost = TestHost.InProcess,
+                TestHost testHost = TestHost.OutOfProcess,
                 string workspaceKind = null,
                 bool includeNonLocalDocumentDiagnostics = false,
                 bool treatPositionIndicatorsAsCode = false)
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             object fixProviderData = null,
             ParseOptions parseOptions = null,
             string title = null,
-            TestHost testHost = TestHost.InProcess)
+            TestHost testHost = TestHost.OutOfProcess)
         {
             return TestInRegularAndScript1Async(
                 initialMarkup, expectedMarkup,
@@ -457,7 +457,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             OptionsCollectionAlias globalOptions = null,
             object fixProviderData = null,
             CodeActionPriority? priority = null,
-            TestHost testHost = TestHost.InProcess)
+            TestHost testHost = TestHost.OutOfProcess)
         {
             return TestAsync(
                 initialMarkup,

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest_NoEditor.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             TestWorkspace workspace, TestParameters parameters)
         {
             var (analyzer, _) = GetOrCreateDiagnosticProviderAndFixer(workspace, parameters);
-            AddAnalyzerToWorkspace(workspace, analyzer, parameters);
+            AddAnalyzerToWorkspace(workspace, analyzer);
 
             var document = GetDocumentAndSelectSpan(workspace, out var span);
             var allDiagnostics = await DiagnosticProviderTestUtilities.GetAllDiagnosticsAsync(workspace, document, span, includeNonLocalDocumentDiagnostics: parameters.includeNonLocalDocumentDiagnostics);
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             TestWorkspace workspace, TestParameters parameters)
         {
             var (analyzer, fixer) = GetOrCreateDiagnosticProviderAndFixer(workspace, parameters);
-            AddAnalyzerToWorkspace(workspace, analyzer, parameters);
+            AddAnalyzerToWorkspace(workspace, analyzer);
 
             GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
 

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionDiagnosticTest_NoEditor.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             TestWorkspace workspace, TestParameters parameters)
         {
             var (analyzer, _) = CreateDiagnosticProviderAndFixer(workspace);
-            AddAnalyzerToWorkspace(workspace, analyzer, parameters);
+            AddAnalyzerToWorkspace(workspace, analyzer);
 
             var document = GetDocumentAndSelectSpan(workspace, out var span);
             var diagnostics = await DiagnosticProviderTestUtilities.GetAllDiagnosticsAsync(workspace, document, span, includeNonLocalDocumentDiagnostics: parameters.includeNonLocalDocumentDiagnostics);
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             TestWorkspace workspace, TestParameters parameters)
         {
             var (analyzer, fixer) = CreateDiagnosticProviderAndFixer(workspace);
-            AddAnalyzerToWorkspace(workspace, analyzer, parameters);
+            AddAnalyzerToWorkspace(workspace, analyzer);
 
             GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
 

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUnncessarySuppressionDiagnosticTest.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUnncessarySuppressionDiagnosticTest.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.RemoveUnnecessarySuppressions;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.UnitTests.Diagnostics;
 using Xunit.Abstractions;
@@ -32,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         private void AddAnalyzersToWorkspace(TestWorkspace workspace)
         {
             var analyzerReference = new AnalyzerImageReference(OtherAnalyzers.Add(SuppressionAnalyzer));
+            SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
         }
 

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUnncessarySuppressionDiagnosticTest.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUnncessarySuppressionDiagnosticTest.cs
@@ -33,8 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         private void AddAnalyzersToWorkspace(TestWorkspace workspace)
         {
             var analyzerReference = new AnalyzerImageReference(OtherAnalyzers.Add(SuppressionAnalyzer));
-            SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference);
-            workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences([analyzerReference]));
         }
 
         internal override async Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_NoEditor.cs
@@ -108,8 +108,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             {
                 var analyzerImageReference = new AnalyzerImageReference([analyzer]);
                 analyzerReferences = [analyzerImageReference];
-
-                SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerImageReference);
             }
             else
             {

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_NoEditor.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         internal override Task<CodeRefactoring> GetCodeRefactoringAsync(TestWorkspace workspace, TestParameters parameters)
             => throw new NotImplementedException("No refactoring provided in diagnostic test");
 
-        protected static void AddAnalyzerToWorkspace(Workspace workspace, DiagnosticAnalyzer analyzer, TestParameters parameters)
+        protected static void AddAnalyzerToWorkspace(Workspace workspace, DiagnosticAnalyzer analyzer)
         {
             AnalyzerReference[] analyzerReferences;
             if (analyzer != null)

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest_NoEditor.cs
@@ -106,8 +106,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             AnalyzerReference[] analyzerReferences;
             if (analyzer != null)
             {
-                // Contract.ThrowIfTrue(parameters.testHost == TestHost.OutOfProcess, $"Out-of-proc testing is not supported since {analyzer} can't be serialized.");
-
                 var analyzerImageReference = new AnalyzerImageReference([analyzer]);
                 analyzerReferences = [analyzerImageReference];
 

--- a/src/Features/VisualBasicTest/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/Features/VisualBasicTest/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
+Imports Microsoft.CodeAnalysis.Remote.Testing
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
 Imports Microsoft.CodeAnalysis.VisualBasic.SimplifyTypeNames
 
@@ -1821,7 +1822,7 @@ End Module
 
             Await TestInRegularAndScriptAsync(source.Value, expected.Value)
 
-            Using workspace = TestWorkspace.CreateVisualBasic(source.Value, composition:=GetComposition())
+            Using workspace = TestWorkspace.CreateVisualBasic(source.Value, composition:=GetComposition().WithTestHostParts(TestHost.OutOfProcess))
                 Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters())
                 Dim span = diagnosticAndFixes.Item1.First().Location.SourceSpan
                 Assert.NotEqual(span.Start, 0)
@@ -1869,7 +1870,7 @@ End Namespace
 
             Await TestInRegularAndScriptAsync(source.Value, expected.Value)
 
-            Using workspace = TestWorkspace.CreateVisualBasic(source.Value, composition:=GetComposition())
+            Using workspace = TestWorkspace.CreateVisualBasic(source.Value, composition:=GetComposition().WithTestHostParts(TestHost.OutOfProcess))
                 Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters())
                 Dim span = diagnosticAndFixes.Item1.First().Location.SourceSpan
                 Assert.Equal(span.Start, expected.Value.ReplaceLineEndings(vbLf).IndexOf("new C", StringComparison.Ordinal) + 4)
@@ -1903,7 +1904,7 @@ End Module
 
             Await TestInRegularAndScriptAsync(source.Value, expected.Value)
 
-            Using workspace = TestWorkspace.CreateVisualBasic(source.Value, composition:=GetComposition())
+            Using workspace = TestWorkspace.CreateVisualBasic(source.Value, composition:=GetComposition().WithTestHostParts(TestHost.OutOfProcess))
                 Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters())
                 Dim span = diagnosticAndFixes.Item1.First().Location.SourceSpan
                 Assert.Equal(span.Start, expected.Value.ReplaceLineEndings(vbLf).IndexOf("Console.WriteLine(""goo"")", StringComparison.Ordinal))

--- a/src/Workspaces/Core/Portable/Serialization/SerializedMetadataReference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializedMetadataReference.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis.Host;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Serialization;
+
+using static TemporaryStorageService;
+
+internal partial class SerializerService
+{
+    [DebuggerDisplay("{" + nameof(Display) + ",nq}")]
+    private sealed class SerializedMetadataReference : PortableExecutableReference, ISupportTemporaryStorage
+    {
+        private readonly Metadata _metadata;
+        private readonly ImmutableArray<TemporaryStorageStreamHandle> _storageHandles;
+        private readonly DocumentationProvider _provider;
+
+        public IReadOnlyList<ITemporaryStorageStreamHandle> StorageHandles => _storageHandles;
+
+        public SerializedMetadataReference(
+            MetadataReferenceProperties properties,
+            string? fullPath,
+            Metadata metadata,
+            ImmutableArray<TemporaryStorageStreamHandle> storageHandles,
+            DocumentationProvider initialDocumentation)
+            : base(properties, fullPath, initialDocumentation)
+        {
+            Contract.ThrowIfTrue(storageHandles.IsDefault);
+            _metadata = metadata;
+            _storageHandles = storageHandles;
+
+            _provider = initialDocumentation;
+        }
+
+        protected override DocumentationProvider CreateDocumentationProvider()
+        {
+            // this uses documentation provider given at the constructor
+            throw ExceptionUtilities.Unreachable();
+        }
+
+        protected override Metadata GetMetadataImpl()
+            => _metadata;
+
+        protected override PortableExecutableReference WithPropertiesImpl(MetadataReferenceProperties properties)
+            => new SerializedMetadataReference(properties, FilePath, _metadata, _storageHandles, _provider);
+
+        public override string ToString()
+        {
+            var metadata = TryGetMetadata(this);
+            var modules = GetModules(metadata);
+
+            return $"""
+            {nameof(SerializedMetadataReference)}
+                FilePath={this.FilePath}
+                Kind={this.Properties.Kind}
+                Aliases={this.Properties.Aliases.Join(",")}
+                EmbedInteropTypes={this.Properties.EmbedInteropTypes}
+                MetadataKind={metadata switch { null => "null", AssemblyMetadata => "assembly", ModuleMetadata => "module", _ => metadata.GetType().Name }}
+                Guids={modules.Select(m => GetMetadataGuid(m).ToString()).Join(",")}
+            """;
+
+            static ImmutableArray<ModuleMetadata> GetModules(Metadata? metadata)
+            {
+                if (metadata is AssemblyMetadata assemblyMetadata)
+                {
+                    if (TryGetModules(assemblyMetadata, out var modules))
+                        return modules;
+                }
+                else if (metadata is ModuleMetadata moduleMetadata)
+                {
+                    return [moduleMetadata];
+                }
+
+                return [];
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection.Metadata;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -23,6 +21,13 @@ internal partial class SerializerService
 {
     private const int MetadataFailed = int.MaxValue;
 
+    /// <summary>
+    /// Allow analyzer tests to exercise the oop codepaths, even though they're referring to in-memory instances of
+    /// DiagnosticAnalyzers.  In that case, we'll just share the in-memory instance of the analyzer across the OOP
+    /// boundary (which still runs in proc in tests), but we will still exercise all codepaths that use the RemoteClient
+    /// as well as exercising all codepaths that send data across the OOP boundary.  Effectively, this allows us to
+    /// pretend that a <see cref="AnalyzerImageReference"/> is a <see cref="AnalyzerFileReference"/> during tests.
+    /// </summary>
     private static readonly object s_analyzerImageReferenceMapGate = new();
     private static IBidirectionalMap<AnalyzerImageReference, Guid> s_analyzerImageReferenceMap = BidirectionalMap<AnalyzerImageReference, Guid>.Empty;
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -537,7 +537,10 @@ internal partial class SerializerService
         public static void AddAnalyzerImageReference(AnalyzerImageReference analyzerImageReference)
         {
             lock (s_analyzerImageReferenceMapGate)
-                s_analyzerImageReferenceMap = s_analyzerImageReferenceMap.Add(analyzerImageReference, Guid.NewGuid());
+            {
+                if (!s_analyzerImageReferenceMap.ContainsKey(analyzerImageReference))
+                    s_analyzerImageReferenceMap = s_analyzerImageReferenceMap.Add(analyzerImageReference, Guid.NewGuid());
+            }
         }
     }
 }

--- a/src/Workspaces/CoreTest/FindAllDeclarationsTests.TestSolutionsAndProject.cs
+++ b/src/Workspaces/CoreTest/FindAllDeclarationsTests.TestSolutionsAndProject.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        private Workspace CreateWorkspace(TestHost testHost = TestHost.InProcess)
+        private Workspace CreateWorkspace(TestHost testHost = TestHost.OutOfProcess)
         {
             var composition = FeaturesTestCompositions.Features.WithTestHostParts(testHost);
             var workspace = new AdhocWorkspace(composition.GetHostServices());
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             return workspace;
         }
 
-        private Workspace CreateWorkspaceWithSolution(SolutionKind solutionKind, out Solution solution, TestHost testHost = TestHost.InProcess)
+        private Workspace CreateWorkspaceWithSolution(SolutionKind solutionKind, out Solution solution, TestHost testHost = TestHost.OutOfProcess)
             => solutionKind switch
             {
                 SolutionKind.SingleClass => CreateWorkspaceWithSingleProjectSolution(testHost, [SingleClass], out solution),
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 _ => throw ExceptionUtilities.UnexpectedValue(solutionKind),
             };
 
-        private Workspace CreateWorkspaceWithProject(SolutionKind solutionKind, out Project project, TestHost testHost = TestHost.InProcess)
+        private Workspace CreateWorkspaceWithProject(SolutionKind solutionKind, out Project project, TestHost testHost = TestHost.OutOfProcess)
         {
             var workspace = CreateWorkspaceWithSolution(solutionKind, out var solution, testHost);
             project = solution.Projects.First();

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
             {
                 var remoteLogger = new TraceSource("InProcRemoteClient")
                 {
-                    Switch = { Level = SourceLevels.Off },
+                    Switch = { Level = SourceLevels.Warning },
                 };
 
                 if (traceListener != null)

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
             {
                 var remoteLogger = new TraceSource("InProcRemoteClient")
                 {
-                    Switch = { Level = SourceLevels.Verbose },
+                    Switch = { Level = SourceLevels.Off },
                 };
 
                 if (traceListener != null)

--- a/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
@@ -22,6 +22,7 @@ using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.CodeAnalysis.UnitTests;
@@ -746,6 +747,23 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
 
             return submissions;
+        }
+
+        public override bool TryApplyChanges(Solution newSolution)
+        {
+            var result = base.TryApplyChanges(newSolution);
+
+            foreach (var analyzer in this.CurrentSolution.AnalyzerReferences)
+            {
+                if (analyzer is AnalyzerImageReference analyzerImageReference)
+                {
+#pragma warning disable CA1416 // Validate platform compatibility
+                    SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerImageReference);
+#pragma warning restore CA1416 // Validate platform compatibility
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
@@ -753,6 +753,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             var result = base.TryApplyChanges(newSolution);
 
+            // Ensure that any in-memory analyzer references in this test workspace are known by the serializer service
+            // so that we can validate OOP scenarios involving analyzers.
             foreach (var analyzer in this.CurrentSolution.AnalyzerReferences)
             {
                 if (analyzer is AnalyzerImageReference analyzerImageReference)


### PR DESCRIPTION
This is the mode users run in, and we want to verify that any work they do that involves communicating with OOP are tested by our standard unit tests.