### PR TITLE
Add dummy type to SemanticSearch.ReferenceAssemblies

### DIFF
--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Dummy.cs
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Dummy.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace SemanticSearch.ReferenceAssemblies;
+
+/// <summary>
+/// Dummy type to avoid having empty DLL.
+/// An experiment ot see if it would prevent locking of the intermediate output during build.
+/// </summary>
+internal class Dummy
+{
+}


### PR DESCRIPTION
Attempt to avoid build issues:

The process cannot access the file 'D:\a\_work\1\s\artifacts\obj\SemanticSearch.ReferenceAssemblies\Release\net8.0\SemanticSearch.ReferenceAssemblies.dll' because it is being used by another process.

Perhaps anti-malware suspects empty dlls?