### PR TITLE
Fixup improper parenthesized expression in 'use pattern combinators'.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzer.cs
@@ -130,10 +130,10 @@ internal sealed class CSharpUsePatternCombinatorsDiagnosticAnalyzer :
     {
         return node.WalkUpParentheses().Parent switch
         {
-            LambdaExpressionSyntax _ => true,
-            AssignmentExpressionSyntax _ => true,
-            ConditionalExpressionSyntax _ => true,
-            ExpressionSyntax _ => false,
+            LambdaExpressionSyntax => true,
+            AssignmentExpressionSyntax => true,
+            ConditionalExpressionSyntax => true,
+            ExpressionSyntax => false,
             _ => true
         };
     }
@@ -142,10 +142,10 @@ internal sealed class CSharpUsePatternCombinatorsDiagnosticAnalyzer :
     {
         return pattern switch
         {
-            Not { Pattern: Constant _ } => true,
-            Not { Pattern: Source { PatternSyntax: ConstantPatternSyntax _ } } => true,
-            Not _ => false,
-            Binary _ => false,
+            Not { Pattern: Constant } => true,
+            Not { Pattern: Source { PatternSyntax: ConstantPatternSyntax } } => true,
+            Not => false,
+            Binary => false,
             _ => true
         };
     }

--- a/src/Features/CSharp/Portable/Debugging/DataTipInfoGetter.cs
+++ b/src/Features/CSharp/Portable/Debugging/DataTipInfoGetter.cs
@@ -37,7 +37,7 @@ internal static class DataTipInfoGetter
                     : default;
             }
 
-            if (expression.IsAnyLiteralExpression())
+            if (expression is LiteralExpressionSyntax)
             {
                 // If the user hovers over a literal, give them a DataTip for the type of the
                 // literal they're hovering over.

--- a/src/Features/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
+++ b/src/Features/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternCombinators
             await TestAllMissingOnExpressionAsync(expression);
         }
 
-        [InlineData("i == default || i > default(int)", "i is default(int) or > (default(int))")]
+        [InlineData("i == default || i > default(int)", "i is default(int) or > default(int)")]
         [InlineData("!(o is C c)", "o is not C c")]
         [InlineData("o is int ii && o is long jj", "o is int ii and long jj")]
         [InlineData("o is string || o is Exception", "o is string or Exception")]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/TypeStyle/TypeStyleHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/TypeStyle/TypeStyleHelper.cs
@@ -69,7 +69,7 @@ internal static class TypeStyleHelper
         }
 
         // literals, use var if options allow usage here.
-        if (initializerExpression.IsAnyLiteralExpression())
+        if (initializerExpression is LiteralExpressionSyntax)
         {
             return stylePreferences.HasFlag(UseVarPreference.ForBuiltInTypes);
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -166,9 +166,6 @@ internal static partial class ExpressionSyntaxExtensions
         return true;
     }
 
-    public static bool IsAnyLiteralExpression(this ExpressionSyntax expression)
-        => expression is LiteralExpressionSyntax;
-
     public static bool IsInConstantContext([NotNullWhen(true)] this ExpressionSyntax? expression)
     {
         if (expression == null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -219,7 +219,15 @@ internal static class ParenthesizedExpressionSyntaxExtensions
         //   (null)    -> null
         //   (default) -> default;
         //   (1)       -> 1
-        if (expression.IsAnyLiteralExpression())
+        if (expression is LiteralExpressionSyntax)
+            return true;
+
+        // (typeof(int)) -> typeof(int)
+        // (default(int)) -> default(int)
+        // (checked(1)) -> checked(1)
+        // (unchecked(1)) -> unchecked(1)
+        // (sizeof(int)) -> sizeof(int)
+        if (expression is TypeOfExpressionSyntax or DefaultExpressionSyntax or CheckedExpressionSyntax or SizeOfExpressionSyntax)
             return true;
 
         // (this)   -> this


### PR DESCRIPTION
Extracted from https://github.com/dotnet/roslyn/pull/73357.