### PR TITLE
Provide solution methods to allow updating a bulk set of documents at once.

### DIFF
--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/DocumentBasedFixAllProviderHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/DocumentBasedFixAllProviderHelpers.cs
@@ -72,7 +72,7 @@ internal static class DocumentBasedFixAllProviderHelpers
             // so we never resync or recompute anything.
             using var _ = await RemoteKeepAliveSession.CreateAsync(originalSolution, cancellationToken).ConfigureAwait(false);
 
-            return await ProducerConsumer<(DocumentId documentId, (SyntaxNode? node, SourceText? text))>.RunParallelAsync(
+            var changedRootsAndTexts = await ProducerConsumer<(DocumentId documentId, (SyntaxNode? node, SourceText? text))>.RunParallelAsync(
                 source: fixAllContexts,
                 produceItems: static async (fixAllContext, callback, args, cancellationToken) =>
                 {
@@ -95,36 +95,22 @@ internal static class DocumentBasedFixAllProviderHelpers
                             callback((newDocument.Id, (newRoot, newText)));
                         }).ConfigureAwait(false);
                 },
-                consumeItems: static async (stream, args, cancellationToken) =>
-                {
-                    var currentSolution = args.originalSolution;
-
-                    // Next, go and insert those all into the solution so all the docs in this particular project point
-                    // at the new trees (or text).  At this point though, the trees have not been semantically cleaned
-                    // up. We don't cleanup the documents as they are created, or one at a time as we add them, as that
-                    // would cause us to run semantic cleanup on N different solution forks (which would be very
-                    // expensive as we'd fork, produce semantics, fork, produce semantics, etc. etc.). Instead, by
-                    // adding all the changed documents to one solution, and then cleaning *those* we only perform
-                    // cleanup semantics on one forked solution.
-
-                    using var _1 = ArrayBuilder<(DocumentId documentId, SyntaxNode newRoot, PreservationMode mode)>.GetInstance(out var syntaxRoots);
-                    using var _2 = ArrayBuilder<(DocumentId documentId, SourceText newText, PreservationMode mode)>.GetInstance(out var newTexts);
-
-                    await foreach (var (documentId, (newRoot, newText)) in stream)
-                    {
-                        if (newRoot != null)
-                            syntaxRoots.Add((documentId, newRoot, PreservationMode.PreserveValue));
-                        else
-                            newTexts.Add((documentId, newText!, PreservationMode.PreserveValue));
-                    }
-
-                    return args.originalSolution
-                        .WithDocumentSyntaxRoots(syntaxRoots.ToImmutableAndClear())
-                        .WithDocumentTexts(newTexts.ToImmutableAndClear());
-
-                },
                 args: (getFixedDocumentsAsync, progressTracker, originalSolution),
                 cancellationToken).ConfigureAwait(false);
+
+            // Next, go and insert those all into the solution so all the docs in this particular project point
+            // at the new trees (or text).  At this point though, the trees have not been semantically cleaned
+            // up. We don't cleanup the documents as they are created, or one at a time as we add them, as that
+            // would cause us to run semantic cleanup on N different solution forks (which would be very
+            // expensive as we'd fork, produce semantics, fork, produce semantics, etc. etc.). Instead, by
+            // adding all the changed documents to one solution, and then cleaning *those* we only perform
+            // cleanup semantics on one forked solution.
+            var changedRoots = changedRootsAndTexts.SelectAsArray(t => t.Item2.node != null, t => (t.documentId, t.Item2.node!, PreservationMode.PreserveValue));
+            var changedTexts = changedRootsAndTexts.SelectAsArray(t => t.Item2.text != null, t => (t.documentId, t.Item2.text!, PreservationMode.PreserveValue));
+
+            return originalSolution
+                .WithDocumentSyntaxRoots(changedRoots)
+                .WithDocumentTexts(changedTexts);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -185,15 +185,15 @@ internal partial class ProjectState
     }
 
     private AsyncLazy<VersionStamp> CreateLazyLatestDocumentTopLevelChangeVersion(
-        TextDocumentState newDocument,
+        ImmutableArray<TextDocumentState> newDocuments,
         TextDocumentStates<DocumentState> newDocumentStates,
         TextDocumentStates<AdditionalDocumentState> newAdditionalDocumentStates)
     {
         if (_lazyLatestDocumentTopLevelChangeVersion.TryGetValue(out var oldVersion))
         {
             return AsyncLazy.Create(static (arg, cancellationToken) =>
-                ComputeTopLevelChangeTextVersionAsync(arg.oldVersion, arg.newDocument, cancellationToken),
-                arg: (oldVersion, newDocument));
+                ComputeTopLevelChangeTextVersionAsync(arg.oldVersion, arg.newDocuments, cancellationToken),
+                arg: (oldVersion, newDocuments));
         }
         else
         {
@@ -204,10 +204,16 @@ internal partial class ProjectState
     }
 
     private static async Task<VersionStamp> ComputeTopLevelChangeTextVersionAsync(
-        VersionStamp oldVersion, TextDocumentState newDocument, CancellationToken cancellationToken)
+        VersionStamp oldVersion, ImmutableArray<TextDocumentState> newDocuments, CancellationToken cancellationToken)
     {
-        var newVersion = await newDocument.GetTopLevelChangeTextVersionAsync(cancellationToken).ConfigureAwait(false);
-        return newVersion.GetNewerVersion(oldVersion);
+        var finalVersion = oldVersion;
+        foreach (var newDocument in newDocuments)
+        {
+            var newVersion = await newDocument.GetTopLevelChangeTextVersionAsync(cancellationToken).ConfigureAwait(false);
+            finalVersion = newVersion.GetNewerVersion(finalVersion);
+        }
+
+        return finalVersion;
     }
 
     private static async Task<VersionStamp> ComputeLatestDocumentTopLevelChangeVersionAsync(TextDocumentStates<DocumentState> documentStates, TextDocumentStates<AdditionalDocumentState> additionalDocumentStates, CancellationToken cancellationToken)
@@ -850,7 +856,10 @@ internal partial class ProjectState
 
         // When computing the latest dependent version, we just need to know how 
         GetLatestDependentVersions(
-            newDocumentStates, AdditionalDocumentStates, oldDocuments, newDocuments, contentChanged,
+            newDocumentStates, AdditionalDocumentStates,
+            oldDocuments.CastArray<TextDocumentState>(),
+            newDocuments.CastArray<TextDocumentState>(),
+            contentChanged,
             out var dependentDocumentVersion, out var dependentSemanticVersion);
 
         return With(
@@ -869,7 +878,7 @@ internal partial class ProjectState
 
         var newDocumentStates = AdditionalDocumentStates.SetState(newDocument);
         GetLatestDependentVersions(
-            DocumentStates, newDocumentStates, oldDocument, newDocument, contentChanged,
+            DocumentStates, newDocumentStates, [oldDocument], [newDocument], contentChanged,
             out var dependentDocumentVersion, out var dependentSemanticVersion);
 
         return this.With(
@@ -906,47 +915,71 @@ internal partial class ProjectState
     private void GetLatestDependentVersions(
         TextDocumentStates<DocumentState> newDocumentStates,
         TextDocumentStates<AdditionalDocumentState> newAdditionalDocumentStates,
-        TextDocumentState oldDocument,
-        TextDocumentState newDocument,
+        ImmutableArray<TextDocumentState> oldDocuments,
+        ImmutableArray<TextDocumentState> newDocuments,
         bool contentChanged,
-        out AsyncLazy<VersionStamp> dependentDocumentVersion, out AsyncLazy<VersionStamp> dependentSemanticVersion)
+        out AsyncLazy<VersionStamp> dependentDocumentVersion,
+        out AsyncLazy<VersionStamp> dependentSemanticVersion)
     {
         var recalculateDocumentVersion = false;
         var recalculateSemanticVersion = false;
 
         if (contentChanged)
         {
-            if (oldDocument.TryGetTextVersion(out var oldVersion))
+            foreach (var oldDocument in oldDocuments)
             {
-                if (!_lazyLatestDocumentVersion.TryGetValue(out var documentVersion) || documentVersion == oldVersion)
+                if (oldDocument.TryGetTextVersion(out var oldVersion))
                 {
-                    recalculateDocumentVersion = true;
+                    if (!_lazyLatestDocumentVersion.TryGetValue(out var documentVersion) || documentVersion == oldVersion)
+                        recalculateDocumentVersion = true;
+
+                    if (!_lazyLatestDocumentTopLevelChangeVersion.TryGetValue(out var semanticVersion) || semanticVersion == oldVersion)
+                        recalculateSemanticVersion = true;
                 }
 
-                if (!_lazyLatestDocumentTopLevelChangeVersion.TryGetValue(out var semanticVersion) || semanticVersion == oldVersion)
-                {
-                    recalculateSemanticVersion = true;
-                }
+                if (recalculateDocumentVersion && recalculateSemanticVersion)
+                    break;
             }
         }
 
-        dependentDocumentVersion = recalculateDocumentVersion
-            ? AsyncLazy.Create(static (arg, cancellationToken) =>
+        if (recalculateDocumentVersion)
+        {
+            dependentDocumentVersion = AsyncLazy.Create(static (arg, cancellationToken) =>
                 ComputeLatestDocumentVersionAsync(arg.newDocumentStates, arg.newAdditionalDocumentStates, cancellationToken),
-                arg: (newDocumentStates, newAdditionalDocumentStates))
-            : contentChanged
-                ? AsyncLazy.Create(
-                    static (newDocument, cancellationToken) => newDocument.GetTextVersionAsync(cancellationToken),
-                    arg: newDocument)
-                : _lazyLatestDocumentVersion;
+                arg: (newDocumentStates, newAdditionalDocumentStates));
+        }
+        else if (contentChanged)
+        {
+            dependentDocumentVersion = AsyncLazy.Create(
+                static async (newDocuments, cancellationToken) =>
+                {
+                    var finalVersion = await newDocuments[0].GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
+                    for (var i = 1; i < newDocuments.Length; i++)
+                        finalVersion = finalVersion.GetNewerVersion(await newDocuments[i].GetTextVersionAsync(cancellationToken).ConfigureAwait(false));
 
-        dependentSemanticVersion = recalculateSemanticVersion
-            ? AsyncLazy.Create(static (arg, c) =>
-                ComputeLatestDocumentTopLevelChangeVersionAsync(arg.newDocumentStates, arg.newAdditionalDocumentStates, c),
-                arg: (newDocumentStates, newAdditionalDocumentStates))
-            : contentChanged
-                ? CreateLazyLatestDocumentTopLevelChangeVersion(newDocument, newDocumentStates, newAdditionalDocumentStates)
-                : _lazyLatestDocumentTopLevelChangeVersion;
+                    return finalVersion;
+                },
+                arg: newDocuments);
+        }
+        else
+        {
+            dependentDocumentVersion = _lazyLatestDocumentVersion;
+        }
+
+        if (recalculateSemanticVersion)
+        {
+            dependentSemanticVersion = AsyncLazy.Create(static (arg, cancellationToken) =>
+                ComputeLatestDocumentTopLevelChangeVersionAsync(arg.newDocumentStates, arg.newAdditionalDocumentStates, cancellationToken),
+                arg: (newDocumentStates, newAdditionalDocumentStates));
+        }
+        else if (contentChanged)
+        {
+            dependentSemanticVersion = CreateLazyLatestDocumentTopLevelChangeVersion(newDocuments, newDocumentStates, newAdditionalDocumentStates);
+        }
+        else
+        {
+            dependentSemanticVersion = _lazyLatestDocumentTopLevelChangeVersion;
+        }
     }
 
     public void AddDocumentIdsWithFilePath(ref TemporaryArray<DocumentId> temporaryArray, string filePath)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1181,20 +1181,22 @@ public partial class Solution
     /// specified.
     /// </summary>
     public Solution WithDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
+        => WithDocumentTexts([(documentId, text, mode)]);
+
+    internal Solution WithDocumentTexts(ImmutableArray<(DocumentId documentId, SourceText text, PreservationMode mode)> texts)
     {
-        CheckContainsDocument(documentId);
-
-        if (text == null)
+        foreach (var (documentId, text, mode) in texts)
         {
-            throw new ArgumentNullException(nameof(text));
+            CheckContainsDocument(documentId);
+
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
+            if (!mode.IsValid())
+                throw new ArgumentOutOfRangeException(nameof(mode));
         }
 
-        if (!mode.IsValid())
-        {
-            throw new ArgumentOutOfRangeException(nameof(mode));
-        }
-
-        return WithCompilationState(_compilationState.WithDocumentText(documentId, text, mode));
+        return WithCompilationState(_compilationState.WithDocumentTexts(texts));
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1307,20 +1307,23 @@ public partial class Solution
     /// rooted by the specified syntax node.
     /// </summary>
     public Solution WithDocumentSyntaxRoot(DocumentId documentId, SyntaxNode root, PreservationMode mode = PreservationMode.PreserveValue)
+        => WithDocumentSyntaxRoots([(documentId, root, mode)]);
+
+    /// <inheritdoc cref="WithDocumentSyntaxRoot"/>.
+    internal Solution WithDocumentSyntaxRoots(ImmutableArray<(DocumentId documentId, SyntaxNode root, PreservationMode mode)> syntaxRoots)
     {
-        CheckContainsDocument(documentId);
-
-        if (root == null)
+        foreach (var (documentId, root, mode) in syntaxRoots)
         {
-            throw new ArgumentNullException(nameof(root));
+            CheckContainsDocument(documentId);
+
+            if (root == null)
+                throw new ArgumentNullException(nameof(root));
+
+            if (!mode.IsValid())
+                throw new ArgumentOutOfRangeException(nameof(mode));
         }
 
-        if (!mode.IsValid())
-        {
-            throw new ArgumentOutOfRangeException(nameof(mode));
-        }
-
-        return WithCompilationState(_compilationState.WithDocumentSyntaxRoot(documentId, root, mode));
+        return WithCompilationState(_compilationState.WithDocumentSyntaxRoots(syntaxRoots));
     }
 
     internal Solution WithDocumentContentsFrom(DocumentId documentId, DocumentState documentState, bool forceEvenIfTreesWouldDiffer)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker_Generators.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker_Generators.cs
@@ -144,7 +144,7 @@ internal partial class SolutionCompilationState
                 foreach (var (documentIdentity, _, generationDateTime) in infos)
                 {
                     var documentId = documentIdentity.DocumentId;
-                    oldGeneratedDocuments = oldGeneratedDocuments.SetState(documentId, oldGeneratedDocuments.GetRequiredState(documentId).WithGenerationDateTime(generationDateTime));
+                    oldGeneratedDocuments = oldGeneratedDocuments.SetState(oldGeneratedDocuments.GetRequiredState(documentId).WithGenerationDateTime(generationDateTime));
                 }
 
                 // If there are no generated documents though, then just use the compilationWithoutGeneratedFiles so we

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.GeneratedFileReplacingCompilationTracker.cs
@@ -162,7 +162,7 @@ internal partial class SolutionCompilationState
                 {
                     // The generated file still exists in the underlying compilation, but the contents may not match the open file if the open file
                     // is stale. Replace the syntax tree so we have a tree that matches the text.
-                    newStates = newStates.SetState(id, replacementState);
+                    newStates = newStates.SetState(replacementState);
                 }
                 else
                 {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -988,24 +988,6 @@ internal sealed partial class SolutionState
         return UpdateAnalyzerConfigDocumentState(oldDocument.UpdateText(textAndVersion, mode));
     }
 
-    /// <summary>
-    /// Creates a new solution instance with the document specified updated to have a syntax tree
-    /// rooted by the specified syntax node.
-    /// </summary>
-    public StateChange WithDocumentSyntaxRoot(DocumentId documentId, SyntaxNode root, PreservationMode mode = PreservationMode.PreserveValue)
-    {
-        var oldDocument = GetRequiredDocumentState(documentId);
-        if (oldDocument.TryGetSyntaxTree(out var oldTree) &&
-            oldTree.TryGetRoot(out var oldRoot) &&
-            oldRoot == root)
-        {
-            var oldProject = GetRequiredProjectState(documentId.ProjectId);
-            return new(this, oldProject, oldProject);
-        }
-
-        return UpdateDocumentState(oldDocument.UpdateTree(root, mode), contentChanged: true);
-    }
-
     /// <param name="forceEvenIfTreesWouldDiffer">Whether or not the specified document is forced to have the same text and
     /// green-tree-root from <paramref name="documentState"/>.  If <see langword="true"/>, then they will share
     /// these values.  If <see langword="false"/>, then they will only be shared when safe to do so (for example,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -168,14 +168,27 @@ internal sealed class TextDocumentStates<TState>
         return new(_ids.RemoveRange(enumerableIds), _map.RemoveRange(enumerableIds), filePathToDocumentIds: null);
     }
 
-    internal TextDocumentStates<TState> SetState(DocumentId id, TState state)
-    {
-        var oldState = _map[id];
-        var filePathToDocumentIds = oldState.FilePath != state.FilePath
-            ? null
-            : _filePathToDocumentIds;
+    internal TextDocumentStates<TState> SetState(TState state)
+        => SetStates([state]);
 
-        return new(_ids, _map.SetItem(id, state), filePathToDocumentIds);
+    internal TextDocumentStates<TState> SetStates(ImmutableArray<TState> states)
+    {
+        var builder = _map.ToBuilder();
+        var filePathToDocumentIds = _filePathToDocumentIds;
+
+        foreach (var state in states)
+        {
+            var id = state.Id;
+            var oldState = _map[id];
+
+            // If any file paths have changed, don't preseve the computed map.  We'll regenerate the new map on demand when needed.
+            if (filePathToDocumentIds != null && oldState.FilePath != state.FilePath)
+                filePathToDocumentIds = null;
+
+            builder[id] = state;
+        }
+
+        return new(_ids, builder.ToImmutable(), filePathToDocumentIds);
     }
 
     public TextDocumentStates<TState> UpdateStates<TArg>(Func<TState, TArg, TState> transformation, TArg arg)


### PR DESCRIPTION
Useful for fix-all scenarios where we don't want to fork the solution N times per document changed.  This now allows there to just be a single fork we apply at once.