### PR TITLE
Use null for diagnostic ExpandedMessage so the client falls back appropriately

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -411,8 +411,11 @@ internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams
 
             if (capabilities.HasVisualStudioLspCapability())
             {
+                // The client expects us to return null if there is no message (not an empty string).
+                var expandedMessage = string.IsNullOrEmpty(diagnosticData.Description) ? null : diagnosticData.Description;
+
                 diagnostic.DiagnosticType = diagnosticData.Category;
-                diagnostic.ExpandedMessage = diagnosticData.Description;
+                diagnostic.ExpandedMessage = expandedMessage;
                 diagnostic.Projects =
                 [
                     new VSDiagnosticProjectInformation

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -180,6 +180,28 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         Assert.Equal(vsDiagnostic.ExpandedMessage, AnalyzersResources.Avoid_unused_parameters_in_your_code_If_the_parameter_cannot_be_removed_then_change_its_name_so_it_starts_with_an_underscore_and_is_optionally_followed_by_an_integer_such_as__comma__1_comma__2_etc_These_are_treated_as_special_discard_symbol_names);
     }
 
+    [Theory, CombinatorialData, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2050705")]
+    public async Task TestDocumentDiagnosticsUsesNullForExpandedMessage(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"class A {";
+        await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, mutatingLspWorkspace, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics: true);
+
+        // Calling GetTextBuffer will effectively open the file.
+        testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
+
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+        await OpenDocumentAsync(testLspServer, document);
+
+        var results = await RunGetDocumentPullDiagnosticsAsync(
+            testLspServer, document.GetURI(), useVSDiagnostics: true);
+
+        Assert.Equal("CS1513", results.Single().Diagnostics.Single().Code);
+        var vsDiagnostic = (VSDiagnostic)results.Single().Diagnostics.Single();
+        Assert.Null(vsDiagnostic.ExpandedMessage);
+    }
+
     [Theory, CombinatorialData]
     public async Task TestDocumentTodoCommentsDiagnosticsForOpenFile_Category(bool mutatingLspWorkspace)
     {


### PR DESCRIPTION


Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2050705