### PR TITLE
Update local deployment instructions

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -86,8 +86,7 @@ give it a try.
 ### Deploying with command-line (recommended method)
 
 You can build and deploy with the following command:
-`.\Restore.cmd -Configuration Release` followed by
-`.\Build.cmd -Configuration Release -deployExtensions -launch`.
+`.\Build.cmd -Restore -Configuration Release -deployExtensions -launch`.
 
 Then you can launch the `RoslynDev` hive with `devenv /rootSuffix RoslynDev`.
 

--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -86,6 +86,7 @@ give it a try.
 ### Deploying with command-line (recommended method)
 
 You can build and deploy with the following command:
+`.\Restore.cmd -Configuration Release` followed by
 `.\Build.cmd -Configuration Release -deployExtensions -launch`.
 
 Then you can launch the `RoslynDev` hive with `devenv /rootSuffix RoslynDev`.


### PR DESCRIPTION
If I just do a normal restore, then I get the following error:
```
C:\repos\roslyn\.dotnet\sdk\8.0.101\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(396,5): error NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found.
Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing. When targeting .NET 6 or higher, make sure to restore packages with the PublishReadyToRun property set
 to true. [C:\repos\roslyn\src\Interactive\HostProcess\x64\InteractiveHost64.csproj::TargetFramework=net8.0-windows]
 ```