### PR TITLE
Reduce LOH allocs when applying code fixes.

### DIFF
--- a/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
+++ b/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.LinkedFiles;
 
-public partial class LinkedFileDiffMergingEditorTests : AbstractCodeActionTest
+public sealed class LinkedFileDiffMergingEditorTests : AbstractCodeActionTest
 {
     private const string WorkspaceXml = """
         <Workspace>
@@ -95,7 +95,7 @@ public partial class LinkedFileDiffMergingEditorTests : AbstractCodeActionTest
     protected override ParseOptions GetScriptOptions()
         => throw new NotSupportedException();
 
-    private class TestCodeRefactoringProvider : CodeRefactoringProvider
+    private sealed class TestCodeRefactoringProvider : CodeRefactoringProvider
     {
         public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
@@ -108,9 +108,7 @@ public partial class LinkedFileDiffMergingEditorTests : AbstractCodeActionTest
                 .WithDocumentText(document.Id, (await document.GetTextAsync()).Replace(textString.IndexOf("public"), "public".Length, "internal"))
                 .WithDocumentText(linkedDocument.Id, sourceText.Replace(textString.LastIndexOf("public"), "public".Length, "private"));
 
-#pragma warning disable RS0005
-            context.RegisterRefactoring(CodeAction.Create("Description", (ct) => Task.FromResult(newSolution)), context.Span);
-#pragma warning restore RS0005
+            context.RegisterRefactoring(CodeAction.Create("Description", _ => Task.FromResult(newSolution)), context.Span);
         }
     }
 }

--- a/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
+++ b/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
@@ -13,97 +13,104 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.UnitTests.LinkedFiles
-{
-    public partial class LinkedFileDiffMergingEditorTests : AbstractCodeActionTest
-    {
-        private const string WorkspaceXml = @"<Workspace>
-            <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj"" PreprocessorSymbols=""Proj1"">
-                <Document FilePath = ""C.cs""><![CDATA[public class [|C|]
-{
-    public class D
-    {
-    }
-}]]></Document>
-            </Project>
-            <Project Language = ""C#"" CommonReferences=""true"" PreprocessorSymbols=""Proj2"">
-                <Document IsLinkFile = ""true"" LinkAssemblyName=""CSProj"" LinkFilePath=""C.cs""/>
-            </Project>
-        </Workspace>";
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.LinkedFiles;
 
-        private const string s_expectedCode = """
-            internal class C
+public partial class LinkedFileDiffMergingEditorTests : AbstractCodeActionTest
+{
+    private const string WorkspaceXml = """
+        <Workspace>
+            <Project Language="C#" CommonReferences="true" AssemblyName="CSProj" PreprocessorSymbols="Proj1">
+                <Document FilePath = "C.cs"><![CDATA[public class [|C|]
+        {
+            public class D
             {
-                private class D
-                {
-                }
             }
-            """;
+        }]]></Document>
+            </Project>
+            <Project Language = "C#" CommonReferences="true" PreprocessorSymbols="Proj2">
+                <Document IsLinkFile = "true" LinkAssemblyName="CSProj" LinkFilePath="C.cs"/>
+            </Project>
+        </Workspace>
+        """;
 
-        protected internal override string GetLanguage()
-            => LanguageNames.CSharp;
-
-        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(EditorTestWorkspace workspace, TestParameters parameters)
-            => new TestCodeRefactoringProvider();
-
-        [WpfFact]
-        public async Task TestCodeActionPreviewAndApply()
+    private const string s_expectedCode = """
+        internal class C
         {
-            // TODO: WPF required due to https://github.com/dotnet/roslyn/issues/46153
-            using var workspace = EditorTestWorkspace.Create(WorkspaceXml, composition: EditorTestCompositions.EditorFeaturesWpf);
-            var codeIssueOrRefactoring = await GetCodeRefactoringAsync(workspace, new TestParameters());
-
-            await TestActionOnLinkedFiles(
-                workspace,
-                expectedText: s_expectedCode,
-                action: codeIssueOrRefactoring.CodeActions[0].action,
-                expectedPreviewContents: s_expectedCode);
-        }
-
-        [Fact]
-        public async Task TestWorkspaceTryApplyChangesDirectCall()
-        {
-            using var workspace = EditorTestWorkspace.Create(WorkspaceXml);
-            var solution = workspace.CurrentSolution;
-
-            var documentId = workspace.Documents.Single(d => !d.IsLinkFile).Id;
-            var text = await workspace.CurrentSolution.GetRequiredDocument(documentId).GetTextAsync();
-
-            var linkedDocumentId = workspace.Documents.Single(d => d.IsLinkFile).Id;
-            var linkedText = await workspace.CurrentSolution.GetRequiredDocument(linkedDocumentId).GetTextAsync();
-
-            var textString = linkedText.ToString();
-
-            var newSolution = solution
-                .WithDocumentText(documentId, text.Replace(textString.IndexOf("public"), "public".Length, "internal"))
-                .WithDocumentText(linkedDocumentId, linkedText.Replace(textString.LastIndexOf("public"), "public".Length, "private"));
-
-            workspace.TryApplyChanges(newSolution);
-
-            Assert.Equal(s_expectedCode, (await workspace.CurrentSolution.GetRequiredDocument(documentId).GetTextAsync()).ToString());
-            Assert.Equal(s_expectedCode, (await workspace.CurrentSolution.GetRequiredDocument(linkedDocumentId).GetTextAsync()).ToString());
-        }
-
-        protected override ParseOptions GetScriptOptions()
-            => throw new NotSupportedException();
-
-        private class TestCodeRefactoringProvider : CodeRefactoringProvider
-        {
-            public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+            private class D
             {
-                var document = context.Document;
-                var linkedDocument = document.Project.Solution.Projects.Single(p => p != document.Project).Documents.Single();
-                var sourceText = await linkedDocument.GetTextAsync();
-                var textString = sourceText.ToString();
+            }
+        }
+        """;
 
-                var newSolution = document.Project.Solution
-                    .WithDocumentText(document.Id, (await document.GetTextAsync()).Replace(textString.IndexOf("public"), "public".Length, "internal"))
-                    .WithDocumentText(linkedDocument.Id, sourceText.Replace(textString.LastIndexOf("public"), "public".Length, "private"));
+    protected internal override string GetLanguage()
+        => LanguageNames.CSharp;
+
+    protected override CodeRefactoringProvider CreateCodeRefactoringProvider(EditorTestWorkspace workspace, TestParameters parameters)
+        => new TestCodeRefactoringProvider();
+
+    [WpfFact]
+    public async Task TestCodeActionPreviewAndApply()
+    {
+        // TODO: WPF required due to https://github.com/dotnet/roslyn/issues/46153
+        using var workspace = EditorTestWorkspace.Create(WorkspaceXml, composition: EditorTestCompositions.EditorFeaturesWpf);
+        var codeIssueOrRefactoring = await GetCodeRefactoringAsync(workspace, new TestParameters());
+
+        await TestActionOnLinkedFiles(
+            workspace,
+            expectedText: s_expectedCode,
+            action: codeIssueOrRefactoring.CodeActions[0].action,
+            expectedPreviewContents: """
+                internal class C
+                {
+                    private class D
+                    {
+                ...
+                """);
+    }
+
+    [Fact]
+    public async Task TestWorkspaceTryApplyChangesDirectCall()
+    {
+        using var workspace = EditorTestWorkspace.Create(WorkspaceXml);
+        var solution = workspace.CurrentSolution;
+
+        var documentId = workspace.Documents.Single(d => !d.IsLinkFile).Id;
+        var text = await workspace.CurrentSolution.GetRequiredDocument(documentId).GetTextAsync();
+
+        var linkedDocumentId = workspace.Documents.Single(d => d.IsLinkFile).Id;
+        var linkedText = await workspace.CurrentSolution.GetRequiredDocument(linkedDocumentId).GetTextAsync();
+
+        var textString = linkedText.ToString();
+
+        var newSolution = solution
+            .WithDocumentText(documentId, text.Replace(textString.IndexOf("public"), "public".Length, "internal"))
+            .WithDocumentText(linkedDocumentId, linkedText.Replace(textString.LastIndexOf("public"), "public".Length, "private"));
+
+        workspace.TryApplyChanges(newSolution);
+
+        Assert.Equal(s_expectedCode, (await workspace.CurrentSolution.GetRequiredDocument(documentId).GetTextAsync()).ToString());
+        Assert.Equal(s_expectedCode, (await workspace.CurrentSolution.GetRequiredDocument(linkedDocumentId).GetTextAsync()).ToString());
+    }
+
+    protected override ParseOptions GetScriptOptions()
+        => throw new NotSupportedException();
+
+    private class TestCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var linkedDocument = document.Project.Solution.Projects.Single(p => p != document.Project).Documents.Single();
+            var sourceText = await linkedDocument.GetTextAsync();
+            var textString = sourceText.ToString();
+
+            var newSolution = document.Project.Solution
+                .WithDocumentText(document.Id, (await document.GetTextAsync()).Replace(textString.IndexOf("public"), "public".Length, "internal"))
+                .WithDocumentText(linkedDocument.Id, sourceText.Replace(textString.LastIndexOf("public"), "public".Length, "private"));
 
 #pragma warning disable RS0005
-                context.RegisterRefactoring(CodeAction.Create("Description", (ct) => Task.FromResult(newSolution)), context.Span);
+            context.RegisterRefactoring(CodeAction.Create("Description", (ct) => Task.FromResult(newSolution)), context.Span);
 #pragma warning restore RS0005
-            }
         }
     }
 }

--- a/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
+++ b/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
@@ -203,6 +203,6 @@ internal class CSharpEncapsulateFieldService : AbstractEncapsulateFieldService
         return NameGenerator.GenerateUniqueName(baseName, containingTypeMemberNames.ToSet(), StringComparer.Ordinal);
     }
 
-    internal override IEnumerable<SyntaxNode> GetConstructorNodes(INamedTypeSymbol containingType)
+    protected override IEnumerable<SyntaxNode> GetConstructorNodes(INamedTypeSymbol containingType)
         => containingType.Constructors.SelectMany(c => c.DeclaringSyntaxReferences.Select(d => d.GetSyntax()));
 }

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField;
 internal abstract partial class AbstractEncapsulateFieldService : ILanguageService
 {
     private static readonly CultureInfo EnUSCultureInfo = new("en-US");
-    private static SymbolRenameOptions s_symbolRenameOptions = new(
+    private static readonly SymbolRenameOptions s_symbolRenameOptions = new(
         RenameOverloads: false,
         RenameInStrings: false,
         RenameInComments: false,

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -30,6 +30,8 @@ namespace Microsoft.CodeAnalysis.EncapsulateField;
 
 internal abstract partial class AbstractEncapsulateFieldService : ILanguageService
 {
+    private static readonly CultureInfo EnUSCultureInfo = new("en-US");
+
     protected abstract Task<SyntaxNode> RewriteFieldNameAndAccessibilityAsync(string originalFieldName, bool makePrivate, Document document, SyntaxAnnotation declarationAnnotation, CodeAndImportGenerationOptionsProvider fallbackOptions, CancellationToken cancellationToken);
     protected abstract Task<ImmutableArray<IFieldSymbol>> GetFieldsAsync(Document document, TextSpan span, CancellationToken cancellationToken);
     protected abstract IEnumerable<SyntaxNode> GetConstructorNodes(INamedTypeSymbol containingType);
@@ -44,7 +46,7 @@ internal abstract partial class AbstractEncapsulateFieldService : ILanguageServi
         return new EncapsulateFieldResult(
             firstField.ToDisplayString(),
             firstField.GetGlyph(),
-            c => EncapsulateFieldsAsync(document, fields, fallbackOptions, useDefaultBehavior, c));
+            cancellationToken => EncapsulateFieldsAsync(document, fields, fallbackOptions, useDefaultBehavior, cancellationToken));
     }
 
     public async Task<ImmutableArray<CodeAction>> GetEncapsulateFieldCodeActionsAsync(Document document, TextSpan span, CleanCodeGenerationOptionsProvider fallbackOptions, CancellationToken cancellationToken)
@@ -77,11 +79,11 @@ internal abstract partial class AbstractEncapsulateFieldService : ILanguageServi
         => [
             CodeAction.Create(
                 FeaturesResources.Encapsulate_fields_and_use_property,
-                c => EncapsulateFieldsAsync(document, fields, fallbackOptions, updateReferences: true, c),
+                cancellationToken => EncapsulateFieldsAsync(document, fields, fallbackOptions, updateReferences: true, cancellationToken),
                 nameof(FeaturesResources.Encapsulate_fields_and_use_property)),
             CodeAction.Create(
                 FeaturesResources.Encapsulate_fields_but_still_use_field,
-                c => EncapsulateFieldsAsync(document, fields, fallbackOptions, updateReferences: false, c),
+                cancellationToken => EncapsulateFieldsAsync(document, fields, fallbackOptions, updateReferences: false, cancellationToken),
                 nameof(FeaturesResources.Encapsulate_fields_but_still_use_field)),
         ];
 
@@ -92,11 +94,11 @@ internal abstract partial class AbstractEncapsulateFieldService : ILanguageServi
         [
             CodeAction.Create(
                 string.Format(FeaturesResources.Encapsulate_field_colon_0_and_use_property, field.Name),
-                c => EncapsulateFieldsAsync(document, fields, fallbackOptions, updateReferences: true, c),
+                cancellationToken => EncapsulateFieldsAsync(document, fields, fallbackOptions, updateReferences: true, cancellationToken),
                 nameof(FeaturesResources.Encapsulate_field_colon_0_and_use_property) + "_" + field.Name),
             CodeAction.Create(
                 string.Format(FeaturesResources.Encapsulate_field_colon_0_but_still_use_field, field.Name),
-                c => EncapsulateFieldsAsync(document, fields, fallbackOptions, updateReferences: false, c),
+                cancellationToken => EncapsulateFieldsAsync(document, fields, fallbackOptions, updateReferences: false, cancellationToken),
                 nameof(FeaturesResources.Encapsulate_field_colon_0_but_still_use_field) + "_" + field.Name),
         ];
     }
@@ -437,6 +439,4 @@ internal abstract partial class AbstractEncapsulateFieldService : ILanguageServi
         var firstCharacter = EnUSCultureInfo.TextInfo.ToUpper(baseName[0]);
         return firstCharacter.ToString() + baseName[1..];
     }
-
-    private static readonly CultureInfo EnUSCultureInfo = new("en-US");
 }

--- a/src/Features/VisualBasic/Portable/EncapsulateField/VisualBasicEncapsulateFieldService.vb
+++ b/src/Features/VisualBasic/Portable/EncapsulateField/VisualBasicEncapsulateFieldService.vb
@@ -130,11 +130,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EncapsulateField
             Return NameGenerator.GenerateUniqueName(propertyName, containingTypeMemberNames.ToSet(), StringComparer.OrdinalIgnoreCase)
         End Function
 
-        Friend Overrides Function GetConstructorNodes(containingType As INamedTypeSymbol) As IEnumerable(Of SyntaxNode)
+        Protected Overrides Function GetConstructorNodes(containingType As INamedTypeSymbol) As IEnumerable(Of SyntaxNode)
             Return containingType.Constructors.SelectMany(Function(c As IMethodSymbol)
                                                               Return c.DeclaringSyntaxReferences.Select(Function(d) d.GetSyntax().Parent)
                                                           End Function)
         End Function
-
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/AbstractLinkedFileMergeConflictCommentAdditionService.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/AbstractLinkedFileMergeConflictCommentAdditionService.cs
@@ -16,7 +16,7 @@ internal abstract class AbstractLinkedFileMergeConflictCommentAdditionService : 
 {
     internal abstract string GetConflictCommentText(string header, string beforeString, string afterString);
 
-    public List<TextChange> CreateEdits(SourceText originalSourceText, IEnumerable<UnmergedDocumentChanges> unmergedChanges)
+    public List<TextChange> CreateEdits(SourceText originalSourceText, List<UnmergedDocumentChanges> unmergedChanges)
     {
         var commentChanges = new List<TextChange>();
 
@@ -31,9 +31,9 @@ internal abstract class AbstractLinkedFileMergeConflictCommentAdditionService : 
         return commentChanges;
     }
 
-    private static IEnumerable<IEnumerable<TextChange>> PartitionChangesForDocument(IEnumerable<TextChange> changes, SourceText originalSourceText)
+    private static List<List<TextChange>> PartitionChangesForDocument(IEnumerable<TextChange> changes, SourceText originalSourceText)
     {
-        var partitionedChanges = new List<IEnumerable<TextChange>>();
+        var partitionedChanges = new List<List<TextChange>>();
         var currentPartition = new List<TextChange>
         {
             changes.First()

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/AbstractLinkedFileMergeConflictCommentAdditionService.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/AbstractLinkedFileMergeConflictCommentAdditionService.cs
@@ -16,7 +16,7 @@ internal abstract class AbstractLinkedFileMergeConflictCommentAdditionService : 
 {
     internal abstract string GetConflictCommentText(string header, string beforeString, string afterString);
 
-    public IEnumerable<TextChange> CreateEdits(SourceText originalSourceText, IEnumerable<UnmergedDocumentChanges> unmergedChanges)
+    public List<TextChange> CreateEdits(SourceText originalSourceText, IEnumerable<UnmergedDocumentChanges> unmergedChanges)
     {
         var commentChanges = new List<TextChange>();
 

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/IMergeConflictHandler.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/IMergeConflictHandler.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 
@@ -11,5 +9,5 @@ namespace Microsoft.CodeAnalysis;
 
 internal interface IMergeConflictHandler
 {
-    IEnumerable<TextChange> CreateEdits(SourceText originalSourceText, IEnumerable<UnmergedDocumentChanges> unmergedChanges);
+    List<TextChange> CreateEdits(SourceText originalSourceText, List<UnmergedDocumentChanges> unmergedChanges);
 }

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -63,7 +63,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
 
     private async Task<LinkedFileMergeResult> MergeLinkedDocumentGroupAsync(
         ImmutableArray<DocumentId> allLinkedDocuments,
-        IEnumerable<DocumentId> linkedDocumentGroup,
+        IGrouping<string, DocumentId> linkedDocumentGroup,
         LinkedFileDiffMergingSessionInfo sessionInfo,
         IMergeConflictHandler mergeConflictHandler,
         CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -62,7 +62,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
     }
 
     private async Task<LinkedFileMergeResult> MergeLinkedDocumentGroupAsync(
-        IEnumerable<DocumentId> allLinkedDocuments,
+        ImmutableArray<DocumentId> allLinkedDocuments,
         IEnumerable<DocumentId> linkedDocumentGroup,
         LinkedFileDiffMergingSessionInfo sessionInfo,
         IMergeConflictHandler mergeConflictHandler,

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -94,7 +94,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
 
         // Add comments in source explaining diffs that could not be merged
 
-        IEnumerable<TextChange> allChanges;
+        ImmutableArray<TextChange> allChanges;
         var mergeConflictResolutionSpan = new List<TextSpan>();
 
         if (unmergedChanges.Count != 0)
@@ -209,14 +209,14 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
         return successfullyMergedChanges.ToImmutable();
     }
 
-    private static IEnumerable<TextChange> MergeChangesWithMergeFailComments(
+    private static ImmutableArray<TextChange> MergeChangesWithMergeFailComments(
         ImmutableArray<TextChange> mergedChanges,
-        IEnumerable<TextChange> commentChanges,
+        List<TextChange> commentChanges,
         List<TextSpan> mergeConflictResolutionSpans,
         LinkedFileGroupSessionInfo groupSessionInfo)
     {
-        var mergedChangesList = NormalizeChanges(mergedChanges).ToList();
-        var commentChangesList = NormalizeChanges(commentChanges).ToList();
+        var mergedChangesList = NormalizeChanges(mergedChanges);
+        var commentChangesList = NormalizeChanges(commentChanges);
 
         var combinedChanges = new List<TextChange>();
         var insertedMergeConflictCommentsAtAdjustedLocation = 0;
@@ -272,17 +272,15 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
         groupSessionInfo.InsertedMergeConflictComments = commentChanges.Count();
         groupSessionInfo.InsertedMergeConflictCommentsAtAdjustedLocation = insertedMergeConflictCommentsAtAdjustedLocation;
 
-        return NormalizeChanges(combinedChanges);
+        return NormalizeChanges(combinedChanges).ToImmutableArray();
     }
 
-    private static IEnumerable<TextChange> NormalizeChanges(IEnumerable<TextChange> changes)
+    private static IList<TextChange> NormalizeChanges(IList<TextChange> changes)
     {
-        if (changes.Count() <= 1)
-        {
+        if (changes.Count <= 1)
             return changes;
-        }
 
-        changes = changes.OrderBy(c => c.Span.Start);
+        var orderedChanges = changes.OrderBy(c => c.Span.Start).ToList();
         var normalizedChanges = new List<TextChange>();
 
         var currentChange = changes.First();

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -309,7 +309,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
             => LinkedFileGroups.Add(info);
     }
 
-    internal class LinkedFileGroupSessionInfo
+    internal sealed class LinkedFileGroupSessionInfo
     {
         public int LinkedDocuments;
         public int DocumentsWithChanges;

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -206,7 +206,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
                 oldDocument.Id));
         }
 
-        return successfullyMergedChanges.ToImmutable();
+        return successfullyMergedChanges.ToImmutableAndClear();
     }
 
     private static ImmutableArray<TextChange> MergeChangesWithMergeFailComments(

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -73,7 +73,8 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
         // Automatically merge non-conflicting diffs while collecting the conflicting diffs
 
         var textDifferencingService = oldSolution.Services.GetRequiredService<IDocumentTextDifferencingService>();
-        var appliedChanges = await textDifferencingService.GetTextChangesAsync(oldSolution.GetDocument(linkedDocumentGroup.First()), newSolution.GetDocument(linkedDocumentGroup.First()), cancellationToken).ConfigureAwait(false);
+        var appliedChanges = await textDifferencingService.GetTextChangesAsync(
+            oldSolution.GetDocument(linkedDocumentGroup.First()), newSolution.GetDocument(linkedDocumentGroup.First()), TextDifferenceTypes.Line, cancellationToken).ConfigureAwait(false);
         var unmergedChanges = new List<UnmergedDocumentChanges>();
 
         foreach (var documentId in linkedDocumentGroup.Skip(1))
@@ -129,8 +130,9 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
 
         var cumulativeChangeIndex = 0;
 
-        var textchanges = await textDiffService.GetTextChangesAsync(oldDocument, newDocument, cancellationToken).ConfigureAwait(false);
-        foreach (var change in textchanges)
+        var textChanges = await textDiffService.GetTextChangesAsync(
+            oldDocument, newDocument, TextDifferenceTypes.Line, cancellationToken).ConfigureAwait(false);
+        foreach (var change in textChanges)
         {
             while (cumulativeChangeIndex < cumulativeChanges.Count && cumulativeChanges[cumulativeChangeIndex].Span.End < change.Span.Start)
             {

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -301,7 +301,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
         return normalizedChanges;
     }
 
-    internal class LinkedFileDiffMergingSessionInfo
+    internal sealed class LinkedFileDiffMergingSessionInfo
     {
         public readonly List<LinkedFileGroupSessionInfo> LinkedFileGroups = [];
 

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -95,9 +95,9 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
         // Add comments in source explaining diffs that could not be merged
 
         IEnumerable<TextChange> allChanges;
-        IList<TextSpan> mergeConflictResolutionSpan = [];
+        var mergeConflictResolutionSpan = new List<TextSpan>();
 
-        if (unmergedChanges.Any())
+        if (unmergedChanges.Count != 0)
         {
             mergeConflictHandler ??= oldSolution.GetDocument(linkedDocumentGroup.First()).GetLanguageService<ILinkedFileMergeConflictCommentAdditionService>();
             var mergeConflictTextEdits = mergeConflictHandler.CreateEdits(originalSourceText, unmergedChanges);
@@ -212,7 +212,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
     private static IEnumerable<TextChange> MergeChangesWithMergeFailComments(
         IEnumerable<TextChange> mergedChanges,
         IEnumerable<TextChange> commentChanges,
-        IList<TextSpan> mergeConflictResolutionSpans,
+        List<TextSpan> mergeConflictResolutionSpans,
         LinkedFileGroupSessionInfo groupSessionInfo)
     {
         var mergedChangesList = NormalizeChanges(mergedChanges).ToList();

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -126,7 +126,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
         CancellationToken cancellationToken)
     {
         var unmergedDocumentChanges = new List<TextChange>();
-        var successfullyMergedChanges = ArrayBuilder<TextChange>.GetInstance();
+        using var _ = ArrayBuilder<TextChange>.GetInstance(out var successfullyMergedChanges);
 
         var cumulativeChangeIndex = 0;
 
@@ -206,7 +206,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
                 oldDocument.Id));
         }
 
-        return successfullyMergedChanges.ToImmutableAndFree();
+        return successfullyMergedChanges.ToImmutable();
     }
 
     private static IEnumerable<TextChange> MergeChangesWithMergeFailComments(

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -198,10 +198,10 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
             groupSessionInfo.IsolatedDiffs++;
         }
 
-        if (unmergedDocumentChanges.Any())
+        if (unmergedDocumentChanges.Count != 0)
         {
             unmergedChanges.Add(new UnmergedDocumentChanges(
-                unmergedDocumentChanges.AsEnumerable(),
+                unmergedDocumentChanges,
                 oldDocument.Project.Name,
                 oldDocument.Id));
         }
@@ -210,7 +210,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
     }
 
     private static IEnumerable<TextChange> MergeChangesWithMergeFailComments(
-        IEnumerable<TextChange> mergedChanges,
+        ImmutableArray<TextChange> mergedChanges,
         IEnumerable<TextChange> commentChanges,
         List<TextSpan> mergeConflictResolutionSpans,
         LinkedFileGroupSessionInfo groupSessionInfo)

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeResult.cs
@@ -2,18 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis;
 
-internal sealed class LinkedFileMergeResult(IEnumerable<DocumentId> documentIds, SourceText mergedSourceText, IEnumerable<TextSpan> mergeConflictResolutionSpans)
+internal sealed class LinkedFileMergeResult(ImmutableArray<DocumentId> documentIds, SourceText mergedSourceText, IEnumerable<TextSpan> mergeConflictResolutionSpans)
 {
-    public IEnumerable<DocumentId> DocumentIds { get; internal set; } = documentIds;
-    public SourceText MergedSourceText { get; internal set; } = mergedSourceText;
-    public IEnumerable<TextSpan> MergeConflictResolutionSpans { get; } = mergeConflictResolutionSpans;
-    public bool HasMergeConflicts { get { return MergeConflictResolutionSpans.Any(); } }
+    public ImmutableArray<DocumentId> DocumentIds => documentIds;
+    public SourceText MergedSourceText => mergedSourceText;
+    public IEnumerable<TextSpan> MergeConflictResolutionSpans => mergeConflictResolutionSpans;
+    public bool HasMergeConflicts => MergeConflictResolutionSpans.Any();
 }

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeResult.cs
@@ -9,10 +9,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis;
 
-internal sealed class LinkedFileMergeResult(ImmutableArray<DocumentId> documentIds, SourceText mergedSourceText, IEnumerable<TextSpan> mergeConflictResolutionSpans)
+internal sealed class LinkedFileMergeResult(ImmutableArray<DocumentId> documentIds, SourceText mergedSourceText, List<TextSpan> mergeConflictResolutionSpans)
 {
     public ImmutableArray<DocumentId> DocumentIds => documentIds;
     public SourceText MergedSourceText => mergedSourceText;
-    public IEnumerable<TextSpan> MergeConflictResolutionSpans => mergeConflictResolutionSpans;
-    public bool HasMergeConflicts => MergeConflictResolutionSpans.Any();
+    public List<TextSpan> MergeConflictResolutionSpans => mergeConflictResolutionSpans;
+    public bool HasMergeConflicts => MergeConflictResolutionSpans.Count != 0;
 }

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 
@@ -13,8 +11,7 @@ internal sealed class LinkedFileMergeSessionResult
 {
     public Solution MergedSolution { get; }
 
-    private readonly Dictionary<DocumentId, IEnumerable<TextSpan>> _mergeConflictCommentSpans = [];
-    public Dictionary<DocumentId, IEnumerable<TextSpan>> MergeConflictCommentSpans => _mergeConflictCommentSpans;
+    private readonly Dictionary<DocumentId, List<TextSpan>> MergeConflictCommentSpans = [];
 
     public LinkedFileMergeSessionResult(Solution mergedSolution, List<LinkedFileMergeResult> fileMergeResults)
     {
@@ -23,9 +20,7 @@ internal sealed class LinkedFileMergeSessionResult
         foreach (var fileMergeResult in fileMergeResults)
         {
             foreach (var documentId in fileMergeResult.DocumentIds)
-            {
-                _mergeConflictCommentSpans.Add(documentId, fileMergeResult.MergeConflictResolutionSpans);
-            }
+                MergeConflictCommentSpans.Add(documentId, fileMergeResult.MergeConflictResolutionSpans);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
@@ -16,7 +16,7 @@ internal sealed class LinkedFileMergeSessionResult
     private readonly Dictionary<DocumentId, IEnumerable<TextSpan>> _mergeConflictCommentSpans = [];
     public Dictionary<DocumentId, IEnumerable<TextSpan>> MergeConflictCommentSpans => _mergeConflictCommentSpans;
 
-    public LinkedFileMergeSessionResult(Solution mergedSolution, IEnumerable<LinkedFileMergeResult> fileMergeResults)
+    public LinkedFileMergeSessionResult(Solution mergedSolution, List<LinkedFileMergeResult> fileMergeResults)
     {
         this.MergedSolution = mergedSolution;
 

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
@@ -11,7 +11,7 @@ internal sealed class LinkedFileMergeSessionResult
 {
     public Solution MergedSolution { get; }
 
-    private readonly Dictionary<DocumentId, List<TextSpan>> MergeConflictCommentSpans = [];
+    public readonly Dictionary<DocumentId, List<TextSpan>> MergeConflictCommentSpans = [];
 
     public LinkedFileMergeSessionResult(Solution mergedSolution, List<LinkedFileMergeResult> fileMergeResults)
     {

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/UnmergedDocumentChanges.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/UnmergedDocumentChanges.cs
@@ -9,9 +9,9 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis;
 
-internal sealed class UnmergedDocumentChanges(IEnumerable<TextChange> unmergedChanges, string projectName, DocumentId documentId)
+internal sealed class UnmergedDocumentChanges(List<TextChange> unmergedChanges, string projectName, DocumentId documentId)
 {
-    public IEnumerable<TextChange> UnmergedChanges { get; } = unmergedChanges;
+    public List<TextChange> UnmergedChanges { get; } = unmergedChanges;
     public string ProjectName { get; } = projectName;
     public DocumentId DocumentId { get; } = documentId;
 }

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/UnmergedDocumentChanges.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/UnmergedDocumentChanges.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 


### PR DESCRIPTION
Drops LOH allocs from 1.1GB:

![image](https://github.com/dotnet/roslyn/assets/4564579/a2fe0e8c-5484-48d9-8aaf-42676523e3ce)

to around 50mb:

![image](https://github.com/dotnet/roslyn/assets/4564579/d7f5374f-8c14-4ab9-be6a-7e4a286a696a)
