### PR TITLE
Remove virtual from 'SourceMethodSymbolWithAttributes.SyntaxNode'

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal virtual CSharpSyntaxNode SyntaxNode
+        internal CSharpSyntaxNode SyntaxNode
         {
             get
             {


### PR DESCRIPTION
I noticed that nothing is overriding this so went ahead and removed the virtual modifier.