### PR TITLE
Add more "ref in async" tests

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -3105,6 +3105,7 @@ ref struct C
                     public void Dispose() { }
                 }
                 """;
+            // https://github.com/dotnet/roslyn/issues/73280 - should not be a langversion error since this remains an error in C# 13
             CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
                 // (6,16): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         using (new R())
@@ -3379,6 +3380,7 @@ ref struct C
                     public ValueTask DisposeAsync() => default;
                 }
                 """;
+            // https://github.com/dotnet/roslyn/issues/73280 - should not be a langversion error since this remains an error in C# 13
             CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
                 // (6,22): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await using (new R())
@@ -3416,6 +3418,7 @@ ref struct C
                     public ValueTask DisposeAsync() => default;
                 }
                 """ + AsyncStreamsTypes;
+            // https://github.com/dotnet/roslyn/issues/73280 - should not be a langversion error since this remains an error in C# 13
             CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
                 // (7,22): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await using (new R())
@@ -3451,6 +3454,7 @@ ref struct C
                     public ValueTask DisposeAsync() => default;
                 }
                 """ + AsyncStreamsTypes;
+            // https://github.com/dotnet/roslyn/issues/73280 - should not be a langversion error since this remains an error in C# 13
             CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
                 // (7,21): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         await using var _ = new R();

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -3084,5 +3084,436 @@ ref struct C
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "DISPOSED");
         }
+
+        [Fact]
+        public void RefStruct_AwaitInside()
+        {
+            var source = """
+                using System.Threading.Tasks;
+                class C
+                {
+                    async Task M()
+                    {
+                        using (new R())
+                        {
+                            await Task.Yield();
+                        }
+                    }
+                }
+                ref struct R
+                {
+                    public void Dispose() { }
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+                // (6,16): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         using (new R())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "new R()").WithArguments("ref and unsafe in async and iterator methods").WithLocation(6, 16));
+
+            var expectedDiagnostics = new[]
+            {
+                // (6,16): error CS4007: Instance of type 'R' cannot be preserved across 'await' or 'yield' boundary.
+                //         using (new R())
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "new R()").WithArguments("R").WithLocation(6, 16)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyEmitDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefStruct_YieldReturnInside()
+        {
+            var source = """
+                using System.Collections.Generic;
+                class C
+                {
+                    IEnumerable<int> M()
+                    {
+                        using (new R())
+                        {
+                            yield return 1;
+                        }
+                    }
+                }
+                ref struct R
+                {
+                    public void Dispose() { }
+                }
+                """;
+
+            var expectedDiagnostics = new[]
+            {
+                // (6,16): error CS4007: Instance of type 'R' cannot be preserved across 'await' or 'yield' boundary.
+                //         using (new R())
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "new R()").WithArguments("R").WithLocation(6, 16)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyEmitDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefStruct_YieldBreakInside()
+        {
+            var source = """
+                using System;
+                using System.Collections.Generic;
+                class C
+                {
+                    static void Main()
+                    {
+                        foreach (var x in M(true)) { Console.Write(x); }
+                        Console.Write(" ");
+                        foreach (var x in M(false)) { Console.Write(x); }
+                    }
+                    static IEnumerable<int> M(bool b)
+                    {
+                        yield return 123;
+                        using (new R())
+                        {
+                            if (b) { yield break; }
+                        }
+                        yield return 456;
+                    }
+                }
+                ref struct R
+                {
+                    public R() => Console.Write("C");
+                    public void Dispose() => Console.Write("D");
+                }
+                """;
+
+            var expectedOutput = "123CD 123CD456";
+
+            CompileAndVerify(source, expectedOutput: expectedOutput, parseOptions: TestOptions.Regular12).VerifyDiagnostics();
+            CompileAndVerify(source, expectedOutput: expectedOutput, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CompileAndVerify(source, expectedOutput: expectedOutput).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefStruct_AwaitResource()
+        {
+            var source = """
+                using System;
+                using System.Threading.Tasks;
+                class C
+                {
+                    static async Task Main()
+                    {
+                        Console.Write("1");
+                        using ((await GetC()).GetR())
+                        {
+                            Console.Write("2");
+                        }
+                        Console.Write("3");
+                    }
+                    static async Task<C> GetC()
+                    {
+                        Console.Write("Ga");
+                        await Task.Yield();
+                        Console.Write("Gb");
+                        return new C();
+                    }
+                    R GetR() => new R();
+                }
+                ref struct R
+                {
+                    public R() => Console.Write("C");
+                    public void Dispose() => Console.Write("D");
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+                // (8,16): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         using ((await GetC()).GetR())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "(await GetC()).GetR()").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 16));
+
+            var expectedOutput = "1GaGbC2D3";
+
+            CompileAndVerify(source, expectedOutput: expectedOutput, parseOptions: TestOptions.RegularNext, verify: Verification.FailsILVerify).VerifyDiagnostics();
+            CompileAndVerify(source, expectedOutput: expectedOutput, verify: Verification.FailsILVerify).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefStruct_AwaitOutside()
+        {
+            var source = """
+                using System;
+                using System.Threading.Tasks;
+                class C
+                {
+                    static async Task Main()
+                    {
+                        Console.Write("1");
+                        await Task.Yield();
+                        Console.Write("2");
+                        using (new R())
+                        {
+                            Console.Write("3");
+                        }
+                        Console.Write("4");
+                        await Task.Yield();
+                        Console.Write("5");
+                    }
+                }
+                ref struct R
+                {
+                    public R() => Console.Write("C");
+                    public void Dispose() => Console.Write("D");
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+                // (10,16): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         using (new R())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "new R()").WithArguments("ref and unsafe in async and iterator methods").WithLocation(10, 16));
+
+            var expectedOutput = "12C3D45";
+
+            CompileAndVerify(source, expectedOutput: expectedOutput, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CompileAndVerify(source, expectedOutput: expectedOutput).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefStruct_YieldReturnOutside()
+        {
+            var source = """
+                using System;
+                using System.Collections.Generic;
+                class C
+                {
+                    static void Main()
+                    {
+                        foreach (var x in M())
+                        {
+                            Console.Write(x);
+                        }
+                    }
+                    static IEnumerable<string> M()
+                    {
+                        Console.Write("1");
+                        yield return "a";
+                        Console.Write("2");
+                        using (new R())
+                        {
+                            Console.Write("3");
+                        }
+                        Console.Write("4");
+                        yield return "b";
+                        Console.Write("5");
+                    }
+                }
+                ref struct R
+                {
+                    public R() => Console.Write("C");
+                    public void Dispose() => Console.Write("D");
+                }
+                """;
+
+            var expectedOutput = "1a2C3D4b5";
+
+            CompileAndVerify(source, expectedOutput: expectedOutput, parseOptions: TestOptions.Regular12).VerifyDiagnostics();
+            CompileAndVerify(source, expectedOutput: expectedOutput, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CompileAndVerify(source, expectedOutput: expectedOutput).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefStruct_AwaitUsing()
+        {
+            var source = """
+                using System;
+                using System.Threading.Tasks;
+                class C
+                {
+                    static async Task Main()
+                    {
+                        Console.Write("1");
+                        await using (new R())
+                        {
+                            Console.Write("2");
+                        }
+                        Console.Write("3");
+                    }
+                }
+                ref struct R
+                {
+                    public R() => Console.Write("C");
+                    public ValueTask DisposeAsync()
+                    {
+                        Console.Write("D");
+                        return default;
+                    }
+                }
+                """;
+            CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+                // (8,22): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         await using (new R())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "new R()").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 22));
+
+            var expectedOutput = "1C2D3";
+
+            var comp = CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            comp = CreateCompilationWithTasksExtensions(source, options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefStruct_AwaitUsing_AwaitInside()
+        {
+            var source = """
+                using System.Threading.Tasks;
+                class C
+                {
+                    async Task M()
+                    {
+                        await using (new R())
+                        {
+                            await Task.Yield();
+                        }
+                    }
+                }
+                ref struct R
+                {
+                    public ValueTask DisposeAsync() => default;
+                }
+                """;
+            CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+                // (6,22): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         await using (new R())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "new R()").WithArguments("ref and unsafe in async and iterator methods").WithLocation(6, 22));
+
+            var expectedDiagnostics = new[]
+            {
+                // (6,22): error CS4007: Instance of type 'R' cannot be preserved across 'await' or 'yield' boundary.
+                //         await using (new R())
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "new R()").WithArguments("R").WithLocation(6, 22)
+            };
+
+            CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilationWithTasksExtensions(source).VerifyEmitDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefStruct_AwaitUsing_YieldReturnInside()
+        {
+            var source = """
+                using System.Collections.Generic;
+                using System.Threading.Tasks;
+                class C
+                {
+                    async IAsyncEnumerable<int> M()
+                    {
+                        await using (new R())
+                        {
+                            yield return 123;
+                        }
+                    }
+                }
+                ref struct R
+                {
+                    public ValueTask DisposeAsync() => default;
+                }
+                """ + AsyncStreamsTypes;
+            CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+                // (7,22): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         await using (new R())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "new R()").WithArguments("ref and unsafe in async and iterator methods").WithLocation(7, 22));
+
+            var expectedDiagnostics = new[]
+            {
+                // (7,22): error CS4007: Instance of type 'R' cannot be preserved across 'await' or 'yield' boundary.
+                //         await using (new R())
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "new R()").WithArguments("R").WithLocation(7, 22)
+            };
+
+            CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilationWithTasksExtensions(source).VerifyEmitDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefStruct_AwaitUsing_YieldReturnInside_Var()
+        {
+            var source = """
+                using System.Collections.Generic;
+                using System.Threading.Tasks;
+                class C
+                {
+                    async IAsyncEnumerable<int> M()
+                    {
+                        await using var _ = new R();
+                        yield return 123;
+                    }
+                }
+                ref struct R
+                {
+                    public ValueTask DisposeAsync() => default;
+                }
+                """ + AsyncStreamsTypes;
+            CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+                // (7,21): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         await using var _ = new R();
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "var").WithArguments("ref and unsafe in async and iterator methods").WithLocation(7, 21));
+
+            var expectedDiagnostics = new[]
+            {
+                // (7,25): error CS4007: Instance of type 'R' cannot be preserved across 'await' or 'yield' boundary.
+                //         await using var _ = new R();
+                Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "_ = new R()").WithArguments("R").WithLocation(7, 25)
+            };
+
+            CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilationWithTasksExtensions(source).VerifyEmitDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefStruct_AwaitUsing_YieldBreakInside()
+        {
+            var source = """
+                using System;
+                using System.Collections.Generic;
+                using System.Threading.Tasks;
+                class C
+                {
+                    static async Task Main()
+                    {
+                        await foreach (var x in M(true)) { Console.Write(x); }
+                        Console.Write(" ");
+                        await foreach (var x in M(false)) { Console.Write(x); }
+                    }
+                    static async IAsyncEnumerable<int> M(bool b)
+                    {
+                        yield return 1;
+                        await using (new R())
+                        {
+                            if (b) { yield break; }
+                        }
+                        yield return 2;
+                    }
+                }
+                ref struct R
+                {
+                    public R() => Console.Write("C");
+                    public ValueTask DisposeAsync()
+                    {
+                        Console.Write("D");
+                        return default;
+                    }
+                }
+                """ + AsyncStreamsTypes;
+            CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+                // (15,22): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         await using (new R())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "new R()").WithArguments("ref and unsafe in async and iterator methods").WithLocation(15, 22));
+
+            var expectedOutput = "1CD 1CD2";
+
+            var comp = CreateCompilationWithTasksExtensions(source, parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            comp = CreateCompilationWithTasksExtensions(source, options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -1359,6 +1359,7 @@ unsafe class Program
         yield return sizeof(System.UIntPtr);
     }
 }";
+            // https://github.com/dotnet/roslyn/issues/73280 - should not be a langversion error since this remains an error in C# 13
             var expectedDiagnostics = new[]
             {
                 // (6,22): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.

--- a/src/Compilers/CSharp/Test/Emit3/RefUnsafeInIteratorAndAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/RefUnsafeInIteratorAndAsyncTests.cs
@@ -1,0 +1,1099 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public class RefUnsafeInIteratorAndAsyncTests : CSharpTestBase
+{
+    private static string? IfSpans(string expectedOutput)
+        => ExecutionConditionUtil.IsDesktop ? null : expectedOutput;
+
+    [Fact]
+    public void LangVersion_RefLocalInAsync()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task M(int x)
+                {
+                    ref int y = ref x;
+                    ref readonly int z = ref y;
+                    await Task.Yield();
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+            // (6,17): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         ref int y = ref x;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(6, 17),
+            // (7,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         ref readonly int z = ref y;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "z").WithArguments("ref and unsafe in async and iterator methods").WithLocation(7, 26));
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation(source).VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void LangVersion_RefLocalInIterator()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M(int x)
+                {
+                    ref int y = ref x;
+                    ref readonly int z = ref y;
+                    yield return x;
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+            // (6,17): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         ref int y = ref x;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(6, 17),
+            // (7,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         ref readonly int z = ref y;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "z").WithArguments("ref and unsafe in async and iterator methods").WithLocation(7, 26));
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation(source).VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void LangVersion_RefLocalInIterator_IEnumerator()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerator<int> M(int x)
+                {
+                    ref int y = ref x;
+                    ref readonly int z = ref y;
+                    yield return x;
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+            // (6,17): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         ref int y = ref x;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "y").WithArguments("ref and unsafe in async and iterator methods").WithLocation(6, 17),
+            // (7,26): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         ref readonly int z = ref y;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "z").WithArguments("ref and unsafe in async and iterator methods").WithLocation(7, 26));
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation(source).VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void LangVersion_RefStructInAsync()
+    {
+        var source = """
+            #pragma warning disable CS0219 // variable unused
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task M()
+                {
+                    R y = default;
+                    scoped R z = default;
+                    await Task.Yield();
+                }
+            }
+            ref struct R { }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+            // (7,9): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         R y = default;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "R").WithArguments("ref and unsafe in async and iterator methods").WithLocation(7, 9),
+            // (8,16): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         scoped R z = default;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "R").WithArguments("ref and unsafe in async and iterator methods").WithLocation(8, 16));
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation(source).VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void LangVersion_RefStructInIterator()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M(R r)
+                {
+                    M(r);
+                    yield return -1;        
+                }
+            }
+            ref struct R { }
+            """;
+
+        var expectedDiagnostics = new[]
+        {
+            // (6,11): error CS4007: Instance of type 'R' cannot be preserved across 'await' or 'yield' boundary.
+            //         M(r);
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "r").WithArguments("R").WithLocation(6, 11)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyEmitDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyEmitDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void LangVersion_RestrictedInAsync()
+    {
+        var source = """
+            #pragma warning disable CS0219 // variable unused
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task M()
+                {
+                    System.TypedReference t = default;
+                    await Task.Yield();
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyDiagnostics(
+            // (7,9): error CS8652: The feature 'ref and unsafe in async and iterator methods' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         System.TypedReference t = default;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.TypedReference").WithArguments("ref and unsafe in async and iterator methods").WithLocation(7, 9));
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation(source).VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void LangVersion_RestrictedInIterator()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M(System.TypedReference t)
+                {
+                    t.GetHashCode();
+                    yield return -1;
+                }
+            }
+            """;
+
+        var expectedDiagnostics = new[]
+        {
+            // (6,9): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
+            //         t.GetHashCode();
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "t").WithArguments("System.TypedReference").WithLocation(6, 9)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12).VerifyEmitDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyEmitDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void Await_RefLocal_Across()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task M(int x)
+                {
+                    ref int y = ref x;
+                    await Task.Yield();
+                    System.Console.Write(y);
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyEmitDiagnostics(
+            // (8,30): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+            //         System.Console.Write(y);
+            Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(8, 30));
+    }
+
+    [Fact]
+    public void Await_RefLocal_Across_Reassign()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            class C
+            {
+                static Task Main() => M(123, 456);
+                static async Task M(int x, int z)
+                {
+                    ref int y = ref x;
+                    await Task.Yield();
+                    y = ref z;
+                    System.Console.Write(y);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "456").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Await_RefLocal_Between()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            class C
+            {
+                static Task Main() => M(123);
+                static async Task M(int x)
+                {
+                    ref int y = ref x;
+                    System.Console.Write(y);
+                    await Task.Yield();
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "123").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Await_RefStruct_Across()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task M(int x)
+                {
+                    Span<int> y = new(ref x);
+                    await Task.Yield();
+                    Console.Write(y.ToString());
+                }
+            }
+            """;
+        CreateCompilation(source, targetFramework: TargetFramework.Net70).VerifyEmitDiagnostics(
+            // (9,23): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
+            //         Console.Write(y.ToString());
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "y").WithArguments("System.Span<int>").WithLocation(9, 23));
+    }
+
+    [Fact]
+    public void Await_RefStruct_Across_Reassign()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            class C
+            {
+                static Task Main() => M(123, 456);
+                static async Task M(int x, int z)
+                {
+                    Span<int> y = new(ref x);
+                    await Task.Yield();
+                    y = new(ref z);
+                    Console.Write(y[0]);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: IfSpans("456"), verify: Verification.FailsPEVerify, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Await_RefStruct_Between()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            class C
+            {
+                static Task Main() => M(123);
+                static async Task M(int x)
+                {
+                    Span<int> y = new(ref x);
+                    Console.Write(y[0]);
+                    await Task.Yield();
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: IfSpans("123"), verify: Verification.FailsPEVerify, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Await_Restricted_Across()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task M()
+                {
+                    TypedReference y = default;
+                    await Task.Yield();
+                    Console.Write(y.GetHashCode());
+                }
+            }
+            """;
+        CreateCompilation(source, targetFramework: TargetFramework.Net70).VerifyEmitDiagnostics(
+            // (9,23): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
+            //         Console.Write(y.GetHashCode());
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "y").WithArguments("System.TypedReference").WithLocation(9, 23));
+    }
+
+    [Fact]
+    public void Await_Restricted_Across_Reassign()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    TypedReference y = default;
+                    await Task.Yield();
+                    y = default;
+                    Console.Write(y.GetHashCode());
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Await_Restricted_Between()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    TypedReference y = default;
+                    Console.Write(y.GetHashCode());
+                    await Task.Yield();
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Across()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M(int x)
+                {
+                    ref int y = ref x;
+                    yield return 1;
+                    System.Console.Write(y);
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyEmitDiagnostics(
+            // (8,30): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+            //         System.Console.Write(y);
+            Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(8, 30));
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Across_Indexer()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> this[int x]
+                {
+                    get
+                    {
+                        ref int y = ref x;
+                        yield return 1;
+                        System.Console.Write(y);
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyEmitDiagnostics(
+            // (10,34): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+            //             System.Console.Write(y);
+            Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(10, 34));
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Across_NestedBlock()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M(int x)
+                {
+                    ref int y = ref x;
+                    if (x != 0) { yield return 1; }
+                    System.Console.Write(y);
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyEmitDiagnostics(
+            // (8,30): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+            //         System.Console.Write(y);
+            Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(8, 30));
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Across_Async()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                async IAsyncEnumerable<int> M(int x)
+                {
+                    ref int y = ref x;
+                    yield return 1; await Task.Yield();
+                    System.Console.Write(y);
+                }
+            }
+            """ + AsyncStreamsTypes;
+        CreateCompilationWithTasksExtensions(source).VerifyEmitDiagnostics(
+            // (9,30): error CS9217: A 'ref' local cannot be preserved across 'await' or 'yield' boundary.
+            //         System.Console.Write(y);
+            Diagnostic(ErrorCode.ERR_RefLocalAcrossAwait, "y").WithLocation(9, 30));
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Across_Reassign()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var i in M(123, 456))
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static IEnumerable<int> M(int x, int z)
+                {
+                    ref int y = ref x;
+                    yield return -1;
+                    y = ref z;
+                    Console.Write(y);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "-1 456").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Across_Reassign_Indexer()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var i in new C()[123, 456])
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                IEnumerable<int> this[int x, int z]
+                {
+                    get
+                    {
+                        ref int y = ref x;
+                        yield return -1;
+                        y = ref z;
+                        Console.Write(y);
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "-1 456").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Across_Reassign_Async()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    await foreach (var i in M(123, 456))
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static async IAsyncEnumerable<int> M(int x, int z)
+                {
+                    ref int y = ref x;
+                    yield return -1; await Task.Yield();
+                    y = ref z;
+                    Console.Write(y);
+                }
+            }
+            """ + AsyncStreamsTypes;
+        var comp = CreateCompilationWithTasksExtensions(source, options: TestOptions.ReleaseExe);
+        CompileAndVerify(comp, expectedOutput: "-1 456").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Between()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var i in M(123))
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static IEnumerable<int> M(int x)
+                {
+                    ref int y = ref x;
+                    Console.Write(y);
+                    yield return -1;
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "123-1").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefLocal_Between_Async()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    await foreach (var i in M(123))
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static async IAsyncEnumerable<int> M(int x)
+                {
+                    ref int y = ref x;
+                    Console.Write(y);
+                    yield return -1; await Task.Yield();
+                }
+            }
+            """ + AsyncStreamsTypes;
+        var comp = CreateCompilationWithTasksExtensions(source, options: TestOptions.ReleaseExe);
+        CompileAndVerify(comp, expectedOutput: "123-1").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefStruct_Across()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M(int x)
+                {
+                    Span<int> y = new(ref x);
+                    yield return -1;
+                    Console.Write(y.ToString());
+                }
+            }
+            """;
+        CreateCompilation(source, targetFramework: TargetFramework.Net70).VerifyEmitDiagnostics(
+            // (9,23): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
+            //         Console.Write(y.ToString());
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "y").WithArguments("System.Span<int>").WithLocation(9, 23));
+    }
+
+    [Fact]
+    public void YieldReturn_RefStruct_Across_Indexer()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> this[int x]
+                {
+                    get
+                    {
+                        Span<int> y = new(ref x);
+                        yield return -1;
+                        Console.Write(y.ToString());
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, targetFramework: TargetFramework.Net70).VerifyEmitDiagnostics(
+            // (11,27): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
+            //             Console.Write(y.ToString());
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "y").WithArguments("System.Span<int>").WithLocation(11, 27));
+    }
+
+    [Fact]
+    public void YieldReturn_RefStruct_Across_NestedBlock()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M(int x)
+                {
+                    Span<int> y = new(ref x);
+                    if (x != 0) { yield return -1; }
+                    Console.Write(y.ToString());
+                }
+            }
+            """;
+        CreateCompilation(source, targetFramework: TargetFramework.Net70).VerifyEmitDiagnostics(
+            // (9,23): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
+            //         Console.Write(y.ToString());
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "y").WithArguments("System.Span<int>").WithLocation(9, 23));
+    }
+
+    [Fact]
+    public void YieldReturn_RefStruct_Across_Async()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                async IAsyncEnumerable<int> M(int x)
+                {
+                    Span<int> y = new(ref x);
+                    yield return -1; await Task.Yield();
+                    Console.Write(y.ToString());
+                }
+            }
+            """;
+        CreateCompilation(source, targetFramework: TargetFramework.Net70).VerifyEmitDiagnostics(
+            // (10,23): error CS4007: Instance of type 'System.Span<int>' cannot be preserved across 'await' or 'yield' boundary.
+            //         Console.Write(y.ToString());
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "y").WithArguments("System.Span<int>").WithLocation(10, 23));
+    }
+
+    [Fact]
+    public void YieldReturn_RefStruct_Across_Reassign()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var i in M(123, 456))
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static IEnumerable<int> M(int x, int z)
+                {
+                    Span<int> y = new(ref x);
+                    yield return -1;
+                    y = new(ref z);
+                    Console.Write(y[0]);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: IfSpans("-1 456"), verify: Verification.FailsPEVerify, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefStruct_Across_Reassign_Indexer()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var i in new C()[123, 456])
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                IEnumerable<int> this[int x, int z]
+                {
+                    get
+                    {
+                        Span<int> y = new(ref x);
+                        yield return -1;
+                        y = new(ref z);
+                        Console.Write(y[0]);
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: IfSpans("-1 456"), verify: Verification.FailsPEVerify, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefStruct_Across_Reassign_Async()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    await foreach (var i in M(123, 456))
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static async IAsyncEnumerable<int> M(int x, int z)
+                {
+                    Span<int> y = new(ref x);
+                    yield return -1; await Task.Yield();
+                    y = new(ref z);
+                    Console.Write(y[0]);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: IfSpans("-1 456"), verify: Verification.FailsPEVerify, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_RefStruct_Between()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var i in M(123))
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static IEnumerable<int> M(int x)
+                {
+                    Span<int> y = new(ref x);
+                    Console.Write(y[0]);
+                    yield return -1;
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: IfSpans("123-1"), verify: Verification.FailsPEVerify, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_Restricted_Across()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M()
+                {
+                    TypedReference y = default;
+                    yield return -1;
+                    Console.Write(y.GetHashCode());
+                }
+            }
+            """;
+        CreateCompilation(source, targetFramework: TargetFramework.Net70).VerifyEmitDiagnostics(
+            // (9,23): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
+            //         Console.Write(y.GetHashCode());
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "y").WithArguments("System.TypedReference").WithLocation(9, 23));
+    }
+
+    [Fact]
+    public void YieldReturn_Restricted_Across_Async()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                async IAsyncEnumerable<int> M()
+                {
+                    TypedReference y = default;
+                    yield return -1; await Task.Yield();
+                    Console.Write(y.GetHashCode());
+                }
+            }
+            """;
+        CreateCompilation(source, targetFramework: TargetFramework.Net70).VerifyEmitDiagnostics(
+            // (10,23): error CS4007: Instance of type 'System.TypedReference' cannot be preserved across 'await' or 'yield' boundary.
+            //         Console.Write(y.GetHashCode());
+            Diagnostic(ErrorCode.ERR_ByRefTypeAndAwait, "y").WithArguments("System.TypedReference").WithLocation(10, 23));
+    }
+
+    [Fact]
+    public void YieldReturn_Restricted_Across_Reassign()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var i in M())
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static IEnumerable<int> M()
+                {
+                    TypedReference y = default;
+                    yield return -1;
+                    y = default;
+                    Console.Write(y.GetHashCode());
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "-1 0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_Restricted_Across_Reassign_Async()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    await foreach (var i in M())
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static async IAsyncEnumerable<int> M()
+                {
+                    TypedReference y = default;
+                    yield return -1; await Task.Yield();
+                    y = default;
+                    Console.Write(y.GetHashCode());
+                }
+            }
+            """ + AsyncStreamsTypes;
+        var comp = CreateCompilationWithTasksExtensions(source, options: TestOptions.ReleaseExe);
+        CompileAndVerify(comp, expectedOutput: "-1 0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldReturn_Restricted_Between()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var i in M())
+                    {
+                        Console.Write(i + " ");
+                    }
+                }
+                static IEnumerable<int> M()
+                {
+                    TypedReference y = default;
+                    Console.Write(y.GetHashCode());
+                    yield return -1;
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "0-1").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldBreak_RefLocal_Across()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var a in M(10)) { throw null; }
+                    foreach (var b in M(123)) { throw null; }
+                }
+                static IEnumerable<int> M(int x)
+                {
+                    ref int y = ref x;
+                    if (x < 100) yield break;
+                    System.Console.Write(y);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "123").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldBreak_RefLocal_Across_Async()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    await foreach (var a in M(10)) { throw null; }
+                    await foreach (var b in M(123)) { throw null; }
+                }
+                static async IAsyncEnumerable<int> M(int x)
+                {
+                    ref int y = ref x;
+                    if (x < 100) { await Task.Yield(); yield break; }
+                    System.Console.Write(y);
+                }
+            }
+            """ + AsyncStreamsTypes;
+        var comp = CreateCompilationWithTasksExtensions(source, options: TestOptions.ReleaseExe);
+        CompileAndVerify(comp, expectedOutput: "123").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldBreak_RefStruct_Across()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var a in M(10)) { throw null; }
+                    foreach (var b in M(123)) { throw null; }
+                }
+                static IEnumerable<int> M(int x)
+                {
+                    Span<int> y = new(ref x);
+                    if (x < 100) yield break;
+                    Console.Write(y[0]);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: IfSpans("123"), verify: Verification.FailsPEVerify, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldBreak_RefStruct_Across_Async()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    await foreach (var a in M(10)) { throw null; }
+                    await foreach (var b in M(123)) { throw null; }
+                }
+                static async IAsyncEnumerable<int> M(int x)
+                {
+                    Span<int> y = new(ref x);
+                    if (x < 100) { await Task.Yield(); yield break; }
+                    Console.Write(y[0]);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: IfSpans("123"), verify: Verification.FailsPEVerify, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldBreak_Restricted_Across()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            class C
+            {
+                static void Main()
+                {
+                    foreach (var a in M(10)) { throw null; }
+                    foreach (var b in M(123)) { throw null; }
+                }
+                static IEnumerable<int> M(int x)
+                {
+                    TypedReference t = default;
+                    if (x < 100) yield break;
+                    Console.Write(x + t.GetHashCode());
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: "123").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void YieldBreak_Restricted_Across_Async()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class C
+            {
+                static async Task Main()
+                {
+                    await foreach (var a in M(10)) { throw null; }
+                    await foreach (var b in M(123)) { throw null; }
+                }
+                static async IAsyncEnumerable<int> M(int x)
+                {
+                    TypedReference t = default;
+                    if (x < 100) { await Task.Yield(); yield break; }
+                    Console.Write(x + t.GetHashCode());
+                }
+            }
+            """ + AsyncStreamsTypes;
+        var comp = CreateCompilationWithTasksExtensions(source, options: TestOptions.ReleaseExe);
+        CompileAndVerify(comp, expectedOutput: "123").VerifyDiagnostics();
+    }
+}


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/72662

All remaining tests from the test plan should be covered:

- ref / ref struct local in iterator method: RefUnsafeInIteratorAndAsyncTests.LangVersion_*
- unsafe block in async method in C#12-13: UnsafeTests.UnsafeBlock_InAsyncMethod
- effect on unsafe context within iterator's body (the breaking change): UnsafeTests.UnsafeContext_LocalFunctionInIterator_BreakingChange_*
- use ref / ref struct local
  - within / across await: RefUnsafeInIteratorAndAsyncTests.Await_*
  - within / across yield return; in
    - regular iterators: RefUnsafeInIteratorAndAsyncTests.YieldReturn_*
    - async iterators: RefUnsafeInIteratorAndAsyncTests.YieldReturn_*_Async
  - across yield break; in
    - regular iterators: RefUnsafeInIteratorAndAsyncTests.YieldBreak_*
    - async iterators: RefUnsafeInIteratorAndAsyncTests.YieldBreak_*_Async
  - within / across async foreach block: CodeGenAwaitForeachTests.TestWithPattern_Ref*
  - yield in nested block: YieldReturn_*_Across_NestedBlock
  - within async lambda / local function: RefLocalsAndReturnsTests.RefLocal_Async_LocalFunction and similar
  - within iterator local function: RefLocalsAndReturnsTests.RefLocal_Iterator_LocalFunction and similar
  - within property / indexer get iterator: RefUnsafeInIteratorAndAsyncTests.*_Indexer
  - error in async / iterator even in unsafe context - I'm not sure what this means
  - await in elements of stackalloc: StackAllocInitializerTests.TestAwait_Span_02
  - async Task<int[]> M() => ... ReadOnlySpan<int> x = await M();: SpanStackSafetyTests.AwaitAssignSpan
  - Buffer2<int> b = [await a, await b];: InlineArrayTests.Initialization_RefStruct_Await
  - using (refStruct = ...) { await ...; }: CodeGenAwaitUsingTests.RefStruct_*
  - foreach (var _ in refStruct) { await ...; }: CodeGenAwaitForeachTests.TestWithPattern_RefStructEnumerable_Async
  - interpolation handlers - the ref struct is not used when there are awaits - InterpolationTests.AwaitInHoles_UsesFormat
- unsafe context > error for await: BindingAsyncTests.BadAwaitInUnsafeContext