### PR TITLE
Improve memory allocs in interval trees

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -202,9 +202,7 @@ internal partial class IntervalTree<T> : IEnumerable<T>
             var currentNode = currentTuple.node;
             RoslynDebug.Assert(currentNode != null);
 
-            var firstTime = currentTuple.firstTime;
-
-            if (!firstTime)
+            if (!currentTuple.firstTime)
             {
                 // We're seeing this node for the second time (as we walk back up the left
                 // side of it).  Now see if it matches our test, and if so return it out.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -29,7 +29,7 @@ internal partial class IntervalTree<T> : IEnumerable<T>
     /// <summary>
     /// Keep around a fair number of these as we often use them in parallel algorithms.
     /// </summary>
-    private static readonly ObjectPool<Stack<Node>> s_nodePool = new(() => new(), 1024);
+    private static readonly ObjectPool<Stack<Node>> s_nodePool = new(() => new(), 128);
 
     private delegate bool TestInterval<TIntrospector>(T value, int start, int length, in TIntrospector introspector)
         where TIntrospector : struct, IIntervalIntrospector<T>;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -200,7 +200,6 @@ internal partial class IntervalTree<T> : IEnumerable<T>
         while (candidates.TryPop(out var currentTuple))
         {
             var currentNode = currentTuple.node;
-            RoslynDebug.Assert(currentNode != null);
 
             if (!currentTuple.firstTime)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -228,8 +228,6 @@ internal partial class IntervalTree<T> : IEnumerable<T>
 
                 candidates.Push((currentNode, firstTime: false));
 
-                // only if left's maxVal overlaps with interval's start, we should consider 
-                // left subtree
                 if (ShouldExamineLeft(start, currentNode, in introspector, out var left))
                     candidates.Push((left, firstTime: true));
             }


### PR DESCRIPTION
Drops us from:

![image](https://github.com/dotnet/roslyn/assets/4564579/24bde7f8-cf21-47ba-9ac3-4903e49b9f8b)

to:

![image](https://github.com/dotnet/roslyn/assets/4564579/b877b7fc-9186-4fd6-9aa2-d169771a10e4)

