### PR TITLE
Produce less string allocs while formatting documents

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/BottomUpBaseIndentationFinder.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/BottomUpBaseIndentationFinder.cs
@@ -219,7 +219,7 @@ internal class BottomUpBaseIndentationFinder
         allNodes.Do(n => _formattingRules.AddIndentBlockOperations(list, n));
 
         // sort them in right order
-        list.RemoveAll(CommonFormattingHelpers.IsNull);
+        list.RemoveAll(static o => o is null);
         list.Sort(CommonFormattingHelpers.IndentBlockOperationComparer);
 
         return list;
@@ -296,7 +296,7 @@ internal class BottomUpBaseIndentationFinder
         }
 
         // well, found no appropriate one
-        list.RemoveAll(CommonFormattingHelpers.IsNull);
+        list.RemoveAll(static o => o is null);
         if (list.Count == 0)
         {
             return null;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -53,7 +54,8 @@ internal static class FormattingExtensions
         var endToken = tokenStream.GetTokenData(operation.EndToken);
         var previousToken = endToken.GetPreviousTokenData();
 
-        return tokenStream.GetTriviaData(startToken, nextToken).TreatAsElastic || tokenStream.GetTriviaData(previousToken, endToken).TreatAsElastic;
+        return CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(startToken.Token, nextToken.Token) ||
+               CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken.Token, endToken.Token);
     }
 
     public static bool HasAnyWhitespaceElasticTrivia(this SyntaxTriviaList list)
@@ -62,9 +64,7 @@ internal static class FormattingExtensions
         foreach (var trivia in list)
         {
             if (trivia.IsElastic())
-            {
                 return true;
-            }
         }
 
         return false;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CommonFormattingHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CommonFormattingHelpers.cs
@@ -346,20 +346,14 @@ internal static class CommonFormattingHelpers
 
     public static bool HasAnyWhitespaceElasticTrivia(SyntaxToken previousToken, SyntaxToken currentToken)
     {
-        if ((!previousToken.ContainsAnnotations && !currentToken.ContainsAnnotations) ||
-            (!previousToken.HasTrailingTrivia && !currentToken.HasLeadingTrivia))
-        {
+        if (!previousToken.ContainsAnnotations && !currentToken.ContainsAnnotations)
             return false;
-        }
+
+        if (!previousToken.HasTrailingTrivia && !currentToken.HasLeadingTrivia)
+            return false;
 
         return previousToken.TrailingTrivia.HasAnyWhitespaceElasticTrivia() || currentToken.LeadingTrivia.HasAnyWhitespaceElasticTrivia();
     }
-
-    public static bool IsNull<T>(T t) where T : class
-        => t == null;
-
-    public static bool IsNotNull<T>(T t) where T : class
-        => !IsNull(t);
 
     public static TextSpan GetFormattingSpan(SyntaxNode root, TextSpan span)
     {


### PR DESCRIPTION
Takes us from:

![image](https://github.com/dotnet/roslyn/assets/4564579/68857961-7729-47d4-b777-aeccf314b709)

to:

![image](https://github.com/dotnet/roslyn/assets/4564579/0b8f58af-27c7-4421-bff6-dfe3719cc6af)

(we actually call this in several places, which is why we get 800 MB drop).