### PR TITLE
Optimize suppress operations during formatting.  

### DIFF
--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -303,7 +303,12 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         }
 
         public void Sort(Comparison<T> compare)
-            => Sort(Comparer<T>.Create(compare));
+        {
+            if (this.Count <= 1)
+                return;
+
+            Sort(Comparer<T>.Create(compare));
+        }
 
         public void Sort(int startIndex, IComparer<T> comparer)
         {

--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Indentation;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -265,11 +266,11 @@ internal class CurlyBraceCompletionService : AbstractCurlyBraceOrBracketCompleti
             }
         }
 
-        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+        public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
         {
             base.AddSuppressOperations(list, node, in nextOperation);
 
-            // not sure exactly what is happening here, but removing the bellow causesthe indentation to be wrong.
+            // not sure exactly what is happening here, but removing the bellow causes the indentation to be wrong.
 
             // remove suppression rules for array and collection initializer
             if (node.IsInitializerForArrayOrCollectionCreationExpression())

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.MetadataAsSource;
 
@@ -18,7 +19,7 @@ internal partial class AbstractMetadataAsSourceService
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public sealed override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+        public sealed override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
         {
             var nextOperationCopy = nextOperation;
             AddSuppressOperationsSlow(list, node, ref nextOperationCopy);
@@ -73,7 +74,7 @@ internal partial class AbstractMetadataAsSourceService
         /// Returns SuppressWrappingIfOnSingleLineOperations under a node either by itself or by
         /// filtering/replacing operations returned by NextOperation
         /// </summary>
-        public virtual void AddSuppressOperationsSlow(List<SuppressOperation> list, SyntaxNode node, ref NextSuppressOperationAction nextOperation)
+        public virtual void AddSuppressOperationsSlow(ArrayBuilder<SuppressOperation> list, SyntaxNode node, ref NextSuppressOperationAction nextOperation)
             => base.AddSuppressOperations(list, node, in nextOperation);
 
         /// <summary>

--- a/src/Workspaces/CSharp/Portable/Formatting/TypingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/TypingFormattingRule.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 
@@ -13,7 +14,7 @@ internal class TypingFormattingRule : BaseFormattingRule
 {
     public static readonly TypingFormattingRule Instance = new();
 
-    public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
     {
         if (TryAddSuppressionOnMissingCloseBraceCase(list, node))
         {
@@ -23,7 +24,7 @@ internal class TypingFormattingRule : BaseFormattingRule
         base.AddSuppressOperations(list, node, in nextOperation);
     }
 
-    private static bool TryAddSuppressionOnMissingCloseBraceCase(List<SuppressOperation> list, SyntaxNode node)
+    private static bool TryAddSuppressionOnMissingCloseBraceCase(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         var bracePair = node.GetBracePair();
         if (!bracePair.IsValidBracketOrBracePair())

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 
@@ -19,7 +20,7 @@ internal sealed class DefaultOperationProvider : AbstractFormattingRule
     {
     }
 
-    public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
     {
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/BaseFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/BaseFormattingRule.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -116,13 +117,13 @@ internal abstract class BaseFormattingRule : AbstractFormattingRule
         list.Add(FormattingOperations.CreateRelativeIndentBlockOperation(baseToken, startToken, endToken, indentationDelta: 0, option: option));
     }
 
-    protected static void AddSuppressWrappingIfOnSingleLineOperation(List<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption extraOption = SuppressOption.None)
+    protected static void AddSuppressWrappingIfOnSingleLineOperation(ArrayBuilder<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption extraOption = SuppressOption.None)
         => AddSuppressOperation(list, startToken, endToken, SuppressOption.NoWrappingIfOnSingleLine | extraOption);
 
-    protected static void AddSuppressAllOperationIfOnMultipleLine(List<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption extraOption = SuppressOption.None)
+    protected static void AddSuppressAllOperationIfOnMultipleLine(ArrayBuilder<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption extraOption = SuppressOption.None)
         => AddSuppressOperation(list, startToken, endToken, SuppressOption.NoSpacingIfOnMultipleLine | SuppressOption.NoWrapping | extraOption);
 
-    protected static void AddSuppressOperation(List<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption option)
+    protected static void AddSuppressOperation(ArrayBuilder<SuppressOperation> list, SyntaxToken startToken, SyntaxToken endToken, SuppressOption option)
     {
         if (startToken.Kind() == SyntaxKind.None || endToken.Kind() == SyntaxKind.None)
         {
@@ -158,7 +159,7 @@ internal abstract class BaseFormattingRule : AbstractFormattingRule
     protected static AdjustSpacesOperation CreateAdjustSpacesOperation(int space, AdjustSpacesOption option)
         => FormattingOperations.CreateAdjustSpacesOperation(space, option);
 
-    protected static void AddBraceSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    protected static void AddBraceSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         var bracePair = node.GetBracePair();
         if (!bracePair.IsValidBracketOrBracePair())

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
@@ -21,7 +22,7 @@ internal class ElasticTriviaFormattingRule : BaseFormattingRule
 {
     internal const string Name = "CSharp Elastic trivia Formatting Rule";
 
-    public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
     {
         nextOperation.Invoke();
 
@@ -37,7 +38,7 @@ internal class ElasticTriviaFormattingRule : BaseFormattingRule
         AddCollectionExpressionSuppressOperations(list, node);
     }
 
-    private static void AddPropertyDeclarationSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddPropertyDeclarationSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         if (node is BasePropertyDeclarationSyntax basePropertyDeclaration && basePropertyDeclaration.AccessorList != null &&
             basePropertyDeclaration.AccessorList.Accessors.All(a => a.Body == null) &&
@@ -49,7 +50,7 @@ internal class ElasticTriviaFormattingRule : BaseFormattingRule
         }
     }
 
-    private static void AddInitializerSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddInitializerSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         var initializer = GetInitializerNode(node);
         var lastTokenOfType = GetLastTokenOfType(node);
@@ -66,7 +67,7 @@ internal class ElasticTriviaFormattingRule : BaseFormattingRule
         }
     }
 
-    private static void AddCollectionExpressionSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddCollectionExpressionSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         if (node is CollectionExpressionSyntax { OpenBracketToken.IsMissing: false, CloseBracketToken.IsMissing: false } collectionExpression)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/QueryExpressionFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/QueryExpressionFormattingRule.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting;
@@ -38,7 +39,7 @@ internal sealed class QueryExpressionFormattingRule : BaseFormattingRule
         return new QueryExpressionFormattingRule(newOptions);
     }
 
-    public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
     {
         nextOperation.Invoke();
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting;
@@ -557,7 +558,7 @@ internal sealed class SpacingFormattingRule : BaseFormattingRule
         return nextOperation.Invoke(in previousToken, in currentToken);
     }
 
-    public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
     {
         nextOperation.Invoke();
 
@@ -570,7 +571,7 @@ internal sealed class SpacingFormattingRule : BaseFormattingRule
         && forStatement.Condition == null
         && forStatement.Incrementors.Count == 0;
 
-    private void SuppressVariableDeclaration(List<SuppressOperation> list, SyntaxNode node)
+    private void SuppressVariableDeclaration(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         if (node.Kind()
                 is SyntaxKind.FieldDeclaration

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SuppressFormattingRule.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting;
@@ -17,7 +18,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
 {
     internal const string Name = "CSharp Suppress Formatting Rule";
 
-    public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
     {
         nextOperation.Invoke();
 
@@ -32,7 +33,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
         AddSpecificNodesSuppressOperations(list, node);
     }
 
-    private static void AddSpecificNodesSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddSpecificNodesSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         if (node is IfStatementSyntax ifStatementNode)
         {
@@ -259,7 +260,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
         }
     }
 
-    private static void AddStatementExceptBlockSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddStatementExceptBlockSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         if (node is not StatementSyntax statementNode || statementNode.Kind() == SyntaxKind.Block)
         {
@@ -272,7 +273,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
         AddSuppressWrappingIfOnSingleLineOperation(list, firstToken, lastToken);
     }
 
-    private static void AddFormatSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddFormatSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         if (!node.ContainsDirectives)
         {
@@ -293,7 +294,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
         return;
 
         // Local functions
-        static void ProcessTriviaList(List<SuppressOperation> list, SyntaxTriviaList triviaList)
+        static void ProcessTriviaList(ArrayBuilder<SuppressOperation> list, SyntaxTriviaList triviaList)
         {
             foreach (var trivia in triviaList)
             {
@@ -301,7 +302,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
             }
         }
 
-        static void ProcessTrivia(List<SuppressOperation> list, SyntaxTrivia trivia)
+        static void ProcessTrivia(ArrayBuilder<SuppressOperation> list, SyntaxTrivia trivia)
         {
             if (!(trivia.HasStructure))
             {
@@ -311,7 +312,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
             ProcessStructuredTrivia(list, trivia.GetStructure()!);
         }
 
-        static void ProcessStructuredTrivia(List<SuppressOperation> list, SyntaxNode structure)
+        static void ProcessStructuredTrivia(ArrayBuilder<SuppressOperation> list, SyntaxNode structure)
         {
             if (structure is not PragmaWarningDirectiveTriviaSyntax pragmaWarningDirectiveTrivia)
             {
@@ -365,7 +366,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
         return false;
     }
 
-    private static void AddInitializerSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddInitializerSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         // array or collection initializer case
         if (node.IsInitializerForArrayOrCollectionCreationExpression())
@@ -395,7 +396,7 @@ internal class SuppressFormattingRule : BaseFormattingRule
         }
     }
 
-    private static void AddInitializerSuppressOperations(List<SuppressOperation> list, SyntaxNode parent, IEnumerable<SyntaxNode> items)
+    private static void AddInitializerSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode parent, IEnumerable<SyntaxNode> items)
     {
         // make creation node itself to not break into multiple line, if it is on same line
         AddSuppressWrappingIfOnSingleLineOperation(list, parent.GetFirstToken(includeZeroWidth: true), parent.GetLastToken(includeZeroWidth: true));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/WrappingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/WrappingFormattingRule.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
@@ -42,7 +43,7 @@ internal sealed class WrappingFormattingRule : BaseFormattingRule
         return new WrappingFormattingRule(newOptions);
     }
 
-    public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
     {
         nextOperation.Invoke();
 
@@ -88,7 +89,7 @@ internal sealed class WrappingFormattingRule : BaseFormattingRule
         };
     }
 
-    private static void AddSpecificNodesSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddSpecificNodesSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         var (firstToken, lastToken) = GetSpecificNodeSuppressionTokenRange(node);
         if (!firstToken.IsKind(SyntaxKind.None) || !lastToken.IsKind(SyntaxKind.None))
@@ -97,7 +98,7 @@ internal sealed class WrappingFormattingRule : BaseFormattingRule
         }
     }
 
-    private static void AddStatementExceptBlockSuppressOperations(List<SuppressOperation> list, SyntaxNode node)
+    private static void AddStatementExceptBlockSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         if (node is not StatementSyntax statementNode || statementNode.Kind() == SyntaxKind.Block)
         {
@@ -110,7 +111,7 @@ internal sealed class WrappingFormattingRule : BaseFormattingRule
         AddSuppressWrappingIfOnSingleLineOperation(list, firstToken, lastToken);
     }
 
-    private static void RemoveSuppressOperationForStatementMethodDeclaration(List<SuppressOperation> list, SyntaxNode node)
+    private static void RemoveSuppressOperationForStatementMethodDeclaration(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         if (!(node is not StatementSyntax statementNode || statementNode.Kind() == SyntaxKind.Block))
         {
@@ -133,7 +134,7 @@ internal sealed class WrappingFormattingRule : BaseFormattingRule
         }
     }
 
-    private static void RemoveSuppressOperationForBlock(List<SuppressOperation> list, SyntaxNode node)
+    private static void RemoveSuppressOperationForBlock(ArrayBuilder<SuppressOperation> list, SyntaxNode node)
     {
         var bracePair = GetBracePair(node);
         if (!bracePair.IsValidBracketOrBracePair())
@@ -175,7 +176,7 @@ internal sealed class WrappingFormattingRule : BaseFormattingRule
     }
 
     private static void RemoveSuppressOperation(
-        List<SuppressOperation> list,
+        ArrayBuilder<SuppressOperation> list,
         SyntaxToken startToken,
         SyntaxToken endToken)
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Indentation;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -146,7 +147,7 @@ internal class CSharpSmartTokenFormatter : ISmartTokenFormatter
 
     private class SmartTokenFormattingRule : NoLineChangeFormattingRule
     {
-        public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+        public override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
         {
             // don't suppress anything
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ListExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ListExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions;
@@ -40,6 +41,25 @@ internal static class ListExtensions
     }
 
     public static void RemoveOrTransformAll<T, TArg>(this List<T> list, Func<T, TArg, T?> transform, TArg arg)
+        where T : struct
+    {
+        RoslynDebug.AssertNotNull(list);
+        RoslynDebug.AssertNotNull(transform);
+
+        var targetIndex = 0;
+        for (var sourceIndex = 0; sourceIndex < list.Count; sourceIndex++)
+        {
+            var newValue = transform(list[sourceIndex], arg);
+            if (newValue is null)
+                continue;
+
+            list[targetIndex++] = newValue.Value;
+        }
+
+        list.RemoveRange(targetIndex, list.Count - targetIndex);
+    }
+
+    public static void RemoveOrTransformAll<T, TArg>(this ArrayBuilder<T> list, Func<T, TArg, T?> transform, TArg arg)
         where T : struct
     {
         RoslynDebug.AssertNotNull(list);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.cs
@@ -115,7 +115,8 @@ internal partial class FormattingContext
             _initialIndentBlockOperations = indentationOperations;
         }
 
-        suppressOperations?.Do(this.AddInitialSuppressOperation);
+        foreach (var suppressOperation in suppressOperations)
+            this.AddInitialSuppressOperation(suppressOperation);
     }
 
     public void AddIndentBlockOperations(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Formatting;
@@ -43,7 +44,7 @@ internal class ChainedFormattingRules
         _getAdjustSpacesOperationRules = FilterToRulesImplementingMethod(_formattingRules, nameof(AbstractFormattingRule.GetAdjustSpacesOperation));
     }
 
-    public void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode currentNode)
+    public void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode currentNode)
     {
         var action = new NextSuppressOperationAction(_addSuppressOperationsRules, index: 0, currentNode, list);
         action.Invoke();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/AbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/AbstractFormattingRule.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Formatting.Rules;
 
@@ -20,7 +20,7 @@ internal abstract class AbstractFormattingRule
     /// Returns SuppressWrappingIfOnSingleLineOperations under a node either by itself or by
     /// filtering/replacing operations returned by NextOperation
     /// </summary>
-    public virtual void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public virtual void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
         => nextOperation.Invoke();
 
     /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Formatting.Rules;
 
@@ -13,7 +14,7 @@ internal abstract class CompatAbstractFormattingRule : AbstractFormattingRule
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
     [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public sealed override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
+    public sealed override void AddSuppressOperations(ArrayBuilder<SuppressOperation> list, SyntaxNode node, in NextSuppressOperationAction nextOperation)
     {
         var nextOperationCopy = nextOperation;
         AddSuppressOperationsSlow(list, node, ref nextOperationCopy);
@@ -68,7 +69,7 @@ internal abstract class CompatAbstractFormattingRule : AbstractFormattingRule
     /// Returns SuppressWrappingIfOnSingleLineOperations under a node either by itself or by
     /// filtering/replacing operations returned by NextOperation
     /// </summary>
-    public virtual void AddSuppressOperationsSlow(List<SuppressOperation> list, SyntaxNode node, ref NextSuppressOperationAction nextOperation)
+    public virtual void AddSuppressOperationsSlow(ArrayBuilder<SuppressOperation> list, SyntaxNode node, ref NextSuppressOperationAction nextOperation)
         => base.AddSuppressOperations(list, node, in nextOperation);
 
     /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextSuppressOperationAction.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextSuppressOperationAction.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Formatting.Rules;
@@ -13,7 +14,7 @@ internal readonly struct NextSuppressOperationAction(
     ImmutableArray<AbstractFormattingRule> formattingRules,
     int index,
     SyntaxNode node,
-    List<SuppressOperation> list)
+    ArrayBuilder<SuppressOperation> list)
 {
     private NextSuppressOperationAction NextAction
         => new(formattingRules, index + 1, node, list);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/FormattingOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/FormattingOperations.cs
@@ -142,18 +142,6 @@ internal static class FormattingOperations
     }
 
     /// <summary>
-    /// return SuppressOperation for the node provided by the given formatting rules
-    /// </summary>
-    internal static IEnumerable<SuppressOperation> GetSuppressOperations(IEnumerable<AbstractFormattingRule> formattingRules, SyntaxNode node, SyntaxFormattingOptions options)
-    {
-        var chainedFormattingRules = new ChainedFormattingRules(formattingRules, options);
-
-        var list = new List<SuppressOperation>();
-        chainedFormattingRules.AddSuppressOperations(list, node);
-        return list;
-    }
-
-    /// <summary>
     /// return AnchorIndentationOperation for the node provided by the given formatting rules
     /// </summary>
     internal static IEnumerable<AnchorIndentationOperation> GetAnchorIndentationOperations(IEnumerable<AbstractFormattingRule> formattingRules, SyntaxNode node, SyntaxFormattingOptions options)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Indentation/SpecialFormattingOperation.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Indentation/SpecialFormattingOperation.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -18,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
             _indentStyle = indentStyle
         End Sub
 
-        Public Overrides Sub AddSuppressOperationsSlow(list As List(Of SuppressOperation), node As SyntaxNode, ByRef nextOperation As NextSuppressOperationAction)
+        Public Overrides Sub AddSuppressOperationsSlow(list As ArrayBuilder(Of SuppressOperation), node As SyntaxNode, ByRef nextOperation As NextSuppressOperationAction)
             ' don't suppress anything
         End Sub
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 
@@ -36,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Return New DefaultOperationProvider(options)
         End Function
 
-        Public Overrides Sub AddSuppressOperationsSlow(operations As List(Of SuppressOperation), node As SyntaxNode, ByRef nextAction As NextSuppressOperationAction)
+        Public Overrides Sub AddSuppressOperationsSlow(operations As ArrayBuilder(Of SuppressOperation), node As SyntaxNode, ByRef nextAction As NextSuppressOperationAction)
         End Sub
 
         Public Overrides Sub AddAnchorIndentationOperationsSlow(operations As List(Of AnchorIndentationOperation), node As SyntaxNode, ByRef nextAction As NextAnchorIndentationOperationAction)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
@@ -4,6 +4,7 @@
 
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
@@ -14,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Overrides Sub AddSuppressOperationsSlow(list As List(Of SuppressOperation), node As SyntaxNode, ByRef nextOperation As NextSuppressOperationAction)
+        Public Overrides Sub AddSuppressOperationsSlow(list As ArrayBuilder(Of SuppressOperation), node As SyntaxNode, ByRef nextOperation As NextSuppressOperationAction)
             nextOperation.Invoke()
         End Sub
 


### PR DESCRIPTION
Drops us from:

![image](https://github.com/dotnet/roslyn/assets/4564579/68b7f12f-21ea-47d1-b986-d12d75b7e182)

To:

![image](https://github.com/dotnet/roslyn/assets/4564579/a6225ed0-f9c8-40d8-aa5f-be845d259c07)
