### PR TITLE
Remove array allocations for formatting rules.

### DIFF
--- a/src/Analyzers/Core/Analyzers/Formatting/FormatterHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Formatting/FormatterHelper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Text;
@@ -30,10 +31,10 @@ internal static class FormatterHelper
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, [node.FullSpan], syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, [node.FullSpan], syntaxFormattingService, options, rules: default, cancellationToken: cancellationToken);
 
     public static SyntaxNode Format(SyntaxNode node, TextSpan spanToFormat, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, [spanToFormat], syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, [spanToFormat], syntaxFormattingService, options, rules: default, cancellationToken: cancellationToken);
 
     /// <summary>
     /// Formats the whitespace of a syntax tree.
@@ -44,15 +45,15 @@ internal static class FormatterHelper
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
-        => Format(node, GetAnnotatedSpans(node, annotation), syntaxFormattingService, options, rules, cancellationToken: cancellationToken);
+        => Format(node, GetAnnotatedSpans(node, annotation), syntaxFormattingService, options, rules.AsImmutableOrNull(), cancellationToken: cancellationToken);
 
-    internal static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
         => GetFormattingResult(node, spans, syntaxFormattingService, options, rules, cancellationToken).GetFormattedRoot(cancellationToken);
 
-    internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
         => GetFormattingResult(node, spans, syntaxFormattingService, options, rules, cancellationToken).GetTextChanges(cancellationToken);
 
-    internal static IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
         => syntaxFormattingService.GetFormattingResult(node, spans, options, rules, cancellationToken);
 
     /// <summary>
@@ -63,5 +64,5 @@ internal static class FormatterHelper
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The changes necessary to format the tree.</returns>
     public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => GetFormattedTextChanges(node, [node.FullSpan], syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
+        => GetFormattedTextChanges(node, [node.FullSpan], syntaxFormattingService, options, rules: default, cancellationToken: cancellationToken);
 }

--- a/src/Analyzers/Core/Analyzers/Formatting/FormattingAnalyzerHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Formatting/FormattingAnalyzerHelper.cs
@@ -24,7 +24,7 @@ internal static class FormattingAnalyzerHelper
         var root = tree.GetRoot(cancellationToken);
         var span = context.FilterSpan.HasValue ? context.FilterSpan.GetValueOrDefault() : root.FullSpan;
         var spans = SpecializedCollections.SingletonEnumerable(span);
-        var formattingChanges = Formatter.GetFormattedTextChanges(root, spans, formattingProvider, options, rules: null, cancellationToken);
+        var formattingChanges = Formatter.GetFormattedTextChanges(root, spans, formattingProvider, options, rules: default, cancellationToken);
 
         // formattingChanges could include changes that impact a larger section of the original document than
         // necessary. Before reporting diagnostics, process the changes to minimize the span of individual

--- a/src/Analyzers/Core/CodeFixes/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
@@ -850,10 +850,10 @@ internal abstract class AbstractRemoveUnusedValuesCodeFixProvider<TExpressionSyn
         // Run formatter prior to invoking IMoveDeclarationNearReferenceService.
 #if CODE_STYLE
         var provider = GetSyntaxFormatting();
-        rootWithTrackedNodes = FormatterHelper.Format(rootWithTrackedNodes, originalDeclStatementsToMoveOrRemove.Select(s => s.Span), provider, options, rules: null, cancellationToken);
+        rootWithTrackedNodes = FormatterHelper.Format(rootWithTrackedNodes, originalDeclStatementsToMoveOrRemove.Select(s => s.Span), provider, options, rules: default, cancellationToken);
 #else
         var provider = document.Project.Solution.Services;
-        rootWithTrackedNodes = Formatter.Format(rootWithTrackedNodes, originalDeclStatementsToMoveOrRemove.Select(s => s.Span), provider, options, rules: null, cancellationToken);
+        rootWithTrackedNodes = Formatter.Format(rootWithTrackedNodes, originalDeclStatementsToMoveOrRemove.Select(s => s.Span), provider, options, rules: default, cancellationToken);
 #endif
 
         document = document.WithSyntaxRoot(rootWithTrackedNodes);

--- a/src/Analyzers/Core/CodeFixes/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
@@ -72,7 +72,7 @@ internal abstract class AbstractUseConditionalExpressionCodeFixProvider<
         // formatted to explicitly format things.  Note: all we will format is the new
         // conditional expression as that's the only node that has the appropriate
         // annotation on it.
-        var rules = new List<AbstractFormattingRule> { GetMultiLineFormattingRule() };
+        var rules = ImmutableArray.Create(GetMultiLineFormattingRule());
 
 #if CODE_STYLE
         var provider = GetSyntaxFormatting();

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -105,7 +105,7 @@ internal partial class AutomaticLineEnderCommandHandler(
             root,
             [CommonFormattingHelpers.GetFormattingSpan(root, span.Value)],
             options,
-            rules: null,
+            rules: default,
             cancellationToken).GetTextChanges(cancellationToken);
     }
 

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -441,7 +441,7 @@ public class FormattingEngineTests : CSharpFormattingEngineTestBase
         var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
         var syntaxRoot = await document.GetRequiredSyntaxRootAsync(CancellationToken.None);
         var options = CSharpSyntaxFormattingOptions.Default;
-        var node = Formatter.Format(syntaxRoot, spans, workspace.Services.SolutionServices, options, rules: null, CancellationToken.None);
+        var node = Formatter.Format(syntaxRoot, spans, workspace.Services.SolutionServices, options, rules: default, CancellationToken.None);
         Assert.Equal(expected, node.ToFullString());
     }
 

--- a/src/EditorFeatures/Core/CommentSelection/AbstractCommentSelectionBase.cs
+++ b/src/EditorFeatures/Core/CommentSelection/AbstractCommentSelectionBase.cs
@@ -154,7 +154,7 @@ internal abstract class AbstractCommentSelectionBase<TCommand>
 
                 var formattingOptions = subjectBuffer.GetSyntaxFormattingOptions(_editorOptionsService, document.Project.Services, explicitFormat: false);
                 var formattingSpans = trackingSnapshotSpans.Select(change => CommonFormattingHelpers.GetFormattingSpan(newRoot, change.Span.ToTextSpan()));
-                var formattedChanges = Formatter.GetFormattedTextChanges(newRoot, formattingSpans, document.Project.Solution.Services, formattingOptions, rules: null, cancellationToken);
+                var formattedChanges = Formatter.GetFormattedTextChanges(newRoot, formattingSpans, document.Project.Solution.Services, formattingOptions, rules: default, cancellationToken);
 
                 subjectBuffer.ApplyChanges(formattedChanges);
 

--- a/src/EditorFeatures/TestUtilities/Formatting/CoreFormatterTestsBase.cs
+++ b/src/EditorFeatures/TestUtilities/Formatting/CoreFormatterTestsBase.cs
@@ -204,14 +204,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Formatting
                 ? formattingService.GetFormattingOptions(options, fallbackOptions: null)
                 : formattingService.DefaultOptions;
 
-            var rules = formattingRuleProvider.CreateRule(documentSyntax, 0).Concat(Formatter.GetDefaultFormattingRules(document));
+            ImmutableArray<AbstractFormattingRule> rules = [formattingRuleProvider.CreateRule(documentSyntax, 0), .. Formatter.GetDefaultFormattingRules(document)];
             AssertFormat(workspace, expected, formattingOptions, rules, clonedBuffer, documentSyntax.Root, spans);
 
             // format with node and transform
             AssertFormatWithTransformation(workspace, expected, formattingOptions, rules, documentSyntax.Root, spans);
         }
 
-        internal void AssertFormatWithTransformation(Workspace workspace, string expected, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule> rules, SyntaxNode root, IEnumerable<TextSpan> spans)
+        internal void AssertFormatWithTransformation(Workspace workspace, string expected, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, SyntaxNode root, IEnumerable<TextSpan> spans)
         {
             var newRootNode = Formatter.Format(root, spans, workspace.Services.SolutionServices, options, rules, CancellationToken.None);
 
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Formatting
             Assert.True(newRootNodeFromString.IsEquivalentTo(newRootNode));
         }
 
-        internal void AssertFormat(Workspace workspace, string expected, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule> rules, ITextBuffer clonedBuffer, SyntaxNode root, IEnumerable<TextSpan> spans)
+        internal void AssertFormat(Workspace workspace, string expected, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, ITextBuffer clonedBuffer, SyntaxNode root, IEnumerable<TextSpan> spans)
         {
             var result = Formatter.GetFormattedTextChanges(root, spans, workspace.Services.SolutionServices, options, rules, CancellationToken.None);
             var actual = ApplyResultAndGetFormattedText(clonedBuffer, result);

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
@@ -166,7 +166,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             oldTree As SyntaxTree,
             newDirtySpan As SnapshotSpan,
             newTree As SyntaxTree,
-            cancellationToken As CancellationToken) As IEnumerable(Of AbstractFormattingRule)
+            cancellationToken As CancellationToken) As ImmutableArray(Of AbstractFormattingRule)
 
             ' if the span we are going to format is same as the span that got changed, don't bother to do anything special.
             ' just do full format of the span.
@@ -212,12 +212,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             ' for now, do very simple checking. basically, we see whether we get same number of indent operation for the give span. alternative, but little bit
             ' more expensive and complex, we can actually calculate indentation right after the span, and see whether that is changed. not sure whether that much granularity
             ' is needed.
+            Dim coreRules = Formatter.GetDefaultFormattingRules(languageServices)
+
             If GetNumberOfIndentOperations(languageServices, options, oldTree, oldDirtySpan, cancellationToken) =
                GetNumberOfIndentOperations(languageServices, options, newTree, newDirtySpan, cancellationToken) Then
-                Return (New NoAnchorFormatterRule()).Concat(Formatter.GetDefaultFormattingRules(languageServices))
+                Dim result = New FixedSizeArrayBuilder(Of AbstractFormattingRule)(coreRules.Length + 1)
+                result.Add(New NoAnchorFormatterRule())
+                result.AddRange(coreRules)
+                Return result.MoveToImmutable()
             End If
 
-            Return Formatter.GetDefaultFormattingRules(languageServices)
+            Return coreRules
         End Function
 
         Private Shared Function GetNumberOfIndentOperations(

--- a/src/EditorFeatures/VisualBasicTest/Formatting/VisualBasicFormatterTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/VisualBasicFormatterTestBase.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
@@ -66,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting
                     workspace.Documents.First(Function(d) d.SelectedSpans.Any()).SelectedSpans,
                     workspace.Services.SolutionServices,
                     options,
-                    rules,
+                    rules.ToImmutableArray(),
                     CancellationToken.None)
 
                 AssertResult(expected, clonedBuffer, changes)

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -888,8 +888,8 @@ internal sealed class CSharpChangeSignatureService : AbstractChangeSignatureServ
         return convertedMethodGroups;
     }
 
-    protected override IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document)
-        => Formatter.GetDefaultFormattingRules(document).Concat(new ChangeSignatureFormattingRule());
+    protected override ImmutableArray<AbstractFormattingRule> GetFormattingRules(Document document)
+        => [.. Formatter.GetDefaultFormattingRules(document), new ChangeSignatureFormattingRule()];
 
     protected override TArgumentSyntax AddNameToArgument<TArgumentSyntax>(TArgumentSyntax newArgument, string name)
     {

--- a/src/Features/CSharp/Portable/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/Features/CSharp/Portable/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -63,7 +63,7 @@ internal class CSharpDecompiledSourceService : IDecompiledSourceService
              document,
              [node.FullSpan],
              options,
-             CSharpDecompiledSourceFormattingRule.Instance.Concat(Formatter.GetDefaultFormattingRules(document)),
+             [CSharpDecompiledSourceFormattingRule.Instance, .. Formatter.GetDefaultFormattingRules(document)],
              cancellationToken).ConfigureAwait(false);
 
         return formattedDoc;

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -57,8 +57,8 @@ internal partial class CSharpMetadataAsSourceService : AbstractMetadataAsSourceS
         return document.WithSyntaxRoot(newRoot);
     }
 
-    protected override IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document)
-        => s_memberSeparationRule.Concat(Formatter.GetDefaultFormattingRules(document));
+    protected override ImmutableArray<AbstractFormattingRule> GetFormattingRules(Document document)
+        => [s_memberSeparationRule, .. Formatter.GetDefaultFormattingRules(document)];
 
     protected override async Task<Document> ConvertDocCommentsToRegularCommentsAsync(Document document, IDocumentationCommentFormattingService docCommentFormattingService, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -84,13 +85,8 @@ internal class CSharpUseAutoPropertyCodeFixProvider
         return updatedProperty.WithTrailingTrivia(trailingTrivia).WithAdditionalAnnotations(SpecializedFormattingAnnotation);
     }
 
-    protected override IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document)
-    {
-        var rules = new List<AbstractFormattingRule> { new SingleLinePropertyFormattingRule() };
-        rules.AddRange(Formatter.GetDefaultFormattingRules(document));
-
-        return rules;
-    }
+    protected override ImmutableArray<AbstractFormattingRule> GetFormattingRules(Document document)
+        => [new SingleLinePropertyFormattingRule(), .. Formatter.GetDefaultFormattingRules(document)];
 
     private class SingleLinePropertyFormattingRule : AbstractFormattingRule
     {

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -58,7 +58,7 @@ internal abstract class AbstractChangeSignatureService : ILanguageService
         LineFormattingOptionsProvider fallbackOptions,
         CancellationToken cancellationToken);
 
-    protected abstract IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document);
+    protected abstract ImmutableArray<AbstractFormattingRule> GetFormattingRules(Document document);
 
     protected abstract T TransferLeadingWhitespaceTrivia<T>(T newArgument, SyntaxNode oldArgument) where T : SyntaxNode;
 

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
@@ -28,12 +28,12 @@ internal abstract partial class AbstractGenerateEqualsAndGetHashCodeService : IG
 
     public async Task<Document> FormatDocumentAsync(Document document, SyntaxFormattingOptions options, CancellationToken cancellationToken)
     {
-        var rules = new List<AbstractFormattingRule> { new FormatLargeBinaryExpressionRule(document.GetRequiredLanguageService<ISyntaxFactsService>()) };
-        rules.AddRange(Formatter.GetDefaultFormattingRules(document));
-
+        var formatBinaryRule = new FormatLargeBinaryExpressionRule(document.GetRequiredLanguageService<ISyntaxFactsService>());
         var formattedDocument = await Formatter.FormatAsync(
             document, s_specializedFormattingAnnotation,
-            options, rules.ToImmutableArray(), cancellationToken).ConfigureAwait(false);
+            options,
+            [formatBinaryRule, .. Formatter.GetDefaultFormattingRules(document)],
+            cancellationToken).ConfigureAwait(false);
         return formattedDocument;
     }
 

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
@@ -33,7 +33,7 @@ internal abstract partial class AbstractGenerateEqualsAndGetHashCodeService : IG
 
         var formattedDocument = await Formatter.FormatAsync(
             document, s_specializedFormattingAnnotation,
-            options, rules, cancellationToken).ConfigureAwait(false);
+            options, rules.ToImmutableArray(), cancellationToken).ConfigureAwait(false);
         return formattedDocument;
     }
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
@@ -85,7 +85,7 @@ internal abstract partial class AbstractMetadataAsSourceService : IMetadataAsSou
     /// <summary>
     /// provide formatting rules to be used when formatting MAS file
     /// </summary>
-    protected abstract IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document);
+    protected abstract ImmutableArray<AbstractFormattingRule> GetFormattingRules(Document document);
 
     /// <summary>
     /// Prepends a region directive at the top of the document with a name containing

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -41,7 +41,7 @@ internal abstract class AbstractUseAutoPropertyCodeFixProvider<TTypeDeclarationS
     protected abstract TPropertyDeclaration GetPropertyDeclaration(SyntaxNode node);
     protected abstract SyntaxNode GetNodeToRemove(TVariableDeclarator declarator);
 
-    protected abstract IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document);
+    protected abstract ImmutableArray<AbstractFormattingRule> GetFormattingRules(Document document);
 
     protected abstract Task<SyntaxNode> UpdatePropertyAsync(
         Document propertyDocument, Compilation compilation, IFieldSymbol fieldSymbol, IPropertySymbol propertySymbol,
@@ -281,10 +281,8 @@ internal abstract class AbstractUseAutoPropertyCodeFixProvider<TTypeDeclarationS
     private async Task<SyntaxNode> FormatAsync(SyntaxNode newRoot, Document document, CodeCleanupOptionsProvider fallbackOptions, CancellationToken cancellationToken)
     {
         var formattingRules = GetFormattingRules(document);
-        if (formattingRules == null)
-        {
+        if (formattingRules.IsDefault)
             return newRoot;
-        }
 
         var options = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
         return Formatter.Format(newRoot, SpecializedFormattingAnnotation, document.Project.Solution.Services, options, formattingRules, cancellationToken);

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var formattingOptions = await ProtocolConversions.GetFormattingOptionsAsync(options, document, globalOptions, cancellationToken).ConfigureAwait(false);
 
             var services = document.Project.Solution.Services;
-            var textChanges = Formatter.GetFormattedTextChanges(root, [formattingSpan], services, formattingOptions, rules: null, cancellationToken);
+            var textChanges = Formatter.GetFormattedTextChanges(root, [formattingSpan], services, formattingOptions, rules: default, cancellationToken);
 
             var edits = new ArrayBuilder<LSP.TextEdit>();
             edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text)));

--- a/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
@@ -7,6 +7,7 @@ Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.ChangeSignature
+Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.FindSymbols
 Imports Microsoft.CodeAnalysis.Formatting
@@ -734,8 +735,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
             Return results.ToImmutableAndFree()
         End Function
 
-        Protected Overrides Function GetFormattingRules(document As Document) As IEnumerable(Of AbstractFormattingRule)
-            Return SpecializedCollections.SingletonEnumerable(Of AbstractFormattingRule)(New ChangeSignatureFormattingRule()).Concat(Formatter.GetDefaultFormattingRules(document))
+        Protected Overrides Function GetFormattingRules(document As Document) As ImmutableArray(Of AbstractFormattingRule)
+            Dim coreRules = Formatter.GetDefaultFormattingRules(document)
+            Dim result = New FixedSizeArrayBuilder(Of AbstractFormattingRule)(1 + coreRules.Length)
+            result.Add(New ChangeSignatureFormattingRule())
+            result.AddRange(coreRules)
+            Return result.MoveToImmutable()
         End Function
 
         Protected Overrides Function TransferLeadingWhitespaceTrivia(Of T As SyntaxNode)(newArgument As T, oldArgument As SyntaxNode) As T

--- a/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
+++ b/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.MetadataAsSource
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
 Imports Microsoft.CodeAnalysis.VisualBasic.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -63,8 +64,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MetadataAsSource
             Return document.WithSyntaxRoot(newSyntaxRoot)
         End Function
 
-        Protected Overrides Function GetFormattingRules(document As Document) As IEnumerable(Of AbstractFormattingRule)
-            Return _memberSeparationRule.Concat(Formatter.GetDefaultFormattingRules(document))
+        Protected Overrides Function GetFormattingRules(document As Document) As ImmutableArray(Of AbstractFormattingRule)
+            Dim coreRules = Formatter.GetDefaultFormattingRules(document)
+            Dim result = New FixedSizeArrayBuilder(Of AbstractFormattingRule)(1 + coreRules.Length)
+            result.Add(_memberSeparationRule)
+            result.AddRange(coreRules)
+            Return result.MoveToImmutable()
         End Function
 
         Protected Overrides Function GetReducers() As ImmutableArray(Of AbstractReducer)

--- a/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Diagnostics.CodeAnalysis
 Imports System.Threading
@@ -33,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             Return Utilities.GetNodeToRemove(identifier)
         End Function
 
-        Protected Overrides Function GetFormattingRules(document As Document) As IEnumerable(Of AbstractFormattingRule)
+        Protected Overrides Function GetFormattingRules(document As Document) As ImmutableArray(Of AbstractFormattingRule)
             Return Nothing
         End Function
 

--- a/src/Tools/ExternalAccess/OmniSharp/Formatting/OmniSharpFormatter.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Formatting/OmniSharpFormatter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Formatting
     internal static class OmniSharpFormatter
     {
         public static Task<Document> FormatAsync(Document document, IEnumerable<TextSpan>? spans, OmniSharpSyntaxFormattingOptionsWrapper options, CancellationToken cancellationToken)
-            => Formatter.FormatAsync(document, spans, options.CleanupOptions.FormattingOptions, rules: null, cancellationToken);
+            => Formatter.FormatAsync(document, spans, options.CleanupOptions.FormattingOptions, rules: default, cancellationToken);
 
         public static async Task<Document> OrganizeImportsAsync(Document document, OmniSharpOrganizeImportsOptionsWrapper options, CancellationToken cancellationToken)
         {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
@@ -67,12 +67,13 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
         // Since we know we are on the UI thread, lets get the base indentation now, so that there is less
         // cleanup work to do later in Venus.
         var ruleFactory = Workspace.Services.GetService<IHostDependentFormattingRuleFactoryService>();
-        ImmutableArray<AbstractFormattingRule> rules = [ruleFactory.CreateRule(documentSyntax, start), .. Formatter.GetDefaultFormattingRules(document.Project.Services)];
 
         // use formatting that return text changes rather than tree rewrite which is more expensive
         var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();
-        var originalChanges = formatter.GetFormattingResult(root, [adjustedSpan], formattingOptions, rules, cancellationToken)
-            .GetTextChanges(cancellationToken);
+        var originalChanges = formatter.GetFormattingResult(
+            root, [adjustedSpan], formattingOptions,
+            [ruleFactory.CreateRule(documentSyntax, start), .. Formatter.GetDefaultFormattingRules(document.Project.Services)],
+            cancellationToken).GetTextChanges(cancellationToken);
 
         var originalSpan = RoslynTextSpan.FromBounds(start, end);
         var formattedChanges = ruleFactory.FilterFormattedChanges(document.Id, originalSpan, originalChanges);

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -66,7 +67,7 @@ internal abstract partial class AbstractLanguageService<TPackage, TLanguageServi
         // Since we know we are on the UI thread, lets get the base indentation now, so that there is less
         // cleanup work to do later in Venus.
         var ruleFactory = Workspace.Services.GetService<IHostDependentFormattingRuleFactoryService>();
-        var rules = ruleFactory.CreateRule(documentSyntax, start).Concat(Formatter.GetDefaultFormattingRules(document.Project.Services));
+        ImmutableArray<AbstractFormattingRule> rules = [ruleFactory.CreateRule(documentSyntax, start), .. Formatter.GetDefaultFormattingRules(document.Project.Services)];
 
         // use formatting that return text changes rather than tree rewrite which is more expensive
         var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -804,7 +805,7 @@ internal sealed partial class ContainedDocument : IContainedDocument
         venusFormattingRules.Add(baseIndentationRule);
         venusFormattingRules.Add(ContainedDocumentPreserveFormattingRule.Instance);
 
-        var formattingRules = venusFormattingRules.Concat(Formatter.GetDefaultFormattingRules(document));
+        ImmutableArray<AbstractFormattingRule> formattingRules = [.. venusFormattingRules, .. Formatter.GetDefaultFormattingRules(document)];
 
         var services = document.Project.Solution.Services;
         var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
@@ -805,13 +805,13 @@ internal sealed partial class ContainedDocument : IContainedDocument
         venusFormattingRules.Add(baseIndentationRule);
         venusFormattingRules.Add(ContainedDocumentPreserveFormattingRule.Instance);
 
-        ImmutableArray<AbstractFormattingRule> formattingRules = [.. venusFormattingRules, .. Formatter.GetDefaultFormattingRules(document)];
-
         var services = document.Project.Solution.Services;
         var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();
         var changes = formatter.GetFormattingResult(
             root, new TextSpan[] { CommonFormattingHelpers.GetFormattingSpan(root, visibleSpan) },
-            options, formattingRules, CancellationToken.None).GetTextChanges(CancellationToken.None);
+            options,
+            [.. venusFormattingRules, .. Formatter.GetDefaultFormattingRules(document)],
+            CancellationToken.None).GetTextChanges(CancellationToken.None);
 
         visibleSpans.Add(visibleSpan);
         var newChanges = FilterTextChanges(document.GetTextSynchronously(CancellationToken.None), visibleSpans, changes.ToReadOnlyCollection()).Where(t => visibleSpan.Contains(t.Span));

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguageCodeSupport.cs
@@ -228,7 +228,7 @@ internal static class ContainedLanguageCodeSupport
         newRoot = Simplifier.ReduceAsync(
             targetDocument.WithSyntaxRoot(newRoot), Simplifier.Annotation, options.CleanupOptions.SimplifierOptions, cancellationToken).WaitAndGetResult_Venus(cancellationToken).GetSyntaxRootSynchronously(cancellationToken);
 
-        var formattingRules = additionalFormattingRule.Concat(Formatter.GetDefaultFormattingRules(targetDocument));
+        ImmutableArray<AbstractFormattingRule> formattingRules = [additionalFormattingRule, .. Formatter.GetDefaultFormattingRules(targetDocument)];
 
         newRoot = Formatter.Format(
             newRoot,

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguageCodeSupport.cs
@@ -228,14 +228,12 @@ internal static class ContainedLanguageCodeSupport
         newRoot = Simplifier.ReduceAsync(
             targetDocument.WithSyntaxRoot(newRoot), Simplifier.Annotation, options.CleanupOptions.SimplifierOptions, cancellationToken).WaitAndGetResult_Venus(cancellationToken).GetSyntaxRootSynchronously(cancellationToken);
 
-        ImmutableArray<AbstractFormattingRule> formattingRules = [additionalFormattingRule, .. Formatter.GetDefaultFormattingRules(targetDocument)];
-
         newRoot = Formatter.Format(
             newRoot,
             Formatter.Annotation,
             targetDocument.Project.Solution.Services,
             options.CleanupOptions.FormattingOptions,
-            formattingRules,
+            [additionalFormattingRule, .. Formatter.GetDefaultFormattingRules(targetDocument)],
             cancellationToken);
 
         var newMember = newRoot.GetAnnotatedNodesAndTokens(annotation).Single();

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
@@ -331,9 +331,8 @@ internal sealed class CSharpSyntaxFormattingService : CSharpSyntaxFormatting, IS
         var formattingSpan = CommonFormattingHelpers.GetFormattingSpan(document.Root, textSpan);
         var service = _services.GetRequiredService<ISyntaxFormattingService>();
 
-        ImmutableArray<AbstractFormattingRule> rules = [new PasteFormattingRule(), .. service.GetDefaultFormattingRules()];
-
-        var result = service.GetFormattingResult(document.Root, [formattingSpan], options, rules, cancellationToken);
+        var result = service.GetFormattingResult(
+            document.Root, [formattingSpan], options, [new PasteFormattingRule(), .. service.GetDefaultFormattingRules()], cancellationToken);
         return [.. result.GetTextChanges(cancellationToken)];
     }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
@@ -331,8 +331,7 @@ internal sealed class CSharpSyntaxFormattingService : CSharpSyntaxFormatting, IS
         var formattingSpan = CommonFormattingHelpers.GetFormattingSpan(document.Root, textSpan);
         var service = _services.GetRequiredService<ISyntaxFormattingService>();
 
-        var rules = new List<AbstractFormattingRule>() { new PasteFormattingRule() };
-        rules.AddRange(service.GetDefaultFormattingRules());
+        ImmutableArray<AbstractFormattingRule> rules = [new PasteFormattingRule(), .. service.GetDefaultFormattingRules()];
 
         var result = service.GetFormattingResult(document.Root, [formattingSpan], options, rules, cancellationToken);
         return [.. result.GetTextChanges(cancellationToken)];

--- a/src/Workspaces/Core/Portable/CodeCleanup/Providers/FormatCodeCleanupProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/Providers/FormatCodeCleanupProvider.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CodeCleanup.Providers;
 
-internal sealed class FormatCodeCleanupProvider(IEnumerable<AbstractFormattingRule>? rules = null) : ICodeCleanupProvider
+internal sealed class FormatCodeCleanupProvider(ImmutableArray<AbstractFormattingRule> rules = default) : ICodeCleanupProvider
 {
     public string Name => PredefinedCodeCleanupProviderNames.Format;
 

--- a/src/Workspaces/Core/Portable/Formatting/AbstractFormattingService.cs
+++ b/src/Workspaces/Core/Portable/Formatting/AbstractFormattingService.cs
@@ -18,6 +18,6 @@ internal abstract class AbstractFormattingService : IFormattingService
     public Task<Document> FormatAsync(Document document, IEnumerable<TextSpan>? spans, LineFormattingOptions lineFormattingOptions, SyntaxFormattingOptions? syntaxFormattingOptions, CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(syntaxFormattingOptions);
-        return Formatter.FormatAsync(document, spans, syntaxFormattingOptions, rules: null, cancellationToken);
+        return Formatter.FormatAsync(document, spans, syntaxFormattingOptions, rules: default, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Formatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Formatter.cs
@@ -52,7 +52,7 @@ public static class Formatter
 #pragma warning restore
 
     internal static Task<Document> FormatAsync(Document document, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => FormatAsync(document, spans: null, options, rules: null, cancellationToken);
+        => FormatAsync(document, spans: null, options, rules: default, cancellationToken);
 
     /// <summary>
     /// Formats the whitespace in an area of a document corresponding to a text span.
@@ -68,7 +68,7 @@ public static class Formatter
 #pragma warning restore
 
     internal static Task<Document> FormatAsync(Document document, TextSpan span, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => FormatAsync(document, [span], options, rules: null, cancellationToken);
+        => FormatAsync(document, [span], options, rules: default, cancellationToken);
 
     /// <summary>
     /// Formats the whitespace in areas of a document corresponding to multiple non-overlapping spans.
@@ -90,7 +90,7 @@ public static class Formatter
         return await formattingService.FormatAsync(document, spans, lineFormattingOptions, syntaxFormattingOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    internal static async Task<Document> FormatAsync(Document document, IEnumerable<TextSpan>? spans, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static async Task<Document> FormatAsync(Document document, IEnumerable<TextSpan>? spans, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var services = document.Project.Solution.Services;
@@ -106,19 +106,19 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted document.</returns>
     public static Task<Document> FormatAsync(Document document, SyntaxAnnotation annotation, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => FormatAsync(document, annotation, options, rules: null, cancellationToken: cancellationToken);
+        => FormatAsync(document, annotation, options, rules: default, cancellationToken: cancellationToken);
 
     internal static Task<Document> FormatAsync(Document document, SyntaxAnnotation annotation, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => FormatAsync(document, annotation, options, rules: null, cancellationToken);
+        => FormatAsync(document, annotation, options, rules: default, cancellationToken);
 
-    internal static async Task<Document> FormatAsync(Document document, SyntaxAnnotation annotation, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static async Task<Document> FormatAsync(Document document, SyntaxAnnotation annotation, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var services = document.Project.Solution.Services;
         return document.WithSyntaxRoot(Format(root, annotation, services, options, rules, cancellationToken));
     }
 
-    internal static async Task<Document> FormatAsync(Document document, SyntaxAnnotation annotation, OptionSet? optionSet, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static async Task<Document> FormatAsync(Document document, SyntaxAnnotation annotation, OptionSet? optionSet, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         if (document == null)
         {
@@ -150,12 +150,12 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => Format(node, annotation, workspace, options, rules: null, cancellationToken);
+        => Format(node, annotation, workspace, options, rules: default, cancellationToken);
 
     internal static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, annotation, services, options, rules: null, cancellationToken);
+        => Format(node, annotation, services, options, rules: default, cancellationToken);
 
-    private static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, Workspace workspace, OptionSet? options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    private static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, Workspace workspace, OptionSet? options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         if (workspace == null)
         {
@@ -175,7 +175,7 @@ public static class Formatter
         return Format(node, GetAnnotatedSpans(node, annotation), workspace, options, rules, cancellationToken);
     }
 
-    internal static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, SolutionServices services, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, SolutionServices services, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
         => Format(node, GetAnnotatedSpans(node, annotation), services, options, rules, cancellationToken);
 
     /// <summary>
@@ -187,10 +187,10 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => Format(node, [node.FullSpan], workspace, options, rules: null, cancellationToken);
+        => Format(node, [node.FullSpan], workspace, options, rules: default, cancellationToken);
 
     internal static SyntaxNode Format(SyntaxNode node, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, [node.FullSpan], services, options, rules: null, cancellationToken);
+        => Format(node, [node.FullSpan], services, options, rules: default, cancellationToken);
 
     /// <summary>
     /// Formats the whitespace in areas of a syntax tree identified by a span.
@@ -202,10 +202,10 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, TextSpan span, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => Format(node, [span], workspace, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, [span], workspace, options, rules: default, cancellationToken: cancellationToken);
 
     internal static SyntaxNode Format(SyntaxNode node, TextSpan span, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => Format(node, [span], services, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, [span], services, options, rules: default, cancellationToken: cancellationToken);
 
     /// <summary>
     /// Formats the whitespace in areas of a syntax tree identified by multiple non-overlapping spans.
@@ -217,18 +217,18 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The formatted tree's root node.</returns>
     public static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan>? spans, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => Format(node, spans, workspace, options, rules: null, cancellationToken: cancellationToken);
+        => Format(node, spans, workspace, options, rules: default, cancellationToken: cancellationToken);
 
-    private static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan>? spans, Workspace workspace, OptionSet? options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    private static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan>? spans, Workspace workspace, OptionSet? options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         var formattingResult = GetFormattingResult(node, spans, workspace, options, rules, cancellationToken);
         return formattingResult == null ? node : formattingResult.GetFormattedRoot(cancellationToken);
     }
 
-    internal static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan>? spans, SolutionServices services, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan>? spans, SolutionServices services, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
         => GetFormattingResult(node, spans, services, options, rules, cancellationToken).GetFormattedRoot(cancellationToken);
 
-    private static IFormattingResult? GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, Workspace workspace, OptionSet? options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    private static IFormattingResult? GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, Workspace workspace, OptionSet? options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         if (workspace == null)
         {
@@ -252,7 +252,7 @@ public static class Formatter
         return languageFormatter.GetFormattingResult(node, spans, formattingOptions, rules, cancellationToken);
     }
 
-    internal static IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, SolutionServices services, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    internal static IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, SolutionServices services, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         var formatter = services.GetRequiredLanguageService<ISyntaxFormattingService>(node.Language);
         return formatter.GetFormattingResult(node, spans, options, rules, cancellationToken);
@@ -267,10 +267,10 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The changes necessary to format the tree.</returns>
     public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => GetFormattedTextChanges(node, [node.FullSpan], workspace, options, rules: null, cancellationToken: cancellationToken);
+        => GetFormattedTextChanges(node, [node.FullSpan], workspace, options, rules: default, cancellationToken: cancellationToken);
 
     internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        => GetFormattedTextChanges(node, [node.FullSpan], services, options, rules: null, cancellationToken: cancellationToken);
+        => GetFormattedTextChanges(node, [node.FullSpan], services, options, rules: default, cancellationToken: cancellationToken);
 
     /// <summary>
     /// Determines the changes necessary to format the whitespace of a syntax tree.
@@ -282,10 +282,10 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The changes necessary to format the tree.</returns>
     public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, TextSpan span, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => GetFormattedTextChanges(node, [span], workspace, options, rules: null, cancellationToken);
+        => GetFormattedTextChanges(node, [span], workspace, options, rules: default, cancellationToken);
 
     internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, TextSpan span, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken = default)
-        => GetFormattedTextChanges(node, [span], services, options, rules: null, cancellationToken);
+        => GetFormattedTextChanges(node, [span], services, options, rules: default, cancellationToken);
 
     /// <summary>
     /// Determines the changes necessary to format the whitespace of a syntax tree.
@@ -297,12 +297,12 @@ public static class Formatter
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>The changes necessary to format the tree.</returns>
     public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan>? spans, Workspace workspace, OptionSet? options = null, CancellationToken cancellationToken = default)
-        => GetFormattedTextChanges(node, spans, workspace, options, rules: null, cancellationToken);
+        => GetFormattedTextChanges(node, spans, workspace, options, rules: default, cancellationToken);
 
     internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan>? spans, SolutionServices services, SyntaxFormattingOptions options, CancellationToken cancellationToken = default)
-        => GetFormattedTextChanges(node, spans, services, options, rules: null, cancellationToken);
+        => GetFormattedTextChanges(node, spans, services, options, rules: default, cancellationToken);
 
-    private static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan>? spans, Workspace workspace, OptionSet? options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    private static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan>? spans, Workspace workspace, OptionSet? options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         var formattingResult = GetFormattingResult(node, spans, workspace, options, rules, cancellationToken);
         return formattingResult == null
@@ -310,7 +310,7 @@ public static class Formatter
             : formattingResult.GetTextChanges(cancellationToken);
     }
 
-    internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan>? spans, SolutionServices services, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken = default)
+    internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan>? spans, SolutionServices services, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken = default)
     {
         var formatter = services.GetRequiredLanguageService<ISyntaxFormattingService>(node.Language);
         return formatter.GetFormattingResult(node, spans, options, rules, cancellationToken).GetTextChanges(cancellationToken);

--- a/src/Workspaces/CoreTestUtilities/Formatting/FormattingTestBase.cs
+++ b/src/Workspaces/CoreTestUtilities/Formatting/FormattingTestBase.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Formatting
         internal void AssertFormatWithTransformation(
             SolutionServices services, string expected, SyntaxNode root, IEnumerable<TextSpan> spans, SyntaxFormattingOptions options, bool treeCompare = true, ParseOptions? parseOptions = null)
         {
-            var newRootNode = Formatter.Format(root, spans, services, options, rules: null, CancellationToken.None);
+            var newRootNode = Formatter.Format(root, spans, services, options, rules: default, CancellationToken.None);
 
             Assert.Equal(expected, newRootNode.ToFullString());
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormatting.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormatting.cs
@@ -7,10 +7,8 @@ using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
-using Microsoft.CodeAnalysis.Shared.Collections;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Collections;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 
@@ -47,6 +45,6 @@ internal class CSharpSyntaxFormatting : AbstractSyntaxFormatting
     protected override IFormattingResult CreateAggregatedFormattingResult(SyntaxNode node, IList<AbstractFormattingResult> results, TextSpanIntervalTree? formattingSpans = null)
         => new AggregatedFormattingResult(node, results, formattingSpans);
 
-    protected override AbstractFormattingResult Format(SyntaxNode node, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule> formattingRules, SyntaxToken startToken, SyntaxToken endToken, CancellationToken cancellationToken)
+    protected override AbstractFormattingResult Format(SyntaxNode node, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> formattingRules, SyntaxToken startToken, SyntaxToken endToken, CancellationToken cancellationToken)
         => new CSharpFormatEngine(node, options, formattingRules, startToken, endToken).Format(cancellationToken);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -16,7 +15,7 @@ internal class CSharpFormatEngine : AbstractFormatEngine
     public CSharpFormatEngine(
         SyntaxNode node,
         SyntaxFormattingOptions options,
-        IEnumerable<AbstractFormattingRule> formattingRules,
+        ImmutableArray<AbstractFormattingRule> formattingRules,
         SyntaxToken startToken,
         SyntaxToken endToken)
         : base(TreeData.Create(node),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
@@ -103,7 +103,7 @@ internal class CSharpSmartTokenFormatter : ISmartTokenFormatter
             }
         }
 
-        var smartTokenformattingRules = new SmartTokenFormattingRule().Concat(_formattingRules);
+        ImmutableArray<AbstractFormattingRule> smartTokenFormattingRules = [new SmartTokenFormattingRule(), .. _formattingRules];
         var adjustedStartPosition = previousToken.SpanStart;
         if (token.IsKind(SyntaxKind.OpenBraceToken) &&
             _options.IndentStyle != FormattingOptions2.IndentStyle.Smart)
@@ -117,7 +117,7 @@ internal class CSharpSmartTokenFormatter : ISmartTokenFormatter
 
         var formatter = CSharpSyntaxFormatting.Instance;
         var result = formatter.GetFormattingResult(
-            _root, [TextSpan.FromBounds(adjustedStartPosition, adjustedEndPosition)], _options.FormattingOptions, smartTokenformattingRules, cancellationToken);
+            _root, [TextSpan.FromBounds(adjustedStartPosition, adjustedEndPosition)], _options.FormattingOptions, smartTokenFormattingRules, cancellationToken);
         return result.GetTextChanges(cancellationToken);
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/AbstractSyntaxFormatting.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/AbstractSyntaxFormatting.cs
@@ -7,24 +7,18 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Formatting;
 
 internal abstract class AbstractSyntaxFormatting : ISyntaxFormatting
 {
     private static readonly Func<TextSpan, bool> s_notEmpty = s => !s.IsEmpty;
-
-    protected AbstractSyntaxFormatting()
-    {
-    }
 
     public abstract SyntaxFormattingOptions DefaultOptions { get; }
     public abstract SyntaxFormattingOptions GetFormattingOptions(IOptionsReader options, SyntaxFormattingOptions? fallbackOptions);
@@ -33,9 +27,9 @@ internal abstract class AbstractSyntaxFormatting : ISyntaxFormatting
 
     protected abstract IFormattingResult CreateAggregatedFormattingResult(SyntaxNode node, IList<AbstractFormattingResult> results, TextSpanIntervalTree? formattingSpans = null);
 
-    protected abstract AbstractFormattingResult Format(SyntaxNode node, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule> rules, SyntaxToken startToken, SyntaxToken endToken, CancellationToken cancellationToken);
+    protected abstract AbstractFormattingResult Format(SyntaxNode node, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, SyntaxToken startToken, SyntaxToken endToken, CancellationToken cancellationToken);
 
-    public IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+    public IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken)
     {
         IReadOnlyList<TextSpan> spansToFormat;
 
@@ -53,7 +47,8 @@ internal abstract class AbstractSyntaxFormatting : ISyntaxFormatting
             return CreateAggregatedFormattingResult(node, results: []);
         }
 
-        rules ??= GetDefaultFormattingRules();
+        if (rules.IsDefault)
+            rules = GetDefaultFormattingRules();
 
         List<AbstractFormattingResult>? results = null;
         foreach (var (startToken, endToken) in node.ConvertToTokenPairs(spansToFormat))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -46,6 +46,11 @@ internal abstract partial class AbstractFormatEngine
     internal readonly SyntaxFormattingOptions Options;
     internal readonly TreeData TreeData;
 
+    /// <summary>
+    /// It is very common to be formatting lots of documents at teh same time, with the same set of formatting rules and
+    /// options. To help with that, cache the last set of ChainedFormattingRules that was produced, as it is not a cheap
+    /// type to create.
+    /// </summary>
     private static readonly object s_gate = new();
     private static (ImmutableArray<AbstractFormattingRule> formattingRules, SyntaxFormattingOptions options, ChainedFormattingRules chainedRules) s_lastRulesAndOptions;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
@@ -32,7 +32,7 @@ internal class ChainedFormattingRules
     {
         Contract.ThrowIfNull(formattingRules);
 
-        _formattingRules = formattingRules.Select(rule => rule.WithOptions(options)).ToImmutableArray();
+        _formattingRules = formattingRules.SelectAsArray(rule => rule.WithOptions(options));
         _options = options;
 
         _addSuppressOperationsRules = FilterToRulesImplementingMethod(_formattingRules, nameof(AbstractFormattingRule.AddSuppressOperations));
@@ -81,7 +81,7 @@ internal class ChainedFormattingRules
 
     private static ImmutableArray<AbstractFormattingRule> FilterToRulesImplementingMethod(ImmutableArray<AbstractFormattingRule> rules, string name)
     {
-        return rules.Where(rule =>
+        return rules.WhereAsArray(rule =>
         {
             var type = GetTypeImplementingMethod(rule, name);
             if (type == typeof(AbstractFormattingRule))
@@ -99,7 +99,7 @@ internal class ChainedFormattingRules
             }
 
             return true;
-        }).ToImmutableArray();
+        });
     }
 
     private static Type? GetTypeImplementingMethod(object obj, string name)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
@@ -85,17 +85,13 @@ internal class ChainedFormattingRules
         {
             var type = GetTypeImplementingMethod(rule, name);
             if (type == typeof(AbstractFormattingRule))
-            {
                 return false;
-            }
 
             if (type == typeof(CompatAbstractFormattingRule))
             {
                 type = GetTypeImplementingMethod(rule, name + "Slow");
                 if (type == typeof(CompatAbstractFormattingRule))
-                {
                     return false;
-                }
             }
 
             return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/ISyntaxFormatting.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/ISyntaxFormatting.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
@@ -18,5 +17,5 @@ internal interface ISyntaxFormatting
     SyntaxFormattingOptions GetFormattingOptions(IOptionsReader options, SyntaxFormattingOptions? fallbackOptions);
 
     ImmutableArray<AbstractFormattingRule> GetDefaultFormattingRules();
-    IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken);
+    IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> rules, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.cs
@@ -79,7 +79,7 @@ internal partial class CSharpRemoveUnnecessaryImportsService :
 #endif
             var spans = new List<TextSpan>();
             AddFormattingSpans(newRoot, spans, cancellationToken);
-            var formattedRoot = Formatter.Format(newRoot, spans, provider, formattingOptions, rules: null, cancellationToken);
+            var formattedRoot = Formatter.Format(newRoot, spans, provider, formattingOptions, rules: default, cancellationToken);
 
             return document.WithSyntaxRoot(formattedRoot);
         }

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/VisualBasicFormatEngine.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/VisualBasicFormatEngine.vb
@@ -2,7 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Diagnostics
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.LanguageService
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
         Public Sub New(node As SyntaxNode,
                        options As SyntaxFormattingOptions,
-                       formattingRules As IEnumerable(Of AbstractFormattingRule),
+                       formattingRules As ImmutableArray(Of AbstractFormattingRule),
                        startToken As SyntaxToken,
                        endToken As SyntaxToken)
             MyBase.New(TreeData.Create(node),

--- a/src/Workspaces/VisualBasic/Portable/Formatting/VisualBasicSyntaxFormatting.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/VisualBasicSyntaxFormatting.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Return New AggregatedFormattingResult(node, results, formattingSpans)
         End Function
 
-        Protected Overrides Function Format(root As SyntaxNode, options As SyntaxFormattingOptions, formattingRules As IEnumerable(Of AbstractFormattingRule), startToken As SyntaxToken, endToken As SyntaxToken, cancellationToken As CancellationToken) As AbstractFormattingResult
+        Protected Overrides Function Format(root As SyntaxNode, options As SyntaxFormattingOptions, formattingRules As ImmutableArray(Of AbstractFormattingRule), startToken As SyntaxToken, endToken As SyntaxToken, cancellationToken As CancellationToken) As AbstractFormattingResult
             Return New VisualBasicFormatEngine(root, options, formattingRules, startToken, endToken).Format(cancellationToken)
         End Function
     End Class


### PR DESCRIPTION
Removes effectively *all* of these allocatinos: 

![image](https://github.com/dotnet/roslyn/assets/4564579/ef88ab2d-9b82-411b-a1b8-16e694ad24d7)
