### PR TITLE
Add runtime references to the devkit component output directory

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Microsoft.CodeAnalysis.LanguageServer.UnitTests.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Microsoft.CodeAnalysis.LanguageServer.UnitTests.csproj
@@ -23,7 +23,7 @@
   -->
   <Target Name="_CopyDevKitExtensionFiles" AfterTargets="ResolveProjectReferences">
     <MSBuild Projects="..\..\..\VisualStudio\DevKit\Impl\Microsoft.VisualStudio.LanguageServices.DevKit.csproj"
-             Targets="CollectPackInputs">
+             Targets="GetPackInputs">
       <Output TaskParameter="TargetOutputs" ItemName="_DevKitExtensionFile"/>
     </MSBuild>
 

--- a/src/VisualStudio/DevKit/Impl/Microsoft.VisualStudio.LanguageServices.DevKit.csproj
+++ b/src/VisualStudio/DevKit/Impl/Microsoft.VisualStudio.LanguageServices.DevKit.csproj
@@ -9,8 +9,7 @@
       .NET Compiler Platform ("Roslyn") Language Server Protocol internal.
     </PackageDescription>
     <IsPackable>true</IsPackable>
-    <BeforePack>CollectPackInputs;$(BeforePack)</BeforePack>
-  
+
     <!-- This is not a standard nuget package and only consumed by the extension build. We don't care if the folder structure doesn't match what nuget expects. -->
     <NoWarn>$(NoWarn);NU5100</NoWarn>
   </PropertyGroup>
@@ -45,18 +44,20 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.DevKit.UnitTests" />
   </ItemGroup>
-  
-  <!--
-  Add these additional runtime dependencies to our NuGet package.
-  -->
-  <Target Name="CollectPackInputs" DependsOnTargets="Build" BeforeTargets="Pack" Returns="@(Content)">
+
+  <ItemGroup>
+    <Content Include="$(PkgMicrosoft_VisualStudio_Telemetry)\lib\netstandard2.0\Microsoft.VisualStudio.Telemetry.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_VisualStudio_RemoteControl)\lib\netstandard2.0\Microsoft.VisualStudio.RemoteControl.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_VisualStudio_Utilities_Internal)\lib\netstandard2.0\Microsoft.VisualStudio.Utilities.Internal.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(PkgSystem_Configuration_ConfigurationManager)\lib\netstandard2.0\System.Configuration.ConfigurationManager.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_VisualStudio_Debugger_Contracts)\lib\netstandard2.0\Microsoft.VisualStudio.Debugger.Contracts.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(TargetPath)" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!-- Used by LanguageServer.UnitTests project to be able to copy all the content to its own directory -->
+  <Target Name="GetPackInputs" DependsOnTargets="Build" Returns="@(_Content)">
     <ItemGroup>
-      <Content Include="$(PkgMicrosoft_VisualStudio_Telemetry)\lib\netstandard2.0\Microsoft.VisualStudio.Telemetry.dll" Pack="true" PackagePath="content" />
-      <Content Include="$(PkgMicrosoft_VisualStudio_RemoteControl)\lib\netstandard2.0\Microsoft.VisualStudio.RemoteControl.dll" Pack="true" PackagePath="content" />
-      <Content Include="$(PkgMicrosoft_VisualStudio_Utilities_Internal)\lib\netstandard2.0\Microsoft.VisualStudio.Utilities.Internal.dll" Pack="true" PackagePath="content" />
-      <Content Include="$(PkgSystem_Configuration_ConfigurationManager)\lib\netstandard2.0\System.Configuration.ConfigurationManager.dll" Pack="true" PackagePath="content" />
-      <Content Include="$(PkgMicrosoft_VisualStudio_Debugger_Contracts)\lib\netstandard2.0\Microsoft.VisualStudio.Debugger.Contracts.dll" Pack="true" PackagePath="content" />
-      <Content Include="$(TargetPath)" Pack="true" PackagePath="content" />
+      <_Content Include="@(Content)" Condition="'%(Content.Pack)'=='true'"/>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Previously the build output of the project only had the single devkit dll (and none of its required runtime dependencies, like VS telemetry).  

This made it hard to test local changes in VSCode - we would have to first run pack on the project (to pull in the dependencies), then unpack the nuget content to a folder and point VSCode to look in that folder for the devkit component.

Now since we include the additional runtime dependencies in the build output, its very easy to test local changes - just point VSCode to the build output directory (which has the updated devkit dll and updated runtime dependencies).