### PR TITLE
Use TextDocumentChangeRegistrationOptions for didChange registration

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/RazorDynamicDocumentSyncRegistration.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/RazorDynamicDocumentSyncRegistration.cs
@@ -46,7 +46,7 @@ internal sealed class RazorDynamicDocumentSyncRegistration(IGlobalOptionService 
             {
                 var languageServerManager = context.GetRequiredLspService<IClientLanguageServerManager>();
 
-                var documentFilters = new[] { new DocumentFilter() { Pattern = "**/*.razor" }, new DocumentFilter() { Pattern = "**/*.cshtml" } };
+                var documentFilters = new[] { new DocumentFilter() { Pattern = "**/*.{razor, cshtml}", Language = "aspnetcorerazor" } };
                 var registrationOptions = new TextDocumentRegistrationOptions()
                 {
                     DocumentSelector = documentFilters
@@ -66,7 +66,11 @@ internal sealed class RazorDynamicDocumentSyncRegistration(IGlobalOptionService 
                             {
                                 Id = Guid.NewGuid().ToString(), // No need to save this for unregistering
                                 Method = Methods.TextDocumentDidChangeName,
-                                RegisterOptions = registrationOptions
+                                RegisterOptions = new TextDocumentChangeRegistrationOptions()
+                                {
+                                    DocumentSelector = documentFilters,
+                                    SyncKind = TextDocumentSyncKind.Incremental
+                                }
                             },
                             new()
                             {

--- a/src/Features/LanguageServer/Protocol/Protocol/TextDocumentChangeRegistrationOptions.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/TextDocumentChangeRegistrationOptions.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Roslyn.LanguageServer.Protocol
+{
+    /// <summary>
+    /// Class representing the registration options for didChange events.
+    ///
+    /// See the <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentChangeRegistrationOptions">Language Server Protocol specification</see> for additional information.
+    /// </summary>
+    [DataContract]
+    internal class TextDocumentChangeRegistrationOptions : TextDocumentRegistrationOptions
+    {
+        /// <summary>
+        /// How documents are synced to the server. See <see cref="TextDocumentSyncKind.Full"/>
+	    /// and <see cref="TextDocumentSyncKind.Incremental"/>.
+        /// </summary>
+        [DataMember(Name = "syncKind")]
+        public TextDocumentSyncKind SyncKind
+        {
+            get;
+            set;
+        }
+    }
+}


### PR DESCRIPTION
When dynamically registering for razor, the didChange was registered incorrectly. This changes to make sure the change exist and uses incremental, which is what xaml registers as 

Confirmed didchange LSP event in the LSP logs

```
[Trace - 6:13:47 PM] Sending notification 'textDocument/didChange'.
Params: {
    "textDocument": {
        "uri": "file:///s:/BlazorServer/Pages/Counter.razor",
        "version": 2
    },
    "contentChanges": [
        {
            "range": {
                "start": {
                    "line": 16,
                    "character": 24
                },
                "end": {
                    "line": 16,
                    "character": 25
                }
            },
            "rangeLength": 1,
            "text": ""
        }
    ]
}
```