### PR TITLE
Ref count the HubClient and ServiceBrokerClient

### DIFF
--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -260,6 +260,7 @@ internal sealed class EditAndContinueLanguageService(
         UpdateApplyChangesDiagnostics([]);
 
         sourceTextProvider.Deactivate();
+        _debuggingSession?.Dispose();
         _debuggingSession = null;
         _committedDesignTimeSolution = null;
         _pendingUpdatedDesignTimeSolution = null;

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -29,7 +29,7 @@ using Xunit;
 namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
 {
     [UseExportProvider]
-    public class RemoteEditAndContinueServiceTests
+    public sealed class RemoteEditAndContinueServiceTests
     {
         private static string Inspect(DiagnosticData d)
             => $"[{d.ProjectId}] {d.Severity} {d.Id}:" +
@@ -139,7 +139,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
                 return new DebuggingSessionId(1);
             };
 
-            var sessionProxy = await proxy.StartDebuggingSessionAsync(
+            using var sessionProxy = await proxy.StartDebuggingSessionAsync(
                 localWorkspace.CurrentSolution,
                 debuggerService: new MockManagedEditAndContinueDebuggerService()
                 {

--- a/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/SymbolSearchUpdateNoOpEngine.cs
@@ -13,6 +13,11 @@ internal sealed class SymbolSearchUpdateNoOpEngine : ISymbolSearchUpdateEngine
 {
     public static readonly SymbolSearchUpdateNoOpEngine Instance = new();
 
+    public void Dispose()
+    {
+        // Nothing to do for the no-op version.
+    }
+
     public ValueTask<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         => ValueTaskFactory.FromResult(ImmutableArray<PackageWithAssemblyResult>.Empty);
 

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.cs
@@ -65,6 +65,11 @@ internal partial class SymbolSearchUpdateEngine : ISymbolSearchUpdateEngine
         _reportAndSwallowExceptionUnlessCanceled = reportAndSwallowExceptionUnlessCanceled;
     }
 
+    public void Dispose()
+    {
+        // Nothing to do for the core symbol search engine.
+    }
+
     public ValueTask<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
         string source, string name, int arity, CancellationToken cancellationToken)
     {

--- a/src/VisualStudio/Core/Def/Remote/VisualStudioWorkspaceServiceHubConnector.cs
+++ b/src/VisualStudio/Core/Def/Remote/VisualStudioWorkspaceServiceHubConnector.cs
@@ -7,13 +7,10 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Remote;
 

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +22,6 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Storage;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.Settings;
 using Roslyn.Utilities;
 using VSShell = Microsoft.VisualStudio.Shell;
@@ -40,18 +36,18 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch;
 /// date by downloading patches on a daily basis.
 /// </summary>
 [ExportWorkspaceService(typeof(ISymbolSearchService), ServiceLayer.Host), Shared]
-internal partial class VisualStudioSymbolSearchService : AbstractDelayStartedService, ISymbolSearchService
+internal partial class VisualStudioSymbolSearchService : AbstractDelayStartedService, ISymbolSearchService, IDisposable
 {
     private readonly SemaphoreSlim _gate = new(initialCount: 1);
 
     // Note: A remote engine is disposable as it maintains a connection with ServiceHub,
     // but we want to keep it alive until the VS is closed, so we don't dispose it.
-    private ISymbolSearchUpdateEngine _lazyUpdateEngine;
+    private ISymbolSearchUpdateEngine? _lazyUpdateEngine;
 
     private readonly SVsServiceProvider _serviceProvider;
     private readonly IPackageInstallerService _installerService;
 
-    private string _localSettingsDirectory;
+    private string? _localSettingsDirectory;
 
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -69,7 +65,20 @@ internal partial class VisualStudioSymbolSearchService : AbstractDelayStartedSer
                [SymbolSearchOptionsStorage.SearchReferenceAssemblies, SymbolSearchOptionsStorage.SearchNuGetPackages])
     {
         _serviceProvider = serviceProvider;
-        _installerService = workspace.Services.GetService<IPackageInstallerService>();
+        _installerService = workspace.Services.GetRequiredService<IPackageInstallerService>();
+    }
+
+    public void Dispose()
+    {
+        ISymbolSearchUpdateEngine? updateEngine;
+        using (_gate.DisposableWait())
+        {
+            // Once we're disposed, swap out our engine with a no-op one so we don't try to do any more work.
+            updateEngine = _lazyUpdateEngine;
+            _lazyUpdateEngine = SymbolSearchUpdateNoOpEngine.Instance;
+        }
+
+        updateEngine?.Dispose();
     }
 
     protected override async Task EnableServiceAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Remote/IRemoteHostClientProvider.cs
+++ b/src/Workspaces/Core/Portable/Remote/IRemoteHostClientProvider.cs
@@ -5,6 +5,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote;
 

--- a/src/Workspaces/Core/Portable/Remote/NoOpRemoteServiceConnection.cs
+++ b/src/Workspaces/Core/Portable/Remote/NoOpRemoteServiceConnection.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Remote;
+
+internal sealed class NoOpRemoteServiceConnection<T> : RemoteServiceConnection<T>
+    where T : class
+{
+    public static readonly NoOpRemoteServiceConnection<T> Instance = new();
+
+    private NoOpRemoteServiceConnection()
+    {
+    }
+
+    public override void Dispose()
+    {
+    }
+
+    public override ValueTask<bool> TryInvokeAsync(Func<T, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Func<T, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<bool> TryInvokeAsync(Func<T, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Func<T, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<bool> TryInvokeAsync(SolutionCompilationState compilationState, Func<T, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(SolutionCompilationState compilationState, Func<T, Checksum, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<bool> TryInvokeAsync(SolutionCompilationState compilationState, ProjectId projectId, Func<T, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(SolutionCompilationState compilationState, ProjectId projectId, Func<T, Checksum, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<bool> TryInvokeAsync(SolutionCompilationState compilationState, Func<T, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(SolutionCompilationState compilationState, Func<T, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<bool> TryInvokeAsync(SolutionCompilationState compilationState, ProjectId projectId, Func<T, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(SolutionCompilationState compilationState, ProjectId projectId, Func<T, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        => default;
+
+    public override ValueTask<bool> TryInvokeAsync(SolutionCompilationState compilationState1, SolutionCompilationState compilationState2, Func<T, Checksum, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        => default;
+}

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -20,18 +20,7 @@ namespace Microsoft.CodeAnalysis.Remote;
 /// </summary>
 internal abstract class RemoteHostClient : IDisposable
 {
-    public event EventHandler<bool>? StatusChanged;
-
-    protected void Started()
-    {
-        OnStatusChanged(started: true);
-    }
-
-    public virtual void Dispose()
-        => OnStatusChanged(started: false);
-
-    private void OnStatusChanged(bool started)
-        => StatusChanged?.Invoke(this, started);
+    public abstract void Dispose();
 
     public static Task<RemoteHostClient?> TryGetClientAsync(Project project, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch;
 /// Service that allows you to query the SymbolSearch database and which keeps 
 /// the database up to date.  
 /// </summary>
-internal interface ISymbolSearchUpdateEngine
+internal interface ISymbolSearchUpdateEngine : IDisposable
 {
     ValueTask UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory, CancellationToken cancellationToken);
 

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -29,8 +29,6 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
             var inprocServices = new InProcRemoteServices(services, traceListener, testData);
             var instance = new InProcRemoteHostClient(services, inprocServices, callbackDispatchers);
 
-            instance.Started();
-
             // return instance
             return instance;
         }
@@ -76,8 +74,6 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         public override void Dispose()
         {
             _inprocServices.Dispose();
-
-            base.Dispose();
         }
 
         public sealed class ServiceProvider : IServiceProvider

--- a/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
@@ -105,7 +105,6 @@ namespace Microsoft.CodeAnalysis.Remote
                     (service, cancellationToken) => service.EnableAsync(AsynchronousOperationListenerProvider.IsEnabled, listenerProvider.DiagnosticTokensEnabled, cancellationToken),
                     cancellationToken).ConfigureAwait(false);
 
-                client.Started();
                 return client;
             }
         }
@@ -141,8 +140,6 @@ namespace Microsoft.CodeAnalysis.Remote
             _hubClient.Dispose();
 
             _serviceBrokerClient.Dispose();
-
-            base.Dispose();
         }
     }
 }


### PR DESCRIPTION
Ensures we don't dispose of them early while there are outstanding connections to the OOP server and operations in progress.