### PR TITLE
Avoid unnecessary full tree walks in the simplifier system

### DIFF
--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
@@ -10,18 +10,21 @@ using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Simplification;
 
 [ExportLanguageService(typeof(ISimplificationService), LanguageNames.CSharp), Shared]
-internal partial class CSharpSimplificationService : AbstractSimplificationService<ExpressionSyntax, StatementSyntax, CrefSyntax>
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal partial class CSharpSimplificationService()
+    : AbstractSimplificationService<CompilationUnitSyntax, ExpressionSyntax, StatementSyntax, CrefSyntax>(s_reducers)
 {
     // 1. the cast simplifier should run earlier then everything else to minimize the type expressions
     // 2. Extension method reducer may insert parentheses.  So run it before the parentheses remover.
@@ -39,12 +42,6 @@ internal partial class CSharpSimplificationService : AbstractSimplificationServi
             new CSharpInferredMemberNameReducer(),
             new CSharpDefaultExpressionReducer(),
         ];
-
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpSimplificationService() : base(s_reducers)
-    {
-    }
 
     public override SimplifierOptions DefaultOptions
         => CSharpSimplifierOptions.Default;
@@ -229,5 +226,27 @@ internal partial class CSharpSimplificationService : AbstractSimplificationServi
             currentTuple = grandParent;
         }
         while (true);
+    }
+
+    protected override void AddImportDeclarations(CompilationUnitSyntax root, ArrayBuilder<SyntaxNode> importDeclarations)
+    {
+        importDeclarations.AddRange(root.Usings);
+
+        foreach (var member in root.Members)
+        {
+            if (member is BaseNamespaceDeclarationSyntax baseNamespace)
+                AddImportDeclarations(baseNamespace, importDeclarations);
+        }
+
+        static void AddImportDeclarations(BaseNamespaceDeclarationSyntax baseNamespace, ArrayBuilder<SyntaxNode> importDeclarations)
+        {
+            importDeclarations.AddRange(baseNamespace.Usings);
+
+            foreach (var member in baseNamespace.Members)
+            {
+                if (member is BaseNamespaceDeclarationSyntax childNamespace)
+                    AddImportDeclarations(childNamespace, importDeclarations);
+            }
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
+++ b/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
@@ -10,10 +10,10 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -21,7 +21,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Simplification;
 
-internal abstract class AbstractSimplificationService<TExpressionSyntax, TStatementSyntax, TCrefSyntax> : ISimplificationService
+internal abstract class AbstractSimplificationService<TCompilationUnitSyntax, TExpressionSyntax, TStatementSyntax, TCrefSyntax> : ISimplificationService
+    where TCompilationUnitSyntax : SyntaxNode
     where TExpressionSyntax : SyntaxNode
     where TStatementSyntax : SyntaxNode
     where TCrefSyntax : SyntaxNode
@@ -37,6 +38,7 @@ internal abstract class AbstractSimplificationService<TExpressionSyntax, TStatem
     protected abstract ImmutableArray<NodeOrTokenToReduce> GetNodesAndTokensToReduce(SyntaxNode root, Func<SyntaxNodeOrToken, bool> isNodeOrTokenOutsideSimplifySpans);
     protected abstract SemanticModel GetSpeculativeSemanticModel(ref SyntaxNode nodeToSpeculate, SemanticModel originalSemanticModel, SyntaxNode originalNode);
     protected abstract bool NodeRequiresNonSpeculativeSemanticModel(SyntaxNode node);
+    protected abstract void AddImportDeclarations(TCompilationUnitSyntax root, ArrayBuilder<SyntaxNode> importDeclarations);
 
     public abstract SimplifierOptions DefaultOptions { get; }
     public abstract SimplifierOptions GetSimplifierOptions(IOptionsReader options, SimplifierOptions? fallbackOptions);
@@ -102,27 +104,24 @@ internal abstract class AbstractSimplificationService<TExpressionSyntax, TStatem
         // Create a simple interval tree for simplification spans.
         var spansTree = new TextSpanIntervalTree(spans);
 
-        bool isNodeOrTokenOutsideSimplifySpans(SyntaxNodeOrToken nodeOrToken)
-            => !spansTree.HasIntervalThatOverlapsWith(nodeOrToken.FullSpan.Start, nodeOrToken.FullSpan.Length);
-
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-        var root = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+        var root = (TCompilationUnitSyntax)await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
         // prep namespace imports marked for simplification 
         var removeIfUnusedAnnotation = new SyntaxAnnotation();
         var originalRoot = root;
-        root = PrepareNamespaceImportsForRemovalIfUnused(document, root, removeIfUnusedAnnotation, isNodeOrTokenOutsideSimplifySpans);
+        root = PrepareNamespaceImportsForRemovalIfUnused(root, removeIfUnusedAnnotation, IsNodeOrTokenOutsideSimplifySpans);
         var hasImportsToSimplify = root != originalRoot;
 
         if (hasImportsToSimplify)
         {
             document = document.WithSyntaxRoot(root);
             semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            root = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+            root = (TCompilationUnitSyntax)await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         }
 
         // Get the list of syntax nodes and tokens that need to be reduced.
-        var nodesAndTokensToReduce = this.GetNodesAndTokensToReduce(root, isNodeOrTokenOutsideSimplifySpans);
+        var nodesAndTokensToReduce = this.GetNodesAndTokensToReduce(root, IsNodeOrTokenOutsideSimplifySpans);
 
         if (nodesAndTokensToReduce.Any())
         {
@@ -166,6 +165,9 @@ internal abstract class AbstractSimplificationService<TExpressionSyntax, TStatem
         }
 
         return document;
+
+        bool IsNodeOrTokenOutsideSimplifySpans(SyntaxNodeOrToken nodeOrToken)
+            => !spansTree.HasIntervalThatOverlapsWith(nodeOrToken.FullSpan.Start, nodeOrToken.FullSpan.Length);
     }
 
     private async Task ReduceAsync(
@@ -284,20 +286,18 @@ internal abstract class AbstractSimplificationService<TExpressionSyntax, TStatem
 
     // find any namespace imports / using directives marked for simplification in the specified spans
     // and add removeIfUnused annotation
-    private static SyntaxNode PrepareNamespaceImportsForRemovalIfUnused(
-        Document document,
-        SyntaxNode root,
+    private TCompilationUnitSyntax PrepareNamespaceImportsForRemovalIfUnused(
+        TCompilationUnitSyntax root,
         SyntaxAnnotation removeIfUnusedAnnotation,
         Func<SyntaxNodeOrToken, bool> isNodeOrTokenOutsideSimplifySpan)
     {
-        var gen = SyntaxGenerator.GetGenerator(document);
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var importDeclarations);
 
-        var importsToSimplify = root.DescendantNodes().Where(n =>
-            !isNodeOrTokenOutsideSimplifySpan(n)
-            && gen.GetDeclarationKind(n) == DeclarationKind.NamespaceImport
-            && n.HasAnnotation(Simplifier.Annotation));
+        this.AddImportDeclarations(root, importDeclarations);
 
-        return root.ReplaceNodes(importsToSimplify, (o, r) => r.WithAdditionalAnnotations(removeIfUnusedAnnotation));
+        return root.ReplaceNodes(
+            importDeclarations.Where(n => !isNodeOrTokenOutsideSimplifySpan(n) && n.HasAnnotation(Simplifier.Annotation)),
+            (o, r) => r.WithAdditionalAnnotations(removeIfUnusedAnnotation));
     }
 
     private async Task<Document> RemoveUnusedNamespaceImportsAsync(

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.NodesAndTokensToReduceComputer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.NodesAndTokensToReduceComputer.vb
@@ -9,10 +9,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
-
     Partial Friend Class VisualBasicSimplificationService
-        Inherits AbstractSimplificationService(Of ExpressionSyntax, ExecutableStatementSyntax, CrefReferenceSyntax)
-
         Private Class NodesAndTokensToReduceComputer
             Inherits VisualBasicSyntaxRewriter
 
@@ -98,7 +95,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 Me._simplifyAllDescendants = Me._simplifyAllDescendants OrElse token.HasAnnotation(Simplifier.Annotation)
 
                 If Me._simplifyAllDescendants AndAlso Not Me._insideSpeculatedNode AndAlso token.Kind <> SyntaxKind.None Then
-                    Me._nodesAndTokensToReduce.Add(New NodeOrTokenToReduce(token, simplifyAllDescendants:=True, originalNodeOrToken:=token))
+                    Me._nodesAndTokensToReduce.Add(New NodeOrTokenToReduce(token, SimplifyAllDescendants:=True, OriginalNodeOrToken:=token))
                 End If
 
                 If token.ContainsAnnotations OrElse savedSimplifyAllDescendants Then

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
@@ -6,10 +6,10 @@ Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Internal.Log
 Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
@@ -17,7 +17,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
     <ExportLanguageService(GetType(ISimplificationService), LanguageNames.VisualBasic), [Shared]>
     Partial Friend Class VisualBasicSimplificationService
-        Inherits AbstractSimplificationService(Of ExpressionSyntax, ExecutableStatementSyntax, CrefReferenceSyntax)
+        Inherits AbstractSimplificationService(Of CompilationUnitSyntax, ExpressionSyntax, ExecutableStatementSyntax, CrefReferenceSyntax)
 
         Private Shared ReadOnly s_reducers As ImmutableArray(Of AbstractReducer) =
             ImmutableArray.Create(Of AbstractReducer)(
@@ -177,5 +177,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             Next
         End Sub
 
+        Protected Overrides Sub AddImportDeclarations(root As CompilationUnitSyntax, importDeclarations As ArrayBuilder(Of SyntaxNode))
+            importDeclarations.AddRange(root.Imports)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Drops us from:
![image](https://github.com/dotnet/roslyn/assets/4564579/6150877f-2e95-4678-a75c-0ee82872d6e9)

to:

![image](https://github.com/dotnet/roslyn/assets/4564579/64445288-48eb-4844-887b-f5818b02bc2b)


Note: there are *much* more wins from this as this basically drops practically every syntax node kind.  All up this lowers us 25% from:

![image](https://github.com/dotnet/roslyn/assets/4564579/c4ecdd3b-6e6c-4e79-874d-742ce11c2fb1)

to:

![image](https://github.com/dotnet/roslyn/assets/4564579/946c238e-875a-4647-9a18-16f3ccba0fe3)
