### PR TITLE
Avoid enumeration allocations in formatting

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
@@ -178,12 +178,18 @@ internal static partial class SyntaxNodeExtensions
     {
         Contract.ThrowIfTrue(node1.RawKind == 0 || node2.RawKind == 0);
 
-        // find common starting node from two nodes.
-        // as long as two nodes belong to same tree, there must be at least one common root (Ex, compilation unit)
-        var ancestors = node1.GetAncestorsOrThis<SyntaxNode>();
-        var set = new HashSet<SyntaxNode>(node2.GetAncestorsOrThis<SyntaxNode>());
+        // find common starting node from two nodes. as long as two nodes belong to same tree, there must be at least
+        // one common root (Ex, compilation unit)
+        using var _ = PooledHashSet<SyntaxNode>.GetInstance(out var set);
+        set.AddRange(node2.GetAncestorsOrThis<SyntaxNode>());
 
-        return ancestors.First(set.Contains);
+        foreach (var ancestor in node1.AncestorsAndSelf())
+        {
+            if (set.Contains(ancestor))
+                return ancestor;
+        }
+
+        throw ExceptionUtilities.Unreachable();
     }
 
     public static int Width(this SyntaxNode node)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenData.cs
@@ -77,14 +77,15 @@ internal readonly record struct TokenData : IComparable<TokenData>
         if (end != 0)
             return end;
 
-        // this is expansive check. but there is no other way to check.
+        // We have two different tokens, which are at the same location.  This can happen with things like empty/missing
+        // tokens.  In order to give a strict ordering, we need to walk up the tree to find the first common ancestor
+        // and see which token we hit first in that ancestor.
         var commonRoot = this.Token.GetCommonRoot(other.Token);
         RoslynDebug.Assert(commonRoot != null);
 
         using var _ = ArrayBuilder<SyntaxNodeOrToken>.GetInstance(out var stack);
         stack.Push(commonRoot);
 
-        // Do a DFS walk to see which of the two tokens comes first.
         while (stack.TryPop(out var current))
         {
             if (current.IsNode)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenData.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -63,50 +64,20 @@ internal readonly record struct TokenData : IComparable<TokenData>
         Contract.ThrowIfFalse(this.TokenStream == other.TokenStream);
 
         if (this.IndexInStream >= 0 && other.IndexInStream >= 0)
-        {
             return this.IndexInStream - other.IndexInStream;
-        }
+
+        if (this.Token == other.Token)
+            return 0;
 
         var start = this.Token.SpanStart - other.Token.SpanStart;
         if (start != 0)
-        {
             return start;
-        }
 
         var end = this.Token.Span.End - other.Token.Span.End;
         if (end != 0)
-        {
             return end;
-        }
 
-        // this is expansive check. but there is no other way to check.
-        var commonRoot = this.Token.GetCommonRoot(other.Token);
-        RoslynDebug.Assert(commonRoot != null);
-
-        var tokens = commonRoot.DescendantTokens();
-
-        var index1 = Index(tokens, this.Token);
-        var index2 = Index(tokens, other.Token);
-        Contract.ThrowIfFalse(index1 >= 0 && index2 >= 0);
-
-        return index1 - index2;
-    }
-
-    private static int Index(IEnumerable<SyntaxToken> tokens, SyntaxToken token)
-    {
-        var index = 0;
-
-        foreach (var current in tokens)
-        {
-            if (current == token)
-            {
-                return index;
-            }
-
-            index++;
-        }
-
-        return -1;
+        return 0;
     }
 
     public static bool operator <(TokenData left, TokenData right)


### PR DESCRIPTION
This shows up as 0.6% of all our allocs: 

![image](https://github.com/dotnet/roslyn/assets/4564579/68e5a7e8-9d07-4fe9-8dba-46ad6e5fa945)