### PR TITLE
Update bug-report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -15,7 +15,7 @@ A minimal repro, with source-code provided, is ideal.  Using [sharplab](https://
 
 **Diagnostic Id**:
 
-If this is a report about a bug in an analyzer, please include the diagnostic if possible (e.g. `"IDE0030"`).
+If this is a report about a bug in an analyzer, please include the diagnostic ID and message if possible (e.g. `"IDE0030: Use coalesce expression"`).
 
 **Expected Behavior**:
 


### PR DESCRIPTION
Request that people include the diagnostic message as well as the ID since the bug triagers don't have the diagnostic IDs memorized.