### PR TITLE
Move AsyncBatchingWorkQueue usage in telemetry to TelemetryLogging level

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -36,6 +36,8 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
         _requestCounters = new();
         _findDocumentResults = new();
         _usedForkedSolutionCounter = new();
+
+        TelemetryLogging.Flushed += OnFlushed;
     }
 
     public void UpdateFindDocumentTelemetryData(bool success, string? workspaceKind)
@@ -92,6 +94,14 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
             return;
         }
 
+        // Flush all telemetry logged through TelemetryLogging
+        TelemetryLogging.Flush();
+
+        TelemetryLogging.Flushed -= OnFlushed;
+    }
+
+    private void OnFlushed(object? sender, EventArgs e)
+    {
         foreach (var kvp in _requestCounters)
         {
             TelemetryLogging.Log(FunctionId.LSP_RequestCounter, KeyValueLogMessage.Create(LogType.Trace, m =>
@@ -123,9 +133,6 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
                 m[info] = kvp.Value.GetCount();
             }
         }));
-
-        // Flush all telemetry logged through TelemetryLogging
-        TelemetryLogging.Flush();
 
         _requestCounters.Clear();
     }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -114,27 +114,35 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
             }));
         }
 
-        TelemetryLogging.Log(FunctionId.LSP_FindDocumentInWorkspace, KeyValueLogMessage.Create(LogType.Trace, m =>
+        if (!_findDocumentResults.IsEmpty)
         {
-            m["server"] = _serverTypeName;
-            foreach (var kvp in _findDocumentResults)
+            TelemetryLogging.Log(FunctionId.LSP_FindDocumentInWorkspace, KeyValueLogMessage.Create(LogType.Trace, m =>
             {
-                var info = kvp.Key.ToString()!;
-                m[info] = kvp.Value.GetCount();
-            }
-        }));
+                m["server"] = _serverTypeName;
+                foreach (var kvp in _findDocumentResults)
+                {
+                    var info = kvp.Key.ToString()!;
+                    m[info] = kvp.Value.GetCount();
+                }
+            }));
+        }
 
-        TelemetryLogging.Log(FunctionId.LSP_UsedForkedSolution, KeyValueLogMessage.Create(LogType.Trace, m =>
+        if (!_usedForkedSolutionCounter.IsEmpty)
         {
-            m["server"] = _serverTypeName;
-            foreach (var kvp in _usedForkedSolutionCounter)
+            TelemetryLogging.Log(FunctionId.LSP_UsedForkedSolution, KeyValueLogMessage.Create(LogType.Trace, m =>
             {
-                var info = kvp.Key.ToString()!;
-                m[info] = kvp.Value.GetCount();
-            }
-        }));
+                m["server"] = _serverTypeName;
+                foreach (var kvp in _usedForkedSolutionCounter)
+                {
+                    var info = kvp.Key.ToString()!;
+                    m[info] = kvp.Value.GetCount();
+                }
+            }));
+        }
 
         _requestCounters.Clear();
+        _findDocumentResults.Clear();
+        _usedForkedSolutionCounter.Clear();
     }
 
     private class Counter

--- a/src/VisualStudio/Core/Def/Telemetry/Shared/AggregatingTelemetryLogManager.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/Shared/AggregatingTelemetryLogManager.cs
@@ -2,39 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Telemetry;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Telemetry;
 
 /// <summary>
-/// Manages creation and obtaining aggregated telemetry logs. Also, notifies logs to
-/// send aggregated events every 30 minutes.
+/// Manages creation and obtaining aggregated telemetry logs.
 /// </summary>
 internal sealed class AggregatingTelemetryLogManager
 {
-    private static readonly TimeSpan s_batchedTelemetryCollectionPeriod = TimeSpan.FromMinutes(30);
-
     private readonly TelemetrySession _session;
-    private readonly AsyncBatchingWorkQueue _postTelemetryQueue;
 
     private ImmutableDictionary<FunctionId, AggregatingTelemetryLog> _aggregatingLogs = ImmutableDictionary<FunctionId, AggregatingTelemetryLog>.Empty;
 
-    public AggregatingTelemetryLogManager(TelemetrySession session, IAsynchronousOperationListener asyncListener)
+    public AggregatingTelemetryLogManager(TelemetrySession session)
     {
         _session = session;
-
-        _postTelemetryQueue = new AsyncBatchingWorkQueue(
-            s_batchedTelemetryCollectionPeriod,
-            PostCollectedTelemetryAsync,
-            asyncListener,
-            CancellationToken.None);
     }
 
     public ITelemetryLog? GetLog(FunctionId functionId, double[]? bucketBoundaries)
@@ -42,22 +27,11 @@ internal sealed class AggregatingTelemetryLogManager
         if (!_session.IsOptedIn)
             return null;
 
-        return ImmutableInterlocked.GetOrAdd(ref _aggregatingLogs, functionId, functionId => new AggregatingTelemetryLog(_session, functionId, bucketBoundaries, this));
-    }
-
-    public void EnsureTelemetryWorkQueued()
-    {
-        // Ensure PostCollectedTelemetryAsync will get fired after the collection period.
-        _postTelemetryQueue.AddWork();
-    }
-
-    private ValueTask PostCollectedTelemetryAsync(CancellationToken token)
-    {
-        token.ThrowIfCancellationRequested();
-
-        Flush();
-
-        return ValueTaskFactory.CompletedTask;
+        return ImmutableInterlocked.GetOrAdd(
+            ref _aggregatingLogs,
+            functionId,
+            static (functionId, arg) => new AggregatingTelemetryLog(arg._session, functionId, arg.bucketBoundaries),
+            factoryArgument: (_session, bucketBoundaries));
     }
 
     public void Flush()

--- a/src/VisualStudio/Core/Def/Telemetry/Shared/TelemetryLogProvider.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/Shared/TelemetryLogProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
 
@@ -23,11 +22,11 @@ internal sealed class TelemetryLogProvider : ITelemetryLogProvider
         _visualStudioTelemetryLogManager = new VisualStudioTelemetryLogManager(session, telemetryLogger);
     }
 
-    public static TelemetryLogProvider Create(TelemetrySession session, ILogger telemetryLogger, IAsynchronousOperationListener asyncListener)
+    public static TelemetryLogProvider Create(TelemetrySession session, ILogger telemetryLogger)
     {
         var logProvider = new TelemetryLogProvider(session, telemetryLogger);
 
-        TelemetryLogging.SetLogProvider(logProvider, asyncListener);
+        TelemetryLogging.SetLogProvider(logProvider);
 
         return logProvider;
     }

--- a/src/VisualStudio/Core/Def/Telemetry/Shared/TelemetryLogProvider.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/Shared/TelemetryLogProvider.cs
@@ -17,17 +17,17 @@ internal sealed class TelemetryLogProvider : ITelemetryLogProvider
     private readonly AggregatingTelemetryLogManager _aggregatingTelemetryLogManager;
     private readonly VisualStudioTelemetryLogManager _visualStudioTelemetryLogManager;
 
-    private TelemetryLogProvider(TelemetrySession session, ILogger telemetryLogger, IAsynchronousOperationListener asyncListener)
+    private TelemetryLogProvider(TelemetrySession session, ILogger telemetryLogger)
     {
-        _aggregatingTelemetryLogManager = new AggregatingTelemetryLogManager(session, asyncListener);
+        _aggregatingTelemetryLogManager = new AggregatingTelemetryLogManager(session);
         _visualStudioTelemetryLogManager = new VisualStudioTelemetryLogManager(session, telemetryLogger);
     }
 
     public static TelemetryLogProvider Create(TelemetrySession session, ILogger telemetryLogger, IAsynchronousOperationListener asyncListener)
     {
-        var logProvider = new TelemetryLogProvider(session, telemetryLogger, asyncListener);
+        var logProvider = new TelemetryLogProvider(session, telemetryLogger);
 
-        TelemetryLogging.SetLogProvider(logProvider);
+        TelemetryLogging.SetLogProvider(logProvider, asyncListener);
 
         return logProvider;
     }

--- a/src/VisualStudio/Core/Def/Telemetry/Shared/TelemetryLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/Shared/TelemetryLogger.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
 using Roslyn.Utilities;
@@ -27,14 +26,13 @@ internal abstract class TelemetryLogger : ILogger
             LogDelta = logDelta;
         }
 
-        public static new Implementation Create(TelemetrySession session, bool logDelta, IAsynchronousOperationListenerProvider asyncListenerProvider)
+        public static new Implementation Create(TelemetrySession session, bool logDelta)
         {
             var logger = new Implementation(session, logDelta);
-            var asyncListener = asyncListenerProvider.GetListener(FeatureAttribute.Telemetry);
 
             // Two stage initialization as TelemetryLogProvider.Create needs access to
             //  the ILogger that this class implements.
-            TelemetryLogProvider.Create(session, logger, asyncListener);
+            TelemetryLogProvider.Create(session, logger);
 
             return logger;
         }
@@ -95,8 +93,8 @@ internal abstract class TelemetryLogger : ILogger
     private static string GetTelemetryName(FunctionId id, char separator)
         => Enum.GetName(typeof(FunctionId), id)!.Replace('_', separator).ToLowerInvariant();
 
-    public static TelemetryLogger Create(TelemetrySession session, bool logDelta, IAsynchronousOperationListenerProvider asyncListenerProvider)
-        => Implementation.Create(session, logDelta, asyncListenerProvider);
+    public static TelemetryLogger Create(TelemetrySession session, bool logDelta)
+        => Implementation.Create(session, logDelta);
 
     public abstract bool IsEnabled(FunctionId functionId);
     protected abstract void PostEvent(TelemetryEvent telemetryEvent);

--- a/src/VisualStudio/Core/Def/Telemetry/VisualStudioWorkspaceTelemetryService.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VisualStudioWorkspaceTelemetryService.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Remote;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
 using Roslyn.Utilities;
@@ -24,25 +23,22 @@ internal sealed class VisualStudioWorkspaceTelemetryService : AbstractWorkspaceT
 {
     private readonly VisualStudioWorkspace _workspace;
     private readonly IGlobalOptionService _globalOptions;
-    private readonly IAsynchronousOperationListenerProvider _asyncListenerProvider;
 
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public VisualStudioWorkspaceTelemetryService(
         VisualStudioWorkspace workspace,
-        IGlobalOptionService globalOptions,
-        IAsynchronousOperationListenerProvider asyncListenerProvider)
+        IGlobalOptionService globalOptions)
     {
         _workspace = workspace;
         _globalOptions = globalOptions;
-        _asyncListenerProvider = asyncListenerProvider;
     }
 
     protected override ILogger CreateLogger(TelemetrySession telemetrySession, bool logDelta)
         => AggregateLogger.Create(
             CodeMarkerLogger.Instance,
             new EtwLogger(FunctionIdOptions.CreateFunctionIsEnabledPredicate(_globalOptions)),
-            TelemetryLogger.Create(telemetrySession, logDelta, _asyncListenerProvider),
+            TelemetryLogger.Create(telemetrySession, logDelta),
             new FileLogger(_globalOptions),
             Logger.GetLogger());
 

--- a/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
+++ b/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Contracts.Telemetry;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Telemetry;
@@ -22,7 +21,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Logging;
 internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
 {
     private TelemetrySession? _telemetrySession;
-    private readonly IAsynchronousOperationListenerProvider _asyncListenerProvider;
 
     private const string CollectorApiKey = "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255";
     private static int _dumpsSubmitted = 0;
@@ -33,9 +31,8 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
 
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public VSCodeTelemetryLogger(IAsynchronousOperationListenerProvider asyncListenerProvider, ILoggerFactory loggerFactory)
+    public VSCodeTelemetryLogger(ILoggerFactory loggerFactory)
     {
-        _asyncListenerProvider = asyncListenerProvider;
         _logger = loggerFactory.CreateLogger<VSCodeTelemetryLogger>();
     }
 
@@ -58,7 +55,7 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
 
         _telemetrySession = session;
 
-        TelemetryLogger.Create(_telemetrySession, logDelta: false, _asyncListenerProvider);
+        TelemetryLogger.Create(_telemetrySession, logDelta: false);
     }
 
     public void Log(string name, List<KeyValuePair<string, object?>> properties)

--- a/src/Workspaces/Core/Portable/Telemetry/TelemetryLogging.cs
+++ b/src/Workspaces/Core/Portable/Telemetry/TelemetryLogging.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Telemetry;
 
@@ -132,6 +133,6 @@ internal static class TelemetryLogging
         // Create a fire and forget task to handle the next collection. This doesn't use IAsynchronousOperationListener
         // to track this work as no-one needs to ensure this is sent, and the create a new item of work
         // upon previous completion doesn't fit well in that model.
-        _ = PostCollectedTelemetryAsync(CancellationToken.None);
+        _ = PostCollectedTelemetryAsync(CancellationToken.None).ReportNonFatalErrorAsync();
     }
 }

--- a/src/Workspaces/Core/Portable/Telemetry/TelemetryLogging.cs
+++ b/src/Workspaces/Core/Portable/Telemetry/TelemetryLogging.cs
@@ -6,8 +6,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Telemetry;
 
@@ -19,7 +17,6 @@ namespace Microsoft.CodeAnalysis.Telemetry;
 internal static class TelemetryLogging
 {
     private static ITelemetryLogProvider? s_logProvider;
-    private static AsyncBatchingWorkQueue? s_postTelemetryQueue;
 
     public const string KeyName = "Name";
     public const string KeyValue = "Value";
@@ -28,19 +25,11 @@ internal static class TelemetryLogging
 
     public static event EventHandler<EventArgs>? Flushed;
 
-    public static void SetLogProvider(ITelemetryLogProvider logProvider, IAsynchronousOperationListener asyncListener)
+    public static void SetLogProvider(ITelemetryLogProvider logProvider)
     {
         s_logProvider = logProvider;
 
-        InterlockedOperations.Initialize(ref s_postTelemetryQueue, () =>
-            new AsyncBatchingWorkQueue(
-                TimeSpan.FromMinutes(30),
-                PostCollectedTelemetryAsync,
-                asyncListener,
-                CancellationToken.None));
-
-        // Add the initial item to the queue to ensure later processing.
-        s_postTelemetryQueue?.AddWork();
+        _ = PostCollectedTelemetryAsync(CancellationToken.None);
     }
 
     /// <summary>
@@ -134,13 +123,15 @@ internal static class TelemetryLogging
         Flushed?.Invoke(null, EventArgs.Empty);
     }
 
-    private static ValueTask PostCollectedTelemetryAsync(CancellationToken cancellationToken)
+    private static async Task PostCollectedTelemetryAsync(CancellationToken cancellationToken)
     {
+        await Task.Delay(TimeSpan.FromMinutes(30), cancellationToken).ConfigureAwait(false);
+
         Flush();
 
-        // Ensure PostCollectedTelemetryAsync will get fired again after the collection period.
-        s_postTelemetryQueue?.AddWork();
-
-        return ValueTaskFactory.CompletedTask;
+        // Create a fire and forget task to handle the next collection. This doesn't use IAsynchronousOperationListener
+        // to track this work as no-one needs to ensure this is sent, and the create a new item of work
+        // upon previous completion doesn't fit well in that model.
+        _ = PostCollectedTelemetryAsync(CancellationToken.None);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteWorkspaceTelemetryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteWorkspaceTelemetryService.cs
@@ -6,7 +6,6 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
 
@@ -15,18 +14,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
     [ExportWorkspaceService(typeof(IWorkspaceTelemetryService)), Shared]
     internal sealed class RemoteWorkspaceTelemetryService : AbstractWorkspaceTelemetryService
     {
-        private readonly IAsynchronousOperationListenerProvider _asyncListenerProvider;
-
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public RemoteWorkspaceTelemetryService(IAsynchronousOperationListenerProvider asyncListenerProvider)
+        public RemoteWorkspaceTelemetryService()
         {
-            _asyncListenerProvider = asyncListenerProvider;
         }
 
         protected override ILogger CreateLogger(TelemetrySession telemetrySession, bool logDelta)
             => AggregateLogger.Create(
-                TelemetryLogger.Create(telemetrySession, logDelta, _asyncListenerProvider),
+                TelemetryLogger.Create(telemetrySession, logDelta),
                 Logger.GetLogger());
     }
 }


### PR DESCRIPTION
Reapply "Move AsyncBatchingWorkQueue usage in telemetry to TelemetryLogging"

This reverts commit 4bbcd1d34db50d6f5fd778a03f72acc6689e2672 (which was a reversion of 21181a7a2c4af7b8784fc6963c892b2af8a2693e).
Original PR which introduced most of these changes: https://github.com/dotnet/roslyn/pull/73287

Additionally:
1) Switch from AsyncBatchingWorkQueue to just a simple task based fire and forget mechanism. The first PR changed introduced the problem that we added work to the ABWQ immediately when the prior work completed. Thus the IAsynchronousOperationListener system would never see the queue as empty. As adding the work immediately avoided other issues, I wanted to keep that concept in this fixup. So, I instead moved away from ABWQ and just do a simple fire and forget to queue up the next collection.
2) Cleanup _findDocumentResults and _usedForkedSolutionCounter after their data has been flushed.