### PR TITLE
Cache internal objects used by the formatting engine.

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
@@ -29,7 +29,7 @@ internal class CSharpFormatEngine : AbstractFormatEngine
     internal override IHeaderFacts HeaderFacts => CSharpHeaderFacts.Instance;
 
     protected override AbstractTriviaDataFactory CreateTriviaFactory()
-        => new TriviaDataFactory(this.TreeData, this.Options);
+        => new TriviaDataFactory(this.TreeData, this.Options.LineFormatting);
 
     protected override AbstractFormattingResult CreateFormattingResult(TokenStream tokenStream)
         => new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
@@ -43,7 +43,7 @@ internal class CSharpStructuredTriviaFormatEngine : AbstractFormatEngine
     internal override IHeaderFacts HeaderFacts => CSharpHeaderFacts.Instance;
 
     protected override AbstractTriviaDataFactory CreateTriviaFactory()
-        => new TriviaDataFactory(this.TreeData, this.Options);
+        => new TriviaDataFactory(this.TreeData, this.Options.LineFormatting);
 
     protected override FormattingContext CreateFormattingContext(TokenStream tokenStream, CancellationToken cancellationToken)
         => new(this, tokenStream);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -19,9 +19,9 @@ internal partial class TriviaDataFactory
     /// represents a general trivia between two tokens. slightly more expensive than others since it
     /// needs to calculate stuff unlike other cases
     /// </summary>
-    private class ComplexTrivia : AbstractComplexTrivia
+    private sealed class ComplexTrivia : AbstractComplexTrivia
     {
-        public ComplexTrivia(SyntaxFormattingOptions options, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2)
+        public ComplexTrivia(LineFormattingOptions options, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2)
             : base(options, treeInfo, token1, token2)
         {
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
@@ -27,7 +27,7 @@ internal partial class TriviaDataFactory
             int spaces,
             string originalString,
             CancellationToken cancellationToken)
-            : base(context.Options)
+            : base(context.Options.LineFormatting)
         {
             Contract.ThrowIfNull(context);
             Contract.ThrowIfNull(formattingRules);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 
 internal partial class TriviaDataFactory
 {
-    private class FormattedComplexTrivia : TriviaDataWithList
+    private sealed class FormattedComplexTrivia : TriviaDataWithList
     {
         private readonly CSharpTriviaFormatter _formatter;
         private readonly IList<TextChange> _textChanges;
@@ -27,7 +27,7 @@ internal partial class TriviaDataFactory
             int spaces,
             string originalString,
             CancellationToken cancellationToken)
-            : base(context.Options, LanguageNames.CSharp)
+            : base(context.Options)
         {
             Contract.ThrowIfNull(context);
             Contract.ThrowIfNull(formattingRules);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
@@ -14,12 +14,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 
 internal partial class TriviaDataFactory
 {
-    private class ModifiedComplexTrivia : TriviaDataWithList
+    private sealed class ModifiedComplexTrivia : TriviaDataWithList
     {
         private readonly ComplexTrivia _original;
 
         public ModifiedComplexTrivia(SyntaxFormattingOptions options, ComplexTrivia original, int lineBreaks, int space)
-            : base(options, original.Token1.Language)
+            : base(options)
         {
             Contract.ThrowIfNull(original);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
@@ -18,7 +18,7 @@ internal partial class TriviaDataFactory
     {
         private readonly ComplexTrivia _original;
 
-        public ModifiedComplexTrivia(SyntaxFormattingOptions options, ComplexTrivia original, int lineBreaks, int space)
+        public ModifiedComplexTrivia(LineFormattingOptions options, ComplexTrivia original, int lineBreaks, int space)
             : base(options)
         {
             Contract.ThrowIfNull(original);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.cs
@@ -118,7 +118,7 @@ internal partial class TriviaDataFactory : AbstractTriviaDataFactory
         {
             // calculate actual space size from tab
             var spaces = CalculateSpaces(token1, token2);
-            return new ModifiedWhitespace(this.Options, result.LineBreaks, indentation: spaces, elastic: result.TreatAsElastic, language: LanguageNames.CSharp);
+            return new ModifiedWhitespace(this.Options, result.LineBreaks, indentation: spaces, elastic: result.TreatAsElastic);
         }
 
         // check whether we can cache trivia info for current indentation

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaDataFactory.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 /// </summary>
 internal partial class TriviaDataFactory : AbstractTriviaDataFactory
 {
-    public TriviaDataFactory(TreeData treeInfo, SyntaxFormattingOptions options)
+    public TriviaDataFactory(TreeData treeInfo, LineFormattingOptions options)
         : base(treeInfo, options)
     {
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -22,7 +21,7 @@ internal abstract partial class AbstractTriviaDataFactory
         private readonly bool _treatAsElastic;
 
         public AbstractComplexTrivia(SyntaxFormattingOptions options, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2)
-            : base(options, token1.Language)
+            : base(options)
         {
             Contract.ThrowIfNull(treeInfo);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
@@ -20,7 +20,7 @@ internal abstract partial class AbstractTriviaDataFactory
 
         private readonly bool _treatAsElastic;
 
-        public AbstractComplexTrivia(SyntaxFormattingOptions options, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2)
+        public AbstractComplexTrivia(LineFormattingOptions options, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2)
             : base(options)
         {
             Contract.ThrowIfNull(treeInfo);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
@@ -13,12 +13,12 @@ namespace Microsoft.CodeAnalysis.Formatting;
 
 internal abstract partial class AbstractTriviaDataFactory
 {
-    protected class FormattedWhitespace : TriviaData
+    protected sealed class FormattedWhitespace : TriviaData
     {
         private readonly string _newString;
 
-        public FormattedWhitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation, string language)
-            : base(options, language)
+        public FormattedWhitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation)
+            : base(options)
         {
             this.LineBreaks = Math.Max(0, lineBreaks);
             this.Spaces = Math.Max(0, indentation);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
@@ -17,7 +17,7 @@ internal abstract partial class AbstractTriviaDataFactory
     {
         private readonly string _newString;
 
-        public FormattedWhitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation)
+        public FormattedWhitespace(LineFormattingOptions options, int lineBreaks, int indentation)
             : base(options)
         {
             this.LineBreaks = Math.Max(0, lineBreaks);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
@@ -11,18 +11,18 @@ namespace Microsoft.CodeAnalysis.Formatting;
 
 internal abstract partial class AbstractTriviaDataFactory
 {
-    protected class ModifiedWhitespace : Whitespace
+    protected sealed class ModifiedWhitespace : Whitespace
     {
         private readonly Whitespace? _original;
 
-        public ModifiedWhitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation, bool elastic, string language)
-            : base(options, lineBreaks, indentation, elastic, language)
+        public ModifiedWhitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation, bool elastic)
+            : base(options, lineBreaks, indentation, elastic)
         {
             _original = null;
         }
 
-        public ModifiedWhitespace(SyntaxFormattingOptions options, Whitespace original, int lineBreaks, int indentation, bool elastic, string language)
-            : base(options, lineBreaks, indentation, elastic, language)
+        public ModifiedWhitespace(SyntaxFormattingOptions options, Whitespace original, int lineBreaks, int indentation, bool elastic)
+            : base(options, lineBreaks, indentation, elastic)
         {
             Contract.ThrowIfNull(original);
             _original = original;
@@ -83,7 +83,7 @@ internal abstract partial class AbstractTriviaDataFactory
             CancellationToken cancellationToken,
             int tokenPairIndex = TokenPairIndexNotNeeded)
         {
-            formattingResultApplier(tokenPairIndex, context.TokenStream, new FormattedWhitespace(this.Options, this.LineBreaks, this.Spaces, this.Language));
+            formattingResultApplier(tokenPairIndex, context.TokenStream, new FormattedWhitespace(this.Options, this.LineBreaks, this.Spaces));
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
@@ -15,13 +15,13 @@ internal abstract partial class AbstractTriviaDataFactory
     {
         private readonly Whitespace? _original;
 
-        public ModifiedWhitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation, bool elastic)
+        public ModifiedWhitespace(LineFormattingOptions options, int lineBreaks, int indentation, bool elastic)
             : base(options, lineBreaks, indentation, elastic)
         {
             _original = null;
         }
 
-        public ModifiedWhitespace(SyntaxFormattingOptions options, Whitespace original, int lineBreaks, int indentation, bool elastic)
+        public ModifiedWhitespace(LineFormattingOptions options, Whitespace original, int lineBreaks, int indentation, bool elastic)
             : base(options, lineBreaks, indentation, elastic)
         {
             Contract.ThrowIfNull(original);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
@@ -21,13 +21,13 @@ internal abstract partial class AbstractTriviaDataFactory
     {
         private readonly bool _elastic;
 
-        public Whitespace(SyntaxFormattingOptions options, int space, bool elastic)
+        public Whitespace(LineFormattingOptions options, int space, bool elastic)
             : this(options, lineBreaks: 0, indentation: space, elastic: elastic)
         {
             Contract.ThrowIfFalse(space >= 0);
         }
 
-        public Whitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation, bool elastic)
+        public Whitespace(LineFormattingOptions options, int lineBreaks, int indentation, bool elastic)
             : base(options)
         {
             _elastic = elastic;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
@@ -21,14 +21,14 @@ internal abstract partial class AbstractTriviaDataFactory
     {
         private readonly bool _elastic;
 
-        public Whitespace(SyntaxFormattingOptions options, int space, bool elastic, string language)
-            : this(options, lineBreaks: 0, indentation: space, elastic: elastic, language: language)
+        public Whitespace(SyntaxFormattingOptions options, int space, bool elastic)
+            : this(options, lineBreaks: 0, indentation: space, elastic: elastic)
         {
             Contract.ThrowIfFalse(space >= 0);
         }
 
-        public Whitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation, bool elastic, string language)
-            : base(options, language)
+        public Whitespace(SyntaxFormattingOptions options, int lineBreaks, int indentation, bool elastic)
+            : base(options)
         {
             _elastic = elastic;
 
@@ -47,11 +47,9 @@ internal abstract partial class AbstractTriviaDataFactory
         public override TriviaData WithSpace(int space, FormattingContext context, ChainedFormattingRules formattingRules)
         {
             if (this.LineBreaks == 0 && this.Spaces == space)
-            {
                 return this;
-            }
 
-            return new ModifiedWhitespace(this.Options, this, /*lineBreak*/0, space, elastic: false, language: this.Language);
+            return new ModifiedWhitespace(this.Options, this, /*lineBreak*/0, space, elastic: false);
         }
 
         public override TriviaData WithLine(int line, int indentation, FormattingContext context, ChainedFormattingRules formattingRules, CancellationToken cancellationToken)
@@ -63,7 +61,7 @@ internal abstract partial class AbstractTriviaDataFactory
                 return this;
             }
 
-            return new ModifiedWhitespace(this.Options, this, line, indentation, elastic: false, language: this.Language);
+            return new ModifiedWhitespace(this.Options, this, line, indentation, elastic: false);
         }
 
         public override TriviaData WithIndentation(
@@ -74,7 +72,7 @@ internal abstract partial class AbstractTriviaDataFactory
                 return this;
             }
 
-            return new ModifiedWhitespace(this.Options, this, this.LineBreaks, indentation, elastic: false, language: this.Language);
+            return new ModifiedWhitespace(this.Options, this, this.LineBreaks, indentation, elastic: false);
         }
 
         public override void Format(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.cs
@@ -30,7 +30,7 @@ internal abstract partial class AbstractTriviaDataFactory
         _spaces = new Whitespace[SpaceCacheSize];
         for (var i = 0; i < SpaceCacheSize; i++)
         {
-            _spaces[i] = new Whitespace(Options, space: i, elastic: false, language: treeInfo.Root.Language);
+            _spaces[i] = new Whitespace(Options, space: i, elastic: false);
         }
     }
 
@@ -41,7 +41,7 @@ internal abstract partial class AbstractTriviaDataFactory
         // if result has elastic trivia in them, never use cache
         if (elastic)
         {
-            return new Whitespace(this.Options, space, elastic: true, language: this.TreeInfo.Root.Language);
+            return new Whitespace(this.Options, space, elastic: true);
         }
 
         if (space < SpaceCacheSize)
@@ -50,7 +50,7 @@ internal abstract partial class AbstractTriviaDataFactory
         }
 
         // create a new space
-        return new Whitespace(this.Options, space, elastic: false, language: this.TreeInfo.Root.Language);
+        return new Whitespace(this.Options, space, elastic: false);
     }
 
     protected TriviaData GetWhitespaceTriviaData(int lineBreaks, int indentation, bool useTriviaAsItIs, bool elastic)
@@ -80,10 +80,9 @@ internal abstract partial class AbstractTriviaDataFactory
             }
         }
 
-        return
-            useTriviaAsItIs
-                ? new Whitespace(this.Options, lineBreaks, indentation, elastic, language: this.TreeInfo.Root.Language)
-                : new ModifiedWhitespace(this.Options, lineBreaks, indentation, elastic, language: this.TreeInfo.Root.Language);
+        return useTriviaAsItIs
+            ? new Whitespace(this.Options, lineBreaks, indentation, elastic)
+            : new ModifiedWhitespace(this.Options, lineBreaks, indentation, elastic);
     }
 
     private void EnsureWhitespaceTriviaInfo(int lineIndex, int indentationLevel)
@@ -95,7 +94,7 @@ internal abstract partial class AbstractTriviaDataFactory
         if (_whitespaces[lineIndex, indentationLevel] == null)
         {
             var indentation = indentationLevel * Options.IndentationSize;
-            var triviaInfo = new Whitespace(Options, lineBreaks: lineIndex + 1, indentation: indentation, elastic: false, language: this.TreeInfo.Root.Language);
+            var triviaInfo = new Whitespace(Options, lineBreaks: lineIndex + 1, indentation: indentation, elastic: false);
             Interlocked.CompareExchange(ref _whitespaces[lineIndex, indentationLevel], triviaInfo, null);
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractTriviaDataFactory.cs
@@ -15,12 +15,12 @@ internal abstract partial class AbstractTriviaDataFactory
     private const int IndentationLevelCacheSize = 20;
 
     protected readonly TreeData TreeInfo;
-    protected readonly SyntaxFormattingOptions Options;
+    protected readonly LineFormattingOptions Options;
 
     private readonly Whitespace[] _spaces;
     private readonly Whitespace?[,] _whitespaces = new Whitespace[LineBreakCacheSize, IndentationLevelCacheSize];
 
-    protected AbstractTriviaDataFactory(TreeData treeInfo, SyntaxFormattingOptions options)
+    protected AbstractTriviaDataFactory(TreeData treeInfo, LineFormattingOptions options)
     {
         Contract.ThrowIfNull(treeInfo);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TriviaData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TriviaData.cs
@@ -18,12 +18,12 @@ internal abstract class TriviaData
 {
     protected const int TokenPairIndexNotNeeded = int.MinValue;
 
-    protected TriviaData(SyntaxFormattingOptions options)
+    protected TriviaData(LineFormattingOptions options)
     {
         Options = options;
     }
 
-    protected SyntaxFormattingOptions Options { get; }
+    protected LineFormattingOptions Options { get; }
 
     public int LineBreaks { get; protected set; }
     public int Spaces { get; protected set; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TriviaData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TriviaData.cs
@@ -18,16 +18,12 @@ internal abstract class TriviaData
 {
     protected const int TokenPairIndexNotNeeded = int.MinValue;
 
-    private readonly string _language;
-
-    protected TriviaData(SyntaxFormattingOptions options, string language)
+    protected TriviaData(SyntaxFormattingOptions options)
     {
         Options = options;
-        _language = language;
     }
 
     protected SyntaxFormattingOptions Options { get; }
-    protected string Language => _language;
 
     public int LineBreaks { get; protected set; }
     public int Spaces { get; protected set; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TriviaDataWithList.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TriviaDataWithList.cs
@@ -3,11 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Formatting;
 
-internal abstract class TriviaDataWithList(SyntaxFormattingOptions options, string language) : TriviaData(options, language)
+internal abstract class TriviaDataWithList(SyntaxFormattingOptions options) : TriviaData(options)
 {
     public abstract SyntaxTriviaList GetTriviaList(CancellationToken cancellationToken);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TriviaDataWithList.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TriviaDataWithList.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Formatting;
 
-internal abstract class TriviaDataWithList(SyntaxFormattingOptions options) : TriviaData(options)
+internal abstract class TriviaDataWithList(LineFormattingOptions options) : TriviaData(options)
 {
     public abstract SyntaxTriviaList GetTriviaList(CancellationToken cancellationToken);
 }

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                            lineBreaks As Integer,
                            indentation As Integer,
                            elastic As Boolean)
-                MyBase.New(options, lineBreaks, indentation, elastic, LanguageNames.VisualBasic)
+                MyBase.New(options, lineBreaks, indentation, elastic)
 
                 Me._original = original
                 Me._newString = CreateStringFromState()

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Protected ReadOnly _original As String
             Protected ReadOnly _newString As String
 
-            Public Sub New(options As SyntaxFormattingOptions,
+            Public Sub New(options As LineFormattingOptions,
                            original As String,
                            lineBreaks As Integer,
                            indentation As Integer,

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Private Class ComplexTrivia
             Inherits AbstractComplexTrivia
 
-            Public Sub New(options As SyntaxFormattingOptions, treeInfo As TreeData, token1 As SyntaxToken, token2 As SyntaxToken)
+            Public Sub New(options As LineFormattingOptions, treeInfo As TreeData, token1 As SyntaxToken, token2 As SyntaxToken)
                 MyBase.New(options, treeInfo, token1, token2)
                 Contract.ThrowIfNull(treeInfo)
             End Sub

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.Text
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
     Partial Friend Class TriviaDataFactory
-        Private Class FormattedComplexTrivia
+        Private NotInheritable Class FormattedComplexTrivia
             Inherits TriviaDataWithList
 
             Private ReadOnly _formatter As VisualBasicTriviaFormatter
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                            spaces As Integer,
                            originalString As String,
                            cancellationToken As CancellationToken)
-                MyBase.New(context.Options, LanguageNames.VisualBasic)
+                MyBase.New(context.Options)
 
                 Contract.ThrowIfNull(context)
                 Contract.ThrowIfNull(formattingRules)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                            spaces As Integer,
                            originalString As String,
                            cancellationToken As CancellationToken)
-                MyBase.New(context.Options)
+                MyBase.New(context.Options.LineFormatting)
 
                 Contract.ThrowIfNull(context)
                 Contract.ThrowIfNull(formattingRules)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.LineContinuationTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.LineContinuationTrivia.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Private Class LineContinuationTrivia
             Inherits AbstractLineBreakTrivia
 
-            Public Sub New(options As SyntaxFormattingOptions,
+            Public Sub New(options As LineFormattingOptions,
                            originalString As String,
                            indentation As Integer)
                 MyBase.New(options, originalString, 1, indentation, False)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
@@ -9,13 +9,13 @@ Imports Microsoft.CodeAnalysis.Text
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
     Partial Friend Class TriviaDataFactory
-        Private Class ModifiedComplexTrivia
+        Private NotInheritable Class ModifiedComplexTrivia
             Inherits TriviaDataWithList
 
             Private ReadOnly _original As ComplexTrivia
 
             Public Sub New(options As SyntaxFormattingOptions, original As ComplexTrivia, lineBreaks As Integer, space As Integer)
-                MyBase.New(options, LanguageNames.VisualBasic)
+                MyBase.New(options)
                 Contract.ThrowIfNull(original)
 
                 Me._original = original

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
@@ -3,7 +3,6 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Text
 
@@ -14,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             Private ReadOnly _original As ComplexTrivia
 
-            Public Sub New(options As SyntaxFormattingOptions, original As ComplexTrivia, lineBreaks As Integer, space As Integer)
+            Public Sub New(options As LineFormattingOptions, original As ComplexTrivia, lineBreaks As Integer, space As Integer)
                 MyBase.New(options)
                 Contract.ThrowIfNull(original)
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.vb
@@ -160,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             If result.LineBreaks = 0 AndAlso result.Tab > 0 Then
                 ' calculate actual space size from tab
                 Dim spaces = CalculateSpaces(token1, token2)
-                Return New ModifiedWhitespace(Me.Options, result.LineBreaks, indentation:=spaces, elastic:=result.TreatAsElastic, language:=LanguageNames.VisualBasic)
+                Return New ModifiedWhitespace(Me.Options, result.LineBreaks, indentation:=spaces, elastic:=result.TreatAsElastic)
             End If
 
             ' check whether we can cache trivia info for current indentation

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
         Private ReadOnly _lineContinuations(s_lineContinuationCacheSize) As LineContinuationTrivia
 
-        Public Sub New(treeInfo As TreeData, options As SyntaxFormattingOptions)
+        Public Sub New(treeInfo As TreeData, options As LineFormattingOptions)
             MyBase.New(treeInfo, options)
         End Sub
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/VisualBasicFormatEngine.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/VisualBasicFormatEngine.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Friend Overrides ReadOnly Property HeaderFacts As IHeaderFacts = VisualBasicHeaderFacts.Instance
 
         Protected Overrides Function CreateTriviaFactory() As AbstractTriviaDataFactory
-            Return New TriviaDataFactory(Me.TreeData, Me.Options)
+            Return New TriviaDataFactory(Me.TreeData, Me.Options.LineFormatting)
         End Function
 
         Protected Overrides Function CreateFormattingResult(tokenStream As TokenStream) As AbstractFormattingResult

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/VisualBasicStructuredTriviaFormatEngine.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/VisualBasicStructuredTriviaFormatEngine.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Friend Overrides ReadOnly Property HeaderFacts As IHeaderFacts = VisualBasicHeaderFacts.Instance
 
         Protected Overrides Function CreateTriviaFactory() As AbstractTriviaDataFactory
-            Return New TriviaDataFactory(Me.TreeData, Me.Options)
+            Return New TriviaDataFactory(Me.TreeData, Me.Options.LineFormatting)
         End Function
 
         Protected Overrides Function CreateFormattingContext(tokenStream As TokenStream, cancellationToken As CancellationToken) As FormattingContext


### PR DESCRIPTION
Drops allocations by 2.2%.  Review a commit at a time.

![image](https://github.com/dotnet/roslyn/assets/4564579/19847a52-2a6e-4e65-b16f-9385075076c6)
