### PR TITLE
Cache values in dependent project finder

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -375,6 +375,15 @@ internal static partial class DependentProjectsFinder
 
             using (await s_metadataIdToAssemblyNameGate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
+                // Overwrite an existing null name with a non-null one.
+                if (s_metadataIdToAssemblyName.TryGetValue(metadataId, out var existingName) &&
+                    existingName == null &&
+                    name != null)
+                {
+                    s_metadataIdToAssemblyName[metadataId] = name;
+                }
+
+                // Return whatever is in the map, adding ourselves if something is not already there.
                 name = s_metadataIdToAssemblyName.GetOrAdd(metadataId, name);
             }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -156,9 +156,6 @@ internal static partial class DependentProjectsFinder
         // Try to add to cache, returning existing value if another thread already added it.
         using (await s_solutionToDependentProjectMapGate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (dictionary.TryGetValue(key, out dependentProjects))
-                return dependentProjects;
-
             return dictionary.GetOrAdd(key, dependentProjects);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -354,15 +354,11 @@ internal static partial class DependentProjectsFinder
 
             using (await s_metadataIdToAssemblyNameGate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                if (!s_metadataIdToAssemblyName.TryGetValue(metadataId, out var name))
-                {
-                    uncomputedReferences.Add((peReference, metadataId));
-                    continue;
-                }
-
-                if (name == assemblyName)
+                if (s_metadataIdToAssemblyName.TryGetValue(metadataId, out var name) && name == assemblyName)
                     return true;
             }
+
+            uncomputedReferences.Add((peReference, metadataId));
         }
 
         if (uncomputedReferences.Count == 0)
@@ -390,7 +386,6 @@ internal static partial class DependentProjectsFinder
                     s_metadataIdToAssemblyName.TryAdd(metadataId, metadataAssemblyName);
                     if (metadataAssemblyName == assemblyName)
                         return true;
-
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -378,6 +378,8 @@ internal static partial class DependentProjectsFinder
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Attempt to get the assembly name for this pe-reference.  If we fail, we still want to add that info into
+            // the dictionary (by mapping us to 'null').  That way we don't keep trying to compute it over and over.
             var name = compilation.GetAssemblyOrModuleSymbol(peReference) is IAssemblySymbol { Name: string metadataAssemblyName }
                 ? metadataAssemblyName
                 : null;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -179,7 +179,10 @@ internal static partial class DependentProjectsFinder
 
             // If it's not private, then we need to find possible references.
             if (visibility != SymbolVisibility.Private)
-                AddNonSubmissionDependentProjects(solution, symbolOrigination, dependentProjects, cancellationToken);
+            {
+                await AddNonSubmissionDependentProjectsAsync(
+                    solution, symbolOrigination, dependentProjects, cancellationToken).ConfigureAwait(false);
+            }
 
             // submission projects are special here. The fields generated inside the Script object is private, but
             // further submissions can bind to them.
@@ -276,7 +279,7 @@ internal static partial class DependentProjectsFinder
         foreach (var project in solution.Projects)
         {
             if (!project.SupportsCompilation ||
-                !HasReferenceTo(symbolOrigination, project, cancellationToken))
+                !await HasReferenceToAsync(symbolOrigination, project, cancellationToken).ConfigureAwait(false))
             {
                 continue;
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -168,7 +168,7 @@ internal static partial class DependentProjectsFinder
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var dependentProjects = new HashSet<(Project, bool hasInternalsAccess)>();
+            using var _ = PooledHashSet<(Project, bool hasInternalsAccess)>.GetInstance(out var dependentProjects);
 
             // If a symbol was defined in source, then it is always visible to the project it
             // was defined in.


### PR DESCRIPTION
Removes like 60% of a lightbulb scenario:

![image](https://github.com/dotnet/roslyn/assets/4564579/327e332f-953b-43bc-8324-202cb0d940be)

![image](https://github.com/dotnet/roslyn/assets/4564579/702d228d-d990-4881-8e19-90d6943f5700)


Discovered when trying to figure out why a lightbulb was taking several seconds to load.