### PR TITLE
Make the impl of SyntaxNode.GetText more efficient

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -325,9 +325,10 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException"><paramref name="checksumAlgorithm"/> is not supported.</exception>
         public SourceText GetText(Encoding? encoding = null, SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1)
         {
-            var builder = new StringBuilder(this.Green.FullWidth);
-            this.WriteTo(new StringWriter(builder));
-            return new StringBuilderText(builder, encoding, checksumAlgorithm);
+            var fullWidth = this.Green.FullWidth;
+            var writer = SourceTextWriter.Create(encoding, checksumAlgorithm, fullWidth);
+            this.WriteTo(writer);
+            return writer.ToSourceText();
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -325,8 +325,7 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException"><paramref name="checksumAlgorithm"/> is not supported.</exception>
         public SourceText GetText(Encoding? encoding = null, SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1)
         {
-            var fullWidth = this.Green.FullWidth;
-            var writer = SourceTextWriter.Create(encoding, checksumAlgorithm, fullWidth);
+            var writer = SourceTextWriter.Create(encoding, checksumAlgorithm, this.Green.FullWidth);
             this.WriteTo(writer);
             return writer.ToSourceText();
         }

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.ParsedSyntaxTree.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.ParsedSyntaxTree.cs
@@ -48,8 +48,7 @@ internal partial class CSharpSyntaxTreeFactoryService
         {
             if (_lazyText == null)
             {
-                var sourceText = SourceTextExtensions.CreateSourceText(GetRoot(cancellationToken), Encoding, _checksumAlgorithm, cancellationToken);
-                Interlocked.CompareExchange(ref _lazyText, sourceText, null);
+                Interlocked.CompareExchange(ref _lazyText, GetRoot(cancellationToken).GetText(Encoding, _checksumAlgorithm), null);
             }
 
             return _lazyText;

--- a/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicSyntaxTreeFactoryService.ParsedSyntaxTree.vb
+++ b/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicSyntaxTreeFactoryService.ParsedSyntaxTree.vb
@@ -41,8 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Public Overrides Function GetText(Optional cancellationToken As CancellationToken = Nothing) As SourceText
                 If _lazyText Is Nothing Then
-                    Dim text = SourceTextExtensions.CreateSourceText(GetRoot(cancellationToken), Encoding, _checksumAlgorithm, cancellationToken)
-                    Interlocked.CompareExchange(_lazyText, text, Nothing)
+                    Interlocked.CompareExchange(_lazyText, GetRoot(cancellationToken).GetText(Encoding, _checksumAlgorithm), Nothing)
                 End If
 
                 Return _lazyText


### PR DESCRIPTION
The existing impl woudl always allocation into the LOH for large trees.  This manifested as huge growth in the LOH for normal IDE scenarios (like 'fix all'):

![image](https://github.com/dotnet/roslyn/assets/4564579/0f08cc0c-64a4-4b8c-bb6e-30b26f7b978e)

With this change, we drop to:

![image](https://github.com/dotnet/roslyn/assets/4564579/c744a2f1-ca91-4519-8915-e968dfb3445e)

--

Total char[] allocs also drops from:

![image](https://github.com/dotnet/roslyn/assets/4564579/c044f609-2392-42f9-9b89-a87519de2f8d)

To:

![image](https://github.com/dotnet/roslyn/assets/4564579/80593853-f3a5-43d8-8b8e-80e59975e959)

