### PR TITLE
Improve intense CPU hotspot in FAR

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -603,18 +603,15 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
         var semanticFacts = state.SemanticFacts;
         var semanticModel = state.SemanticModel;
 
-        return IsInNamespaceOrTypeContext()
+        var topNameNode = node;
+        while (syntaxFacts.IsQualifiedName(topNameNode.Parent))
+            topNameNode = topNameNode.Parent;
+
+        var isInNamespaceNameContext = syntaxFacts.IsBaseNamespaceDeclaration(topNameNode.Parent);
+
+        return syntaxFacts.IsInNamespaceOrTypeContext(topNameNode)
             ? SymbolUsageInfo.Create(GetTypeOrNamespaceUsageInfo())
             : GetSymbolUsageInfoCommon();
-
-        bool IsInNamespaceOrTypeContext()
-        {
-            var current = node;
-            while (syntaxFacts.IsQualifiedName(current.Parent))
-                current = current.Parent;
-
-            return syntaxFacts.IsInNamespaceOrTypeContext(current);
-        }
 
         // Local functions.
         TypeOrNamespaceUsageInfo GetTypeOrNamespaceUsageInfo()
@@ -623,7 +620,7 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
                 ? TypeOrNamespaceUsageInfo.Qualified
                 : TypeOrNamespaceUsageInfo.None;
 
-            if (semanticFacts.IsNamespaceDeclarationNameContext(semanticModel, node.SpanStart, cancellationToken))
+            if (isInNamespaceNameContext)
             {
                 usageInfo |= TypeOrNamespaceUsageInfo.NamespaceDeclaration;
             }
@@ -697,24 +694,18 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
                     {
                         case SymbolKind.Namespace:
                             var namespaceUsageInfo = TypeOrNamespaceUsageInfo.None;
-                            if (semanticFacts.IsNamespaceDeclarationNameContext(semanticModel, node.SpanStart, cancellationToken))
-                            {
+                            if (isInNamespaceNameContext)
                                 namespaceUsageInfo |= TypeOrNamespaceUsageInfo.NamespaceDeclaration;
-                            }
 
                             if (IsNodeOrAnyAncestorLeftSideOfDot(node, syntaxFacts))
-                            {
                                 namespaceUsageInfo |= TypeOrNamespaceUsageInfo.Qualified;
-                            }
 
                             return SymbolUsageInfo.Create(namespaceUsageInfo);
 
                         case SymbolKind.NamedType:
                             var typeUsageInfo = TypeOrNamespaceUsageInfo.None;
                             if (IsNodeOrAnyAncestorLeftSideOfDot(node, syntaxFacts))
-                            {
                                 typeUsageInfo |= TypeOrNamespaceUsageInfo.Qualified;
-                            }
 
                             return SymbolUsageInfo.Create(typeUsageInfo);
 
@@ -726,9 +717,7 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
                         case SymbolKind.Local:
                             var valueUsageInfo = ValueUsageInfo.Read;
                             if (semanticFacts.IsWrittenTo(semanticModel, node, cancellationToken))
-                            {
                                 valueUsageInfo |= ValueUsageInfo.Write;
-                            }
 
                             return SymbolUsageInfo.Create(valueUsageInfo);
                     }


### PR DESCRIPTION
Takes the inclusive CPU time in FindRefsInDocument from 15%:

![image](https://github.com/dotnet/roslyn/assets/4564579/d2c92ae3-042c-417f-8acb-d4975a628f29)

to 3.5%

![image](https://github.com/dotnet/roslyn/assets/4564579/a02078e9-d6fa-4cc4-8a61-07d52c5adffe)
