### PR TITLE
Allow razor to override RazorDesignTimeTargets to ones shipped with tooling instead of the sdk

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -33,6 +33,7 @@ internal sealed class LanguageServerTestComposition
             ExtensionAssemblyPaths: [],
             DevKitDependencyPath: devKitDependencyPath,
             RazorSourceGenerator: null,
+            RazorDesignTimePath: null,
             ExtensionLogDirectory: string.Empty);
         var extensionAssemblyManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
         return ExportProviderBuilder.CreateExportProviderAsync(extensionAssemblyManager, devKitDependencyPath, loggerFactory: loggerFactory);

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -52,6 +52,7 @@ internal sealed class LanguageServerProjectSystem
     private readonly ILogger _logger;
     private readonly ProjectLoadTelemetryReporter _projectLoadTelemetryReporter;
     private readonly ProjectFileExtensionRegistry _projectFileExtensionRegistry;
+    private readonly ImmutableDictionary<string, string> AdditionalProperties;
 
     /// <summary>
     /// The list of loaded projects in the workspace, keyed by project file path. The outer dictionary is a concurrent dictionary since we may be loading
@@ -69,7 +70,8 @@ internal sealed class LanguageServerProjectSystem
         IGlobalOptionService globalOptionService,
         ILoggerFactory loggerFactory,
         IAsynchronousOperationListenerProvider listenerProvider,
-        ProjectLoadTelemetryReporter projectLoadTelemetry)
+        ProjectLoadTelemetryReporter projectLoadTelemetry,
+        ServerConfigurationFactory serverConfigurationFactory)
     {
         _workspaceFactory = workspaceFactory;
         _fileChangeWatcher = fileChangeWatcher;
@@ -78,6 +80,11 @@ internal sealed class LanguageServerProjectSystem
         _logger = loggerFactory.CreateLogger(nameof(LanguageServerProjectSystem));
         _projectLoadTelemetryReporter = projectLoadTelemetry;
         _projectFileExtensionRegistry = new ProjectFileExtensionRegistry(workspaceFactory.Workspace.CurrentSolution.Services, new DiagnosticReporter(workspaceFactory.Workspace));
+        var razorDesignTimePath = serverConfigurationFactory.ServerConfiguration?.RazorDesignTimePath;
+
+        AdditionalProperties = razorDesignTimePath is null
+            ? ImmutableDictionary<string, string>.Empty
+            : ImmutableDictionary<string, string>.Empty.Add("RazorDesignTimeTargets", razorDesignTimePath);
 
         _projectsToLoadAndReload = new AsyncBatchingWorkQueue<ProjectToLoad>(
             TimeSpan.FromMilliseconds(100),
@@ -96,7 +103,7 @@ internal sealed class LanguageServerProjectSystem
 
             // We'll load solutions out-of-proc, since it's possible we might be running on a runtime that doesn't have a matching SDK installed,
             // and we don't want any MSBuild registration to set environment variables in our process that might impact child processes.
-            await using var buildHostProcessManager = new BuildHostProcessManager(loggerFactory: _loggerFactory);
+            await using var buildHostProcessManager = new BuildHostProcessManager(globalMSBuildProperties: AdditionalProperties, loggerFactory: _loggerFactory);
             var buildHost = await buildHostProcessManager.GetBuildHostAsync(BuildHostProcessKind.NetCore, CancellationToken.None);
 
             // If we don't have a .NET Core SDK on this machine at all, try .NET Framework
@@ -155,7 +162,7 @@ internal sealed class LanguageServerProjectSystem
 
         var binaryLogPath = GetMSBuildBinaryLogPath();
 
-        await using var buildHostProcessManager = new BuildHostProcessManager(binaryLogPath: binaryLogPath, loggerFactory: _loggerFactory);
+        await using var buildHostProcessManager = new BuildHostProcessManager(globalMSBuildProperties: AdditionalProperties, binaryLogPath: binaryLogPath, loggerFactory: _loggerFactory);
         var toastErrorReporter = new ToastErrorReporter();
 
         try

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -204,6 +204,12 @@ static CliRootCommand CreateCommandLineParser()
         Required = false
     };
 
+    var razorDesignTimePathOption = new CliOption<string?>("--razorDesignTimePath")
+    {
+        Description = "Full path to the Razor design time target path (optional).",
+        Required = false
+    };
+
     var rootCommand = new CliRootCommand()
     {
         debugOption,
@@ -215,6 +221,7 @@ static CliRootCommand CreateCommandLineParser()
         extensionAssemblyPathsOption,
         devKitDependencyPathOption,
         razorSourceGeneratorOption,
+        razorDesignTimePathOption,
         extensionLogDirectoryOption
     };
     rootCommand.SetAction((parseResult, cancellationToken) =>
@@ -227,6 +234,7 @@ static CliRootCommand CreateCommandLineParser()
         var extensionAssemblyPaths = parseResult.GetValue(extensionAssemblyPathsOption) ?? [];
         var devKitDependencyPath = parseResult.GetValue(devKitDependencyPathOption);
         var razorSourceGenerator = parseResult.GetValue(razorSourceGeneratorOption);
+        var razorDesignTimePath = parseResult.GetValue(razorDesignTimePathOption);
         var extensionLogDirectory = parseResult.GetValue(extensionLogDirectoryOption)!;
 
         var serverConfiguration = new ServerConfiguration(
@@ -238,6 +246,7 @@ static CliRootCommand CreateCommandLineParser()
             ExtensionAssemblyPaths: extensionAssemblyPaths,
             DevKitDependencyPath: devKitDependencyPath,
             RazorSourceGenerator: razorSourceGenerator,
+            RazorDesignTimePath: razorDesignTimePath,
             ExtensionLogDirectory: extensionLogDirectory);
 
         return RunAsync(serverConfiguration, cancellationToken);

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
@@ -50,4 +50,5 @@ internal record class ServerConfiguration(
     IEnumerable<string> ExtensionAssemblyPaths,
     string? DevKitDependencyPath,
     string? RazorSourceGenerator,
+    string? RazorDesignTimePath,
     string ExtensionLogDirectory);


### PR DESCRIPTION
Roslyn side of https://github.com/dotnet/razor/issues/10351 

See https://github.com/dotnet/razor/pull/10377 

Will also require a dual insertion and vs code updates