### PR TITLE
Install SDK in devcontainer based on global.json

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,20 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:8.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
+
+ARG DOTNET_SDK_INSTALL_URL=https://dot.net/v1/dotnet-install.sh
+# Install the correct Roslyn SDK into the same directory that the base image installs the SDK in.
+ENV DOTNET_INSTALL_DIR=/usr/share/dotnet
+
+# Copy the global.json file so its available in the image before the repo is cloned
+COPY global.json /tmp/
+
+RUN cd /tmp \
+  && curl --location --output dotnet-install.sh "${DOTNET_SDK_INSTALL_URL}" \
+  && chmod +x dotnet-install.sh \
+  && mkdir -p "${DOTNET_INSTALL_DIR}" \
+  && ./dotnet-install.sh --jsonfile "./global.json" --install-dir "${DOTNET_INSTALL_DIR}" \
+  && rm dotnet-install.sh
 
 # Set up machine requirements to build the repo
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,11 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/dotnetcore
 {
-  "name": "C# (.NET 8)",
+  "name": "C# (.NET 9)",
   "build": {
     "dockerfile": "Dockerfile",
+    // Set the context to the workspace folder to allow us to copy files from it.
+    "context": ".."
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Rather than having to continually update the devcontainer base image we're using whenever our global.json updates (or doesn't update), we just use a base image and additionally install the SDK from our global.json into that same install location.