### PR TITLE
Lower the amount of time FAR spends in classification by 4%

### DIFF
--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -35,7 +35,14 @@ internal sealed class NameSyntaxClassifier : AbstractNameSyntaxClassifier
         }
     }
 
-    public override ImmutableArray<Type> SyntaxNodeTypes { get; } = [typeof(NameSyntax)];
+    public override ImmutableArray<Type> SyntaxNodeTypes { get; } =
+    [
+        typeof(AliasQualifiedNameSyntax),
+        typeof(GenericNameSyntax),
+        typeof(IdentifierNameSyntax),
+        typeof(QualifiedNameSyntax),
+        typeof(SimpleNameSyntax),
+    ];
 
     protected override int? GetRightmostNameArity(SyntaxNode node)
     {

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassifier.cs
@@ -13,7 +13,8 @@ namespace Microsoft.CodeAnalysis.Classification.Classifiers;
 internal interface ISyntaxClassifier
 {
     /// <summary>
-    /// The syntax node types this classifier is able to classify
+    /// The syntax node types this classifier is able to classify. This list must be the precise node types matches
+    /// (using <code>n.GetType().Equals(t)</code>).  Subtyping type checks are not supported here.
     /// </summary>
     ImmutableArray<Type> SyntaxNodeTypes { get; }
 

--- a/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs
@@ -94,36 +94,47 @@ internal static class IExtensionManagerExtensions
     public static Func<SyntaxNode, ImmutableArray<TExtension>> CreateNodeExtensionGetter<TExtension>(
         this IExtensionManager extensionManager, IEnumerable<TExtension> extensions, Func<TExtension, ImmutableArray<Type>> nodeTypeGetter)
     {
-        var map = new ConcurrentDictionary<Type, ImmutableArray<TExtension>>();
+        var map = new Dictionary<Type, ImmutableArray<TExtension>>();
 
-        Func<Type, ImmutableArray<TExtension>> getExtensions = (Type t1) =>
+        foreach (var extension in extensions)
         {
-            var query = from e in extensions
-                        let types = extensionManager.PerformFunction(e, () => nodeTypeGetter(e), [])
-                        where !types.Any() || types.Any(static (t2, t1) => t1 == t2 || t1.GetTypeInfo().IsSubclassOf(t2), t1)
-                        select e;
+            if (extension is null)
+                continue;
 
-            return query.ToImmutableArray();
-        };
+            var types = extensionManager.PerformFunction(
+                extension, () => nodeTypeGetter(extension), []);
+            foreach (var type in types)
+            {
+                map[type] = map.TryGetValue(type, out var existing)
+                    ? existing.Add(extension)
+                    : [extension];
+            }
+        }
 
-        return n => map.GetOrAdd(n.GetType(), getExtensions);
+        return n => map.TryGetValue(n.GetType(), out var extensions) ? extensions : [];
     }
 
     [SuppressMessage("Style", "IDE0039:Use local function", Justification = "Avoid per-call delegate allocation")]
     public static Func<SyntaxToken, ImmutableArray<TExtension>> CreateTokenExtensionGetter<TExtension>(
         this IExtensionManager extensionManager, IEnumerable<TExtension> extensions, Func<TExtension, ImmutableArray<int>> tokenKindGetter)
     {
-        var map = new ConcurrentDictionary<int, ImmutableArray<TExtension>>();
-        Func<int, ImmutableArray<TExtension>> getExtensions = (int k) =>
+        var map = new Dictionary<int, ImmutableArray<TExtension>>();
+
+        foreach (var extension in extensions)
         {
-            var query = from e in extensions
-                        let kinds = extensionManager.PerformFunction(e, () => tokenKindGetter(e), [])
-                        where !kinds.Any() || kinds.Contains(k)
-                        select e;
+            if (extension is null)
+                continue;
 
-            return query.ToImmutableArray();
-        };
+            var kinds = extensionManager.PerformFunction(
+                extension, () => tokenKindGetter(extension), []);
+            foreach (var kind in kinds)
+            {
+                map[kind] = map.TryGetValue(kind, out var existing)
+                    ? existing.Add(extension)
+                    : [extension];
+            }
+        }
 
-        return t => map.GetOrAdd(t.RawKind, getExtensions);
+        return t => map.TryGetValue(t.RawKind, out var extensions) ? extensions : [];
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.vb
@@ -7,7 +7,6 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
 Imports Microsoft.CodeAnalysis.Collections
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -17,10 +16,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
         Inherits AbstractNameSyntaxClassifier
 
         Public Overrides ReadOnly Property SyntaxNodeTypes As ImmutableArray(Of Type) = ImmutableArray.Create(
-            GetType(NameSyntax),
-            GetType(ModifiedIdentifierSyntax),
+            GetType(CrefOperatorReferenceSyntax),
+            GetType(GenericNameSyntax),
+            GetType(GlobalNameSyntax),
+            GetType(IdentifierNameSyntax),
+            GetType(LabelSyntax),
             GetType(MethodStatementSyntax),
-            GetType(LabelSyntax))
+            GetType(ModifiedIdentifierSyntax),
+            GetType(QualifiedCrefOperatorReferenceSyntax),
+            GetType(QualifiedNameSyntax),
+            GetType(SimpleNameSyntax))
 
         Public Overrides Sub AddClassifications(
                 syntax As SyntaxNode,


### PR DESCRIPTION
Removes the cost of concurrent dictionaries here:

![image](https://github.com/dotnet/roslyn/assets/4564579/23684692-1bf8-41ce-bbeb-6dbdab9ca0cf)

And lowers total cost from: 

![image](https://github.com/dotnet/roslyn/assets/4564579/30acf548-92ee-4cf4-96cd-6962e6c2c125)

to:

![image](https://github.com/dotnet/roslyn/assets/4564579/adceb998-61d2-4230-a9e2-b304719b1435)


