### PR TITLE
Report EnC warning when entry point is changed

### DIFF
--- a/src/Compilers/Test/Core/Assert/AssertEx.cs
+++ b/src/Compilers/Test/Core/Assert/AssertEx.cs
@@ -674,6 +674,14 @@ namespace Roslyn.Test.Utilities
 
             var expectedString = string.Join(itemSeparator, expected.Take(10).Select(itemInspector));
             var actualString = string.Join(itemSeparator, actual.Select(itemInspector));
+            var diffString = DiffUtil.DiffReport(expected, actual, itemSeparator, comparer, itemInspector);
+
+            if (DifferOnlyInWhitespace(expectedString, actualString))
+            {
+                expectedString = VisualizeWhitespace(expectedString);
+                actualString = VisualizeWhitespace(actualString);
+                diffString = VisualizeWhitespace(diffString);
+            }
 
             var message = new StringBuilder();
 
@@ -693,7 +701,7 @@ namespace Roslyn.Test.Utilities
             message.AppendLine("Actual:");
             message.AppendLine(actualString);
             message.AppendLine("Differences:");
-            message.AppendLine(DiffUtil.DiffReport(expected, actual, itemSeparator, comparer, itemInspector));
+            message.AppendLine(diffString);
 
             if (TryGenerateExpectedSourceFileAndGetDiffLink(actualString, expected.Count(), expectedValueSourcePath, expectedValueSourceLine, out var link))
             {
@@ -701,6 +709,38 @@ namespace Roslyn.Test.Utilities
             }
 
             return message.ToString();
+        }
+
+        private static bool DifferOnlyInWhitespace(IEnumerable<char> expected, IEnumerable<char> actual)
+            => expected.Where(c => !char.IsWhiteSpace(c)).SequenceEqual(actual.Where(c => !char.IsWhiteSpace(c)));
+
+        private static string VisualizeWhitespace(string str)
+        {
+            var result = new StringBuilder(str.Length);
+
+            var i = 0;
+            while (i < str.Length)
+            {
+                var c = str[i++];
+                if (c == '\r' && i < str.Length && str[i] == '\n')
+                {
+                    result.Append("␍␊\r\n");
+                    i++;
+                }
+                else
+                {
+                    result.Append(c switch
+                    {
+                        ' ' => "·",
+                        '\t' => "→",
+                        '\r' => "␍\r",
+                        '\n' => "␊\n",
+                        _ => c,
+                    });
+                }
+            }
+
+            return result.ToString();
         }
 
         public static string GetAssertMessage<T>(

--- a/src/Features/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -109,7 +109,7 @@ class C
 [CreateNewOnMetadataUpdate]
 class C
 {
-    static void Main()
+    static void F()
     {
         <AS:1>Goo(1);</AS:1>
     }
@@ -123,7 +123,7 @@ class C
 [CreateNewOnMetadataUpdate]
 class C
 {
-    static void Main()
+    static void F()
     {
         while (true)
         {
@@ -733,7 +733,7 @@ namespace N
 {
     class C
     {
-        static void Main()
+        static void F()
         {
             <AS:0>Console.WriteLine(1);</AS:0>
         }
@@ -746,7 +746,7 @@ namespace N
 
             edits.VerifySemanticDiagnostics(active,
                 Diagnostic(RudeEditKind.Delete, "", GetResource("class", "N.C")),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "", GetResource("method", "N.C.Main()")));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "", GetResource("method", "N.C.F()")));
         }
 
         [Fact]
@@ -757,7 +757,7 @@ namespace N
 {
     class C
     {
-        static void Main()
+        static void F()
         {
             <AS:0>Console.WriteLine(1);</AS:0>
         }
@@ -770,7 +770,7 @@ namespace N
 
             edits.VerifySemanticDiagnostics(active,
                 Diagnostic(RudeEditKind.Delete, "namespace N", GetResource("class", "C")),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "namespace N", GetResource("method", "N.C.Main()")));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "namespace N", GetResource("method", "N.C.F()")));
         }
 
         [Fact]
@@ -781,7 +781,7 @@ namespace N
 {
     class C
     {
-        static void Main()
+        static void F()
         {
             <AS:0>Console.WriteLine(1);</AS:0>
         }
@@ -800,7 +800,7 @@ namespace N
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "class C", GetResource("method", "N.C.Main()")));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "class C", GetResource("method", "N.C.F()")));
         }
 
         #endregion
@@ -4999,7 +4999,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var aa = new int[4];
         var bb = new int[4];
@@ -5014,7 +5014,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var aa = new int[4];
         var bb = new int[4];
@@ -5039,7 +5039,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         Buffer4 aa = default;
         Buffer4 bb = default;
@@ -5060,7 +5060,7 @@ struct Buffer4
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         Buffer4 aa = default;
         Buffer4 bb = default;
@@ -6236,7 +6236,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>if (B())</AS:1>
         {
@@ -6249,7 +6249,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>if (B())</AS:1>
         {
@@ -6271,7 +6271,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>if (B())</AS:1>
         {
@@ -6284,7 +6284,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>if (!B())</AS:1>
         {
@@ -6307,7 +6307,7 @@ class C
 {
     public static bool B(Func<int> a) => <AS:0>false</AS:0>;
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>if (B(() => 1))</AS:1>
         {
@@ -6320,7 +6320,7 @@ class C
 {
     public static bool B(Func<int> a) => <AS:0>false</AS:0>;
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>if (B(() => 2))</AS:1>
         {
@@ -6342,7 +6342,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>while (B())</AS:1>
         {
@@ -6355,7 +6355,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>while (B())</AS:1>
         {
@@ -6377,7 +6377,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>while (B())</AS:1>
         {
@@ -6390,7 +6390,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>while (!B())</AS:1>
         {
@@ -6413,7 +6413,7 @@ class C
 {
     public static bool B(Func<int> a) => <AS:0>false</AS:0>;
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>while (B(() => 1))</AS:1>
         {
@@ -6426,7 +6426,7 @@ class C
 {
     public static bool B(Func<int> a) => <AS:0>false</AS:0>;
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>while (B(() => 2))</AS:1>
         {
@@ -6448,7 +6448,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         do
         {
@@ -6462,7 +6462,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         do
         {
@@ -6485,7 +6485,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         do
         {
@@ -6499,7 +6499,7 @@ class C
 {
     public static bool B() <AS:0>{</AS:0> return false; }
     
-    public static void Main()
+    public static void F()
     {
         do
         {
@@ -6523,7 +6523,7 @@ class C
 {
     public static bool B(Func<int> a) => <AS:0>false</AS:0>;
     
-    public static void Main()
+    public static void F()
     {
         do
         {
@@ -6537,7 +6537,7 @@ class C
 {
     public static bool B(Func<int> a) => <AS:0>false</AS:0>;
     
-    public static void Main()
+    public static void F()
     {
         do
         {
@@ -6587,7 +6587,7 @@ class C
 {
     public static string F() <AS:0>{</AS:0> return null; }
     
-    public static void Main()
+    public static void G()
     {
         <AS:1>switch (F())</AS:1>
         {
@@ -6601,7 +6601,7 @@ class C
 {
     public static string F() <AS:0>{</AS:0> return null; }
     
-    public static void Main()
+    public static void G()
     {
         <AS:1>switch (F())</AS:1>
         {
@@ -6624,7 +6624,7 @@ class C
 {
     public static bool B(Func<int> a) => <AS:0>false</AS:0>;
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>switch (B(() => 1))</AS:1>
         {
@@ -6638,7 +6638,7 @@ class C
 {
     public static bool B(Func<int> a) => <AS:0>false</AS:0>;
     
-    public static void Main()
+    public static void F()
     {
         <AS:1>switch (B(() => 2))</AS:1>
         {
@@ -7821,7 +7821,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         <AS:0>Console.WriteLine(0);</AS:0>
 
@@ -7838,7 +7838,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         <AS:0>Console.WriteLine(0);</AS:0>
      
@@ -7903,7 +7903,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         <AS:0>Console.WriteLine(0);</AS:0>
         
@@ -7920,7 +7920,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         <AS:0>Console.WriteLine(0);</AS:0>
         
@@ -7946,7 +7946,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         try
         {
@@ -7961,7 +7961,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         try
         {
@@ -8951,7 +8951,7 @@ class C
         <AS:0>return 1;</AS:0>
     }
 
-    static void Main()
+    static void F()
     {
         Func<int, int> f = null;
         try
@@ -8975,7 +8975,7 @@ class C
         <AS:0>return 1;</AS:0>
     }
 
-    static void Main()
+    static void F()
     {
         Func<int, int> f = null;
 
@@ -9004,7 +9004,7 @@ class C
         <AS:0>return 1;</AS:0>
     }
 
-    static void Main()
+    static void F()
     {
         Func<int, int> f = x => 
         {
@@ -9030,7 +9030,7 @@ class C
         <AS:0>return 1;</AS:0>
     }
 
-    static void Main()
+    static void F()
     {
         Func<int, int> f = x => 
         {
@@ -9059,7 +9059,7 @@ class C
         <AS:0>return 1;</AS:0>
     }
 
-    static void Main()
+    static void F()
     {
         try
         {
@@ -9082,7 +9082,7 @@ class C
         <AS:0>return 1;</AS:0>
     }
 
-    static void Main()
+    static void F()
     {
         q = from x in xs
             join y in ys on <AS:1>F()</AS:1> equals G()
@@ -9307,7 +9307,7 @@ using System.Linq;
 
 class Test
 {
-    static void Main()
+    static void F()
     {
         IEnumerable<int> f;
         unchecked
@@ -9329,7 +9329,7 @@ using System.Linq;
 
 class Test
 {
-    static void Main()
+    static void F()
     {
         IEnumerable<int> f;
         checked
@@ -9609,14 +9609,47 @@ class C
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/22696")]
         public void Lambdas_ExpressionToStatements()
         {
+            // TODO: The active statement should be mapped to the return statement.
+
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void Main()
     {
-        Func<int, int> f = a => <AS:0>1</AS:0>;
+              Func<int, int> f = a => <AS:0>1</AS:0>;
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    static void Main()
+    {
+        <AS:0>Func<int, int> f = a => { return 1; };</AS:0>
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(active);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/22696")]
+        public void Lambdas_ExpressionToStatements_WithSignatureChange()
+        {
+            // TODO: The active statement should be mapped to the return statement.
+
+            var src1 = @"
+class C
+{
+    static void Main()
+    {
+              Func<int, int> f = a => <AS:0>1</AS:0>;
     }
 }
 ";
@@ -9632,7 +9665,9 @@ class C
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
-            edits.VerifySemanticDiagnostics(active);
+            edits.VerifySemanticDiagnostics(
+                active,
+                capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
         }
 
         [Fact]
@@ -9642,7 +9677,7 @@ class C
 using System;
 class C
 {
-    static void Main()
+    static void F()
     {
         Func<int, int> f = a => <AS:0>1</AS:0>;
     }
@@ -9652,7 +9687,7 @@ class C
 using System;
 class C
 {
-    static void Main()
+    static void F()
     {
         <AS:0>Func<int, int> f = delegate(int a) { return 1; };</AS:0>
     }
@@ -9747,7 +9782,7 @@ class C
 using System;
 class C
 {
-    static void Main()
+    static void F()
     {
         Func<int, int> f = delegate(int a) { <AS:0>return 1;</AS:0> };
     }
@@ -9757,7 +9792,7 @@ class C
 using System;
 class C
 {
-    static void Main()
+    static void F()
     {
         <AS:0>Func<int, int> f = a => 1;</AS:0>
     }
@@ -9776,7 +9811,7 @@ class C
 using System;
 class C
 {
-    static void Main()
+    static void F()
     {
         Func<int, int> f = a => { <AS:0>return 1;</AS:0> };
     }
@@ -9786,7 +9821,7 @@ class C
 using System;
 class C
 {
-    static void Main()
+    static void F()
     {
         Func<int, int> f = delegate(int a) { <AS:0>return 2;</AS:0> };
     }
@@ -9958,7 +9993,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void Main()
     {
         Func<int, Func<int, int>> f = a =>
         {
@@ -9974,7 +10009,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void Main()
     <AS:0,1>{</AS:0,1>
     
     }
@@ -9984,6 +10019,8 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
+                // reported because the old main body does not have active statement (only the lambda does):
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "static void Main()", GetResource("method")),
                 Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "{", CSharpFeaturesResources.lambda),
                 Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "{", CSharpFeaturesResources.lambda));
         }
@@ -10180,7 +10217,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from x in xs
                 join y in ys on F() equals G() into g
@@ -10190,7 +10227,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from x in xs
                 join y in ys on F() equals G()
@@ -10210,7 +10247,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from x in xs
                 group x by x.F() into g
@@ -10221,7 +10258,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from x in xs
                 group x by x.F() <AS:0>into</AS:0> g
@@ -10242,7 +10279,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from x in xs
                 group x by x.F() into g
@@ -10252,7 +10289,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from x in xs
                 <AS:0>join</AS:0> y in ys on F() equals G() into g
@@ -10273,7 +10310,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from a in array
                 where a > 0
@@ -10283,7 +10320,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from a in array
                 where a > 0
@@ -10306,7 +10343,7 @@ class C
 {
     static int F(IEnumerable<int> e) => <AS:0>1</AS:0>;
 
-    static void Main()
+    static void F()
     {
         <AS:1>F(from a in array where a > 0 select a + 1);</AS:1>
     }
@@ -10316,7 +10353,7 @@ class C
 {
     static int F(IEnumerable<int> e) => <AS:0>1</AS:0>;
    
-    static void Main()
+    static void F()
     {
         <AS:1>F(from a in array where a > 0 select a);</AS:1>
     }
@@ -10335,7 +10372,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from a in array
                 group <AS:0>a + 1</AS:0> by a;
@@ -10344,7 +10381,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         var q = from a in array
                 <AS:0>group</AS:0> a by a;
@@ -10366,7 +10403,7 @@ class C
 {
     static int F(IEnumerable<IGrouping<int, int>> e) => <AS:0>1</AS:0>;
 
-    static void Main()
+    static void F()
     {
         <AS:1>F(from a in array group a by a);</AS:1>
     }
@@ -10376,7 +10413,7 @@ class C
 {
     static int F(IEnumerable<IGrouping<int, int>> e) => <AS:0>1</AS:0>;
    
-    static void Main()
+    static void F()
     {
         <AS:1>F(from a in array group a + 1 by a);</AS:1>
     }
@@ -11961,7 +11998,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     <AS:0>{</AS:0>
         try
         {
@@ -11981,7 +12018,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     <AS:0>{</AS:0>
         try
         {
@@ -12010,7 +12047,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     <AS:0>{</AS:0>
         try
         {
@@ -12030,7 +12067,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     <AS:0>{</AS:0>
         try
         {
@@ -12060,7 +12097,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     <AS:0>{</AS:0>
         try
         {
@@ -12076,7 +12113,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     <AS:0>{</AS:0>
         try
         {

--- a/src/Features/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -472,7 +472,7 @@ class C
             Assert.False(result.HasChanges);
             Assert.False(result.HasChangesAndErrors);
             Assert.False(result.HasChangesAndSyntaxErrors);
-            Assert.True(result.RudeEditErrors.IsEmpty);
+            Assert.True(result.RudeEdits.IsEmpty);
         }
 
         [Fact]
@@ -520,7 +520,7 @@ class C
                 Assert.True(result.HasChanges);
                 Assert.True(result.HasChangesAndErrors);
                 Assert.False(result.HasChangesAndSyntaxErrors);
-                Assert.Equal(RudeEditKind.ExperimentalFeaturesEnabled, result.RudeEditErrors.Single().Kind);
+                Assert.Equal(RudeEditKind.ExperimentalFeaturesEnabled, result.RudeEdits.Single().Kind);
             }
         }
 
@@ -680,7 +680,7 @@ namespace N
             }
 
             Assert.True(result.IsSingle());
-            Assert.Empty(result.Single().RudeEditErrors);
+            Assert.Empty(result.Single().RudeEdits);
         }
 
         [Fact]
@@ -726,7 +726,7 @@ class D
             }
 
             Assert.True(result.IsSingle());
-            Assert.Empty(result.Single().RudeEditErrors);
+            Assert.Empty(result.Single().RudeEdits);
         }
 
         [Theory, CombinatorialData]
@@ -765,7 +765,7 @@ class D
                 // here so that any trailing punctuation is removed from the translated template string.
                 : $"ENC0080: {string.Format(FeaturesResources.Modifying_source_file_0_requires_restarting_the_application_due_to_internal_error_1, filePath, "System.NullReferenceException: NullRef!\n")}".Split('\n').First();
 
-            AssertEx.Equal(new[] { expectedDiagnostic }, result.RudeEditErrors.Select(d => d.ToDiagnostic(newSyntaxTree))
+            AssertEx.Equal(new[] { expectedDiagnostic }, result.RudeEdits.Select(d => d.ToDiagnostic(newSyntaxTree))
                 .Select(d => $"{d.Id}: {d.GetMessage().Split(new[] { Environment.NewLine }, StringSplitOptions.None).First()}"));
         }
 
@@ -801,7 +801,7 @@ class C
 
             var result = await AnalyzeDocumentAsync(oldProject, newDocument, capabilities: EditAndContinueCapabilities.None);
 
-            Assert.Equal(RudeEditKind.NotSupportedByRuntime, result.RudeEditErrors.Single().Kind);
+            Assert.Equal(RudeEditKind.NotSupportedByRuntime, result.RudeEdits.Single().Kind);
         }
     }
 }

--- a/src/Features/CSharpTest/EditAndContinue/Helpers/EditAndContinueValidation.cs
+++ b/src/Features/CSharpTest/EditAndContinue/Helpers/EditAndContinueValidation.cs
@@ -113,6 +113,18 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         }
 
         internal static void VerifySemantics(
+            this EditScript<SyntaxNode> editScript,
+            SemanticEditDescription[] semanticEdits,
+            RudeEditDiagnosticDescription[] warnings,
+            EditAndContinueCapabilities? capabilities = null)
+        {
+            VerifySemantics(
+                [editScript],
+                [new DocumentAnalysisResultsDescription(ActiveStatementsDescription.Empty, semanticEdits: semanticEdits, diagnostics: warnings)],
+                capabilities: capabilities);
+        }
+
+        internal static void VerifySemantics(
             EditScript<SyntaxNode>[] editScripts,
             DocumentAnalysisResultsDescription[] results,
             TargetFramework[]? targetFrameworks = null,

--- a/src/Features/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -4,16 +4,13 @@
 
 #nullable disable
 
-using System;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
-using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditAndContinue;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -9654,7 +9651,9 @@ class Test
             var src2 = "Console.WriteLine(2); int C(int X);";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.WriteLine(2);", GetResource("top-level code"))]);
         }
 
         #endregion
@@ -13137,6 +13136,45 @@ int G1(int[] p) { return p[2]; }
         #region Top Level Statements
 
         [Fact]
+        public void TopLevelStatement_Lambda_Update()
+        {
+            var src1 = @"
+using System;
+
+var x = new Func<int>(() => 1);
+";
+            var src2 = @"
+using System;
+
+var x = new Func<int>(() => 2);
+";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true)]);
+        }
+
+        [Fact]
+        public void TopLevelStatement_Lambda_Insert()
+        {
+            var src1 = @"
+using System;
+
+Console.WriteLine(1);
+";
+            var src2 = @"
+using System;
+
+Console.WriteLine(1);
+var x = new Func<int>(() => 2);
+";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true)],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.WriteLine(1);", GetResource("top-level code"))],
+                capabilities: EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.AddStaticFieldToExistingType | EditAndContinueCapabilities.NewTypeDefinition);
+        }
+
+        [Fact]
         public void TopLevelStatement_Capture_Args()
         {
             var src1 = @"
@@ -13151,7 +13189,7 @@ var x = new Func<string[]>(() => args);
 ";
             var edits = GetTopEdits(src1, src2);
             edits.VerifySemantics(
-                SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true));
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true)]);
         }
 
         [Fact]
@@ -13203,34 +13241,46 @@ var f1 = new Func<int, int>(a1 =>
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21499")]
         public void TopLevelStatement_InsertMultiScopeCapture()
         {
-            var src1 = @"
-using System;
+            var src1 = """
+            using System;
 
-foreach (int x0 in new[] { 1 })  // Group #0
-{                                // Group #1
-    int x1 = 0;
+            foreach (int x0 in new[] { 1 })  // Group #0
+            {                                // Group #1
+                int x1 = 0;
 
-    int f0(int a) => x0;
-    int f1(int a) => x1;
-}
-";
-            var src2 = @"
-using System;
+                int f0(int a) => x0;
+                int f1(int a) => x1;
+            }
+            """;
 
-foreach (int x0 in new[] { 1 })  // Group #0
-{                                // Group #1
-    int x1 = 0;                  
+            var src2 = """
+            using System;
 
-    int f0(int a) => x0;
-    int f1(int a) => x1;
+            foreach (int x0 in new[] { 1 })  // Group #0
+            {                                // Group #1
+                int x1 = 0;
 
-    int f2(int a) => x0 + x1;   // runtime rude edit: connecting previously disconnected closures
-}
-";
+                int f0(int a) => x0;
+                int f1(int a) => x1;
+
+                int f2(int a) => x0 + x1;   // runtime rude edit: connecting previously disconnected closures
+            }
+            """;
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemantics(
                 [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true)],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, """
+                    foreach (int x0 in new[] { 1 })  // Group #0
+                    {                                // Group #1
+                        int x1 = 0;
+
+                        int f0(int a) => x0;
+                        int f1(int a) => x1;
+
+                        int f2(int a) => x0 + x1;   // runtime rude edit: connecting previously disconnected closures
+                    }
+                    """, GetResource("top-level code"))],
                 capabilities: EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.NewTypeDefinition | EditAndContinueCapabilities.UpdateParameters);
         }
 

--- a/src/Features/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -405,7 +405,7 @@ namespace N
 {
     class Program
     {
-        static void Main(string[] args)
+        static void F()
         {
         }
     }
@@ -417,7 +417,7 @@ namespace N
 {
     class Program
     {
-        static void Main(string[] args)
+        static void F()
         {
             Console.WriteLine(""Hello World!"");
         }
@@ -426,7 +426,7 @@ namespace N
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("N.Program.Main")));
+            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("N.Program.F")));
         }
 
         [Fact]
@@ -439,7 +439,7 @@ namespace N
 {
     class Program
     {
-        static void Main(string[] args)
+        static void F()
         {
             Console.WriteLine(""Hello World!"");
         }
@@ -450,7 +450,7 @@ namespace N
 {
     class Program
     {
-        static void Main(string[] args)
+        static void F()
         {
         }
     }
@@ -458,7 +458,7 @@ namespace N
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("N.Program.Main")));
+            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("N.Program.F")));
         }
 
         [Fact]
@@ -7777,7 +7777,7 @@ class Test
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         int a = 1;
         int b = 2;
@@ -7788,7 +7788,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         int b = 2;
         int a = 1;
@@ -7798,12 +7798,12 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                @"Update [static void Main(string[] args)
+                @"Update [static void F()
     {
         int a = 1;
         int b = 2;
         System.Console.WriteLine(a + b);
-    }]@18 -> [static void Main(string[] args)
+    }]@18 -> [static void F()
     {
         int b = 2;
         int a = 1;
@@ -7814,7 +7814,7 @@ class C
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Main"), preserveLocalVariables: false)]);
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"), preserveLocalVariables: false)]);
         }
 
         [Fact]
@@ -7823,26 +7823,26 @@ class C
             var src1 = @"
 class C
 {
-    static int Main(string[] args) => F(1);
+    static int M() => F(1);
     static int F(int a) => 1;
 }
 ";
             var src2 = @"
 class C
 {
-    static int Main(string[] args) => F(2);
+    static int M() => F(2);
     static int F(int a) => 1;
 }";
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                @"Update [static int Main(string[] args) => F(1);]@18 -> [static int Main(string[] args) => F(2);]@18");
+                @"Update [static int M() => F(1);]@18 -> [static int M() => F(2);]@18");
 
             edits.VerifySemanticDiagnostics();
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Main"), preserveLocalVariables: false)]);
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.M"), preserveLocalVariables: false)]);
         }
 
         [Fact]
@@ -7919,7 +7919,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         int x = 1;
         Console.WriteLine(x);
@@ -7929,7 +7929,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         int x = 2;
         Console.WriteLine(x);
@@ -7938,11 +7938,11 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-@"Update [static void Main(string[] args)
+@"Update [static void F()
     {
         int x = 1;
         Console.WriteLine(x);
-    }]@18 -> [static void Main(string[] args)
+    }]@18 -> [static void F()
     {
         int x = 2;
         Console.WriteLine(x);
@@ -8114,7 +8114,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         Console.ReadLine();
     }
@@ -8124,7 +8124,7 @@ class C
 {
     void goo() { }
 
-    static void Main(string[] args)
+    static void F()
     {
         Console.ReadLine();
     }
@@ -8148,7 +8148,7 @@ using System;
 
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         Console.ReadLine();
     }
@@ -8160,7 +8160,7 @@ class C
 {
     void goo(int a) { }
 
-    static void Main(string[] args)
+    static void F()
     {
         Console.ReadLine();
     }
@@ -8184,7 +8184,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         Console.ReadLine();
     }
@@ -8195,7 +8195,7 @@ class C
     [System.Obsolete]
     void goo(int a) { }
 
-    static void Main(string[] args)
+    static void F()
     {
         Console.ReadLine();
     }
@@ -8424,7 +8424,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         
     }
@@ -8432,7 +8432,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F(int a)
     {
         
     }
@@ -8440,17 +8440,17 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Insert [string[] args]@35");
+                "Insert [int a]@32");
 
             edits.VerifySemantics(
                 [
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMember("C.Main"), deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.Main"))
+                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMember("C.F"), deletedSymbolContainerProvider: c => c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.F"))
                 ],
                 capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingSignatureNotSupportedByRuntime, "string[] args", GetResource("method"))],
+                [Diagnostic(RudeEditKind.ChangingSignatureNotSupportedByRuntime, "int a", GetResource("method"))],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -8597,7 +8597,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F(int a)
     {
         
     }
@@ -8605,7 +8605,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main()
+    static void F()
     {
         
     }
@@ -8613,17 +8613,17 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Delete [string[] args]@35");
+                "Delete [int a]@32");
 
             edits.VerifySemantics(
                 [
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMember("C.Main"), deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.Main"))
+                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMember("C.F"), deletedSymbolContainerProvider: c => c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.F"))
                 ],
                 capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingSignatureNotSupportedByRuntime, "static void Main()", GetResource("method"))],
+                [Diagnostic(RudeEditKind.ChangingSignatureNotSupportedByRuntime, "static void F()", GetResource("method"))],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -8666,7 +8666,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F(int a)
     {
         
     }
@@ -8674,7 +8674,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] b)
+    static void F(int b)
     {
         
     }
@@ -8682,15 +8682,15 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Update [string[] args]@35 -> [string[] b]@35");
+                "Update [int a]@32 -> [int b]@32");
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "string[] b", FeaturesResources.parameter)],
+                [Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "int b", FeaturesResources.parameter)],
                 capabilities: EditAndContinueCapabilities.Baseline);
 
             edits.VerifySemantics(
                 [
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Main"))
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"))
                 ],
                 capabilities: EditAndContinueCapabilities.UpdateParameters);
         }
@@ -8701,7 +8701,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F(int a)
     {
         
     }
@@ -8709,7 +8709,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] b)
+    static void F(int b)
     {
         System.Console.Write(1);
     }
@@ -8717,12 +8717,12 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "string[] b", FeaturesResources.parameter)],
+                [Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "int b", FeaturesResources.parameter)],
                 capabilities: EditAndContinueCapabilities.Baseline);
 
             edits.VerifySemantics(
                 [
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Main"))
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"))
                 ],
                 capabilities: EditAndContinueCapabilities.UpdateParameters);
         }
@@ -8733,7 +8733,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F(int a)
     {
         
     }
@@ -8741,17 +8741,17 @@ class C
             var src2 = @"
 class C
 {
-    static void EntryPoint(string[] args)
+    static void G(int a)
     {
         
     }
 }";
             var edits = GetTopEdits(src1, src2);
 
-            var expectedEdit = @"Update [static void Main(string[] args)
+            var expectedEdit = @"Update [static void F(int a)
     {
         
-    }]@18 -> [static void EntryPoint(string[] args)
+    }]@18 -> [static void G(int a)
     {
         
     }]@18";
@@ -8760,13 +8760,13 @@ class C
 
             edits.VerifySemantics(
                 [
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMember("C.Main"), deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.EntryPoint"))
+                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMember("C.F"), deletedSymbolContainerProvider: c => c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.G"))
                 ],
                 capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "static void EntryPoint(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "static void G(int a)", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -8933,46 +8933,52 @@ class C
         [Fact]
         public void MethodUpdate_AsyncMethod1()
         {
-            var src1 = @"
-class Test
-{
-    static void Main(string[] args)
-    {
-        Test f = new Test();
-        string result = f.WaitAsync().Result;
-    }
+            var src1 = """
+            class Test
+            {
+                static void F()
+                {
+                    Test f = new Test();
+                    string result = f.WaitAsync().Result;
+                }
 
-    public async Task<string> WaitAsync()
-    {
-        await Task.Delay(1000);
-        return ""Done"";
-    }
-}";
-            var src2 = @"
-class Test
-{
-    static void Main(string[] args)
-    {
-        Test f = new Test();
-        string result = f.WaitAsync().Result;
-    }
+                public async Task<string> WaitAsync()
+                {
+                    await Task.Delay(1000);
+                    return "Done";
+                }
+            }
+            """;
 
-    public async Task<string> WaitAsync()
-    {
-        await Task.Delay(1000);
-        return ""Not Done"";
-    }
-}";
+            var src2 = """
+            class Test
+            {
+                static void F()
+                {
+                    Test f = new Test();
+                    string result = f.WaitAsync().Result;
+                }
+
+                public async Task<string> WaitAsync()
+                {
+                    await Task.Delay(1000);
+                    return "Not Done";
+                }
+            }
+            """;
+
             var edits = GetTopEdits(src1, src2);
-            var expectedEdit = @"Update [public async Task<string> WaitAsync()
-    {
-        await Task.Delay(1000);
-        return ""Done"";
-    }]@151 -> [public async Task<string> WaitAsync()
-    {
-        await Task.Delay(1000);
-        return ""Not Done"";
-    }]@151";
+            var expectedEdit = """
+            Update [public async Task<string> WaitAsync()
+                {
+                    await Task.Delay(1000);
+                    return "Done";
+                }]@133 -> [public async Task<string> WaitAsync()
+                {
+                    await Task.Delay(1000);
+                    return "Not Done";
+                }]@133
+            """;
 
             edits.VerifyEdits(expectedEdit);
 
@@ -9024,7 +9030,7 @@ using System;
 
 class Test
 {
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9035,24 +9041,24 @@ using System;
 class Test
 {
     [return: Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
 }";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits(@"Update [static void Main(string[] args)
+            edits.VerifyEdits(@"Update [static void F()
     {
         System.Console.Write(5);
     }]@38 -> [[return: Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }]@38");
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9064,7 +9070,7 @@ using System;
 
 class Test
 {
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9075,24 +9081,24 @@ using System;
 class Test
 {
     [Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
 }";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits(@"Update [static void Main(string[] args)
+            edits.VerifyEdits(@"Update [static void F()
     {
         System.Console.Write(5);
     }]@38 -> [[Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }]@38");
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9125,41 +9131,46 @@ class Test
         [Fact]
         public void MethodUpdate_AddAttribute_SupportedByRuntime()
         {
-            var src1 = @"
-using System;
+            var src1 = """
+            using System;
 
-class Test
-{
-    static void Main(string[] args)
-    {
-        System.Console.Write(5);
-    }
-}";
-            var src2 = @"
-using System;
+            class Test
+            {
+                static void F()
+                {
+                    System.Console.Write(5);
+                }
+            }
+            """;
 
-class Test
-{
-    [Obsolete]
-    static void Main(string[] args)
-    {
-        System.Console.Write(5);
-    }
-}";
+            var src2 = """
+            using System;
+
+            class Test
+            {
+                [Obsolete]
+                static void F()
+                {
+                    System.Console.Write(5);
+                }
+            }
+            """;
+
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits(@"Update [static void Main(string[] args)
-    {
-        System.Console.Write(5);
-    }]@38 -> [[Obsolete]
-    static void Main(string[] args)
-    {
-        System.Console.Write(5);
-    }]@38");
+            edits.VerifyEdits("""
+            Update [static void F()
+                {
+                    System.Console.Write(5);
+                }]@36 -> [[Obsolete]
+                static void F()
+                {
+                    System.Console.Write(5);
+                }]@36
+            """);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Test.Main"))],
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Test.F"))],
                 capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
         }
 
@@ -9249,7 +9260,7 @@ using System;
 class Test
 {
     [Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9260,7 +9271,7 @@ using System;
 class Test
 {
     [Obsolete, STAThread]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9268,7 +9279,7 @@ class Test
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9281,7 +9292,7 @@ using System;
 class Test
 {
     [Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9293,7 +9304,7 @@ class Test
 {
     [Obsolete]
     [STAThread]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9301,7 +9312,7 @@ class Test
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9313,7 +9324,7 @@ using System;
 
 class Test
 {
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9324,7 +9335,7 @@ using System;
 class Test
 {
     [Obsolete, STAThread]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9332,7 +9343,7 @@ class Test
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9345,7 +9356,7 @@ using System;
 class Test
 {
     [Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9356,7 +9367,7 @@ using System;
 class Test
 {
     [Obsolete("""")]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9364,7 +9375,7 @@ class Test
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9377,7 +9388,7 @@ using System;
 class Test
 {
     [Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9387,7 +9398,7 @@ using System;
 
 class Test
 {
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9395,7 +9406,7 @@ class Test
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9408,7 +9419,7 @@ using System;
 class Test
 {
     [Obsolete, STAThread]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9419,7 +9430,7 @@ using System;
 class Test
 {
     [Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9427,7 +9438,7 @@ class Test
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9441,7 +9452,7 @@ class Test
 {
     [Obsolete]
     [STAThread]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9452,7 +9463,7 @@ using System;
 class Test
 {
     [Obsolete]
-    static void Main(string[] args)
+    static void F()
     {
         System.Console.Write(5);
     }
@@ -9460,7 +9471,7 @@ class Test
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void Main(string[] args)", FeaturesResources.method)],
+                [Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "static void F()", FeaturesResources.method)],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -9553,7 +9564,10 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc char[16]", FeaturesResources.method));
+            [
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc char[16]", FeaturesResources.method),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "static void Main()", GetResource("method"))
+            ]);
         }
 
         [Fact]
@@ -9562,7 +9576,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main() 
+    static void F() 
     { 
         int i = 10;
         unsafe
@@ -9574,7 +9588,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main() 
+    static void F() 
     { 
         int i = 10;
         unsafe
@@ -9596,7 +9610,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main() 
+    static void F() 
     { 
         int i = 10;
         unsafe
@@ -9609,7 +9623,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main() 
+    static void F() 
     { 
         int i = 10;
         unsafe
@@ -9621,7 +9635,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "static void Main()", FeaturesResources.method));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "static void F()", FeaturesResources.method));
         }
 
         [Fact]
@@ -9784,7 +9798,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         goto Label1;
  
@@ -9797,7 +9811,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         goto Label1;
  
@@ -21822,7 +21836,9 @@ Console.WriteLine(""Hello World"");
 
             edits.VerifyEdits("Update [Console.WriteLine(\"Hello\");]@19 -> [Console.WriteLine(\"Hello World\");]@19");
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, @"Console.WriteLine(""Hello World"");", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -21847,7 +21863,9 @@ var name = Console.ReadLine();
                 "Insert [Console.WriteLine(\"What is your name?\");]@54",
                 "Insert [var name = Console.ReadLine();]@96");
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, @"Console.WriteLine(""Hello World"");", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -21888,7 +21906,9 @@ Console.WriteLine(""World"");
 
             edits.VerifyEdits("Insert [Console.WriteLine(\"World\");]@48");
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, @"Console.WriteLine(""Hello"");", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -21929,7 +21949,9 @@ Console.WriteLine(""Hello"");
 
             edits.VerifyEdits("Delete [Console.WriteLine(\"World\");]@48");
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, @"Console.WriteLine(""Hello"");", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -21941,7 +21963,10 @@ Console.WriteLine(""Hello"");
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[2]", GetResource("top-level code")));
+            [
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[2]", GetResource("top-level code")),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Span<int> = stackalloc int[2];", GetResource("top-level code"))
+            ]);
         }
 
         [Fact]
@@ -21953,7 +21978,10 @@ Console.WriteLine(""Hello"");
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[3]", GetResource("top-level code")));
+            [
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[3]", GetResource("top-level code")),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "unsafe { var x = stackalloc int[3]; System.Console.Write(2); }", GetResource("top-level code"))
+            ]);
         }
 
         [Fact]
@@ -21965,7 +21993,10 @@ Console.WriteLine(""Hello"");
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[3]", GetResource("top-level code")));
+            [
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[3]", GetResource("top-level code")),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "{ var x = stackalloc int[3]; System.Console.Write(2); }", GetResource("top-level code"))
+            ]);
         }
 
         [Fact]
@@ -21986,7 +22017,8 @@ return 1;
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22009,7 +22041,8 @@ return 1;
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22040,7 +22073,8 @@ int Goo()
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22061,7 +22095,10 @@ return 1;
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "await Task.Delay(200);")]);
+            [
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "await Task.Delay(200);"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "await Task.Delay(200);", GetResource("top-level code"))
+            ]);
         }
 
         [Fact]
@@ -22083,10 +22120,14 @@ await Task.Delay(200);
 
             edits.VerifySemantics(
                 [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true)],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "await Task.Delay(100);", GetResource("top-level code"))],
                 capabilities: EditAndContinueCapabilities.AddInstanceFieldToExistingType);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, "await Task.Delay(100);")],
+                [
+                    Diagnostic(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, "await Task.Delay(100);"),
+                    Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "await Task.Delay(100);", GetResource("top-level code"))
+                ],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -22109,7 +22150,9 @@ return 1;
 
             edits.VerifySemanticDiagnostics(
                 [
-                    Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;")
+                    Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"),
+                    Diagnostic(RudeEditKind.ChangingFromAsynchronousToSynchronous, "return 1;", GetResource("top-level code")),
+                    Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "return 1;", GetResource("top-level code"))
                 ],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
@@ -22133,10 +22176,14 @@ await Task.Delay(100);
 
             edits.VerifySemantics(
                 [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true)],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "await Task.Delay(100);", GetResource("top-level code"))],
                 capabilities: EditAndContinueCapabilities.AddInstanceFieldToExistingType);
 
             edits.VerifySemanticDiagnostics(
-                [Diagnostic(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, "await Task.Delay(100);")],
+                [
+                    Diagnostic(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, "await Task.Delay(100);"),
+                    Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "await Task.Delay(100);", GetResource("top-level code"))
+                ],
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -22160,7 +22207,8 @@ Console.Write(1);
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "await Task.Delay(100);"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "await Task.Delay(100);"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "await Task.Delay(100);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22185,7 +22233,8 @@ return 1;
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return 1;"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "await Task.Delay(100);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22213,7 +22262,8 @@ Task<int> GetInt()
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return await GetInt();"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return await GetInt();"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22235,7 +22285,8 @@ Console.Write(1);
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-               Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"));
+               Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"),
+               Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22258,7 +22309,8 @@ return;
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return;"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "return;"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22289,7 +22341,13 @@ int Goo()
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "int Goo()\r\n{\r\n    return 1;\r\n}"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, """
+                    int Goo()
+                    {
+                        return 1;
+                    }
+                    """),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22326,7 +22384,8 @@ public class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22349,7 +22408,9 @@ Console.Write(1);
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"),
+                Diagnostic(RudeEditKind.ChangingFromAsynchronousToSynchronous, "Console.Write(1);", GetResource("top-level code")),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22374,7 +22435,8 @@ Console.Write(1);
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "await Task.Delay(100);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22402,7 +22464,9 @@ Console.Write(1);
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"),
+                Diagnostic(RudeEditKind.ChangingFromAsynchronousToSynchronous, "Console.Write(1);", GetResource("top-level code")),
+                Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.Write(1);", GetResource("top-level code")));
         }
 
         [Fact]
@@ -22426,8 +22490,8 @@ Console.WriteLine(1);
             var syntaxMap = GetSyntaxMap(src1, src2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), syntaxMap[0])]);
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), syntaxMap[0])],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Func<int> a = () => {        return 1;         };", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -22457,8 +22521,8 @@ public class C { }
             var syntaxMap = GetSyntaxMap(src1, src2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), syntaxMap[0])]);
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), syntaxMap[0])],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Func<int> a = () => {        return 1;         };", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -22486,8 +22550,8 @@ public class C { }
             var syntaxMap = GetSyntaxMap(src1, src2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), syntaxMap[0])]);
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), syntaxMap[0])],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Func<int> a = () => {        return 1;         };", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -22513,7 +22577,9 @@ public class C { }
 
             // Since each individual statement is a separate update to a separate node, this just validates we correctly
             // only analyze the things once
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.WriteLine(3);", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -22553,7 +22619,9 @@ public class B
                 [GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)],
                 [
                     DocumentResults(),
-                    DocumentResults(semanticEdits: [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))]),
+                    DocumentResults(
+                        semanticEdits: [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                        diagnostics: [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "Console.WriteLine(2);", GetResource("top-level code"))]),
                 ]);
         }
 
@@ -22572,7 +22640,9 @@ public class B
 
             edits.VerifyEdits("Reorder [{ int b; }]@14 -> @2");
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "{ int b; }", GetResource("top-level code"))]);
         }
 
         [Fact]
@@ -22590,7 +22660,9 @@ System.Console.Write(1);
 
             edits.VerifyEdits("Reorder [System.Console.Write(2);]@28 -> @2");
 
-            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+            edits.VerifySemantics(
+                [SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"))],
+                [Diagnostic(RudeEditKind.UpdateMightNotHaveAnyEffect, "System.Console.Write(2);", GetResource("top-level code"))]);
         }
 
         #endregion

--- a/src/Features/CSharpTest/EditAndContinue/TrackingSpanTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/TrackingSpanTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         <AS:0>Goo(1);</AS:0>
     }
@@ -28,7 +28,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
     <AS:0>}</AS:0>
 
@@ -53,7 +53,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         <AS:0>Goo(1);</AS:0>
     }
@@ -61,7 +61,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         <AS:0>Goo(1);</AS:0>
     }
@@ -86,7 +86,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         Action a = () => { <AS:0>Goo(1);</AS:0> };
     }
@@ -94,7 +94,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         Action a = () => { <AS:0>}</AS:0>;
         <TS:0>Goo(1);</TS:0>
@@ -113,7 +113,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         Action a = () => { <AS:0>Goo(1);</AS:0> };
         Action b = () => { Goo(2); };
@@ -122,7 +122,7 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void F()
     {
         Action a = () => { <AS:0>Goo(1);</AS:0> };
         Action b = () => { <TS:0>Goo(2);</TS:0> };

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -848,7 +848,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
                             Contract.ThrowIfFalse(statementPart == -1);
                             oldBody.FindStatementAndPartner(oldStatementSpan, newBody, out newStatement, out statementPart);
 
-                            // We should fine a partner statement since we are analyzing method body that has not been changed.
+                            // We should find a partner statement since we are analyzing method body that has not been changed.
                             // If this fails we should have calculated the new active statement during the analysis of the updated method body.
                             Contract.ThrowIfNull(newStatement);
                         }

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -667,8 +667,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
             AnalyzeUnchangedActiveMemberBodies(diagnostics, syntacticEdits.Match, newText, oldActiveStatements, newActiveStatementSpans, newActiveStatements, newExceptionRegions, cancellationToken);
             Debug.Assert(newActiveStatements.All(a => a != null));
 
-            var hasRudeEdits = diagnostics.Count > 0;
-            if (hasRudeEdits)
+            if (!diagnostics.IsEmpty())
             {
                 LogRudeEdits(diagnostics, newText, filePath);
             }
@@ -677,19 +676,22 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
                 Log.Write("Capabilities required by '{0}': {1}", filePath, capabilities.GrantedCapabilities);
             }
 
+            var hasBlockingRudeEdits = diagnostics.HasBlockingRudeEdits();
+
             return new DocumentAnalysisResults(
                 newDocument.Id,
                 filePath,
                 newActiveStatements.MoveToImmutable(),
                 diagnostics.ToImmutable(),
                 syntaxError: null,
-                hasRudeEdits ? default : semanticEdits,
-                hasRudeEdits ? default : newExceptionRegions.MoveToImmutable(),
-                hasRudeEdits ? default : lineEdits.ToImmutable(),
-                hasRudeEdits ? default : capabilities.GrantedCapabilities,
+                hasBlockingRudeEdits ? default : semanticEdits,
+                hasBlockingRudeEdits ? default : newExceptionRegions.MoveToImmutable(),
+                hasBlockingRudeEdits ? default : lineEdits.ToImmutable(),
+                hasBlockingRudeEdits ? default : capabilities.GrantedCapabilities,
                 analysisStopwatch.Elapsed,
                 hasChanges: true,
-                hasSyntaxErrors: false);
+                hasSyntaxErrors: false,
+                hasBlockingRudeEdits);
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
         {
@@ -845,6 +847,9 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
                         {
                             Contract.ThrowIfFalse(statementPart == -1);
                             oldBody.FindStatementAndPartner(oldStatementSpan, newBody, out newStatement, out statementPart);
+
+                            // We should fine a partner statement since we are analyzing method body that has not been changed.
+                            // If this fails we should have calculated the new active statement during the analysis of the updated method body.
                             Contract.ThrowIfNull(newStatement);
                         }
 
@@ -949,11 +954,6 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
 
         var activeStatementIndices = oldMemberBody?.GetOverlappingActiveStatementIndices(oldActiveStatements)?.ToArray() ?? [];
 
-        if (isMemberReplaced && !activeStatementIndices.IsEmpty())
-        {
-            diagnosticContext.Report(RudeEditKind.ChangingNameOrSignatureOfActiveMember, cancellationToken);
-        }
-
         try
         {
             if (newMemberBody != null)
@@ -1047,6 +1047,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
             }
 
             var activeNodesInBody = activeNodes.Where(n => n.EnclosingLambdaBody == null).ToArray();
+            var bodyHasActiveStatement = activeNodesInBody.Length != 0;
 
             var memberBodyMap = ComputeDeclarationBodyMap(oldMemberBody, newMemberBody, activeNodesInBody);
             var aggregateBodyMap = IncludeLambdaBodyMaps(memberBodyMap, activeNodes, ref lazyActiveOrMatchedLambdas);
@@ -1054,7 +1055,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
             var oldStateMachineInfo = oldMemberBody?.GetStateMachineInfo() ?? StateMachineInfo.None;
             var newStateMachineInfo = newMemberBody?.GetStateMachineInfo() ?? StateMachineInfo.None;
 
-            ReportStateMachineBodyUpdateRudeEdits(diagnosticContext, memberBodyMap, oldStateMachineInfo, newStateMachineInfo, hasActiveStatement: activeNodesInBody.Length != 0, cancellationToken);
+            ReportStateMachineBodyUpdateRudeEdits(diagnosticContext, memberBodyMap, oldStateMachineInfo, newStateMachineInfo, bodyHasActiveStatement, cancellationToken);
 
             ReportMemberOrLambdaBodyUpdateRudeEdits(
                 diagnosticContext,
@@ -1086,8 +1087,23 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
                 capabilities,
                 diagnostics,
                 out var newBodyHasLambdas,
+                out var hasLambdaBodyUpdate,
                 out var runtimeRudeEdits,
                 cancellationToken);
+
+            // Report rude edit only if the body itself has active statement, not when only a lambda in the body has one.
+            if (isMemberReplaced && bodyHasActiveStatement)
+            {
+                diagnosticContext.Report(RudeEditKind.ChangingNameOrSignatureOfActiveMember, cancellationToken);
+            }
+
+            // Updating entry point that doesn't have an active statement will most likely have no effect, unless the update is in a lambda body.   
+            // In theory, the code could be updating the entry point while executing static constructor of module initializer,
+            // but those cases are rare.
+            if (!hasLambdaBodyUpdate && !bodyHasActiveStatement && oldMember == oldCompilation.GetEntryPoint(cancellationToken))
+            {
+                diagnosticContext.Report(RudeEditKind.UpdateMightNotHaveAnyEffect, cancellationToken);
+            }
 
             // We need to provide syntax map to the compiler if 
             // 1) The new member has a active statement
@@ -3047,13 +3063,16 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
 
                         var replaceMember = IsMemberOrDelegate(oldSymbol) && IsMemberOrDelegateReplaced(oldSymbol, newSymbol);
 
+                        var signatureRudeEdit = RudeEditKind.None;
                         if (replaceMember && oldSymbol.Name == newSymbol.Name)
                         {
-                            var signatureRudeEdit = GetSignatureChangeRudeEdit(oldSymbol, newSymbol, capabilities);
+                            signatureRudeEdit = GetSignatureChangeRudeEdit(oldSymbol, newSymbol, capabilities);
                             if (signatureRudeEdit != RudeEditKind.None)
                             {
                                 diagnosticContext.Report(signatureRudeEdit, cancellationToken);
-                                continue;
+
+                                // Note: Continue analysis - we need to analyze the changed body and
+                                // update any active statements to avoid contract failures.
                             }
                         }
 
@@ -3090,6 +3109,12 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
                                     out syntaxMaps,
                                     cancellationToken);
                             }
+                        }
+
+                        // Skip further symbol update analysis if the member signature change is unsupported:
+                        if (signatureRudeEdit != RudeEditKind.None)
+                        {
+                            continue;
                         }
 
                         AnalyzeSymbolUpdate(diagnosticContext, capabilities, semanticEdits, out var hasAttributeChange, cancellationToken);
@@ -5396,10 +5421,12 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
         EditAndContinueCapabilitiesGrantor capabilities,
         ArrayBuilder<RudeEditDiagnostic> diagnostics,
         out bool syntaxMapRequired,
+        out bool hasLambdaBodyUpdate,
         out Func<SyntaxNode, RuntimeRudeEdit?>? runtimeRudeEdits,
         CancellationToken cancellationToken)
     {
         syntaxMapRequired = false;
+        hasLambdaBodyUpdate = false;
         runtimeRudeEdits = null;
 
         if (activeOrMatchedLambdas != null)
@@ -5443,6 +5470,8 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
 
                 if (!oldLambdaBody.IsSyntaxEquivalentTo(newLambdaBody))
                 {
+                    hasLambdaBodyUpdate = true;
+
                     ReportMemberOrLambdaBodyUpdateRudeEdits(
                         diagnosticContext,
                         oldModel.Compilation,

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -493,15 +493,15 @@ internal sealed class DebuggingSession : IDisposable
                 }
             }
 
-            if (analysis.RudeEditErrors.IsEmpty)
+            if (analysis.RudeEdits.IsEmpty)
             {
                 return [];
             }
 
-            EditSession.Telemetry.LogRudeEditDiagnostics(analysis.RudeEditErrors, project.State.Attributes.TelemetryId);
+            EditSession.Telemetry.LogRudeEditDiagnostics(analysis.RudeEdits, project.State.Attributes.TelemetryId);
 
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            return analysis.RudeEditErrors.SelectAsArray((e, t) => e.ToDiagnostic(t), tree);
+            return analysis.RudeEdits.SelectAsArray((e, t) => e.ToDiagnostic(t), tree);
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
         {

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -54,8 +54,8 @@ internal static class EditAndContinueDiagnosticDescriptors
                 customTags: DiagnosticCustomTags.EditAndContinue);
         }
 
-        void AddRudeEdit(RudeEditKind kind, string resourceName)
-            => add(GetDescriptorIndex(kind), (int)kind, resourceName, s_rudeEditLocString, DiagnosticSeverity.Error);
+        void AddRudeEdit(RudeEditKind kind, string resourceName, DiagnosticSeverity severity = DiagnosticSeverity.Error)
+            => add(GetDescriptorIndex(kind), (int)kind, resourceName, s_rudeEditLocString, severity);
 
         void AddGeneralDiagnostic(EditAndContinueErrorCode code, string resourceName, DiagnosticSeverity severity = DiagnosticSeverity.Error)
             => add(GetDescriptorIndex(code), GeneralDiagnosticBaseId + (int)code, resourceName, s_encLocString, severity);
@@ -147,6 +147,7 @@ internal static class EditAndContinueDiagnosticDescriptors
         AddRudeEdit(RudeEditKind.NotCapturingPrimaryConstructorParameter, nameof(FeaturesResources.Ceasing_to_capture_primary_constructor_parameter_0_of_1_requires_restarting_the_application));
         AddRudeEdit(RudeEditKind.ChangingAttribute, nameof(FeaturesResources.Changing_attribute_0_requires_restarting_the_application));
         AddRudeEdit(RudeEditKind.ChangingNameOrSignatureOfActiveMember, nameof(FeaturesResources.Changing_name_or_signature_of_0_that_contains_an_active_statement_requires_restarting_the_application));
+        AddRudeEdit(RudeEditKind.UpdateMightNotHaveAnyEffect, nameof(FeaturesResources.Changing_0_might_not_have_any_effect_until_the_application_is_restarted), DiagnosticSeverity.Warning);
 
         // VB specific
         AddRudeEdit(RudeEditKind.HandlesClauseUpdate, nameof(FeaturesResources.Updating_the_Handles_clause_of_0_requires_restarting_the_application));

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -570,7 +570,7 @@ internal sealed class EditSession
             }
 
             // rude edits detected:
-            if (!analysis.RudeEditErrors.IsEmpty)
+            if (analysis.HasBlockingRudeEdits)
             {
                 return ProjectAnalysisSummary.RudeEdits;
             }
@@ -914,16 +914,17 @@ internal sealed class EditSession
                 }
                 else if (projectSummary == ProjectAnalysisSummary.RudeEdits)
                 {
-                    foreach (var analysis in changedDocumentAnalyses)
-                    {
-                        if (analysis.RudeEditErrors.Length > 0)
-                        {
-                            documentsWithRudeEdits.Add((analysis.DocumentId, analysis.RudeEditErrors));
-                            Telemetry.LogRudeEditDiagnostics(analysis.RudeEditErrors, newProject.State.Attributes.TelemetryId);
-                        }
-                    }
-
                     isBlocked = true;
+                }
+
+                // Report rude edit diagnostics - these can be blocking (errors) or non-blocking (warnings):
+                foreach (var analysis in changedDocumentAnalyses)
+                {
+                    if (!analysis.RudeEdits.IsEmpty)
+                    {
+                        documentsWithRudeEdits.Add((analysis.DocumentId, analysis.RudeEdits));
+                        Telemetry.LogRudeEditDiagnostics(analysis.RudeEdits, newProject.State.Attributes.TelemetryId);
+                    }
                 }
 
                 if (isModuleEncBlocked || projectSummary != ProjectAnalysisSummary.ValidChanges)

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnostic.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnostic.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Linq;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Text;
 
@@ -41,4 +42,16 @@ internal readonly struct RudeEditDiagnostic
         var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(Kind);
         return Diagnostic.Create(descriptor, tree.GetLocation(Span), Arguments);
     }
+}
+
+internal static class RudeEditExtensions
+{
+    internal static DiagnosticSeverity GetSeverity(this RudeEditKind kind)
+        => EditAndContinueDiagnosticDescriptors.GetDescriptor(kind).DefaultSeverity;
+
+    internal static bool IsBlocking(this RudeEditKind kind)
+        => kind.GetSeverity() == DiagnosticSeverity.Error;
+
+    public static bool HasBlockingRudeEdits(this IEnumerable<RudeEditDiagnostic> diagnostics)
+        => diagnostics.Any(static e => e.Kind.IsBlocking());
 }

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -142,4 +142,5 @@ internal enum RudeEditKind : ushort
     NotCapturingPrimaryConstructorParameter = 115,
     ChangingAttribute = 116,
     ChangingNameOrSignatureOfActiveMember = 117,
+    UpdateMightNotHaveAnyEffect = 118,
 }

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -378,6 +378,9 @@
   <data name="Changing_name_or_signature_of_0_that_contains_an_active_statement_requires_restarting_the_application" xml:space="preserve">
     <value>Changing attribute '{0}' requires restarting the application.</value>
   </data>
+  <data name="Changing_0_might_not_have_any_effect_until_the_application_is_restarted" xml:space="preserve">
+    <value>Changing '{0}' might not have any effect until the application is restarted.</value>
+  </data>
   <data name="Capturing_primary_constructor_parameter_0_that_hasn_t_been_captured_before_requires_restarting_the_application" xml:space="preserve">
     <value>Capturing primary constructor parameter '{0}' that hasn't been capture before requires restarting the application.</value>
   </data>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -405,6 +405,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Změna {0} z asynchronního na synchronní vyžaduje restartování aplikace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">Změna {0} na {1} vyžaduje restartování aplikace, protože mění tvar stavového stroje.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -405,6 +405,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Das Ändern von {0} von asynchron zu synchron erfordert einen Neustart der Anwendung.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">Das Ändern von „{0}“ zu „{1}“ erfordert einen Neustart der Anwendung, da dadurch die Form des Zustandsautomaten geändert wird.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -405,6 +405,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Para cambiar {0} de asíncrona a sincrónica, es necesario reiniciar la aplicación.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">Para cambiar "{0}" a "{1}" se requiere reiniciar la aplicación porque cambia la forma de la máquina de estados.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -405,6 +405,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">Le passage de {0} d'asynchrone à synchrone requiert le redémarrage de l'application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">Le passage de « {0} » en « {1} » nécessite le redémarrage de l’application, car elle modifie la forme de la machine à états.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -405,6 +405,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Se si modifica {0} da asincrono a sincrono, è necessario riavviare l'applicazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">Se si modifica '{0}' in '{1}', è necessario il riavvio dell'applicazione perché l'operazione comporta la modifica della forma della macchina a stati.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -405,6 +405,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">{0} を非同期から同期に変更するには、アプリケーションを再起動する必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">'{0}' を '{1}' に変更すると、ステート マシンの形状が変更されるため、アプリケーションを再起動する必要があります。</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -405,6 +405,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">비동기에서 동기로 {0}을(를) 변경하려면 애플리케이션을 다시 시작해야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">'{0}'을(를) '{1}'(으)로 변경하려면 상태 시스템의 모양을 변경하므로 애플리케이션을 다시 시작해야 합니다.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -405,6 +405,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Zmiana elementu {0} z asynchronicznego na synchroniczny wymaga ponownego uruchomienia aplikacji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">Zmiana elementu „{0}” na „{1}” wymaga ponownego uruchomienia aplikacji, ponieważ zmienia on kształt automatu stanów.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -405,6 +405,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Alterar {0} de assíncrono para síncrono requer a reinicialização do aplicativo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">Alterar '{0}' para '{1}' requer a reinicialização do aplicativo porque altera a forma da máquina de estado.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -405,6 +405,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Для изменения {0} с асинхронного на синхронный требуется перезапустить приложение.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">Для изменения "{0}" на "{1}" требуется перезапустить приложение, так как при этом изменяется форма конечного автомата.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -405,6 +405,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">{0} öğesinin zaman uyumsuzdan zaman uyumluya değiştirilmesi, uygulamanın yeniden başlatılmasını gerektirir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">'{0}' öğesinin '{1}' olarak değiştirilmesi, durum makinesinin şeklini değiştirdiği için uygulamanın yeniden başlatılmasını gerektirir.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -405,6 +405,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">将 {0} 从异步更改为同步需要重启应用程序。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">将“{0}”更改为“{1}”需要重启应用程序，因为它会更改状态机的形状。</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -405,6 +405,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">將 {0} 從非同步變更為同步需要重新啟動應用程式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_might_not_have_any_effect_until_the_application_is_restarted">
+        <source>Changing '{0}' might not have any effect until the application is restarted.</source>
+        <target state="new">Changing '{0}' might not have any effect until the application is restarted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Changing_0_to_1_requires_restarting_the_application_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' requires restarting the application because it changes the shape of the state machine.</source>
         <target state="translated">將 '{0}' 變更為 '{1}' 需要重新啟動應用程式，因為它會變更狀態機器的圖形。</target>

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 actualRequiredCapabilities |= result.RequiredCapabilities;
                 hasValidChanges &= result.HasSignificantValidChanges;
 
-                VerifyDiagnostics(expectedResult.Diagnostics, result.RudeEditErrors.ToDescription(newText, includeFirstLineInDiagnostics), assertMessagePrefix);
+                VerifyDiagnostics(expectedResult.Diagnostics, result.RudeEdits.ToDescription(newText, includeFirstLineInDiagnostics), assertMessagePrefix);
 
                 if (!expectedResult.SemanticEdits.IsDefault)
                 {
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 else
                 {
                     // exception regions not available in presence of rude edits:
-                    Assert.Equal(!expectedResult.Diagnostics.IsEmpty, result.ExceptionRegions.IsDefault);
+                    Assert.Equal(expectedResult.Diagnostics.Any(d => d.RudeEditKind.IsBlocking()), result.ExceptionRegions.IsDefault);
 
                     VerifyDocumentActiveStatementsAndExceptionRegions(
                         expectedResult.ActiveStatements,
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                         result.ExceptionRegions);
                 }
 
-                if (!result.RudeEditErrors.IsEmpty)
+                if (result.HasBlockingRudeEdits)
                 {
                     Assert.True(result.LineEdits.IsDefault);
                     Assert.True(expectedResult.LineEdits.IsDefaultOrEmpty);

--- a/src/Features/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -2,10 +2,9 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports Microsoft.CodeAnalysis.Contracts.EditAndContinue
 Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.Emit
-Imports Microsoft.CodeAnalysis.Contracts.EditAndContinue
-Imports Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
@@ -2403,9 +2402,9 @@ Class C
 End Class
 "
 
-            Dim src2 = "<AS:0/>
+            Dim src2 = "
 Class C
-    Dim a,b(1),c As Integer
+    Dim a,<AS:0>b(1)</AS:0>,c As Integer
 
     Sub New
     End Sub
@@ -4708,7 +4707,7 @@ End Class
         Public Sub Lambdas_ActiveStatementRemoved4()
             Dim src1 = "
 Class C
-    Shared Sub Main()
+    Shared Sub F()
         Dim f = Function(a)
             <AS:1>z(2)</AS:1>
 
@@ -4720,7 +4719,7 @@ Class C
 End Class"
             Dim src2 = "
 Class C
-    <AS:0,1>Shared Sub Main()</AS:0,1>
+    <AS:0,1>Shared Sub F()</AS:0,1>
     End Sub
 End Class
 "
@@ -4728,8 +4727,8 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "Shared Sub Main()", VBFeaturesResources.Lambda),
-                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "Shared Sub Main()", VBFeaturesResources.Lambda))
+                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "Shared Sub F()", VBFeaturesResources.Lambda),
+                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "Shared Sub F()", VBFeaturesResources.Lambda))
         End Sub
 
         <Fact>

--- a/src/Features/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -4815,7 +4815,7 @@ End Structure
         Public Sub MethodUpdate1()
             Dim src1 As String =
                 "Class C" & vbLf &
-                  "Shared Sub Main()" & vbLf &
+                  "Shared Sub F()" & vbLf &
                      "Dim a As Integer = 1 : " &
                      "Dim b As Integer = 2 : " &
                      "Console.ReadLine(a + b) : " &
@@ -4824,7 +4824,7 @@ End Structure
 
             Dim src2 As String =
                 "Class C" & vbLf &
-                  "Shared Sub Main()" & vbLf &
+                  "Shared Sub F()" & vbLf &
                      "Dim a As Integer = 2 : " &
                      "Dim b As Integer = 1 : " &
                      "Console.ReadLine(a + b) : " &
@@ -4833,13 +4833,13 @@ End Structure
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyEdits(
-                "Update [Shared Sub Main()" & vbLf & "Dim a As Integer = 1 : Dim b As Integer = 2 : Console.ReadLine(a + b) : End Sub]@8 -> " &
-                       "[Shared Sub Main()" & vbLf & "Dim a As Integer = 2 : Dim b As Integer = 1 : Console.ReadLine(a + b) : End Sub]@8")
+                "Update [Shared Sub F()" & vbLf & "Dim a As Integer = 1 : Dim b As Integer = 2 : Console.ReadLine(a + b) : End Sub]@8 -> " &
+                       "[Shared Sub F()" & vbLf & "Dim a As Integer = 2 : Dim b As Integer = 1 : Console.ReadLine(a + b) : End Sub]@8")
 
             edits.VerifySemanticDiagnostics()
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Main"), preserveLocalVariables:=False)})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"), preserveLocalVariables:=False)})
         End Sub
 
         <Fact>
@@ -5594,99 +5594,99 @@ End Interface
 
         <Fact>
         Public Sub MethodUpdate_LocalWithCollectionInitializer()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim numbers() = {1, 2, 3} : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim numbers() = {1, 2, 3, 4} : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim numbers() = {1, 2, 3} : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim numbers() = {1, 2, 3, 4} : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [Sub Main()" & vbLf & "Dim numbers() = {1, 2, 3} : End Sub]@12 -> [Sub Main()" & vbLf & "Dim numbers() = {1, 2, 3, 4} : End Sub]@12")
+                "Update [Sub F()" & vbLf & "Dim numbers() = {1, 2, 3} : End Sub]@12 -> [Sub F()" & vbLf & "Dim numbers() = {1, 2, 3, 4} : End Sub]@12")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Main"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"))})
         End Sub
 
         <Fact>
         Public Sub MethodUpdate_CatchVariableType()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Try : Catch a As Exception : End Try : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Try : Catch a As IOException : End Try : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Try : Catch a As Exception : End Try : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Try : Catch a As IOException : End Try : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [Sub Main()" & vbLf & "Try : Catch a As Exception : End Try : End Sub]@12 -> " &
-                       "[Sub Main()" & vbLf & "Try : Catch a As IOException : End Try : End Sub]@12")
+                "Update [Sub F()" & vbLf & "Try : Catch a As Exception : End Try : End Sub]@12 -> " &
+                       "[Sub F()" & vbLf & "Try : Catch a As IOException : End Try : End Sub]@12")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Main"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"))})
         End Sub
 
         <Fact>
         Public Sub MethodUpdate_CatchVariableName()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Try : Catch a As Exception : End Try : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Try : Catch b As Exception : End Try : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Try : Catch a As Exception : End Try : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Try : Catch b As Exception : End Try : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [Sub Main()" & vbLf & "Try : Catch a As Exception : End Try : End Sub]@12 -> " &
-                       "[Sub Main()" & vbLf & "Try : Catch b As Exception : End Try : End Sub]@12")
+                "Update [Sub F()" & vbLf & "Try : Catch a As Exception : End Try : End Sub]@12 -> " &
+                       "[Sub F()" & vbLf & "Try : Catch b As Exception : End Try : End Sub]@12")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Main"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"))})
         End Sub
 
         <Fact>
         Public Sub MethodUpdate_LocalVariableType1()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a As Exception : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a As IOException : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a As Exception : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a As IOException : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [Sub Main()" & vbLf & "Dim a As Exception : End Sub]@12 -> " &
-                       "[Sub Main()" & vbLf & "Dim a As IOException : End Sub]@12")
+                "Update [Sub F()" & vbLf & "Dim a As Exception : End Sub]@12 -> " &
+                       "[Sub F()" & vbLf & "Dim a As IOException : End Sub]@12")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Main"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"))})
         End Sub
 
         <Fact>
         Public Sub MethodUpdate_LocalVariableType2()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a As New Exception : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a As New IOException : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a As New Exception : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a As New IOException : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [Sub Main()" & vbLf & "Dim a As New Exception : End Sub]@12 -> " &
-                       "[Sub Main()" & vbLf & "Dim a As New IOException : End Sub]@12")
+                "Update [Sub F()" & vbLf & "Dim a As New Exception : End Sub]@12 -> " &
+                       "[Sub F()" & vbLf & "Dim a As New IOException : End Sub]@12")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Main"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"))})
         End Sub
 
         <Fact>
         Public Sub MethodUpdate_LocalVariableName1()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a As Exception : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim b As Exception : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a As Exception : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim b As Exception : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [Sub Main()" & vbLf & "Dim a As Exception : End Sub]@12 -> " &
-                       "[Sub Main()" & vbLf & "Dim b As Exception : End Sub]@12")
+                "Update [Sub F()" & vbLf & "Dim a As Exception : End Sub]@12 -> " &
+                       "[Sub F()" & vbLf & "Dim b As Exception : End Sub]@12")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Main"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"))})
         End Sub
 
         <Fact>
         Public Sub MethodUpdate_LocalVariableName2()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a,b As Exception : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a,c As Exception : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a,b As Exception : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a,c As Exception : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [Sub Main()" & vbLf & "Dim a,b As Exception : End Sub]@12 -> " &
-                       "[Sub Main()" & vbLf & "Dim a,c As Exception : End Sub]@12")
+                "Update [Sub F()" & vbLf & "Dim a,b As Exception : End Sub]@12 -> " &
+                       "[Sub F()" & vbLf & "Dim a,c As Exception : End Sub]@12")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Main"))})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.F"))})
         End Sub
 
         <Fact>
@@ -5828,8 +5828,8 @@ End Interface
 
         <Fact>
         Public Sub MethodUpdate_StaticLocal()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Static a = 0 : a = 1 : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Static a = 0 : a = 2 : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Static a = 0 : a = 1 : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Static a = 0 : a = 2 : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
@@ -5838,8 +5838,8 @@ End Interface
 
         <Fact>
         Public Sub MethodUpdate_StaticLocal_Insert()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a = 0 : a = 1 : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Static a = 0 : a = 2 : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a = 0 : a = 1 : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Static a = 0 : a = 2 : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
@@ -5848,12 +5848,12 @@ End Interface
 
         <Fact>
         Public Sub MethodUpdate_StaticLocal_Delete()
-            Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Static a = 0 : a = 1 : End Sub : End Module"
-            Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a = 0 : a = 2 : End Sub : End Module"
+            Dim src1 = "Module C : " & vbLf & "Sub F()" & vbLf & "Static a = 0 : a = 1 : End Sub : End Module"
+            Dim src2 = "Module C : " & vbLf & "Sub F()" & vbLf & "Dim a = 0 : a = 2 : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.UpdateStaticLocal, "Sub Main()", GetResource("method")))
+                Diagnostic(RudeEditKind.UpdateStaticLocal, "Sub F()", GetResource("method")))
         End Sub
 
         <Fact>

--- a/src/Features/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -689,7 +689,7 @@ End Class
                 Next
 
                 Assert.True(result.IsSingle())
-                Assert.Empty(result.Single().RudeEditErrors)
+                Assert.Empty(result.Single().RudeEdits)
             End Using
         End Function
     End Class


### PR DESCRIPTION
Unless the entry point is being executed (it's an active method) changes won't likely have any effect until the app is restarted.
This new rude edit is not blocking - the change can still be applied. It just informs the customer that they might want to restart the app.

Implements: https://github.com/dotnet/roslyn/issues/73472

