### PR TITLE
Install .NET 9 Runtime on Single Machine CI

### DIFF
--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -28,6 +28,15 @@ jobs:
   steps:
     - checkout: none
 
+    # A .NET 9 runtime is needed since our unit tests target net9.0
+    - task: UseDotNet@2
+      displayName: 'Install .NET 9 Runtime'
+      inputs:
+        packageType: runtime
+        version: 9.0.0-preview.3.24172.9
+        includePreviewVersions: true
+        installationPath: '$(Build.SourcesDirectory)/.dotnet'
+
     - task: DownloadPipelineArtifact@2
       displayName: Download Test Payload
       inputs:


### PR DESCRIPTION
Some tests now target net9.0 and require a 9.0 runtime.

Fixes Test_Windows_CoreClr_Debug_Single_Machine leg in [rolling CI main](https://dev.azure.com/dnceng-public/public/_build?definitionId=95&_a=summary&branchFilter=319%2C319%2C319%2C319%2C319%2C319).

Full build of this PR (including the Single_Machine leg which doesn't normally run for PRs): https://dev.azure.com/dnceng-public/public/_build/results?buildId=680131&view=results