### PR TITLE
Add the PR validation branch to publish data

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -237,6 +237,16 @@
       "insertionCreateDraftPR": true,
       "insertionTitlePrefix": "[Telemetry Validation]"
     },
+    "dev/jorobich/pr-val-v3-publishing": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "vsBranch": "main",
+      "vsMajorVersion": 17,
+      "insertionCreateDraftPR": true,
+      "insertionTitlePrefix": "[PR Validation]"
+    },
     "demo/razor-lexer": {
       "nugetKind": [
         "Shipping",


### PR DESCRIPTION
In order to prove out the changes to the PR validation pipeline (https://github.com/dotnet/roslyn/pull/73221), we need to ensure packages are being published from the feature branch.