### PR TITLE
Check language version for more ref-struct-interfaces scenarios

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -10722,7 +10722,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // This is case 4. We need to look for the IEnumerable<T> that this reinferred expression implements,
                     // so that we pick up any nested type substitutions that could have occurred.
                     var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-                    targetTypeWithAnnotations = TypeWithAnnotations.Create(ForEachLoopBinder.GetIEnumerableOfT(resultType, isAsync, compilation, ref discardedUseSiteInfo, out bool foundMultiple));
+                    targetTypeWithAnnotations = TypeWithAnnotations.Create(ForEachLoopBinder.GetIEnumerableOfT(resultType, isAsync, compilation, ref discardedUseSiteInfo, out bool foundMultiple, needSupportForRefStructInterfaces: out _));
                     Debug.Assert(!foundMultiple);
                     Debug.Assert(targetTypeWithAnnotations.HasType);
                 }

--- a/src/Compilers/CSharp/Test/Emit3/RefStructInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/RefStructInterfacesTests.cs
@@ -8536,7 +8536,21 @@ class C
 }
 ";
             var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: s_targetFrameworkSupportingByRefLikeGenerics, parseOptions: TestOptions.Regular12);
-            comp2.VerifyEmitDiagnostics();
+
+            // Even though semantic analysis didn't produce any errors in C# 12 compiler, an attempt to emit was failing with
+            // "Unable to determine specific cause of the failure" error.
+            comp2.VerifyEmitDiagnostics(
+                // (6,27): error CS8652: The feature 'ref struct interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         foreach (var i in new S())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "new S()").WithArguments("ref struct interfaces").WithLocation(6, 27)
+                );
+
+            comp2 = CreateCompilation(src1 + src2, targetFramework: s_targetFrameworkSupportingByRefLikeGenerics, parseOptions: TestOptions.Regular12);
+            comp2.VerifyEmitDiagnostics(
+                // (4,23): error CS8652: The feature 'ref struct interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // public ref struct S : IEnumerable<int>
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "IEnumerable<int>").WithArguments("ref struct interfaces").WithLocation(4, 23)
+                );
 
             comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: s_targetFrameworkSupportingByRefLikeGenerics, parseOptions: TestOptions.RegularNext);
             comp2.VerifyEmitDiagnostics();
@@ -15770,18 +15784,16 @@ using System.Threading.Tasks;
 
 public ref struct S : IAsyncEnumerable<int>
 {
-    IAsyncEnumerator<int> IAsyncEnumerable<int>.GetAsyncEnumerator(CancellationToken token = default) => throw null;
+    IAsyncEnumerator<int> IAsyncEnumerable<int>.GetAsyncEnumerator(CancellationToken token) => throw null;
 }
 ";
 
             var comp1 = CreateCompilation(src1, targetFramework: s_targetFrameworkSupportingByRefLikeGenerics);
 
             var src2 = @"
-using System.Threading.Tasks;
-
 class C
 {
-    static async Task Main()
+    static async System.Threading.Tasks.Task Main()
     {
         await foreach (var i in new S())
         {
@@ -15790,7 +15802,21 @@ class C
 }
 ";
             var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: s_targetFrameworkSupportingByRefLikeGenerics, parseOptions: TestOptions.Regular12);
-            comp2.VerifyEmitDiagnostics();
+
+            // Even though semantic analysis didn't produce any errors in C# 12 compiler, an attempt to emit was failing with
+            // "Unable to determine specific cause of the failure" error.
+            comp2.VerifyEmitDiagnostics(
+                // (6,33): error CS8652: The feature 'ref struct interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         await foreach (var i in new S())
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "new S()").WithArguments("ref struct interfaces").WithLocation(6, 33)
+                );
+
+            comp2 = CreateCompilation(src1 + src2, targetFramework: s_targetFrameworkSupportingByRefLikeGenerics, parseOptions: TestOptions.Regular12);
+            comp2.VerifyEmitDiagnostics(
+                // (6,23): error CS8652: The feature 'ref struct interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // public ref struct S : IAsyncEnumerable<int>
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "IAsyncEnumerable<int>").WithArguments("ref struct interfaces").WithLocation(6, 23)
+                );
 
             comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: s_targetFrameworkSupportingByRefLikeGenerics, parseOptions: TestOptions.RegularNext);
             comp2.VerifyEmitDiagnostics();


### PR DESCRIPTION
The following unit-test reflects behavior of the compiler without the feature merged:
```
        [Fact]
        public void Test()
        {
            // public ref struct S : IEnumerable<int>
            // {
            //     IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw null;
            //     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
            // }

            var il = @"
.class public sequential ansi sealed beforefieldinit S
    extends [mscorlib]System.ValueType
    implements class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,
               [mscorlib]System.Collections.IEnumerable
{
    .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
        01 00 00 00
    )
    .custom instance void [mscorlib]System.ObsoleteAttribute::.ctor(string, bool) = (
        01 00 52 54 79 70 65 73 20 77 69 74 68 20 65 6d
        62 65 64 64 65 64 20 72 65 66 65 72 65 6e 63 65
        73 20 61 72 65 20 6e 6f 74 20 73 75 70 70 6f 72
        74 65 64 20 69 6e 20 74 68 69 73 20 76 65 72 73
        69 6f 6e 20 6f 66 20 79 6f 75 72 20 63 6f 6d 70
        69 6c 65 72 2e 01 00 00
    )
    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute::.ctor(string) = (
        01 00 0a 52 65 66 53 74 72 75 63 74 73 00 00
    )

    .pack 0
    .size 1

    // Methods
    .method private final hidebysig newslot virtual 
        instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> 'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator' () cil managed 
    {
        .custom instance void [mscorlib]System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = (
            01 00 01 00 00
        )
        .override method instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
        // Method begins at RVA 0x2050
        // Code size 2 (0x2)
        .maxstack 8

        IL_0000: ldnull
        IL_0001: throw
    } // end of method S::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'

    .method private final hidebysig newslot virtual 
        instance class [mscorlib]System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator () cil managed 
    {
        .custom instance void [mscorlib]System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = (
            01 00 01 00 00
        )
        .override method instance class [mscorlib]System.Collections.IEnumerator [mscorlib]System.Collections.IEnumerable::GetEnumerator()
        // Method begins at RVA 0x2050
        // Code size 2 (0x2)
        .maxstack 8

        IL_0000: ldnull
        IL_0001: throw
    } // end of method S::System.Collections.IEnumerable.GetEnumerator

} // end of class S
";

            var src = """
class C
{
    static void Main()
    {
        foreach (var i in new S())
        {
        }
    }
}
""";
            var comp = CreateCompilationWithIL(src, il);

            comp.VerifyDiagnostics();

            comp.VerifyEmitDiagnostics(
                // error CS7038: Failed to emit module 'ec94a2fe-ba35-45d7-bd85-e440088ca75c': Unable to determine specific cause of the failure.
                Diagnostic(ErrorCode.ERR_ModuleEmitFailure).WithArguments("ec94a2fe-ba35-45d7-bd85-e440088ca75c", "Unable to determine specific cause of the failure.").WithLocation(1, 1)
                );
        }
```