### PR TITLE
Switch FAR data from an immutable dictionary to an immutable array

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptFindUsagesContext.cs
@@ -59,7 +59,7 @@ internal sealed class VSTypeScriptDefinitionItem
             metadataLocations: [],
             classifiedSpans: default,
             properties: null,
-            displayableProperties: ImmutableDictionary<string, string>.Empty,
+            displayableProperties: [],
             displayIfNoReferences: true)
     {
         private readonly VSTypeScriptDefinitionItemNavigator _navigator = navigator;
@@ -90,7 +90,7 @@ internal sealed class VSTypeScriptDefinitionItem
     {
         return new(DefinitionItem.Create(
             tags, displayParts, sourceSpans.SelectAsArray(static span => span.ToDocumentSpan()), classifiedSpans: [],
-            metadataLocations: [], nameDisplayParts, properties: null, displayableProperties: ImmutableDictionary<string, string>.Empty, displayIfNoReferences: displayIfNoReferences));
+            metadataLocations: [], nameDisplayParts, properties: null, displayableProperties: [], displayIfNoReferences: displayIfNoReferences));
     }
 
     public static VSTypeScriptDefinitionItem CreateExternal(

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -146,10 +146,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                                        d.Name, d.AnnotatedSpans(annotationKey).ToList())).ToList()
                             Dim actual = GetFileNamesAndSpans(
                                 context.References.Where(Function(r)
-                                                             Dim actualValue As String = Nothing
-                                                             If r.AdditionalProperties.TryGetValue(propertyName, actualValue) Then
-                                                                 Return actualValue = propertyValue
-                                                             End If
+                                                             For Each tuple In r.AdditionalProperties
+                                                                 If tuple.key = propertyName Then
+                                                                     Return tuple.value = propertyValue
+                                                                 End If
+                                                             Next
 
                                                              Return propertyValue.Length = 0
                                                          End Function).Select(Function(r) r.SourceSpan))
@@ -377,17 +378,19 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                         For Each propertyValue In kvp.Value
                             Dim annotationKey = AdditionalPropertyKey + propertyName + "." + propertyValue
                             For Each doc In documentsWithAnnotatedSpans.Where(Function(d) d.AnnotatedSpans.ContainsKey(annotationKey))
-
                                 Dim expectedSpans = doc.AnnotatedSpans(annotationKey).Order()
 
-                                actualReferences = GetActualReferences(result, uiVisibleOnly, options, document, Function(r)
-                                                                                                                     Dim actualValue As String = Nothing
-                                                                                                                     If r.AdditionalProperties.TryGetValue(propertyName, actualValue) Then
-                                                                                                                         Return actualValue = propertyValue
-                                                                                                                     End If
+                                actualReferences = GetActualReferences(
+                                    result, uiVisibleOnly, options, document,
+                                    Function(r)
+                                        For Each tuple In r.AdditionalProperties
+                                            If tuple.key = propertyName Then
+                                                Return tuple.value = propertyValue
+                                            End If
+                                        Next
 
-                                                                                                                     Return propertyValue.Length = 0
-                                                                                                                 End Function)
+                                        Return propertyValue.Length = 0
+                                    End Function)
                                 Dim actualSpans = actualReferences(GetFilePathAndProjectLabel(doc)).Order()
 
                                 If Not TextSpansMatch(expectedSpans, actualSpans) Then

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDefinitionItemBase.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDefinitionItemBase.cs
@@ -15,12 +15,12 @@ internal abstract class VSTypeScriptDefinitionItemBase : DefinitionItem
         : base(
             tags,
             displayParts,
-            [],
+            nameDisplayParts: [],
             sourceSpans: default,
-            metadataLocations: ImmutableArray<AssemblyLocation>.Empty,
+            metadataLocations: [],
             classifiedSpans: default,
             properties: null,
-            displayableProperties: ImmutableDictionary<string, string>.Empty,
+            displayableProperties: [],
             displayIfNoReferences: true)
     {
     }

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
@@ -28,7 +28,7 @@ internal partial class DefinitionItem
         ImmutableArray<ClassifiedSpansAndHighlightSpan?> classifiedSpans,
         ImmutableArray<AssemblyLocation> metadataLocations,
         ImmutableDictionary<string, string>? properties,
-        ImmutableDictionary<string, string>? displayableProperties,
+        ImmutableArray<(string key, string value)> displayableProperties,
         bool displayIfNoReferences) : DefinitionItem(
             tags, displayParts, nameDisplayParts,
             sourceSpans, classifiedSpans, metadataLocations, properties, displayableProperties, displayIfNoReferences)

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DetachedDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DetachedDefinitionItem.cs
@@ -23,7 +23,7 @@ internal sealed class DetachedDefinitionItem(
     ImmutableArray<DocumentIdSpan> sourceSpans,
     ImmutableArray<AssemblyLocation> metadataLocations,
     ImmutableDictionary<string, string> properties,
-    ImmutableDictionary<string, string> displayableProperties,
+    ImmutableArray<(string key, string value)> displayableProperties,
     bool displayIfNoReferences) : IEquatable<DetachedDefinitionItem>
 {
     [DataMember(Order = 0)]
@@ -39,7 +39,7 @@ internal sealed class DetachedDefinitionItem(
     [DataMember(Order = 5)]
     public readonly ImmutableDictionary<string, string> Properties = properties;
     [DataMember(Order = 6)]
-    public readonly ImmutableDictionary<string, string> DisplayableProperties = displayableProperties;
+    public readonly ImmutableArray<(string key, string value)> DisplayableProperties = displayableProperties;
     [DataMember(Order = 7)]
     public readonly bool DisplayIfNoReferences = displayIfNoReferences;
 

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
@@ -19,8 +19,7 @@ namespace Microsoft.CodeAnalysis.FindUsages;
 /// Information about a symbol's definition that can be displayed in an editor
 /// and used for navigation.
 /// 
-/// Standard implmentations can be obtained through the various <see cref="DefinitionItem"/>.Create
-/// overloads.
+/// Standard implementations can be obtained through the various <see cref="DefinitionItem"/>.Create overloads.
 /// 
 /// Subclassing is also supported for scenarios that fall outside the bounds of
 /// these common cases.
@@ -69,10 +68,10 @@ internal abstract partial class DefinitionItem
     public ImmutableDictionary<string, string> Properties { get; }
 
     /// <summary>
-    /// Additional diplayable properties that can be attached to the definition for clients that want to
-    /// display additional data.
+    /// Additional displayable properties that can be attached to the definition for clients that want to display
+    /// additional data.
     /// </summary>
-    public ImmutableDictionary<string, string> DisplayableProperties { get; }
+    public ImmutableArray<(string key, string value)> DisplayableProperties { get; }
 
     /// <summary>
     /// The DisplayParts just for the name of this definition.  Generally used only for 
@@ -124,7 +123,7 @@ internal abstract partial class DefinitionItem
         ImmutableArray<ClassifiedSpansAndHighlightSpan?> classifiedSpans,
         ImmutableArray<AssemblyLocation> metadataLocations,
         ImmutableDictionary<string, string>? properties,
-        ImmutableDictionary<string, string>? displayableProperties,
+        ImmutableArray<(string key, string value)> displayableProperties,
         bool displayIfNoReferences)
     {
         Tags = tags;
@@ -134,7 +133,7 @@ internal abstract partial class DefinitionItem
         ClassifiedSpans = classifiedSpans.NullToEmpty();
         MetadataLocations = metadataLocations.NullToEmpty();
         Properties = properties ?? ImmutableDictionary<string, string>.Empty;
-        DisplayableProperties = displayableProperties ?? ImmutableDictionary<string, string>.Empty;
+        DisplayableProperties = displayableProperties.NullToEmpty();
         DisplayIfNoReferences = displayIfNoReferences;
 
         Contract.ThrowIfFalse(classifiedSpans.IsEmpty || sourceSpans.Length == classifiedSpans.Length);
@@ -204,7 +203,7 @@ internal abstract partial class DefinitionItem
     {
         return Create(
             tags, displayParts, sourceSpans, classifiedSpans, ImmutableArray<AssemblyLocation>.Empty, nameDisplayParts,
-            properties: null, displayableProperties: ImmutableDictionary<string, string>.Empty, displayIfNoReferences: displayIfNoReferences);
+            properties: null, displayableProperties: [], displayIfNoReferences: displayIfNoReferences);
     }
 
     [Obsolete("TypeScript: Use external access APIs")]
@@ -230,7 +229,7 @@ internal abstract partial class DefinitionItem
         ImmutableArray<AssemblyLocation> metadataLocations,
         ImmutableArray<TaggedText> nameDisplayParts = default,
         ImmutableDictionary<string, string>? properties = null,
-        ImmutableDictionary<string, string>? displayableProperties = null,
+        ImmutableArray<(string key, string value)> displayableProperties = default,
         bool displayIfNoReferences = true)
     {
         Contract.ThrowIfTrue(sourceSpans.IsDefault);
@@ -273,7 +272,7 @@ internal abstract partial class DefinitionItem
             classifiedSpans: [],
             metadataLocations,
             properties: properties,
-            displayableProperties: ImmutableDictionary<string, string>.Empty,
+            displayableProperties: [],
             displayIfNoReferences: displayIfNoReferences);
     }
 

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -247,8 +247,6 @@ internal readonly struct SerializableDefinitionItem(
 internal readonly struct SerializableClassifiedSpansAndHighlightSpan(
     SerializableClassifiedSpans classifiedSpans, TextSpan highlightSpan)
 {
-    private static readonly ObjectPool<SegmentedList<ClassifiedSpan>> s_listPool = new(() => new());
-
     [DataMember(Order = 0)]
     public readonly SerializableClassifiedSpans ClassifiedSpans = classifiedSpans;
 

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -259,11 +259,7 @@ internal readonly struct SerializableClassifiedSpansAndHighlightSpan(
         => new(SerializableClassifiedSpans.Dehydrate(classifiedSpansAndHighlightSpan.ClassifiedSpans), classifiedSpansAndHighlightSpan.HighlightSpan);
 
     public ClassifiedSpansAndHighlightSpan Rehydrate()
-    {
-        using var pooledObject = s_listPool.GetPooledObject();
-        this.ClassifiedSpans.Rehydrate(pooledObject.Object);
-        return new ClassifiedSpansAndHighlightSpan(pooledObject.Object.ToImmutableArray(), this.HighlightSpan);
-    }
+        => new(this.ClassifiedSpans.Rehydrate(), this.HighlightSpan);
 }
 
 [DataContract]

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -184,7 +184,7 @@ internal readonly struct SerializableDefinitionItem(
     ImmutableArray<SerializableDocumentSpan> sourceSpans,
     ImmutableArray<AssemblyLocation> metadataLocations,
     ImmutableDictionary<string, string> properties,
-    ImmutableDictionary<string, string> displayableProperties,
+    ImmutableArray<(string key, string value)> displayableProperties,
     bool displayIfNoReferences)
 {
     [DataMember(Order = 0)]
@@ -209,7 +209,7 @@ internal readonly struct SerializableDefinitionItem(
     public readonly ImmutableDictionary<string, string> Properties = properties;
 
     [DataMember(Order = 7)]
-    public readonly ImmutableDictionary<string, string> DisplayableProperties = displayableProperties;
+    public readonly ImmutableArray<(string key, string value)> DisplayableProperties = displayableProperties;
 
     [DataMember(Order = 8)]
     public readonly bool DisplayIfNoReferences = displayIfNoReferences;
@@ -272,7 +272,7 @@ internal readonly struct SerializableSourceReferenceItem(
     SerializableDocumentSpan sourceSpan,
     SerializableClassifiedSpansAndHighlightSpan classifiedSpans,
     SymbolUsageInfo symbolUsageInfo,
-    ImmutableDictionary<string, string> additionalProperties)
+    ImmutableArray<(string key, string value)> additionalProperties)
 {
     [DataMember(Order = 0)]
     public readonly int DefinitionId = definitionId;
@@ -287,7 +287,7 @@ internal readonly struct SerializableSourceReferenceItem(
     public readonly SymbolUsageInfo SymbolUsageInfo = symbolUsageInfo;
 
     [DataMember(Order = 4)]
-    public readonly ImmutableDictionary<string, string> AdditionalProperties = additionalProperties;
+    public readonly ImmutableArray<(string key, string value)> AdditionalProperties = additionalProperties;
 
     public static SerializableSourceReferenceItem Dehydrate(int definitionId, SourceReferenceItem item)
         => new(definitionId,
@@ -302,5 +302,5 @@ internal readonly struct SerializableSourceReferenceItem(
                await SourceSpan.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false),
                this.ClassifiedSpans.Rehydrate(),
                SymbolUsageInfo,
-               AdditionalProperties.ToImmutableDictionary(t => t.Key, t => t.Value));
+               AdditionalProperties);
 }

--- a/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
+++ b/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
@@ -46,14 +46,14 @@ internal sealed class SourceReferenceItem
     /// Additional properties for the reference.
     /// For example, { "ContainingTypeInfo" } = { "MyClass" }
     /// </summary>
-    public ImmutableDictionary<string, string> AdditionalProperties { get; }
+    public ImmutableArray<(string key, string value)> AdditionalProperties { get; }
 
     private SourceReferenceItem(
         DefinitionItem definition,
         DocumentSpan sourceSpan,
         ClassifiedSpansAndHighlightSpan? classifiedSpans,
         SymbolUsageInfo symbolUsageInfo,
-        ImmutableDictionary<string, string> additionalProperties,
+        ImmutableArray<(string key, string value)> additionalProperties,
         bool isWrittenTo)
     {
         Definition = definition;
@@ -61,7 +61,7 @@ internal sealed class SourceReferenceItem
         ClassifiedSpans = classifiedSpans;
         SymbolUsageInfo = symbolUsageInfo;
         IsWrittenTo = isWrittenTo;
-        AdditionalProperties = additionalProperties ?? ImmutableDictionary<string, string>.Empty;
+        AdditionalProperties = additionalProperties.NullToEmpty();
     }
 
     // Used by F#
@@ -72,11 +72,11 @@ internal sealed class SourceReferenceItem
 
     // Used by TypeScript
     internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, SymbolUsageInfo symbolUsageInfo)
-        : this(definition, sourceSpan, classifiedSpans, symbolUsageInfo, additionalProperties: ImmutableDictionary<string, string>.Empty)
+        : this(definition, sourceSpan, classifiedSpans, symbolUsageInfo, additionalProperties: [])
     {
     }
 
-    internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, SymbolUsageInfo symbolUsageInfo, ImmutableDictionary<string, string> additionalProperties)
+    internal SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, ClassifiedSpansAndHighlightSpan? classifiedSpans, SymbolUsageInfo symbolUsageInfo, ImmutableArray<(string key, string value)> additionalProperties)
         : this(definition, sourceSpan, classifiedSpans, symbolUsageInfo, additionalProperties, isWrittenTo: symbolUsageInfo.IsWrittenTo())
     {
     }

--- a/src/Features/Core/Portable/SemanticSearch/SearchCompilationFailureDefinitionItem.cs
+++ b/src/Features/Core/Portable/SemanticSearch/SearchCompilationFailureDefinitionItem.cs
@@ -31,7 +31,7 @@ internal sealed class SearchCompilationFailureDefinitionItem(QueryCompilationErr
         classifiedSpans: [],
         metadataLocations: [],
         properties: null,
-        displayableProperties: null,
+        displayableProperties: [],
         displayIfNoReferences: true)
 {
     internal override bool IsExternal => false;

--- a/src/Features/Core/Portable/SemanticSearch/SearchExceptionDefinitionItem.cs
+++ b/src/Features/Core/Portable/SemanticSearch/SearchExceptionDefinitionItem.cs
@@ -28,14 +28,11 @@ internal sealed class SearchExceptionDefinitionItem(string message, ImmutableArr
             .. stackTrace
         ],
         nameDisplayParts: exceptionTypeName,
-        sourceSpans:
-        [
-            documentSpan
-        ],
+        sourceSpans: [documentSpan],
         classifiedSpans: [],
         metadataLocations: [],
         properties: null,
-        displayableProperties: null,
+        displayableProperties: [],
         displayIfNoReferences: true)
 {
     internal override bool IsExternal => false;

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             int definitionId,
             int id,
             DocumentSpan? documentSpan,
-            ImmutableDictionary<string, string> properties,
+            ImmutableArray<(string key, string value)> properties,
             ClassifiedTextElement? definitionText,
             Glyph definitionGlyph,
             SymbolUsageInfo? symbolUsageInfo,

--- a/src/Features/LanguageServer/Protocol/Handler/References/ILspReferencesResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/ILspReferencesResultCreationService.cs
@@ -11,46 +11,41 @@ using Roslyn.LanguageServer.Protocol;
 using Roslyn.Text.Adornments;
 using LSP = Roslyn.LanguageServer.Protocol;
 
-namespace Microsoft.CodeAnalysis.LanguageServer.Handler
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+internal interface ILspReferencesResultCreationService : IWorkspaceService
 {
-    internal interface ILspReferencesResultCreationService : IWorkspaceService
+    SumType<VSInternalReferenceItem, LSP.Location>? CreateReference(
+        int definitionId,
+        int id,
+        ClassifiedTextElement text,
+        DocumentSpan? documentSpan,
+        ImmutableArray<(string key, string value)> properties,
+        ClassifiedTextElement? definitionText,
+        Glyph definitionGlyph,
+        SymbolUsageInfo? symbolUsageInfo,
+        LSP.Location? location);
+}
+
+[ExportWorkspaceService(typeof(ILspReferencesResultCreationService)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class DefaultLspReferencesResultCreationService() : ILspReferencesResultCreationService
+{
+    public SumType<VSInternalReferenceItem, LSP.Location>? CreateReference(
+        int definitionId,
+        int id,
+        ClassifiedTextElement text,
+        DocumentSpan? documentSpan,
+        ImmutableArray<(string key, string value)> properties,
+        ClassifiedTextElement? definitionText,
+        Glyph definitionGlyph,
+        SymbolUsageInfo? symbolUsageInfo,
+        LSP.Location? location)
     {
-        SumType<VSInternalReferenceItem, LSP.Location>? CreateReference(
-            int definitionId,
-            int id,
-            ClassifiedTextElement text,
-            DocumentSpan? documentSpan,
-            ImmutableDictionary<string, string> properties,
-            ClassifiedTextElement? definitionText,
-            Glyph definitionGlyph,
-            SymbolUsageInfo? symbolUsageInfo,
-            LSP.Location? location);
-    }
+        if (location is null)
+            return null;
 
-    [ExportWorkspaceService(typeof(ILspReferencesResultCreationService)), Shared]
-    internal sealed class DefaultLspReferencesResultCreationService : ILspReferencesResultCreationService
-    {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultLspReferencesResultCreationService()
-        {
-        }
-
-        public SumType<VSInternalReferenceItem, LSP.Location>? CreateReference(
-            int definitionId,
-            int id,
-            ClassifiedTextElement text,
-            DocumentSpan? documentSpan,
-            ImmutableDictionary<string, string> properties,
-            ClassifiedTextElement? definitionText,
-            Glyph definitionGlyph,
-            SymbolUsageInfo? symbolUsageInfo,
-            LSP.Location? location)
-        {
-            if (location is null)
-                return null;
-
-            return location;
-        }
+        return location;
     }
 }

--- a/src/Features/Test/FindUsages/DefinitionItemFactoryTests.cs
+++ b/src/Features/Test/FindUsages/DefinitionItemFactoryTests.cs
@@ -60,9 +60,16 @@ public class DefinitionItemFactoryTests
     }
 
     private static void VerifyProperties(IEnumerable<(string key, string value)> expected, IReadOnlyDictionary<string, string> actual, string? propertyName, IReadOnlyDictionary<string, string> expressionMap)
-        => AssertEx.SetEqual(
+        => VerifyProperties(
             expected,
             actual.Select(item => (key: item.Key, value: item.Value)).OrderBy(item => item.key),
+            propertyName,
+            expressionMap);
+
+    private static void VerifyProperties(IEnumerable<(string key, string value)> expected, IEnumerable<(string key, string value)> actual, string? propertyName, IReadOnlyDictionary<string, string> expressionMap)
+        => AssertEx.SetEqual(
+            expected,
+            actual.OrderBy(item => item.key),
             itemSeparator: "," + Environment.NewLine,
             itemInspector: item => $"({Inspect(item.key)}, {InspectValueAsExpression(item.value, expressionMap)})",
             message: PropertyMessage(propertyName));

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -417,7 +417,7 @@ internal partial class StreamingFindUsagesPresenter
             ClassifiedSpansAndHighlightSpan? classifiedSpans,
             HighlightSpanKind spanKind,
             SymbolUsageInfo symbolUsageInfo,
-            ImmutableDictionary<string, string> additionalProperties,
+            ImmutableArray<(string key, string value)> additionalProperties,
             CancellationToken cancellationToken)
         {
             var document = documentSpan.Document;

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -35,6 +35,7 @@ internal partial class StreamingFindUsagesPresenter
         : AbstractItemEntry(definitionBucket, context.Presenter), ISupportsNavigation
     {
         private readonly object _boxedProjectGuid = projectGuid;
+        private string? _trimmedLineText = null;
 
         protected abstract Document Document { get; }
 
@@ -68,7 +69,7 @@ internal partial class StreamingFindUsagesPresenter
                 StandardTableKeyNames.Column => mappedSpanResult.LinePositionSpan.Start.Character,
                 StandardTableKeyNames.ProjectName => GetProjectName(),
                 StandardTableKeyNames.ProjectGuid => _boxedProjectGuid,
-                StandardTableKeyNames.Text => lineText.ToString().Trim(),
+                StandardTableKeyNames.Text => _trimmedLineText ??= lineText.ToString().Trim(),
                 _ => null,
             };
 

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/DocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/DocumentSpanEntry.cs
@@ -43,7 +43,7 @@ internal partial class StreamingFindUsagesPresenter
         private readonly HighlightSpanKind _spanKind;
         private readonly ExcerptResult _excerptResult;
         private readonly SymbolReferenceKinds _symbolReferenceKinds;
-        private readonly ImmutableDictionary<string, string> _customColumnsData;
+        private readonly ImmutableArray<(string key, string value)> _customColumnsData;
         private readonly string _rawProjectName;
         private readonly List<string> _projectFlavors = [];
 
@@ -60,7 +60,7 @@ internal partial class StreamingFindUsagesPresenter
             ExcerptResult excerptResult,
             SourceText lineText,
             SymbolUsageInfo symbolUsageInfo,
-            ImmutableDictionary<string, string> customColumnsData,
+            ImmutableArray<(string key, string value)> customColumnsData,
             IThreadingContext threadingContext)
             : base(context, definitionBucket, projectGuid, lineText, mappedSpanResult, threadingContext)
         {
@@ -87,8 +87,8 @@ internal partial class StreamingFindUsagesPresenter
             lock (_projectFlavors)
             {
                 _cachedProjectName ??= _projectFlavors.Count < 2
-                        ? _rawProjectName
-                        : $"{_rawProjectName} ({string.Join(", ", _projectFlavors)})";
+                    ? _rawProjectName
+                    : $"{_rawProjectName} ({string.Join(", ", _projectFlavors)})";
 
                 return _cachedProjectName;
             }
@@ -123,7 +123,7 @@ internal partial class StreamingFindUsagesPresenter
             ExcerptResult excerptResult,
             SourceText lineText,
             SymbolUsageInfo symbolUsageInfo,
-            ImmutableDictionary<string, string> customColumnsData,
+            ImmutableArray<(string key, string value)> customColumnsData,
             IThreadingContext threadingContext)
         {
             var entry = new DocumentSpanEntry(
@@ -216,9 +216,10 @@ internal partial class StreamingFindUsagesPresenter
                 return _symbolReferenceKinds;
             }
 
-            if (_customColumnsData.TryGetValue(keyName, out var value))
+            foreach (var (key, value) in _customColumnsData)
             {
-                return value;
+                if (key == keyName)
+                    return value;
             }
 
             return base.GetValueWorker(keyName);

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/DocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/DocumentSpanEntry.cs
@@ -82,16 +82,21 @@ internal partial class StreamingFindUsagesPresenter
 
         protected override string GetProjectName()
         {
-            // Check if we have any flavors.  If we have at least 2, combine with the project name
-            // so the user can know htat in the UI.
-            lock (_projectFlavors)
+            if (_cachedProjectName is null)
             {
-                _cachedProjectName ??= _projectFlavors.Count < 2
-                    ? _rawProjectName
-                    : $"{_rawProjectName} ({string.Join(", ", _projectFlavors)})";
+                // Check if we have any flavors.  If we have at least 2, combine with the project name
+                // so the user can know htat in the UI.
+                lock (_projectFlavors)
+                {
+                    _cachedProjectName ??= _projectFlavors.Count < 2
+                        ? _rawProjectName
+                        : $"{_rawProjectName} ({string.Join(", ", _projectFlavors)})";
 
-                return _cachedProjectName;
+                    return _cachedProjectName;
+                }
             }
+
+            return _cachedProjectName;
         }
 
         private void AddFlavor(string? projectFlavor)

--- a/src/VisualStudio/Core/Def/FindReferences/RoslynDefinitionBucket.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/RoslynDefinitionBucket.cs
@@ -36,6 +36,8 @@ internal partial class StreamingFindUsagesPresenter
         /// </summary>
         private readonly Dictionary<(string? filePath, TextSpan span), DocumentSpanEntry> _locationToEntry = [];
 
+        private string? _text;
+
         public RoslynDefinitionBucket(
             string name,
             bool expandedByDefault,
@@ -108,7 +110,7 @@ internal partial class StreamingFindUsagesPresenter
             {
                 case StandardTableKeyNames.Text:
                 case StandardTableKeyNames.FullText:
-                    return DefinitionItem.DisplayParts.JoinText();
+                    return _text ??= DefinitionItem.DisplayParts.JoinText();
 
                 case StandardTableKeyNames2.TextInlines:
                     var inlines = new List<Inline> { new Run(" ") };

--- a/src/VisualStudio/Core/Def/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
@@ -84,7 +84,7 @@ internal class VisualStudioDefinitionsAndReferencesFactory(
             metadataLocations: default,
             classifiedSpans: default,
             properties: null,
-            displayableProperties: null,
+            displayableProperties: [],
             displayIfNoReferences: true)
     {
         internal override bool IsExternal => true;

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -106,28 +106,23 @@ internal sealed class SerializableClassifiedSpans(ImmutableArray<string> classif
     {
         classifiedSpans.EnsureCapacity(classifiedSpans.Count + (ClassificationTriples.Length / 3));
         for (int i = 0, n = ClassificationTriples.Length; i < n; i += 3)
-        {
-            classifiedSpans.Add(new ClassifiedSpan(
-                ClassificationTypes[ClassificationTriples[i + 0]],
-                new TextSpan(
-                    ClassificationTriples[i + 1],
-                    ClassificationTriples[i + 2])));
-        }
+            classifiedSpans.Add(GetClassifiedSpanAt(i));
     }
+
+    private ClassifiedSpan GetClassifiedSpanAt(int index)
+        => new(
+            ClassificationTypes[ClassificationTriples[index + 0]],
+            new TextSpan(
+                ClassificationTriples[index + 1],
+                ClassificationTriples[index + 2]));
 
     internal ImmutableArray<ClassifiedSpan> Rehydrate()
     {
-        var result = new FixedSizeArrayBuilder<ClassifiedSpan>(this.ClassificationTriples.Length / 3);
+        var classifiedSpans = new FixedSizeArrayBuilder<ClassifiedSpan>(this.ClassificationTriples.Length / 3);
 
         for (int i = 0, n = ClassificationTriples.Length; i < n; i += 3)
-        {
-            result.Add(new ClassifiedSpan(
-                ClassificationTypes[ClassificationTriples[i + 0]],
-                new TextSpan(
-                    ClassificationTriples[i + 1],
-                    ClassificationTriples[i + 2])));
-        }
+            classifiedSpans.Add(GetClassifiedSpanAt(i));
 
-        return result.MoveToImmutable();
+        return classifiedSpans.MoveToImmutable();
     }
 }

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -116,7 +116,7 @@ internal sealed class SerializableClassifiedSpans(ImmutableArray<string> classif
 
     internal ImmutableArray<ClassifiedSpan> Rehydrate()
     {
-        var result = new FixedSizeArrayBuilder<ClassifiedSpan>(this.ClassificationTriples.Length);
+        var result = new FixedSizeArrayBuilder<ClassifiedSpan>(this.ClassificationTriples.Length / 3);
 
         for (int i = 0, n = ClassificationTriples.Length; i < n; i += 3)
         {

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -109,13 +109,6 @@ internal sealed class SerializableClassifiedSpans(ImmutableArray<string> classif
             classifiedSpans.Add(GetClassifiedSpanAt(i));
     }
 
-    private ClassifiedSpan GetClassifiedSpanAt(int index)
-        => new(
-            ClassificationTypes[ClassificationTriples[index + 0]],
-            new TextSpan(
-                ClassificationTriples[index + 1],
-                ClassificationTriples[index + 2]));
-
     internal ImmutableArray<ClassifiedSpan> Rehydrate()
     {
         var classifiedSpans = new FixedSizeArrayBuilder<ClassifiedSpan>(this.ClassificationTriples.Length / 3);
@@ -125,4 +118,11 @@ internal sealed class SerializableClassifiedSpans(ImmutableArray<string> classif
 
         return classifiedSpans.MoveToImmutable();
     }
+
+    private ClassifiedSpan GetClassifiedSpanAt(int index)
+        => new(
+            ClassificationTypes[ClassificationTriples[index + 0]],
+            new TextSpan(
+                ClassificationTriples[index + 1],
+                ClassificationTriples[index + 2]));
 }

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -113,4 +113,20 @@ internal sealed class SerializableClassifiedSpans(ImmutableArray<string> classif
                     ClassificationTriples[i + 2])));
         }
     }
+
+    internal ImmutableArray<ClassifiedSpan> Rehydrate()
+    {
+        var result = new FixedSizeArrayBuilder<ClassifiedSpan>(this.ClassificationTriples.Length);
+
+        for (int i = 0, n = ClassificationTriples.Length; i < n; i += 3)
+        {
+            result.Add(new ClassifiedSpan(
+                ClassificationTypes[ClassificationTriples[i + 0]],
+                new TextSpan(
+                    ClassificationTriples[i + 1],
+                    ClassificationTriples[i + 2])));
+        }
+
+        return result.MoveToImmutable();
+    }
 }

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -104,6 +104,7 @@ internal sealed class SerializableClassifiedSpans(ImmutableArray<string> classif
 
     internal void Rehydrate(SegmentedList<ClassifiedSpan> classifiedSpans)
     {
+        classifiedSpans.EnsureCapacity(classifiedSpans.Count + (ClassificationTriples.Length / 3));
         for (int i = 0, n = ClassificationTriples.Length; i < n; i += 3)
         {
             classifiedSpans.Add(new ClassifiedSpan(

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -72,13 +72,8 @@ internal sealed class SerializableClassifiedSpans(ImmutableArray<string> classif
 
     internal static SerializableClassifiedSpans Dehydrate(ImmutableArray<ClassifiedSpan> classifiedSpans)
     {
-        using var _ = PooledDictionary<string, int>.GetInstance(out var classificationTypeToId);
-        return Dehydrate(classifiedSpans, classificationTypeToId);
-    }
-
-    private static SerializableClassifiedSpans Dehydrate(ImmutableArray<ClassifiedSpan> classifiedSpans, Dictionary<string, int> classificationTypeToId)
-    {
-        using var _1 = ArrayBuilder<string>.GetInstance(out var classificationTypes);
+        using var _1 = PooledDictionary<string, int>.GetInstance(out var classificationTypeToId);
+        using var _2 = ArrayBuilder<string>.GetInstance(out var classificationTypes);
         var classificationTriples = new FixedSizeArrayBuilder<int>(classifiedSpans.Length * 3);
 
         foreach (var classifiedSpan in classifiedSpans)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -745,86 +745,64 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
         return false;
     }
 
-    internal static ImmutableDictionary<string, string> GetAdditionalFindUsagesProperties(
+    internal static ImmutableArray<(string key, string value)> GetAdditionalFindUsagesProperties(
         SyntaxNode node, FindReferencesDocumentState state)
     {
-        var additionalProperties = ImmutableDictionary.CreateBuilder<string, string>();
+        using var additionalProperties = TemporaryArray<(string key, string value)>.Empty;
 
         var syntaxFacts = state.SyntaxFacts;
         var semanticModel = state.SemanticModel;
 
-        if (TryGetAdditionalProperty(
-                syntaxFacts.GetContainingTypeDeclaration(node, node.SpanStart),
-                ContainingTypeInfoPropertyName,
-                semanticModel,
-                out var containingTypeProperty))
+        TryAddAdditionalProperty(
+            syntaxFacts.GetContainingTypeDeclaration(node, node.SpanStart),
+            ContainingTypeInfoPropertyName);
+
+        TryAddAdditionalProperty(
+            syntaxFacts.GetContainingMemberDeclaration(node, node.SpanStart),
+            ContainingMemberInfoPropertyName);
+
+        return additionalProperties.ToImmutableAndClear();
+
+        void TryAddAdditionalProperty(
+            SyntaxNode? node, string key)
         {
-            additionalProperties.Add(containingTypeProperty);
-        }
-
-        if (TryGetAdditionalProperty(
-                syntaxFacts.GetContainingMemberDeclaration(node, node.SpanStart),
-                ContainingMemberInfoPropertyName,
-                semanticModel,
-                out var containingMemberProperty))
-        {
-            additionalProperties.Add(containingMemberProperty);
-        }
-
-        return additionalProperties.ToImmutable();
-    }
-
-    internal static ImmutableDictionary<string, string> GetAdditionalFindUsagesProperties(ISymbol definition)
-    {
-        var additionalProperties = ImmutableDictionary.CreateBuilder<string, string>();
-
-        var containingType = definition.ContainingType;
-        if (containingType != null &&
-            TryGetAdditionalProperty(ContainingTypeInfoPropertyName, containingType, out var containingTypeProperty))
-        {
-            additionalProperties.Add(containingTypeProperty);
-        }
-
-        var containingSymbol = definition.ContainingSymbol;
-
-        // Containing member should only include fields, properties, methods, or events.  Since ContainingSymbol can return other types, use the return value of GetMemberType to restrict to members only.)
-        if (containingSymbol != null &&
-            containingSymbol.GetMemberType() != null &&
-            TryGetAdditionalProperty(ContainingMemberInfoPropertyName, containingSymbol, out var containingMemberProperty))
-        {
-            additionalProperties.Add(containingMemberProperty);
-        }
-
-        return additionalProperties.ToImmutable();
-    }
-
-    private static bool TryGetAdditionalProperty(SyntaxNode? node, string name, SemanticModel semanticModel, out KeyValuePair<string, string> additionalProperty)
-    {
-        if (node != null)
-        {
-            var symbol = semanticModel.GetDeclaredSymbol(node);
-            if (symbol != null &&
-                TryGetAdditionalProperty(name, symbol, out additionalProperty))
+            if (node != null)
             {
-                return true;
+                var symbol = semanticModel.GetDeclaredSymbol(node);
+                if (symbol != null)
+                    additionalProperties.Add((key, symbol.Name));
             }
         }
-
-        additionalProperty = default;
-        return false;
     }
 
-    private static bool TryGetAdditionalProperty(string propertyName, ISymbol symbol, out KeyValuePair<string, string> additionalProperty)
+    internal static ImmutableArray<(string key, string value)> GetAdditionalFindUsagesProperties(ISymbol definition)
     {
-        if (symbol == null)
-        {
-            additionalProperty = default;
-            return false;
-        }
+        using var additionalProperties = TemporaryArray<(string key, string value)>.Empty;
 
-        additionalProperty = KeyValuePairUtil.Create(propertyName, symbol.Name);
-        return true;
+        var containingType = definition.ContainingType;
+        if (containingType != null)
+            additionalProperties.Add((ContainingTypeInfoPropertyName, containingType.Name));
+
+        // Containing member should only include fields, properties, methods, or events.  Since ContainingSymbol can
+        // return other types, use the return value of GetMemberType to restrict to members only.)
+        var containingSymbol = definition.ContainingSymbol;
+        if (containingSymbol != null && containingSymbol.GetMemberType() != null)
+            additionalProperties.Add((ContainingMemberInfoPropertyName, containingSymbol.Name));
+
+        return additionalProperties.ToImmutableAndClear();
     }
+
+    //private static bool TryGetAdditionalProperty(string propertyName, ISymbol symbol, out KeyValuePair<string, string> additionalProperty)
+    //{
+    //    if (symbol == null)
+    //    {
+    //        additionalProperty = default;
+    //        return false;
+    //    }
+
+    //    additionalProperty = KeyValuePairUtil.Create(propertyName, symbol.Name);
+    //    return true;
+    //}
 }
 
 internal abstract partial class AbstractReferenceFinder<TSymbol> : AbstractReferenceFinder

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -790,8 +790,6 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
 
         return additionalProperties.ToImmutableAndClear();
     }
-
-
 }
 
 internal abstract partial class AbstractReferenceFinder<TSymbol> : AbstractReferenceFinder

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -763,8 +763,7 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
 
         return additionalProperties.ToImmutableAndClear();
 
-        void TryAddAdditionalProperty(
-            SyntaxNode? node, string key)
+        void TryAddAdditionalProperty(SyntaxNode? node, string key)
         {
             if (node != null)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/ReferenceLocation.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/ReferenceLocation.cs
@@ -52,7 +52,7 @@ public readonly record struct ReferenceLocation : IComparable<ReferenceLocation>
     /// <summary>
     /// Additional properties for this reference
     /// </summary>
-    internal ImmutableDictionary<string, string> AdditionalProperties { get; }
+    internal ImmutableArray<(string key, string value)> AdditionalProperties { get; }
 
     /// <summary>
     /// If this reference location is within a string literal, then this property
@@ -69,7 +69,7 @@ public readonly record struct ReferenceLocation : IComparable<ReferenceLocation>
         Location location,
         bool isImplicit,
         SymbolUsageInfo symbolUsageInfo,
-        ImmutableDictionary<string, string> additionalProperties,
+        ImmutableArray<(string key, string value)> additionalProperties,
         CandidateReason candidateReason,
         Location containingStringLocation)
     {
@@ -78,7 +78,7 @@ public readonly record struct ReferenceLocation : IComparable<ReferenceLocation>
         this.Location = location;
         this.IsImplicit = isImplicit;
         this.SymbolUsageInfo = symbolUsageInfo;
-        this.AdditionalProperties = additionalProperties ?? ImmutableDictionary<string, string>.Empty;
+        this.AdditionalProperties = additionalProperties.NullToEmpty();
         this.CandidateReason = candidateReason;
         this.ContainingStringLocation = containingStringLocation;
     }
@@ -86,7 +86,7 @@ public readonly record struct ReferenceLocation : IComparable<ReferenceLocation>
     /// <summary>
     /// Creates a reference location with the given properties.
     /// </summary>
-    internal ReferenceLocation(Document document, IAliasSymbol? alias, Location location, bool isImplicit, SymbolUsageInfo symbolUsageInfo, ImmutableDictionary<string, string> additionalProperties, CandidateReason candidateReason)
+    internal ReferenceLocation(Document document, IAliasSymbol? alias, Location location, bool isImplicit, SymbolUsageInfo symbolUsageInfo, ImmutableArray<(string key, string value)> additionalProperties, CandidateReason candidateReason)
         : this(document, alias, location, isImplicit, symbolUsageInfo, additionalProperties, candidateReason, containingStringLocation: Location.None)
     {
     }
@@ -97,7 +97,7 @@ public readonly record struct ReferenceLocation : IComparable<ReferenceLocation>
     /// </summary>
     internal ReferenceLocation(Document document, Location location, Location containingStringLocation)
         : this(document, alias: null, location, isImplicit: false,
-               SymbolUsageInfo.None, additionalProperties: ImmutableDictionary<string, string>.Empty,
+               SymbolUsageInfo.None, additionalProperties: [],
                CandidateReason.None, containingStringLocation)
     {
     }

--- a/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
@@ -132,7 +132,7 @@ internal readonly struct SerializableReferenceLocation(
     TextSpan location,
     bool isImplicit,
     SymbolUsageInfo symbolUsageInfo,
-    ImmutableDictionary<string, string> additionalProperties,
+    ImmutableArray<(string key, string value)> additionalProperties,
     CandidateReason candidateReason)
 {
     [DataMember(Order = 0)]
@@ -151,7 +151,7 @@ internal readonly struct SerializableReferenceLocation(
     public readonly SymbolUsageInfo SymbolUsageInfo = symbolUsageInfo;
 
     [DataMember(Order = 5)]
-    public readonly ImmutableDictionary<string, string> AdditionalProperties = additionalProperties;
+    public readonly ImmutableArray<(string key, string value)> AdditionalProperties = additionalProperties;
 
     [DataMember(Order = 6)]
     public readonly CandidateReason CandidateReason = candidateReason;
@@ -180,10 +180,10 @@ internal readonly struct SerializableReferenceLocation(
             document,
             aliasSymbol,
             CodeAnalysis.Location.Create(syntaxTree, Location),
-            isImplicit: IsImplicit,
-            symbolUsageInfo: SymbolUsageInfo,
-            additionalProperties: additionalProperties ?? ImmutableDictionary<string, string>.Empty,
-            candidateReason: CandidateReason);
+            IsImplicit,
+            SymbolUsageInfo,
+            additionalProperties,
+            CandidateReason);
     }
 
     private async Task<IAliasSymbol?> RehydrateAliasAsync(


### PR DESCRIPTION
First commit moves us from an expensive immutable dictionary to a simple immutable array.  As this array only ever holds a max of two items, the dictionary was gross overkill.

Second commit avoids lock overhead in a common case where the FAR window repeatedly asks the same entities for data after we tell it to refresh.

This drops us from about 35Msecs computation time on the client to around 31Msecs