### PR TITLE
Implement alg that determines which projects need to be restarted/rebuilt due to rude edits

### DIFF
--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -327,7 +327,7 @@ internal sealed class EditAndContinueLanguageService(
 
         UpdateApplyChangesDiagnostics(diagnosticData);
 
-        var diagnostics = await EmitSolutionUpdateResults.GetHotReloadDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, moduleUpdates.Status, cancellationToken).ConfigureAwait(false);
+        var diagnostics = await EmitSolutionUpdateResults.GetAllDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, moduleUpdates.Status, cancellationToken).ConfigureAwait(false);
         return new ManagedHotReloadUpdates(moduleUpdates.Updates.FromContract(), diagnostics.FromContract());
     }
 }

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -109,9 +109,6 @@ public class EditAndContinueLanguageServiceTests : EditAndContinueWorkspaceTestB
 
         var localService = localWorkspace.GetService<EditAndContinueLanguageService>();
 
-        var projectId = ProjectId.CreateNewId();
-        var documentId = DocumentId.CreateNewId(projectId);
-
         DocumentId documentId;
         await localWorkspace.ChangeSolutionAsync(localWorkspace.CurrentSolution
             .AddTestProject("proj", out var projectId).Solution

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -112,10 +112,11 @@ public class EditAndContinueLanguageServiceTests : EditAndContinueWorkspaceTestB
         var projectId = ProjectId.CreateNewId();
         var documentId = DocumentId.CreateNewId(projectId);
 
+        DocumentId documentId;
         await localWorkspace.ChangeSolutionAsync(localWorkspace.CurrentSolution
-            .AddProject(projectId, "proj", "proj", LanguageNames.CSharp)
+            .AddTestProject("proj", out var projectId).Solution
             .AddMetadataReferences(projectId, TargetFrameworkUtil.GetReferences(TargetFramework.Mscorlib40))
-            .AddDocument(documentId, "test.cs", SourceText.From("class C { }", Encoding.UTF8), filePath: "test.cs"));
+            .AddDocument(documentId = DocumentId.CreateNewId(projectId), "test.cs", SourceText.From("class C { }", Encoding.UTF8), filePath: "test.cs"));
 
         var solution = localWorkspace.CurrentSolution;
         var project = solution.GetRequiredProject(projectId);
@@ -179,12 +180,13 @@ public class EditAndContinueLanguageServiceTests : EditAndContinueWorkspaceTestB
         AssertEx.Equal(
         [
             $"Error ENC1001: test.cs(0, 1, 0, 2): {string.Format(FeaturesResources.ErrorReadingFile, "doc", "error 1")}",
-            $"Error ENC1001: {string.Format(FeaturesResources.ErrorReadingFile, "proj", "error 2")}"
+            $"Error ENC1001: proj.csproj(0, 0, 0, 0): {string.Format(FeaturesResources.ErrorReadingFile, "proj", "error 2")}"
         ], sessionState.ApplyChangesDiagnostics.Select(Inspect));
 
         AssertEx.Equal(
         [
             $"Error ENC1001: test.cs(0, 1, 0, 2): {string.Format(FeaturesResources.ErrorReadingFile, "doc", "error 1")}",
+            $"Error ENC1001: proj.csproj(0, 0, 0, 0): {string.Format(FeaturesResources.ErrorReadingFile, "proj", "error 2")}",
             $"Error ENC1001: test.cs(0, 1, 0, 2): {string.Format(FeaturesResources.ErrorReadingFile, "doc", "syntax error 3")}",
             $"RestartRequired ENC0033: test.cs(0, 2, 0, 3): {string.Format(FeaturesResources.Deleting_0_requires_restarting_the_application, "x")}"
         ], updates.Diagnostics.Select(Inspect));

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadUpdate.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadUpdate.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 internal readonly struct ManagedHotReloadUpdate(
     Guid module,
     string moduleName,
+    ProjectId projectId,
     ImmutableArray<byte> ilDelta,
     ImmutableArray<byte> metadataDelta,
     ImmutableArray<byte> pdbDelta,
@@ -27,6 +28,9 @@ internal readonly struct ManagedHotReloadUpdate(
 
     [DataMember(Name = "moduleName")]
     public string ModuleName { get; } = moduleName;
+
+    [DataMember(Name = "projectId")]
+    public ProjectId ProjectId { get; } = projectId;
 
     [DataMember(Name = "ilDelta")]
     public ImmutableArray<byte> ILDelta { get; } = ilDelta;

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -805,6 +805,12 @@ internal sealed class EditSession
             var hasEmitErrors = false;
             foreach (var newProject in solution.Projects)
             {
+                if (newProject.FilePath == null)
+                {
+                    log.Write("Skipping project '{0}' without a file path", newProject.Id);
+                    continue;
+                }
+
                 var oldProject = oldSolution.GetProject(newProject.Id);
                 if (oldProject == null)
                 {
@@ -1049,6 +1055,7 @@ internal sealed class EditSession
                         var delta = new ManagedHotReloadUpdate(
                             mvid,
                             newCompilation.AssemblyName ?? newProject.Name, // used for display in debugger diagnostics
+                            newProject.Id,
                             ilStream.ToImmutableArray(),
                             metadataStream.ToImmutableArray(),
                             pdbStream.ToImmutableArray(),

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -2,14 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -67,9 +71,142 @@ internal readonly struct EmitSolutionUpdateResults
         return DiagnosticData.Create(SyntaxError, solution.GetRequiredDocument(SyntaxError.Location.SourceTree));
     }
 
+    private IEnumerable<Project> GetProjectsContainingBlockingRudeEdits(Solution solution)
+        => RudeEdits
+            .Where(static e => e.Diagnostics.Any(static d => d.Kind.IsBlocking()))
+            .Select(static e => e.DocumentId.ProjectId)
+            .Distinct()
+            .OrderBy(static id => id)
+            .Select(solution.GetRequiredProject);
+
+    /// <summary>
+    /// Returns projects that need to be rebuilt and/or restarted due to blocking rude edits in order to apply changes.
+    /// </summary>
+    /// <param name="isRunningProject">Identifies projects that have been launched.</param>
+    /// <param name="projectsToRestart">Running projects that have to be restarted.</param>
+    /// <param name="projectsToRebuild">Projects whose source have been updated and need to be rebuilt.</param>
+    public void GetProjectsToRebuildAndRestart(
+        Solution solution,
+        Func<Project, bool> isRunningProject,
+        ISet<Project> projectsToRestart,
+        ISet<Project> projectsToRebuild)
+    {
+        var graph = solution.GetProjectDependencyGraph();
+
+        // First, find all running projects that transitively depend on projects with rude edits.
+        // These will need to be rebuilt and restarted. In order to rebuilt these projects
+        // all their transitive references must either be free of source changes or be rebuilt as well.
+        // This may add more running projects to the set of projects we need to restart.
+        // We need to repeat this process until we find a fixed point.
+
+        using var _1 = ArrayBuilder<Project>.GetInstance(out var traversalStack);
+
+        projectsToRestart.Clear();
+        projectsToRebuild.Clear();
+
+        foreach (var projectWithRudeEdit in GetProjectsContainingBlockingRudeEdits(solution))
+        {
+            if (AddImpactedRunningProjects(projectsToRestart, projectWithRudeEdit))
+            {
+                projectsToRebuild.Add(projectWithRudeEdit);
+            }
+        }
+
+        // At this point the restart set contains all running projects directly affected by rude edits.
+        // Next, find projects that were successfully updated and affect running projects.
+
+        if (ModuleUpdates.Updates.IsEmpty || projectsToRestart.IsEmpty())
+        {
+            return;
+        }
+
+        // The set of updated projects is usually much smaller then the number of all projects in the solution.
+        // We iterate over this set updating the reset set until no new project is added to the reset set.
+        // Once a project is determined to affect a running process, all running processes that
+        // reference this project are added to the reset set. The project is then removed from updated
+        // project set as it can't contribute any more running projects to the reset set. 
+        // If an updated project does not affect reset set in a given iteration, it stays in the set
+        // because it may affect reset set later on, after another running project is added to it.
+
+        using var _2 = PooledHashSet<Project>.GetInstance(out var updatedProjects);
+        using var _3 = ArrayBuilder<Project>.GetInstance(out var updatedProjectsToRemove);
+        foreach (var update in ModuleUpdates.Updates)
+        {
+            updatedProjects.Add(solution.GetRequiredProject(update.ProjectId));
+        }
+
+        using var _4 = ArrayBuilder<Project>.GetInstance(out var impactedProjects);
+
+        while (true)
+        {
+            Debug.Assert(updatedProjectsToRemove.Count == 0);
+
+            foreach (var updatedProject in updatedProjects)
+            {
+                if (AddImpactedRunningProjects(impactedProjects, updatedProject) &&
+                    impactedProjects.Any(projectsToRestart.Contains))
+                {
+                    projectsToRestart.AddRange(impactedProjects);
+                    updatedProjectsToRemove.Add(updatedProject);
+                    projectsToRebuild.Add(updatedProject);
+                }
+
+                impactedProjects.Clear();
+            }
+
+            if (updatedProjectsToRemove is [])
+            {
+                // none of the remaining updated projects affect restart set:
+                break;
+            }
+
+            updatedProjects.RemoveAll(updatedProjectsToRemove);
+            updatedProjectsToRemove.Clear();
+        }
+
+        return;
+
+        bool AddImpactedRunningProjects(ICollection<Project> impactedProjects, Project initialProject)
+        {
+            Debug.Assert(traversalStack.Count == 0);
+            traversalStack.Push(initialProject);
+
+            var added = false;
+
+            while (traversalStack.Count > 0)
+            {
+                var project = traversalStack.Pop();
+                if (isRunningProject(project))
+                {
+                    impactedProjects.Add(project);
+                    added = true;
+                }
+
+                foreach (var referencingProjectId in graph.GetProjectsThatDirectlyDependOnThisProject(project.Id))
+                {
+                    traversalStack.Push(solution.GetRequiredProject(referencingProjectId));
+                }
+            }
+
+            return added;
+        }
+    }
+
     public async Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync(Solution solution, CancellationToken cancellationToken)
     {
         using var _ = ArrayBuilder<Diagnostic>.GetInstance(out var diagnostics);
+
+        // add semantic and lowering diagnostics reported during delta emit:
+        foreach (var (_, projectEmitDiagnostics) in Diagnostics)
+        {
+            diagnostics.AddRange(projectEmitDiagnostics);
+        }
+
+        // add syntax error:
+        if (SyntaxError != null)
+        {
+            diagnostics.Add(SyntaxError);
+        }
 
         // add rude edits:
         foreach (var (documentId, documentRudeEdits) in RudeEdits)
@@ -84,16 +221,10 @@ internal readonly struct EmitSolutionUpdateResults
             }
         }
 
-        // add emit diagnostics:
-        foreach (var (_, projectEmitDiagnostics) in Diagnostics)
-        {
-            diagnostics.AddRange(projectEmitDiagnostics);
-        }
-
         return diagnostics.ToImmutableAndClear();
     }
 
-    internal static async ValueTask<ImmutableArray<ManagedHotReloadDiagnostic>> GetHotReloadDiagnosticsAsync(
+    internal static async ValueTask<ImmutableArray<ManagedHotReloadDiagnostic>> GetAllDiagnosticsAsync(
         Solution solution,
         ImmutableArray<DiagnosticData> diagnosticData,
         ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> rudeEdits,
@@ -103,22 +234,14 @@ internal readonly struct EmitSolutionUpdateResults
     {
         using var _ = ArrayBuilder<ManagedHotReloadDiagnostic>.GetInstance(out var builder);
 
-        // Add the first compiler emit error. Do not report warnings - they do not block applying the edit.
-        // It's unnecessary to report more then one error since all the diagnostics are already reported in the Error List
-        // and this is just messaging to the agent.
+        // Add semantic and lowering diagnostics reported during delta emit:
 
         foreach (var data in diagnosticData)
         {
-            if (data.Severity != DiagnosticSeverity.Error)
-            {
-                continue;
-            }
-
             builder.Add(data.ToHotReloadDiagnostic(updateStatus));
-
-            // only report first error
-            break;
         }
+
+        // Add syntax error:
 
         if (syntaxError != null)
         {

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -2,13 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET7_0_OR_GREATER
+
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
@@ -30,20 +35,67 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
             => ValueTaskFactory.CompletedTask;
     }
 
-    public readonly struct Update(
-        Guid moduleId,
-        ImmutableArray<byte> ilDelta,
-        ImmutableArray<byte> metadataDelta,
-        ImmutableArray<byte> pdbDelta,
-        ImmutableArray<int> updatedTypes,
-        ImmutableArray<string> requiredCapabilities)
+    public readonly struct Update
     {
-        public readonly Guid ModuleId = moduleId;
-        public readonly ImmutableArray<byte> ILDelta = ilDelta;
-        public readonly ImmutableArray<byte> MetadataDelta = metadataDelta;
-        public readonly ImmutableArray<byte> PdbDelta = pdbDelta;
-        public readonly ImmutableArray<int> UpdatedTypes = updatedTypes;
-        public readonly ImmutableArray<string> RequiredCapabilities = requiredCapabilities;
+        public readonly Guid ModuleId;
+        public readonly ProjectId ProjectId;
+        public readonly ImmutableArray<byte> ILDelta;
+        public readonly ImmutableArray<byte> MetadataDelta;
+        public readonly ImmutableArray<byte> PdbDelta;
+        public readonly ImmutableArray<int> UpdatedTypes;
+        public readonly ImmutableArray<string> RequiredCapabilities;
+
+        internal Update(
+            Guid moduleId,
+            ProjectId projectId,
+            ImmutableArray<byte> ilDelta,
+            ImmutableArray<byte> metadataDelta,
+            ImmutableArray<byte> pdbDelta,
+            ImmutableArray<int> updatedTypes,
+            ImmutableArray<string> requiredCapabilities)
+        {
+            ModuleId = moduleId;
+            ProjectId = projectId;
+            ILDelta = ilDelta;
+            MetadataDelta = metadataDelta;
+            PdbDelta = pdbDelta;
+            UpdatedTypes = updatedTypes;
+            RequiredCapabilities = requiredCapabilities;
+        }
+    }
+
+    public readonly struct Updates(
+        ModuleUpdateStatus status,
+        ImmutableArray<Diagnostic> diagnostics,
+        ImmutableArray<Update> projectUpdates,
+        IReadOnlySet<Project> projectsToRestart,
+        IReadOnlySet<Project> projectsToRebuild)
+    {
+        /// <summary>
+        /// Status of the updates.
+        /// </summary>
+        public readonly ModuleUpdateStatus Status { get; } = status;
+
+        /// <summary>
+        /// Hot Reload specific diagnostics to be reported (includes rude edits and emit errors).
+        /// </summary>
+        public ImmutableArray<Diagnostic> Diagnostics { get; } = diagnostics;
+
+        /// <summary>
+        /// Updates to be applied to modules. Empty if there are blocking rude edits.
+        /// Only updates to projects that are not included in <see cref="ProjectsToRebuild"/> are listed.
+        /// </summary>
+        public ImmutableArray<Update> ProjectUpdates { get; } = projectUpdates;
+
+        /// <summary>
+        /// Running projects that need to be restarted due to rude edits in order to apply changes.
+        /// </summary>
+        public IReadOnlySet<Project> ProjectsToRestart { get; } = projectsToRestart;
+
+        /// <summary>
+        /// Projects with hcanges that need to be rebuilt in order to apply changes.
+        /// </summary>
+        public IReadOnlySet<Project> ProjectsToRebuild { get; } = projectsToRebuild;
     }
 
     private static readonly ActiveStatementSpanProvider s_solutionActiveStatementSpanProvider =
@@ -56,6 +108,13 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
     public WatchHotReloadService(HostWorkspaceServices services, ImmutableArray<string> capabilities)
         : this(services.SolutionServices, () => ValueTaskFactory.FromResult(AddImplicitDotNetCapabilities(capabilities)))
     {
+    }
+
+    private DebuggingSessionId GetDebuggingSession()
+    {
+        var sessionId = _sessionId;
+        Contract.ThrowIfFalse(sessionId != default, "Session has not started");
+        return sessionId;
     }
 
     /// <summary>
@@ -89,10 +148,13 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
     /// </summary>
     public void CapabilitiesChanged()
     {
-        var sessionId = _sessionId;
-        Contract.ThrowIfFalse(sessionId != default, "Session has not started");
+        _encService.BreakStateOrCapabilitiesChanged(GetDebuggingSession(), inBreakState: null);
+    }
 
-        _encService.BreakStateOrCapabilitiesChanged(sessionId, inBreakState: null);
+    public async Task<(ImmutableArray<Update> updates, ImmutableArray<Diagnostic> diagnostics)> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken)
+    {
+        var result = await GetUpdatesAsync(solution, isRunningProject: static _ => false, cancellationToken).ConfigureAwait(false);
+        return (result.ProjectUpdates, result.Diagnostics);
     }
 
     /// <summary>
@@ -100,14 +162,14 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
     /// the one passed to <see cref="StartSessionAsync(Solution, CancellationToken)"/> for the first invocation.
     /// </summary>
     /// <param name="solution">Solution snapshot.</param>
+    /// <param name="isRunningProject">Identifies projects that launched a process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// Updates (one for each changed project) and Rude Edit diagnostics. Does not include syntax or semantic diagnostics.
     /// </returns>
-    public async Task<(ImmutableArray<Update> updates, ImmutableArray<Diagnostic> diagnostics)> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken)
+    public async Task<Updates> GetUpdatesAsync(Solution solution, Func<Project, bool> isRunningProject, CancellationToken cancellationToken)
     {
-        var sessionId = _sessionId;
-        Contract.ThrowIfFalse(sessionId != default, "Session has not started");
+        var sessionId = GetDebuggingSession();
 
         var results = await _encService.EmitSolutionUpdateAsync(sessionId, solution, s_solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
 
@@ -116,32 +178,41 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
             _encService.CommitSolutionUpdate(sessionId);
         }
 
-        var updates = results.ModuleUpdates.Updates.SelectAsArray(
-            update => new Update(update.Module, update.ILDelta, update.MetadataDelta, update.PdbDelta, update.UpdatedTypes, update.RequiredCapabilities));
-
         var diagnostics = await results.GetAllDiagnosticsAsync(solution, cancellationToken).ConfigureAwait(false);
 
-        return (updates, diagnostics);
+        var projectsToRestart = new HashSet<Project>();
+        var projectsToRebuild = new HashSet<Project>();
+        results.GetProjectsToRebuildAndRestart(solution, isRunningProject, projectsToRestart, projectsToRebuild);
+
+        var projectUpdates =
+            from update in results.ModuleUpdates.Updates
+            let project = solution.GetRequiredProject(update.ProjectId)
+            where !projectsToRestart.Contains(project)
+            select new Update(
+                update.Module,
+                project.Id,
+                update.ILDelta,
+                update.MetadataDelta,
+                update.PdbDelta,
+                update.UpdatedTypes,
+                update.RequiredCapabilities);
+
+        return new Updates(results.ModuleUpdates.Status, diagnostics, projectUpdates.ToImmutableArray(), projectsToRestart, projectsToRebuild);
     }
 
     public void EndSession()
     {
-        Contract.ThrowIfFalse(_sessionId != default, "Session has not started");
-        _encService.EndDebuggingSession(_sessionId);
+        _encService.EndDebuggingSession(GetDebuggingSession());
         _sessionId = default;
     }
 
     internal TestAccessor GetTestAccessor()
         => new(this);
 
-    internal readonly struct TestAccessor
+    internal readonly struct TestAccessor(WatchHotReloadService instance)
     {
-        private readonly WatchHotReloadService _instance;
-
-        internal TestAccessor(WatchHotReloadService instance)
-            => _instance = instance;
-
         public DebuggingSessionId SessionId
-            => _instance._sessionId;
+            => instance._sessionId;
     }
 }
+#endif

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NET7_0_OR_GREATER
+#if NET
 
 using System;
 using System.Collections.Generic;
@@ -93,7 +93,7 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
         public IReadOnlySet<Project> ProjectsToRestart { get; } = projectsToRestart;
 
         /// <summary>
-        /// Projects with hcanges that need to be rebuilt in order to apply changes.
+        /// Projects with changes that need to be rebuilt in order to apply changes.
         /// </summary>
         public IReadOnlySet<Project> ProjectsToRebuild { get; } = projectsToRebuild;
     }

--- a/src/Features/Test/EditAndContinue/EmitSolutionUpdateResultsTests.cs
+++ b/src/Features/Test/EditAndContinue/EmitSolutionUpdateResultsTests.cs
@@ -2,16 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
@@ -19,13 +23,45 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
     [UseExportProvider]
     public class EmitSolutionUpdateResultsTests
     {
+        private static TestWorkspace CreateWorkspace(out Solution solution)
+        {
+            var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);
+            solution = workspace.CurrentSolution;
+            return workspace;
+        }
+
+        private static ManagedHotReloadUpdate CreateMockUpdate(ProjectId projectId)
+            => new(
+                projectId.Id,
+                projectId.ToString(),
+                projectId,
+                ilDelta: [],
+                metadataDelta: [],
+                pdbDelta: [],
+                updatedTypes: [],
+                requiredCapabilities: [],
+                updatedMethods: [],
+                sequencePoints: [],
+                activeStatements: [],
+                exceptionRegions: []);
+
+        private static EmitSolutionUpdateResults CreateMockResults(IEnumerable<ProjectId> updates, IEnumerable<ProjectId> rudeEdits)
+        => new()
+        {
+            ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.Blocked, [.. updates.Select(CreateMockUpdate)]),
+            RudeEdits = [.. rudeEdits.Select(id => (DocumentId.CreateNewId(id), ImmutableArray.Create(new RudeEditDiagnostic(RudeEditKind.InternalError, span: default))))],
+            Diagnostics = [],
+            SyntaxError = null,
+        };
+
         [Fact]
         public async Task GetHotReloadDiagnostics()
         {
             using var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);
 
             var sourcePath = Path.Combine(TempRoot.Root, "x", "a.cs");
-            var razorPath = Path.Combine(TempRoot.Root, "a.razor");
+            var razorPath1 = Path.Combine(TempRoot.Root, "x", "a.razor");
+            var razorPath2 = Path.Combine(TempRoot.Root, "a.razor");
 
             var document = workspace.CurrentSolution.
                 AddProject("proj", "proj", LanguageNames.CSharp).
@@ -46,7 +82,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                     customTags: ImmutableArray.Create("Test2"),
                     properties: ImmutableDictionary<string, string?>.Empty,
                     document.Project.Id,
-                    DiagnosticDataLocation.TestAccessor.Create(new("a.cs", new(0, 0), new(0, 5)), document.Id, new("a.razor", new(10, 10), new(10, 15)), forceMappedPath: true),
+                    DiagnosticDataLocation.TestAccessor.Create(new(sourcePath, new(0, 0), new(0, 5)), document.Id, new("a.razor", new(10, 10), new(10, 15)), forceMappedPath: true),
                     language: "C#",
                     title: "title",
                     description: "description",
@@ -90,15 +126,169 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 (document.Id, ImmutableArray.Create(new RudeEditDiagnostic(RudeEditKind.Delete, TextSpan.FromBounds(1, 10), 123, ["b"]))));
 
             var updateStatus = ModuleUpdateStatus.Blocked;
-            var actual = await EmitSolutionUpdateResults.GetHotReloadDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, updateStatus, CancellationToken.None);
+            var actual = await EmitSolutionUpdateResults.GetAllDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, updateStatus, CancellationToken.None);
 
             AssertEx.Equal(new[]
             {
-                $@"Error CS0012: {razorPath} (10,10)-(10,15): error",
+                $@"Warning CS0001: {razorPath1} (10,10)-(10,15): warning",
+                $@"Error CS0012: {razorPath2} (10,10)-(10,15): error",
                 $@"Error CS0002: {sourcePath} (0,1)-(0,5): syntax error",
                 $@"RestartRequired ENC0021: {sourcePath} (0,1)-(0,10): {string.Format(FeaturesResources.Adding_0_requires_restarting_the_application, "a")}",
                 $@"RestartRequired ENC0033: {sourcePath} (0,1)-(0,10): {string.Format(FeaturesResources.Deleting_0_requires_restarting_the_application, "b")}",
             }, actual.Select(d => $"{d.Severity} {d.Id}: {d.FilePath} {d.Span.GetDebuggerDisplay()}: {d.Message}"));
+        }
+
+        [Fact]
+        public void RunningProjects_Updates()
+        {
+            using var _ = CreateWorkspace(out var solution);
+
+            solution = solution
+                .AddTestProject("C", out var c).Solution
+                .AddTestProject("D", out var d).Solution
+                .AddTestProject("A", out var a).AddProjectReferences([new(c)]).Solution
+                .AddTestProject("B", out var b).AddProjectReferences([new(c), new(d)]).Solution;
+
+            var runningProjects = new[] { a, b };
+            var results = CreateMockResults(updates: [c, d], rudeEdits: []);
+
+            var projectsToRestart = new HashSet<Project>();
+            var projectsToRebuild = new HashSet<Project>();
+
+            results.GetProjectsToRebuildAndRestart(solution, p => runningProjects.Contains(p.Id), projectsToRestart, projectsToRebuild);
+
+            Assert.Empty(projectsToRestart);
+            Assert.Empty(projectsToRebuild);
+        }
+
+        [Fact]
+        public void RunningProjects_RudeEdits()
+        {
+            using var _ = CreateWorkspace(out var solution);
+
+            solution = solution
+                .AddTestProject("C", out var c).Solution
+                .AddTestProject("D", out var d).Solution
+                .AddTestProject("A", out var a).AddProjectReferences([new(c)]).Solution
+                .AddTestProject("B", out var b).AddProjectReferences([new(c), new(d)]).Solution;
+
+            var runningProjects = new[] { a, b };
+            var results = CreateMockResults(updates: [], rudeEdits: [d]);
+
+            var projectsToRestart = new HashSet<Project>();
+            var projectsToRebuild = new HashSet<Project>();
+
+            results.GetProjectsToRebuildAndRestart(solution, p => runningProjects.Contains(p.Id), projectsToRestart, projectsToRebuild);
+
+            // D has rude edit ==> B has to restart
+            AssertEx.SetEqual([b], projectsToRestart.Select(p => p.Id));
+
+            // D has rude edit:
+            AssertEx.SetEqual([d], projectsToRebuild.Select(p => p.Id));
+        }
+
+        [Fact]
+        public void RunningProjects_RudeEdits_NotImpactingRunningProjects()
+        {
+            using var _ = CreateWorkspace(out var solution);
+
+            solution = solution
+                .AddTestProject("C", out var c).Solution
+                .AddTestProject("D", out var d).Solution
+                .AddTestProject("A", out var a).AddProjectReferences([new(c)]).Solution
+                .AddTestProject("B", out var b).AddProjectReferences([new(c), new(d)]).Solution;
+
+            var runningProjects = new[] { a };
+            var results = CreateMockResults(updates: [], rudeEdits: [d]);
+
+            var projectsToRestart = new HashSet<Project>();
+            var projectsToRebuild = new HashSet<Project>();
+
+            results.GetProjectsToRebuildAndRestart(solution, p => runningProjects.Contains(p.Id), projectsToRestart, projectsToRebuild);
+
+            Assert.Empty(projectsToRestart);
+            Assert.Empty(projectsToRebuild);
+        }
+
+        [Fact]
+        public void RunningProjects_RudeEditAndUpdate_Dependent()
+        {
+            using var _ = CreateWorkspace(out var solution);
+
+            solution = solution
+                .AddTestProject("C", out var c).Solution
+                .AddTestProject("D", out var d).Solution
+                .AddTestProject("A", out var a).AddProjectReferences([new(c)]).Solution
+                .AddTestProject("B", out var b).AddProjectReferences([new(c), new(d)]).Solution;
+
+            var runningProjects = new[] { a, b };
+            var results = CreateMockResults(updates: [c], rudeEdits: [d]);
+
+            var projectsToRestart = new HashSet<Project>();
+            var projectsToRebuild = new HashSet<Project>();
+
+            results.GetProjectsToRebuildAndRestart(solution, p => runningProjects.Contains(p.Id), projectsToRestart, projectsToRebuild);
+
+            // D has rude edit => B has to restart
+            // C has update, B -> C and A -> C ==> A has to restart
+            AssertEx.SetEqual([a, b], projectsToRestart.Select(p => p.Id));
+
+            // D has rude edit, C has update that impacts restart set:
+            AssertEx.SetEqual([c, d], projectsToRebuild.Select(p => p.Id));
+        }
+
+        [Fact]
+        public void RunningProjects_RudeEditAndUpdate_Independent()
+        {
+            using var _ = CreateWorkspace(out var solution);
+
+            solution = solution
+                .AddTestProject("C", out var c).Solution
+                .AddTestProject("D", out var d).Solution
+                .AddTestProject("A", out var a).AddProjectReferences([new(c)]).Solution
+                .AddTestProject("B", out var b).AddProjectReferences([new(d)]).Solution;
+
+            var runningProjects = new[] { a, b };
+            var results = CreateMockResults(updates: [c], rudeEdits: [d]);
+
+            var projectsToRestart = new HashSet<Project>();
+            var projectsToRebuild = new HashSet<Project>();
+
+            results.GetProjectsToRebuildAndRestart(solution, p => runningProjects.Contains(p.Id), projectsToRestart, projectsToRebuild);
+
+            // D has rude edit => B has to restart
+            AssertEx.SetEqual([b], projectsToRestart.Select(p => p.Id));
+
+            // D has rude edit, C has update that does not impacts restart set:
+            AssertEx.SetEqual([d], projectsToRebuild.Select(p => p.Id));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void RunningProjects_RudeEditAndUpdate_Chain(bool reverse)
+        {
+            using var _ = CreateWorkspace(out var solution);
+
+            solution = solution
+                .AddTestProject("P1", out var p1).Solution
+                .AddTestProject("P2", out var p2).Solution
+                .AddTestProject("P3", out var p3).Solution
+                .AddTestProject("P4", out var p4).Solution
+                .AddTestProject("R1", out var r1).AddProjectReferences([new(p1), new(p2)]).Solution
+                .AddTestProject("R2", out var r2).AddProjectReferences([new(p2), new(p3)]).Solution
+                .AddTestProject("R3", out var r3).AddProjectReferences([new(p3), new(p4)]).Solution
+                .AddTestProject("R4", out var r4).AddProjectReferences([new(p4)]).Solution;
+
+            var runningProjects = new[] { r1, r2, r3, r4 };
+            var results = CreateMockResults(updates: reverse ? [p4, p3, p2] : [p2, p3, p4], rudeEdits: [p1]);
+
+            var projectsToRestart = new HashSet<Project>();
+            var projectsToRebuild = new HashSet<Project>();
+
+            results.GetProjectsToRebuildAndRestart(solution, p => runningProjects.Contains(p.Id), projectsToRestart, projectsToRebuild);
+
+            AssertEx.SetEqual([r1, r2, r3, r4], projectsToRestart.Select(p => p.Id));
+            AssertEx.SetEqual([p1, p2, p3, p4], projectsToRebuild.Select(p => p.Id));
         }
     }
 }

--- a/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -182,6 +182,7 @@ public class RemoteEditAndContinueServiceTests
             var deltas = ImmutableArray.Create(new ManagedHotReloadUpdate(
                 module: moduleId1,
                 moduleName: "mod",
+                projectId: projectId,
                 ilDelta: ImmutableArray.Create<byte>(1, 2),
                 metadataDelta: ImmutableArray.Create<byte>(3, 4),
                 pdbDelta: ImmutableArray.Create<byte>(5, 6),

--- a/src/Features/Test/EditAndContinue/UnitTestingHotReloadServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/UnitTestingHotReloadServiceTests.cs
@@ -35,7 +35,7 @@ public sealed class UnitTestingHotReloadServiceTests : EditAndContinueWorkspaceT
         using var workspace = CreateWorkspace(out var solution, out var encService);
 
         var projectP = solution.
-            AddProject("P", "P", LanguageNames.CSharp).
+            AddTestProject("P").
             WithMetadataReferences(TargetFrameworkUtil.GetReferences(DefaultTargetFramework));
 
         solution = projectP.Solution;
@@ -49,15 +49,15 @@ public sealed class UnitTestingHotReloadServiceTests : EditAndContinueWorkspaceT
 
         var hotReload = new UnitTestingHotReloadService(workspace.Services);
 
-        await hotReload.StartSessionAsync(solution, ImmutableArray.Create("Baseline", "AddDefinitionToExistingType", "NewTypeDefinition"), CancellationToken.None);
+        await hotReload.StartSessionAsync(solution, ["Baseline", "AddDefinitionToExistingType", "NewTypeDefinition"], CancellationToken.None);
 
         var sessionId = hotReload.GetTestAccessor().SessionId;
         var session = encService.GetTestAccessor().GetDebuggingSession(sessionId);
         var matchingDocuments = session.LastCommittedSolution.Test_GetDocumentStates();
-        AssertEx.Equal(new[]
-        {
+        AssertEx.Equal(
+        [
             "(A, MatchesBuildOutput)"
-        }, matchingDocuments.Select(e => (solution.GetDocument(e.id).Name, e.state)).OrderBy(e => e.Name).Select(e => e.ToString()));
+        ], matchingDocuments.Select(e => (solution.GetDocument(e.id).Name, e.state)).OrderBy(e => e.Name).Select(e => e.ToString()));
 
         // Valid change
         solution = solution.WithDocumentText(documentIdA, CreateText(source2));

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
@@ -74,20 +74,9 @@ public abstract class EditAndContinueWorkspaceTestBase : TestBase
     }
 
     internal static Project AddEmptyTestProject(Solution solution)
-    {
-        var projectId = ProjectId.CreateNewId();
-
-        return solution.
-            AddProject(ProjectInfo.Create(
-                projectId,
-                VersionStamp.Create(),
-                "proj",
-                "proj",
-                LanguageNames.CSharp,
-                parseOptions: CSharpParseOptions.Default.WithNoRefSafetyRulesAttribute())
-                .WithTelemetryId(s_defaultProjectTelemetryId)).GetRequiredProject(projectId).
-            WithMetadataReferences(TargetFrameworkUtil.GetReferences(DefaultTargetFramework));
-    }
+        => solution
+            .AddTestProject("proj")
+            .WithMetadataReferences(TargetFrameworkUtil.GetReferences(DefaultTargetFramework));
 
     internal static Solution AddDefaultTestProject(
         Solution solution,

--- a/src/Features/TestUtilities/EditAndContinue/Extensions.cs
+++ b/src/Features/TestUtilities/EditAndContinue/Extensions.cs
@@ -7,7 +7,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.UnitTests;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Roslyn.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 {
@@ -40,5 +49,47 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 i = eoln + LineSeparator.Length;
             }
         }
+
+        public static Project AddTestProject(this Solution solution, string projectName, string language = LanguageNames.CSharp)
+            => AddTestProject(solution, projectName, language, out _);
+
+        public static Project AddTestProject(this Solution solution, string projectName, out ProjectId id)
+            => AddTestProject(solution, projectName, LanguageNames.CSharp, out id);
+
+        public static Project AddTestProject(this Solution solution, string projectName, string language, out ProjectId id)
+        {
+            var info = CreateProjectInfo(projectName, language);
+            return solution.AddProject(info).GetRequiredProject(id = info.Id);
+        }
+
+        public static Guid CreateProjectTelemetryId(string projectName)
+        {
+            Assert.True(Encoding.UTF8.GetByteCount(projectName) <= 20, "Use shorter project names in tests");
+            return BlobContentId.FromHash(Encoding.UTF8.GetBytes(projectName.PadRight(20, '\0'))).Guid;
+        }
+
+        public static ProjectInfo CreateProjectInfo(string projectName, string language = LanguageNames.CSharp)
+            => ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                name: projectName,
+                assemblyName: projectName,
+                language,
+                parseOptions: language switch
+                {
+                    LanguageNames.CSharp => CSharpParseOptions.Default.WithNoRefSafetyRulesAttribute(),
+                    LanguageNames.VisualBasic => VisualBasicParseOptions.Default,
+                    NoCompilationConstants.LanguageName => null,
+                    _ => throw ExceptionUtilities.UnexpectedValue(language)
+                },
+                filePath: projectName + language switch
+                {
+                    LanguageNames.CSharp => ".csproj",
+                    LanguageNames.VisualBasic => ".vbproj",
+                    NoCompilationConstants.LanguageName => ".noproj",
+                    _ => throw ExceptionUtilities.UnexpectedValue(language)
+                })
+                .WithTelemetryId(CreateProjectTelemetryId(projectName));
+
     }
 }

--- a/src/Tools/ExternalAccess/Debugger/GlassTestsHotReloadService.cs
+++ b/src/Tools/ExternalAccess/Debugger/GlassTestsHotReloadService.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Debugger
         public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(Solution solution, CancellationToken cancellationToken)
         {
             var result = await _encService.EmitSolutionUpdateAsync(GetSessionId(), solution, s_noActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
-            var diagnostics = await EmitSolutionUpdateResults.GetHotReloadDiagnosticsAsync(solution, result.Diagnostics.ToDiagnosticData(solution), result.RudeEdits, result.GetSyntaxErrorData(solution), result.ModuleUpdates.Status, cancellationToken).ConfigureAwait(false);
+            var diagnostics = await EmitSolutionUpdateResults.GetAllDiagnosticsAsync(solution, result.Diagnostics.ToDiagnosticData(solution), result.RudeEdits, result.GetSyntaxErrorData(solution), result.ModuleUpdates.Status, cancellationToken).ConfigureAwait(false);
             return new ManagedHotReloadUpdates(result.ModuleUpdates.Updates.FromContract(), diagnostics.FromContract());
         }
     }

--- a/src/Workspaces/Remote/Core/EditAndContinue/ManagedHotReloadLanguageService.cs
+++ b/src/Workspaces/Remote/Core/EditAndContinue/ManagedHotReloadLanguageService.cs
@@ -285,7 +285,7 @@ internal sealed partial class ManagedHotReloadLanguageService(
                 _pendingUpdatedDesignTimeSolution = designTimeSolution;
             }
 
-            var diagnostics = await EmitSolutionUpdateResults.GetHotReloadDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, moduleUpdates.Status, cancellationToken).ConfigureAwait(false);
+            var diagnostics = await EmitSolutionUpdateResults.GetAllDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, moduleUpdates.Status, cancellationToken).ConfigureAwait(false);
             return new ManagedHotReloadUpdates(moduleUpdates.Updates, diagnostics);
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))


### PR DESCRIPTION
When emitting changes skip projects that do not have a file path and update EnC test helpers to always set project file path. Project file path is used by EnC host to map Roslyn projects to msbuild/project system projects.

Pass all semantic and emit diagnostics reported by EmitDifference to the host (e.g. dotnet-watch).

Update dotnet-watch External Access with APIs that provide project info.


