### PR TITLE
Compute classifications for FAR results in parallel.

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptFindUsagesContext.cs
@@ -26,7 +26,7 @@ internal sealed class VSTypeScriptFindUsagesContext(FindUsagesContext underlying
         => UnderlyingObject.OnDefinitionFoundAsync(definition.UnderlyingObject, cancellationToken);
 
     public ValueTask OnReferenceFoundAsync(VSTypeScriptSourceReferenceItem reference, CancellationToken cancellationToken)
-        => UnderlyingObject.OnReferenceFoundAsync(reference.UnderlyingObject, cancellationToken);
+        => UnderlyingObject.OnReferencesFoundAsync([reference.UnderlyingObject], cancellationToken);
 
     public ValueTask OnCompletedAsync(CancellationToken cancellationToken)
         => UnderlyingObject.OnCompletedAsync(cancellationToken);

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptFindUsagesService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptFindUsagesService.cs
@@ -46,7 +46,7 @@ internal sealed class VSTypeScriptFindUsagesService(IVSTypeScriptFindUsagesServi
             => _context.OnDefinitionFoundAsync(definition.UnderlyingObject, cancellationToken);
 
         public ValueTask OnReferenceFoundAsync(VSTypeScriptSourceReferenceItem reference, CancellationToken cancellationToken)
-            => _context.OnReferenceFoundAsync(reference.UnderlyingObject, cancellationToken);
+            => _context.OnReferencesFoundAsync([reference.UnderlyingObject], cancellationToken);
 
         public ValueTask OnCompletedAsync(CancellationToken cancellationToken)
             => ValueTaskFactory.CompletedTask;

--- a/src/EditorFeatures/Core/FindUsages/BufferedFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/BufferedFindUsagesContext.cs
@@ -201,7 +201,7 @@ internal sealed class BufferedFindUsagesContext : IFindUsagesContext, IStreaming
         }
     }
 
-    ValueTask IFindUsagesContext.OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
+    ValueTask IFindUsagesContext.OnReferencesFoundAsync(ImmutableArray<SourceReferenceItem> references, CancellationToken cancellationToken)
     {
         // Entirely ignored.  These features do not show references.
         Contract.Fail("GoToImpl/Base should never report a reference.");

--- a/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
+++ b/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
@@ -23,7 +23,7 @@ internal interface IStreamingFindUsagesPresenter
     /// <summary>
     /// Tells the presenter that a search is starting.  The returned <see cref="FindUsagesContext"/>
     /// is used to push information about the search into.  i.e. when a reference is found
-    /// <see cref="FindUsagesContext.OnReferenceFoundAsync"/> should be called.  When the
+    /// <see cref="FindUsagesContext.OnReferencesFoundAsync"/> should be called.  When the
     /// search completes <see cref="FindUsagesContext.OnCompletedAsync"/> should be called. 
     /// etc. etc.
     /// </summary>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -249,9 +249,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 Return Nothing
             End Function
 
-            Public Overrides Function OnReferenceFoundAsync(reference As SourceReferenceItem, cancellationToken As CancellationToken) As ValueTask
+            Public Overrides Function OnReferencesFoundAsync(references As ImmutableArray(Of SourceReferenceItem), cancellationToken As CancellationToken) As ValueTask
                 SyncLock gate
-                    References.Add(reference)
+                    Me.References.AddRange(references)
                 End SyncLock
 
                 Return Nothing

--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.DefinitionTrackingContext.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.DefinitionTrackingContext.cs
@@ -6,9 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.FindUsages;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 
@@ -42,8 +39,8 @@ internal abstract partial class AbstractFindUsagesService
         public ValueTask SetSearchTitleAsync(string title, CancellationToken cancellationToken)
             => _underlyingContext.SetSearchTitleAsync(title, cancellationToken);
 
-        public ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
-            => _underlyingContext.OnReferenceFoundAsync(reference, cancellationToken);
+        public ValueTask OnReferencesFoundAsync(ImmutableArray<SourceReferenceItem> references, CancellationToken cancellationToken)
+            => _underlyingContext.OnReferencesFoundAsync(references, cancellationToken);
 
         public ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -108,7 +108,7 @@ internal abstract partial class AbstractFindUsagesService
         }
 
         public async ValueTask OnReferencesFoundAsync(
-            ImmutableArray<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references, CancellationToken cancellationToken)
+            IAsyncEnumerable<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references, CancellationToken cancellationToken)
         {
             await ProducerConsumer<SourceReferenceItem>.RunParallelAsync(
                 source: references,

--- a/src/Features/Core/Portable/FindUsages/FindUsagesContext.cs
+++ b/src/Features/Core/Portable/FindUsages/FindUsagesContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Notification;
@@ -28,7 +29,7 @@ internal abstract class FindUsagesContext : IFindUsagesContext
 
     public virtual ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken) => default;
 
-    public virtual ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken) => default;
+    public virtual ValueTask OnReferencesFoundAsync(ImmutableArray<SourceReferenceItem> references, CancellationToken cancellationToken) => default;
 
     protected virtual ValueTask ReportProgressAsync(int current, int maximum, CancellationToken cancellationToken) => default;
 }

--- a/src/Features/Core/Portable/FindUsages/IFindUsagesContext.cs
+++ b/src/Features/Core/Portable/FindUsages/IFindUsagesContext.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Notification;
@@ -35,5 +36,5 @@ internal interface IFindUsagesContext
     ValueTask SetSearchTitleAsync(string title, CancellationToken cancellationToken);
 
     ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken);
-    ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken);
+    ValueTask OnReferencesFoundAsync(ImmutableArray<SourceReferenceItem> references, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/ValueTracking/ValueTracker.FindReferencesProgress.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTracker.FindReferencesProgress.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
@@ -30,10 +30,10 @@ internal static partial class ValueTracker
         public ValueTask OnDefinitionFoundAsync(SymbolGroup symbolGroup, CancellationToken _) => new();
 
         public async ValueTask OnReferencesFoundAsync(
-            ImmutableArray<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references,
+            IAsyncEnumerable<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references,
             CancellationToken cancellationToken)
         {
-            foreach (var (_, symbol, location) in references)
+            await foreach (var (_, symbol, location) in references)
                 await OnReferenceFoundAsync(symbol, location, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Features/LanguageServer/Protocol/Features/FindUsages/SimpleFindUsagesContext.cs
+++ b/src/Features/LanguageServer/Protocol/Features/FindUsages/SimpleFindUsagesContext.cs
@@ -65,11 +65,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
             return default;
         }
 
-        public override ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
+        public override ValueTask OnReferencesFoundAsync(ImmutableArray<SourceReferenceItem> references, CancellationToken cancellationToken)
         {
             lock (_gate)
             {
-                _referenceItems.Add(reference);
+                _referenceItems.AddRange(references);
             }
 
             return default;

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -129,41 +129,44 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
         }
 
-        public override async ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
+        public override async ValueTask OnReferencesFoundAsync(ImmutableArray<SourceReferenceItem> references, CancellationToken cancellationToken)
         {
             using (await _semaphore.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                // Each reference should be associated with a definition. If this somehow isn't the
-                // case, we bail out early.
-                if (!_definitionToId.TryGetValue(reference.Definition, out var definitionId))
-                    return;
-
-                var documentSpan = reference.SourceSpan;
-                var document = documentSpan.Document;
-
-                // If this is reference to the same physical location we've already reported, just
-                // filter this out.  it will clutter the UI to show the same places.
-                if (!_referenceLocations.Add((document.FilePath, reference.SourceSpan.SourceSpan)))
-                    return;
-
-                // If the definition hasn't been reported yet, add it to our list of references to report.
-                if (_definitionsWithoutReference.TryGetValue(definitionId, out var definition))
+                foreach (var reference in references)
                 {
-                    _workQueue.AddWork(definition);
-                    _definitionsWithoutReference.Remove(definitionId);
+                    // Each reference should be associated with a definition. If this somehow isn't the
+                    // case, we bail out early.
+                    if (!_definitionToId.TryGetValue(reference.Definition, out var definitionId))
+                        return;
+
+                    var documentSpan = reference.SourceSpan;
+                    var document = documentSpan.Document;
+
+                    // If this is reference to the same physical location we've already reported, just
+                    // filter this out.  it will clutter the UI to show the same places.
+                    if (!_referenceLocations.Add((document.FilePath, reference.SourceSpan.SourceSpan)))
+                        return;
+
+                    // If the definition hasn't been reported yet, add it to our list of references to report.
+                    if (_definitionsWithoutReference.TryGetValue(definitionId, out var definition))
+                    {
+                        _workQueue.AddWork(definition);
+                        _definitionsWithoutReference.Remove(definitionId);
+                    }
+
+                    // give this reference a fresh id.
+                    _id++;
+
+                    // Creating a new VSReferenceItem for the reference
+                    var referenceItem = await GenerateVSReferenceItemAsync(
+                        definitionId, _id, reference.SourceSpan,
+                        reference.AdditionalProperties, definitionText: null,
+                        definitionGlyph: Glyph.None, reference.SymbolUsageInfo, reference.IsWrittenTo, cancellationToken).ConfigureAwait(false);
+
+                    if (referenceItem != null)
+                        _workQueue.AddWork(referenceItem.Value);
                 }
-
-                // give this reference a fresh id.
-                _id++;
-
-                // Creating a new VSReferenceItem for the reference
-                var referenceItem = await GenerateVSReferenceItemAsync(
-                    definitionId, _id, reference.SourceSpan,
-                    reference.AdditionalProperties, definitionText: null,
-                    definitionGlyph: Glyph.None, reference.SymbolUsageInfo, reference.IsWrittenTo, cancellationToken).ConfigureAwait(false);
-
-                if (referenceItem != null)
-                    _workQueue.AddWork(referenceItem.Value);
             }
         }
 

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FindUsages/FSharpFindUsagesContext.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FindUsages/FSharpFindUsagesContext.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor.FindUsage
 
         public Task OnReferenceFoundAsync(FSharp.FindUsages.FSharpSourceReferenceItem reference)
         {
-            return _context.OnReferenceFoundAsync(reference.RoslynSourceReferenceItem, _cancellationToken).AsTask();
+            return _context.OnReferencesFoundAsync([reference.RoslynSourceReferenceItem], _cancellationToken).AsTask();
         }
 
         public Task ReportMessageAsync(string message)

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -484,11 +484,12 @@ internal partial class StreamingFindUsagesPresenter
             return (excerptResult, AbstractDocumentSpanEntry.GetLineContainingPosition(sourceText, documentSpan.SourceSpan.Start));
         }
 
-        public sealed override async ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
+        public sealed override async ValueTask OnReferencesFoundAsync(ImmutableArray<SourceReferenceItem> references, CancellationToken cancellationToken)
         {
             try
             {
-                await OnReferenceFoundWorkerAsync(reference, cancellationToken).ConfigureAwait(false);
+                foreach (var reference in references)
+                    await OnReferenceFoundWorkerAsync(reference, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
             {

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -405,13 +405,13 @@ internal partial class StreamingFindUsagesPresenter
                 return null;
             }
 
-            var (guid, projectName, _) = GetGuidAndProjectInfo(documentSpan.Document);
+            var (guid, projectName) = GetGuidAndProjectName(documentSpan.Document);
 
             return new DefinitionItemEntry(
                 this,
                 definitionBucket,
-                projectName,
                 guid,
+                projectName,
                 lineText,
                 mappedDocumentSpan.Value,
                 documentSpan,
@@ -439,14 +439,13 @@ internal partial class StreamingFindUsagesPresenter
                 return null;
             }
 
-            var (guid, projectName, projectFlavor) = GetGuidAndProjectInfo(document);
+            var (guid, projectName) = GetGuidAndProjectName(document);
 
             return DocumentSpanEntry.TryCreate(
                 this,
                 definitionBucket,
                 guid,
                 projectName,
-                projectFlavor,
                 document.FilePath,
                 documentSpan.SourceSpan,
                 spanKind,

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -18,23 +18,25 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages;
 internal partial class StreamingFindUsagesPresenter
 {
     /// <summary>
-    /// Base type of all <see cref="Entry"/>s that represent some source location in 
-    /// a <see cref="Document"/>.  Navigation to that location is provided by this type.
-    /// Subclasses can be used to provide customized line text to display in the entry.
+    /// Base type of all <see cref="Entry"/>s that represent some source location in a <see cref="Document"/>.
+    /// Navigation to that location is provided by this type. Subclasses can be used to provide customized line text to
+    /// display in the entry.
     /// 
-    /// Implements navigation since the target document doesn't necessarily exist on disk,
-    /// and only Roslyn knows how to navigate to it.
+    /// Implements navigation since the target document doesn't necessarily exist on disk, and only Roslyn knows how to
+    /// navigate to it.
     /// </summary>
     private abstract class AbstractDocumentSpanEntry(
         AbstractTableDataSourceFindUsagesContext context,
         RoslynDefinitionBucket definitionBucket,
         Guid projectGuid,
+        string projectName,
         SourceText lineText,
         MappedSpanResult mappedSpanResult,
         IThreadingContext threadingContext)
         : AbstractItemEntry(definitionBucket, context.Presenter), ISupportsNavigation
     {
         private readonly object _boxedProjectGuid = projectGuid;
+        private readonly string _projectName = projectName;
         private string? _trimmedLineText = null;
 
         protected abstract Document Document { get; }
@@ -59,15 +61,13 @@ internal partial class StreamingFindUsagesPresenter
                 cancellationToken).ConfigureAwait(false);
         }
 
-        protected abstract string GetProjectName();
-
         protected override object? GetValueWorker(string keyName)
             => keyName switch
             {
                 StandardTableKeyNames.DocumentName => mappedSpanResult.FilePath,
                 StandardTableKeyNames.Line => mappedSpanResult.LinePositionSpan.Start.Line,
                 StandardTableKeyNames.Column => mappedSpanResult.LinePositionSpan.Start.Character,
-                StandardTableKeyNames.ProjectName => GetProjectName(),
+                StandardTableKeyNames.ProjectName => _projectName,
                 StandardTableKeyNames.ProjectGuid => _boxedProjectGuid,
                 StandardTableKeyNames.Text => _trimmedLineText ??= lineText.ToString().Trim(),
                 _ => null,

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/DefinitionItemEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/DefinitionItemEntry.cs
@@ -18,25 +18,22 @@ internal partial class StreamingFindUsagesPresenter
     /// <summary>
     /// Entry created for a definition with a single source location.
     /// </summary>
-    private class DefinitionItemEntry(
+    private sealed class DefinitionItemEntry(
         AbstractTableDataSourceFindUsagesContext context,
         RoslynDefinitionBucket definitionBucket,
-        string projectName,
         Guid projectGuid,
+        string projectName,
         SourceText lineText,
         MappedSpanResult mappedSpanResult,
         DocumentSpan documentSpan,
         IThreadingContext threadingContext)
-        : AbstractDocumentSpanEntry(context, definitionBucket, projectGuid, lineText, mappedSpanResult, threadingContext)
+        : AbstractDocumentSpanEntry(context, definitionBucket, projectGuid, projectName, lineText, mappedSpanResult, threadingContext)
     {
         protected override Document Document
             => documentSpan.Document;
 
         protected override TextSpan NavigateToTargetSpan
             => documentSpan.SourceSpan;
-
-        protected override string GetProjectName()
-            => projectName;
 
         protected override IList<Inline> CreateLineTextInlines()
             => DefinitionBucket.DefinitionItem.DisplayParts.ToInlines(Presenter.ClassificationFormatMap, Presenter.TypeMap);

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/DocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/DocumentSpanEntry.cs
@@ -44,17 +44,12 @@ internal partial class StreamingFindUsagesPresenter
         private readonly ExcerptResult _excerptResult;
         private readonly SymbolReferenceKinds _symbolReferenceKinds;
         private readonly ImmutableArray<(string key, string value)> _customColumnsData;
-        private readonly string _rawProjectName;
-        private readonly List<string> _projectFlavors = [];
-
-        private string? _cachedProjectName;
 
         private DocumentSpanEntry(
             AbstractTableDataSourceFindUsagesContext context,
             RoslynDefinitionBucket definitionBucket,
-            string rawProjectName,
-            string? projectFlavor,
             Guid projectGuid,
+            string projectName,
             HighlightSpanKind spanKind,
             MappedSpanResult mappedSpanResult,
             ExcerptResult excerptResult,
@@ -62,16 +57,12 @@ internal partial class StreamingFindUsagesPresenter
             SymbolUsageInfo symbolUsageInfo,
             ImmutableArray<(string key, string value)> customColumnsData,
             IThreadingContext threadingContext)
-            : base(context, definitionBucket, projectGuid, lineText, mappedSpanResult, threadingContext)
+            : base(context, definitionBucket, projectGuid, projectName, lineText, mappedSpanResult, threadingContext)
         {
             _spanKind = spanKind;
             _excerptResult = excerptResult;
             _symbolReferenceKinds = symbolUsageInfo.ToSymbolReferenceKinds();
             _customColumnsData = customColumnsData;
-            _rawProjectName = rawProjectName;
-
-            if (projectFlavor != null)
-                _projectFlavors.Add(projectFlavor);
         }
 
         protected override Document Document
@@ -80,47 +71,11 @@ internal partial class StreamingFindUsagesPresenter
         protected override TextSpan NavigateToTargetSpan
             => _excerptResult.Span;
 
-        protected override string GetProjectName()
-        {
-            if (_cachedProjectName is null)
-            {
-                // Check if we have any flavors.  If we have at least 2, combine with the project name
-                // so the user can know htat in the UI.
-                lock (_projectFlavors)
-                {
-                    _cachedProjectName ??= _projectFlavors.Count < 2
-                        ? _rawProjectName
-                        : $"{_rawProjectName} ({string.Join(", ", _projectFlavors)})";
-
-                    return _cachedProjectName;
-                }
-            }
-
-            return _cachedProjectName;
-        }
-
-        private void AddFlavor(string? projectFlavor)
-        {
-            if (projectFlavor == null)
-                return;
-
-            lock (_projectFlavors)
-            {
-                if (_projectFlavors.Contains(projectFlavor))
-                    return;
-
-                _projectFlavors.Add(projectFlavor);
-                _projectFlavors.Sort();
-                _cachedProjectName = null;
-            }
-        }
-
         public static DocumentSpanEntry? TryCreate(
             AbstractTableDataSourceFindUsagesContext context,
             RoslynDefinitionBucket definitionBucket,
             Guid guid,
             string projectName,
-            string? projectFlavor,
             string? filePath,
             TextSpan sourceSpan,
             HighlightSpanKind spanKind,
@@ -132,27 +87,21 @@ internal partial class StreamingFindUsagesPresenter
             IThreadingContext threadingContext)
         {
             var entry = new DocumentSpanEntry(
-                context, definitionBucket,
-                projectName, projectFlavor, guid,
-                spanKind, mappedSpanResult, excerptResult,
-                lineText, symbolUsageInfo, customColumnsData,
-                threadingContext);
+                context, definitionBucket, guid, projectName, spanKind, mappedSpanResult, excerptResult,
+                lineText, symbolUsageInfo, customColumnsData, threadingContext);
 
-            // Because of things like linked files, we may have a reference up in multiple
-            // different locations that are effectively at the exact same navigation location
-            // for the user. i.e. they're the same file/span.  Showing multiple entries for these
-            // is just noisy and gets worse and worse with shared projects and whatnot.  So, we
-            // collapse things down to only show a single entry for each unique file/span pair.
+            // Because of things like linked files, we may have a reference up in multiple different locations that are
+            // effectively at the exact same navigation location for the user. i.e. they're the same file/span.  Showing
+            // multiple entries for these is just noisy and gets worse and worse with shared projects and whatnot.  So,
+            // we collapse things down to only show a single entry for each unique file/span pair.
             var winningEntry = definitionBucket.GetOrAddEntry(filePath, sourceSpan, entry);
 
-            // If we were the one that successfully added this entry to the bucket, then pass us
-            // back out to be put in the ui.
+            // If we were the one that successfully added this entry to the bucket, then pass us back out to be put in
+            // the ui.
             if (winningEntry == entry)
                 return entry;
 
-            // We were not the winner.  Add our flavor to the entry that already exists, but throw
-            // away the item we created as we do not want to add it to the ui.
-            winningEntry.AddFlavor(projectFlavor);
+            // We were not the winner.  Throw away the item we created as we do not want to add it to the ui.
             return null;
         }
 

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/MetadataDefinitionItemEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/MetadataDefinitionItemEntry.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages;
 
 internal partial class StreamingFindUsagesPresenter
 {
-    private class MetadataDefinitionItemEntry(
+    private sealed class MetadataDefinitionItemEntry(
         AbstractTableDataSourceFindUsagesContext context,
         RoslynDefinitionBucket definitionBucket,
         AssemblyLocation metadataLocation,

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/NonNavigableEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/NonNavigableEntry.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages;
 
 internal partial class StreamingFindUsagesPresenter
 {
-    private class NonNavigableDefinitionItemEntry(AbstractTableDataSourceFindUsagesContext context, RoslynDefinitionBucket definitionBucket)
+    private sealed class NonNavigableDefinitionItemEntry(AbstractTableDataSourceFindUsagesContext context, RoslynDefinitionBucket definitionBucket)
         : AbstractItemEntry(definitionBucket, context.Presenter)
     {
         protected override object? GetValueWorker(string keyName)

--- a/src/VisualStudio/Core/Def/FindReferences/StreamingFindUsagesPresenter.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/StreamingFindUsagesPresenter.cs
@@ -267,7 +267,7 @@ internal sealed partial class StreamingFindUsagesPresenter : IStreamingFindUsage
         tableControl.SetColumnStates(newColumns);
     }
 
-    private static (Guid, string projectName, string? projectFlavor) GetGuidAndProjectInfo(Document document)
+    private static (Guid, string projectName) GetGuidAndProjectName(Document document)
     {
         // The FAR system needs to know the guid for the project that a def/reference is 
         // from (to support features like filtering).  Normally that would mean we could
@@ -277,12 +277,12 @@ internal sealed partial class StreamingFindUsagesPresenter : IStreamingFindUsage
         // certain features (like filtering) may not work in that context.
         var vsWorkspace = document.Project.Solution.Workspace as VisualStudioWorkspace;
 
-        var (projectName, projectFlavor) = document.Project.State.NameAndFlavor;
+        var (projectName, _) = document.Project.State.NameAndFlavor;
         projectName ??= document.Project.Name;
 
         var guid = vsWorkspace?.GetProjectGuid(document.Project.Id) ?? Guid.Empty;
 
-        return (guid, projectName, projectFlavor);
+        return (guid, projectName);
     }
 
     private void RemoveExistingInfoBar()

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/NoOpStreamingFindReferencesProgress.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/NoOpStreamingFindReferencesProgress.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -27,7 +27,7 @@ internal class NoOpStreamingFindReferencesProgress : IStreamingFindReferencesPro
     public ValueTask OnCompletedAsync(CancellationToken cancellationToken) => default;
     public ValueTask OnStartedAsync(CancellationToken cancellationToken) => default;
     public ValueTask OnDefinitionFoundAsync(SymbolGroup group, CancellationToken cancellationToken) => default;
-    public ValueTask OnReferencesFoundAsync(ImmutableArray<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references, CancellationToken cancellationToken) => default;
+    public ValueTask OnReferencesFoundAsync(IAsyncEnumerable<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references, CancellationToken cancellationToken) => default;
 
     private class NoOpProgressTracker : IStreamingProgressTracker
     {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/StreamingFindReferencesProgress.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/StreamingFindReferencesProgress.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols;
 /// Wraps an <see cref="IFindReferencesProgress"/> into an <see cref="IStreamingFindReferencesProgress"/>
 /// so it can be used from the new streaming find references APIs.
 /// </summary>
-internal class StreamingFindReferencesProgressAdapter : IStreamingFindReferencesProgress
+internal sealed class StreamingFindReferencesProgressAdapter : IStreamingFindReferencesProgress
 {
     private readonly IFindReferencesProgress _progress;
 
@@ -53,12 +53,10 @@ internal class StreamingFindReferencesProgressAdapter : IStreamingFindReferences
         }
     }
 
-    public ValueTask OnReferencesFoundAsync(ImmutableArray<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references, CancellationToken cancellationToken)
+    public async ValueTask OnReferencesFoundAsync(IAsyncEnumerable<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references, CancellationToken cancellationToken)
     {
-        foreach (var (_, symbol, location) in references)
+        await foreach (var (_, symbol, location) in references)
             _progress.OnReferenceFound(symbol, location);
-
-        return default;
     }
 
     public ValueTask OnStartedAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/IStreamingFindReferencesProgress.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/IStreamingFindReferencesProgress.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.FindSymbols;
 
@@ -73,7 +74,7 @@ internal interface IStreamingFindReferencesProgress
     ValueTask OnCompletedAsync(CancellationToken cancellationToken);
 
     ValueTask OnDefinitionFoundAsync(SymbolGroup group, CancellationToken cancellationToken);
-    ValueTask OnReferencesFoundAsync(ImmutableArray<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references, CancellationToken cancellationToken);
+    ValueTask OnReferencesFoundAsync(IAsyncEnumerable<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> references, CancellationToken cancellationToken);
 }
 
 internal interface IStreamingFindLiteralReferencesProgress

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.FindReferencesServerCallback.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.FindReferencesServerCallback.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -64,38 +66,40 @@ public static partial class SymbolFinder
             await progress.OnDefinitionFoundAsync(symbolGroup, cancellationToken).ConfigureAwait(false);
         }
 
-        public async ValueTask OnReferencesFoundAsync(
+        public ValueTask OnReferencesFoundAsync(
             ImmutableArray<(SerializableSymbolGroup serializableSymbolGroup, SerializableSymbolAndProjectId serializableSymbol, SerializableReferenceLocation reference)> references,
             CancellationToken cancellationToken)
         {
-            using var _ = ArrayBuilder<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)>.GetInstance(references.Length, out var rehydrated);
-            foreach (var (serializableSymbolGroup, serializableSymbol, reference) in references)
+            return progress.OnReferencesFoundAsync(ConvertAsync(cancellationToken), cancellationToken);
+
+            async IAsyncEnumerable<(SymbolGroup group, ISymbol symbol, ReferenceLocation location)> ConvertAsync([EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                SymbolGroup? symbolGroup;
-                ISymbol? symbol;
-                lock (_gate)
+                foreach (var (serializableSymbolGroup, serializableSymbol, reference) in references)
                 {
-                    // The definition may not be in the map if we failed to map it over using TryRehydrateAsync in OnDefinitionFoundAsync.
-                    // Just ignore this reference.  Note: while this is a degraded experience:
-                    //
-                    // 1. TryRehydrateAsync logs an NFE so we can track down while we're failing to roundtrip the
-                    //    definition so we can track down that issue.
-                    // 2. NFE'ing and failing to show a result, is much better than NFE'ing and then crashing
-                    //    immediately afterwards.
-                    if (!_groupMap.TryGetValue(serializableSymbolGroup, out symbolGroup) ||
-                        !_definitionMap.TryGetValue(serializableSymbol, out symbol))
+                    SymbolGroup? symbolGroup;
+                    ISymbol? symbol;
+                    lock (_gate)
                     {
-                        continue;
+                        // The definition may not be in the map if we failed to map it over using TryRehydrateAsync in OnDefinitionFoundAsync.
+                        // Just ignore this reference.  Note: while this is a degraded experience:
+                        //
+                        // 1. TryRehydrateAsync logs an NFE so we can track down while we're failing to roundtrip the
+                        //    definition so we can track down that issue.
+                        // 2. NFE'ing and failing to show a result, is much better than NFE'ing and then crashing
+                        //    immediately afterwards.
+                        if (!_groupMap.TryGetValue(serializableSymbolGroup, out symbolGroup) ||
+                            !_definitionMap.TryGetValue(serializableSymbol, out symbol))
+                        {
+                            continue;
+                        }
                     }
+
+                    var referenceLocation = await reference.RehydrateAsync(
+                        solution, cancellationToken).ConfigureAwait(false);
+
+                    yield return (symbolGroup, symbol, referenceLocation);
                 }
-
-                var referenceLocation = await reference.RehydrateAsync(
-                    solution, cancellationToken).ConfigureAwait(false);
-                rehydrated.Add((symbolGroup, symbol, referenceLocation));
             }
-
-            if (rehydrated.Count > 0)
-                await progress.OnReferencesFoundAsync(rehydrated.ToImmutableAndClear(), cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
This is a large savings that gets us down to around 3-5 seconds for a expensive FAR total in Roslyn.