### PR TITLE
Add `AllowsKeywordRecommender` to `KeywordCompletionProvider`

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -28,6 +28,7 @@ internal class KeywordCompletionProvider : AbstractKeywordCompletionProvider<CSh
             new AbstractKeywordRecommender(),
             new AddKeywordRecommender(),
             new AliasKeywordRecommender(),
+            new AllowsKeywordRecommender(),
             new AndKeywordRecommender(),
             new AnnotationsKeywordRecommender(),
             new AscendingKeywordRecommender(),


### PR DESCRIPTION
Without this completion for `allows` keyword doesn't work in IDE