### PR TITLE
Expose folding range functionality to Razor

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static JsonSerializerOptions AddLspSerializerOptions(this JsonSerializerOptions options)
         {
             LSP.VSInternalExtensionUtilities.AddVSInternalExtensionConverters(options);
-            options.Converters.Add(new NaturalObjectConverter());
+            options.Converters.Add(new LSP.NaturalObjectConverter());
             return options;
         }
 

--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -34,7 +34,11 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures2.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.AspNetCore" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" />
+    <!-- Full IVT is through ExternalAccess for functionality -->
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" />
+    <!-- Restricted IVT is direct for protocol types only -->
+    <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor" Namespace="Roslyn.LanguageServer.Protocol" Partner="Razor" Key="$(RazorKey)" />
+    <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Razor" Namespace="Roslyn.LanguageServer.Protocol" Partner="Razor" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Xaml" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.Features.UnitTests" />

--- a/src/Features/LanguageServer/Protocol/Protocol/Converters/NaturalObjectConverter.cs
+++ b/src/Features/LanguageServer/Protocol/Protocol/Converters/NaturalObjectConverter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+
+namespace Roslyn.LanguageServer.Protocol;
 
 // copied from https://github.com/dotnet/runtime/issues/98038 to match newtonsoft behavior
 internal class NaturalObjectConverter : JsonConverter<object>

--- a/src/Tools/ExternalAccess/Razor/Cohost/Handlers/FoldingRanges.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/Handlers/FoldingRanges.cs
@@ -9,17 +9,16 @@ using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.LanguageServer.Protocol;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers
-{
-    internal static class FoldingRanges
-    {
-        public static Task<FoldingRange[]> GetFoldingRangesAsync(Document document, CancellationToken cancellationToken)
-        {
-            // We need to manually get the IGlobalOptionsService out of the Mef composition, because Razor has its own
-            // composition so can't import it (and its internal anyway)
-            var globalOptions = document.Project.Solution.Services.ExportProvider.GetExports<IGlobalOptionService>().First().Value;
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 
-            return FoldingRangesHandler.GetFoldingRangesAsync(globalOptions, document, cancellationToken);
-        }
+internal static class FoldingRanges
+{
+    public static Task<FoldingRange[]> GetFoldingRangesAsync(Document document, CancellationToken cancellationToken)
+    {
+        // We need to manually get the IGlobalOptionsService out of the Mef composition, because Razor has its own
+        // composition so can't import it (and its internal anyway)
+        var globalOptions = document.Project.Solution.Services.ExportProvider.GetExports<IGlobalOptionService>().First().Value;
+
+        return FoldingRangesHandler.GetFoldingRangesAsync(globalOptions, document, cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Cohost/Handlers/FoldingRanges.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/Handlers/FoldingRanges.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Options;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers
+{
+    internal static class FoldingRanges
+    {
+        public static Task<FoldingRange[]> GetFoldingRangesAsync(Document document, CancellationToken cancellationToken)
+        {
+            // We need to manually get the IGlobalOptionsService out of the Mef composition, because Razor has its own
+            // composition so can't import it (and its internal anyway)
+            var globalOptions = document.Project.Solution.Services.ExportProvider.GetExports<IGlobalOptionService>().First().Value;
+
+            return FoldingRangesHandler.GetFoldingRangesAsync(globalOptions, document, cancellationToken);
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/RazorLanguageServerFactoryWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorLanguageServerFactoryWrapper.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
         internal override void AddJsonConverters(JsonSerializerOptions options)
         {
-            VSInternalExtensionUtilities.AddVSInternalExtensionConverters(options);
+            ProtocolConversions.AddLspSerializerOptions(options);
         }
 
         private class RazorCapabilitiesProvider : ICapabilitiesProvider


### PR DESCRIPTION
Three things:

* Allow Razor to get folding ranges through a C# call rather than LSP
* Expose LSP types through restricted IVT so we don't have to wrap the return from the above call
* Minor fix to Json formatter code just in case