### PR TITLE
Add extract method support for ref struct interfaces

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
@@ -59,6 +59,39 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             }
 
             [Fact]
+            public async Task SelectTypeParameterWithAllowsRefStructAntiConstraint()
+            {
+                var code = """
+                    using System;
+
+                    class Program
+                    {
+                        void MyMethod1<TT>(TT tt) where TT : IDisposable, allows ref struct
+                        {
+                            [|tt.Dispose();|]
+                        }
+                    }
+                    """;
+                var expected = """
+                    using System;
+
+                    class Program
+                    {
+                        void MyMethod1<TT>(TT tt) where TT : IDisposable, allows ref struct
+                        {
+                            NewMethod(tt);
+                        }
+                    
+                        private static void NewMethod<TT>(TT tt) where TT : IDisposable, allows ref struct
+                        {
+                            tt.Dispose();
+                        }
+                    }
+                    """;
+
+                await TestExtractMethodAsync(code, expected);
+            }
+            [Fact]
             public async Task SelectTypeParameter()
             {
                 var code = """

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -344,7 +344,7 @@ internal abstract partial class MethodExtractor<TSelectionResult, TStatementSynt
                 typeParameters.Add(CodeGenerationSymbolFactory.CreateTypeParameter(
                     parameter.GetAttributes(), parameter.Variance, parameter.Name, [], parameter.NullableAnnotation,
                     parameter.HasConstructorConstraint, parameter.HasReferenceTypeConstraint, parameter.HasUnmanagedTypeConstraint,
-                    parameter.HasValueTypeConstraint, parameter.HasNotNullConstraint, parameter.Ordinal));
+                    parameter.HasValueTypeConstraint, parameter.AllowsRefLikeType, parameter.HasNotNullConstraint, parameter.Ordinal));
             }
 
             return typeParameters.ToImmutableAndFree();

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -344,7 +344,7 @@ internal abstract partial class MethodExtractor<TSelectionResult, TStatementSynt
                 typeParameters.Add(CodeGenerationSymbolFactory.CreateTypeParameter(
                     parameter.GetAttributes(), parameter.Variance, parameter.Name, [], parameter.NullableAnnotation,
                     parameter.HasConstructorConstraint, parameter.HasReferenceTypeConstraint, parameter.HasUnmanagedTypeConstraint,
-                    parameter.HasValueTypeConstraint, parameter.AllowsRefLikeType, parameter.HasNotNullConstraint, parameter.Ordinal));
+                    parameter.HasValueTypeConstraint, parameter.HasNotNullConstraint, parameter.AllowsRefLikeType, parameter.Ordinal));
             }
 
             return typeParameters.ToImmutableAndFree();

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -135,6 +135,7 @@ internal static partial class IMethodSymbolExtensions
                 typeParameter.HasConstructorConstraint,
                 typeParameter.HasReferenceTypeConstraint,
                 typeParameter.HasValueTypeConstraint,
+                typeParameter.AllowsRefLikeType,
                 typeParameter.HasUnmanagedTypeConstraint,
                 typeParameter.HasNotNullConstraint,
                 typeParameter.Ordinal);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -135,9 +135,9 @@ internal static partial class IMethodSymbolExtensions
                 typeParameter.HasConstructorConstraint,
                 typeParameter.HasReferenceTypeConstraint,
                 typeParameter.HasValueTypeConstraint,
-                typeParameter.AllowsRefLikeType,
                 typeParameter.HasUnmanagedTypeConstraint,
                 typeParameter.HasNotNullConstraint,
+                typeParameter.AllowsRefLikeType,
                 typeParameter.Ordinal);
 
             newTypeParameters.Add(newTypeParameter);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeParameterSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeParameterSymbolExtensions.cs
@@ -74,6 +74,12 @@ internal static class ITypeParameterSymbolExtensions
             constraints.Add(ConstructorConstraint());
         }
 
+        if (typeParameter.AllowsRefLikeType)
+        {
+            // "allows ref struct" anti-constraint must be last
+            constraints.Add(AllowsConstraintClause([RefStructConstraint()]));
+        }
+
         if (constraints.Count == 0)
         {
             return;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -322,7 +322,8 @@ internal static class CodeGenerationSymbolFactory
             attributes: default, varianceKind: VarianceKind.None,
             name: name, constraintTypes: [],
             hasConstructorConstraint: false, hasReferenceConstraint: false, hasValueConstraint: false,
-            hasUnmanagedConstraint: false, hasNotNullConstraint: false, ordinal: ordinal);
+            allowsRefLikeType: false, hasUnmanagedConstraint: false, hasNotNullConstraint: false, 
+            ordinal: ordinal);
     }
 
     /// <summary>
@@ -337,10 +338,11 @@ internal static class CodeGenerationSymbolFactory
         bool hasReferenceConstraint = false,
         bool hasUnmanagedConstraint = false,
         bool hasValueConstraint = false,
+        bool allowsRefLikeType = false,
         bool hasNotNullConstraint = false,
         int ordinal = 0)
     {
-        return new CodeGenerationTypeParameterSymbol(null, attributes, varianceKind, name, nullableAnnotation, constraintTypes, hasConstructorConstraint, hasReferenceConstraint, hasValueConstraint, hasUnmanagedConstraint, hasNotNullConstraint, ordinal);
+        return new CodeGenerationTypeParameterSymbol(null, attributes, varianceKind, name, nullableAnnotation, constraintTypes, hasConstructorConstraint, hasReferenceConstraint, hasValueConstraint, hasUnmanagedConstraint, allowsRefLikeType, hasNotNullConstraint, ordinal);
     }
 
     /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -322,7 +322,7 @@ internal static class CodeGenerationSymbolFactory
             attributes: default, varianceKind: VarianceKind.None,
             name: name, constraintTypes: [],
             hasConstructorConstraint: false, hasReferenceConstraint: false, hasValueConstraint: false,
-            allowsRefLikeType: false, hasUnmanagedConstraint: false, hasNotNullConstraint: false, 
+            allowsRefLikeType: false, hasUnmanagedConstraint: false, hasNotNullConstraint: false,
             ordinal: ordinal);
     }
 
@@ -338,11 +338,11 @@ internal static class CodeGenerationSymbolFactory
         bool hasReferenceConstraint = false,
         bool hasUnmanagedConstraint = false,
         bool hasValueConstraint = false,
-        bool allowsRefLikeType = false,
         bool hasNotNullConstraint = false,
+        bool allowsRefLikeType = false,
         int ordinal = 0)
     {
-        return new CodeGenerationTypeParameterSymbol(null, attributes, varianceKind, name, nullableAnnotation, constraintTypes, hasConstructorConstraint, hasReferenceConstraint, hasValueConstraint, hasUnmanagedConstraint, allowsRefLikeType, hasNotNullConstraint, ordinal);
+        return new CodeGenerationTypeParameterSymbol(null, attributes, varianceKind, name, nullableAnnotation, constraintTypes, hasConstructorConstraint, hasReferenceConstraint, hasValueConstraint, hasUnmanagedConstraint, hasNotNullConstraint, allowsRefLikeType, ordinal);
     }
 
     /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -322,7 +322,7 @@ internal static class CodeGenerationSymbolFactory
             attributes: default, varianceKind: VarianceKind.None,
             name: name, constraintTypes: [],
             hasConstructorConstraint: false, hasReferenceConstraint: false, hasValueConstraint: false,
-            allowsRefLikeType: false, hasUnmanagedConstraint: false, hasNotNullConstraint: false,
+            hasUnmanagedConstraint: false, hasNotNullConstraint: false, allowsRefLikeType: false,
             ordinal: ordinal);
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
@@ -18,9 +18,9 @@ internal class CodeGenerationTypeParameterSymbol(
     bool hasConstructorConstraint,
     bool hasReferenceConstraint,
     bool hasValueConstraint,
-    bool allowsRefLikeType,
     bool hasUnmanagedConstraint,
     bool hasNotNullConstraint,
+    bool allowsRefLikeType,
     int ordinal) : CodeGenerationTypeSymbol(containingType?.ContainingAssembly, containingType, attributes, Accessibility.NotApplicable, default, name, SpecialType.None, nullableAnnotation), ITypeParameterSymbol
 {
     public VarianceKind Variance { get; } = varianceKind;
@@ -38,8 +38,8 @@ internal class CodeGenerationTypeParameterSymbol(
         return new CodeGenerationTypeParameterSymbol(
             this.ContainingType, this.GetAttributes(), this.Variance, this.Name, nullableAnnotation,
             this.ConstraintTypes, this.HasConstructorConstraint, this.HasReferenceTypeConstraint,
-            this.HasValueTypeConstraint, this.AllowsRefLikeType, this.HasUnmanagedTypeConstraint, 
-            this.HasNotNullConstraint, this.Ordinal);
+            this.HasValueTypeConstraint, this.HasUnmanagedTypeConstraint, this.HasNotNullConstraint,
+            this.AllowsRefLikeType, this.Ordinal);
     }
 
     public new ITypeParameterSymbol OriginalDefinition => this;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
@@ -18,6 +18,7 @@ internal class CodeGenerationTypeParameterSymbol(
     bool hasConstructorConstraint,
     bool hasReferenceConstraint,
     bool hasValueConstraint,
+    bool allowsRefLikeType,
     bool hasUnmanagedConstraint,
     bool hasNotNullConstraint,
     int ordinal) : CodeGenerationTypeSymbol(containingType?.ContainingAssembly, containingType, attributes, Accessibility.NotApplicable, default, name, SpecialType.None, nullableAnnotation), ITypeParameterSymbol
@@ -27,7 +28,7 @@ internal class CodeGenerationTypeParameterSymbol(
     public bool HasConstructorConstraint { get; } = hasConstructorConstraint;
     public bool HasReferenceTypeConstraint { get; } = hasReferenceConstraint;
     public bool HasValueTypeConstraint { get; } = hasValueConstraint;
-    public bool AllowsRefLikeType => false;
+    public bool AllowsRefLikeType { get; } = allowsRefLikeType;
     public bool HasUnmanagedTypeConstraint { get; } = hasUnmanagedConstraint;
     public bool HasNotNullConstraint { get; } = hasNotNullConstraint;
     public int Ordinal { get; } = ordinal;
@@ -37,7 +38,8 @@ internal class CodeGenerationTypeParameterSymbol(
         return new CodeGenerationTypeParameterSymbol(
             this.ContainingType, this.GetAttributes(), this.Variance, this.Name, nullableAnnotation,
             this.ConstraintTypes, this.HasConstructorConstraint, this.HasReferenceTypeConstraint,
-            this.HasValueTypeConstraint, this.HasUnmanagedTypeConstraint, this.HasNotNullConstraint, this.Ordinal);
+            this.HasValueTypeConstraint, this.AllowsRefLikeType, this.HasUnmanagedTypeConstraint, 
+            this.HasNotNullConstraint, this.Ordinal);
     }
 
     public new ITypeParameterSymbol OriginalDefinition => this;


### PR DESCRIPTION
The method extraction code uses ITypeParameterSymbol's constraints to generate the new method's text. This codepath had not yet been modified to support ITypeParameterSymbol.AllowsRefLikeType

This is in support of the "allows ref struct" on interfaces feature outlined here: https://github.com/dotnet/roslyn/issues/72124

This ref structs for interfaces feature was merged via this PR: https://github.com/dotnet/roslyn/pull/73567