### PR TITLE
Add object browser support for ref struct interfaces

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ObjectBrowser/DescriptionBuilder.cs
+++ b/src/VisualStudio/CSharp/Impl/ObjectBrowser/DescriptionBuilder.cs
@@ -342,7 +342,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
             if (typeParameterSymbol.ConstraintTypes.Length == 0 &&
                 !typeParameterSymbol.HasConstructorConstraint &&
                 !typeParameterSymbol.HasReferenceTypeConstraint &&
-                !typeParameterSymbol.HasValueTypeConstraint)
+                !typeParameterSymbol.HasValueTypeConstraint &&
+                !typeParameterSymbol.AllowsRefLikeType)
             {
                 return;
             }
@@ -396,6 +397,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
                 }
 
                 AddText("new()");
+            }
+
+            if (typeParameterSymbol.AllowsRefLikeType)
+            {
+                if (!isFirst)
+                {
+                    AddComma();
+                }
+
+                AddText("allows ref struct");
             }
         }
 

--- a/src/VisualStudio/CSharp/Impl/ObjectBrowser/DescriptionBuilder.cs
+++ b/src/VisualStudio/CSharp/Impl/ObjectBrowser/DescriptionBuilder.cs
@@ -397,6 +397,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
                 }
 
                 AddText("new()");
+                isFirst = false;
             }
 
             if (typeParameterSymbol.AllowsRefLikeType)

--- a/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
@@ -728,12 +728,17 @@ $"    {String.Format(ServicesVSResources.Member_of_0, "UnsafeC")}")
 using System.Collections.Generic;
 class C
 {
-    T M&lt;T, U, V&gt;()
+    T M1&lt;T, U, V&gt;()
         where T : class, new()
         where U : V
         where V : List&lt;T&gt;
     {
         return null;
+    }
+
+    void M2&lt;T&gt;(T t)
+        where T : IDisposable, allows ref struct
+    {
     }
 }
 </Code>
@@ -744,12 +749,20 @@ class C
                 list = list.GetTypeList(0)
                 list = list.GetMemberList(0)
 
-                list.VerifyImmediateMemberDescriptions(
-"private T M<T, U, V>()" & vbCrLf &
+                Dim memberDescription1 =
+"private T M1<T, U, V>()" & vbCrLf &
 vbTab & "where T : class, new()" & vbCrLf &
 vbTab & "where U : V" & vbCrLf &
 vbTab & "where V : System.Collections.Generic.List<T>" & vbCrLf &
-$"    {String.Format(ServicesVSResources.Member_of_0, "C")}")
+$"    {String.Format(ServicesVSResources.Member_of_0, "C")}"
+
+                Dim memberDescription2 =
+"private void M2<T>(T t)" & vbCrLf &
+vbTab & "where T : IDisposable, allows ref struct" & vbCrLf &
+$"    {String.Format(ServicesVSResources.Member_of_0, "C")}"
+
+                list.VerifyImmediateMemberDescriptions(memberDescription1, memberDescription2)
+
             End Using
         End Sub
 

--- a/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
@@ -762,7 +762,6 @@ vbTab & "where T : IDisposable, allows ref struct" & vbCrLf &
 $"    {String.Format(ServicesVSResources.Member_of_0, "C")}"
 
                 list.VerifyImmediateMemberDescriptions(memberDescription1, memberDescription2)
-
             End Using
         End Sub
 


### PR DESCRIPTION
The description building code for method constraints in the object browser had not yet been modified to support ITypeParameterSymbol.AllowsRefLikeType

This is in support of the "allows ref struct" on interfaces feature outlined here: #72124

This ref structs for interfaces feature was merged via this PR: #73567