### PR TITLE
Add signature help support for ref struct interfaces

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -451,6 +451,30 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
             await TestAsync(markup, expectedOrderedItems);
         }
 
+        [Fact]
+        public async Task DeclaringGenericTypeWithConstraintsAllowRefStruct()
+        {
+            var markup = """
+                class G<S> where S : allows ref struct
+                { };
+
+                class C
+                {
+                    void Goo()
+                    {
+                        [|G<$$|]>
+                    }
+                }
+                """;
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>
+            {
+                new SignatureHelpTestItem("G<S> where S : allows ref struct", string.Empty, string.Empty, currentParameterIndex: 0)
+            };
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
         #endregion
 
         #region "Generic member invocation"

--- a/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider.cs
@@ -284,6 +284,22 @@ internal partial class GenericNameSignatureHelpProvider : AbstractCSharpSignatur
                 parts.Add(Keyword(SyntaxKind.NewKeyword));
                 parts.Add(Punctuation(SyntaxKind.OpenParenToken));
                 parts.Add(Punctuation(SyntaxKind.CloseParenToken));
+                needComma = true;
+            }
+
+            if (typeParam.AllowsRefLikeType)
+            {
+                if (needComma)
+                {
+                    parts.Add(Punctuation(SyntaxKind.CommaToken));
+                    parts.Add(Space());
+                }
+
+                parts.Add(Keyword(SyntaxKind.AllowsKeyword));
+                parts.Add(Space());
+                parts.Add(Keyword(SyntaxKind.RefKeyword));
+                parts.Add(Space());
+                parts.Add(Keyword(SyntaxKind.StructKeyword));
             }
         }
 
@@ -293,6 +309,7 @@ internal partial class GenericNameSignatureHelpProvider : AbstractCSharpSignatur
     private static bool TypeParameterHasConstraints(ITypeParameterSymbol typeParam)
     {
         return !typeParam.ConstraintTypes.IsDefaultOrEmpty || typeParam.HasConstructorConstraint ||
-            typeParam.HasReferenceTypeConstraint || typeParam.HasValueTypeConstraint;
+            typeParam.HasReferenceTypeConstraint || typeParam.HasValueTypeConstraint ||
+            typeParam.AllowsRefLikeType;
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SignatureComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SignatureComparer.cs
@@ -223,7 +223,8 @@ internal sealed class SignatureComparer
     {
         if (typeParameter1.HasConstructorConstraint != typeParameter2.HasConstructorConstraint ||
             typeParameter1.HasReferenceTypeConstraint != typeParameter2.HasReferenceTypeConstraint ||
-            typeParameter1.HasValueTypeConstraint != typeParameter2.HasValueTypeConstraint)
+            typeParameter1.HasValueTypeConstraint != typeParameter2.HasValueTypeConstraint ||
+            typeParameter1.AllowsRefLikeType != typeParameter2.AllowsRefLikeType)
         {
             return false;
         }


### PR DESCRIPTION
The selected display part building code for method constraints in signature help had not yet been modified to support ITypeParameterSymbol.AllowsRefLikeType

This is in support of the "allows ref struct" on interfaces feature outlined here: #72124

This ref structs for interfaces feature was merged via this PR: #73567