### PR TITLE
Drop roslyn impact on scrolling perf by 30%

### DIFF
--- a/src/Dependencies/Collections/Internal/ArraySortHelper.cs
+++ b/src/Dependencies/Collections/Internal/ArraySortHelper.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             // Add a try block here to detect bogus comparisons
             try
             {
-                IntrospectiveSort(keys, comparer);
+                IntrospectiveSort(keys, comparer!);
             }
             catch (IndexOutOfRangeException)
             {

--- a/src/Dependencies/Collections/Internal/ArraySortHelper.cs
+++ b/src/Dependencies/Collections/Internal/ArraySortHelper.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             // Add a try block here to detect bogus comparisons
             try
             {
-                IntrospectiveSort(keys, comparer!);
+                IntrospectiveSort(keys, comparer);
             }
             catch (IndexOutOfRangeException)
             {

--- a/src/Dependencies/Collections/SegmentedArray.cs
+++ b/src/Dependencies/Collections/SegmentedArray.cs
@@ -394,6 +394,22 @@ namespace Microsoft.CodeAnalysis.Collections
             }
         }
 
+        public static void Sort<T>(SegmentedArray<T> array, int index, int length, Comparison<T> comparison)
+        {
+            if (index < 0)
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
+            if (length < 0)
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
+            if (array.Length - index < length)
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
+
+            if (length > 1)
+            {
+                var segment = new SegmentedArraySegment<T>(array, index, length);
+                SegmentedArraySortHelper<T>.Sort(segment, comparison);
+            }
+        }
+
         public static void Sort<T>(SegmentedArray<T> array, Comparison<T> comparison)
         {
             if (comparison is null)

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -1198,7 +1198,7 @@ namespace Microsoft.CodeAnalysis.Collections
 
             if (_size > 1)
             {
-                SegmentedArray.Sort<T>(_items, 0, _size, Comparer<T>.Create(comparison));
+                SegmentedArray.Sort(_items, 0, _size, comparison);
             }
             _version++;
         }

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -90,7 +90,7 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
         }
 
         private static IEnumerable<ITagSpan<IClassificationTag>> GetIntersectingTags(NormalizedSnapshotSpanCollection spans, TagSpanIntervalTree<IClassificationTag> cachedTags)
-            => SegmentedListPool<ITagSpan<IClassificationTag>>.ComputeList(
+            => SegmentedListPool<TagSpan<IClassificationTag>>.ComputeList(
                 static (args, tags) => args.cachedTags.AddIntersectingTagSpans(args.spans, tags),
                 (cachedTags, spans));
 
@@ -138,7 +138,7 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
             var options = _globalOptions.GetClassificationOptions(document.Project.Language);
 
             // Final list of tags to produce, containing syntax/semantic/embedded classification tags.
-            using var _ = SegmentedListPool.GetPooledList<ITagSpan<IClassificationTag>>(out var mergedTags);
+            using var _ = SegmentedListPool.GetPooledList<TagSpan<IClassificationTag>>(out var mergedTags);
 
             _owner._threadingContext.JoinableTaskFactory.Run(async () =>
             {
@@ -166,7 +166,7 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
 
             return GetIntersectingTags(spans, cachedTags);
 
-            Func<NormalizedSnapshotSpanCollection, SegmentedList<ITagSpan<IClassificationTag>>, VoidResult, Task> GetTaggingFunction(
+            Func<NormalizedSnapshotSpanCollection, SegmentedList<TagSpan<IClassificationTag>>, VoidResult, Task> GetTaggingFunction(
                 bool requireSingleSpan, Func<TextSpan, SegmentedList<ClassifiedSpan>, Task> addTagsAsync)
             {
                 Contract.ThrowIfTrue(requireSingleSpan && spans.Count != 1, "We should only be asking for a single span");
@@ -175,7 +175,7 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
 
             async Task AddSpansAsync(
                 NormalizedSnapshotSpanCollection spans,
-                SegmentedList<ITagSpan<IClassificationTag>> result,
+                SegmentedList<TagSpan<IClassificationTag>> result,
                 Func<TextSpan, SegmentedList<ClassifiedSpan>, Task> addAsync)
             {
                 // temp buffer we can use across all our classification calls.  Should be cleared between each call.

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -392,7 +392,7 @@ internal partial class SyntacticClassificationTaggerProvider
                 return _lastProcessedData;
         }
 
-        public void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<IClassificationTag>> tags)
+        public void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<TagSpan<IClassificationTag>> tags)
         {
             _taggerProvider._threadingContext.ThrowIfNotOnUIThread();
 
@@ -400,7 +400,7 @@ internal partial class SyntacticClassificationTaggerProvider
                 AddTagsWorker(spans, tags);
         }
 
-        private void AddTagsWorker(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<IClassificationTag>> tags)
+        private void AddTagsWorker(NormalizedSnapshotSpanCollection spans, SegmentedList<TagSpan<IClassificationTag>> tags)
         {
             _taggerProvider._threadingContext.ThrowIfNotOnUIThread();
             if (spans.Count == 0 || _workspace == null)

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.Tagger.cs
@@ -24,7 +24,7 @@ internal partial class SyntacticClassificationTaggerProvider
 
         public override void AddTags(
             NormalizedSnapshotSpanCollection spans,
-            SegmentedList<ITagSpan<IClassificationTag>> tags)
+            SegmentedList<TagSpan<IClassificationTag>> tags)
         {
             var tagComputer = _tagComputer ?? throw new ObjectDisposedException(GetType().FullName);
             tagComputer.AddTags(spans, tags);

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -77,9 +78,9 @@ internal sealed class TotalClassificationAggregateTagger(
     EfficientTagger<IClassificationTag> embeddedTagger)
     : AbstractAggregateTagger<IClassificationTag>([syntacticTagger, semanticTagger, embeddedTagger])
 {
-    private static readonly Comparison<ITagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start.Position - s2.Span.Start.Position;
+    private static readonly IComparer<TagSpan<IClassificationTag>> s_spanComparer = new TagSpanComparer();
 
-    public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<IClassificationTag>> totalTags)
+    public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<TagSpan<IClassificationTag>> totalTags)
     {
         // Everything we pass in is synchronous, so we should immediately get a completed task back out.
         AddTagsAsync(
@@ -105,10 +106,10 @@ internal sealed class TotalClassificationAggregateTagger(
 
     public static async Task AddTagsAsync<TArg>(
         NormalizedSnapshotSpanCollection spans,
-        SegmentedList<ITagSpan<IClassificationTag>> totalTags,
-        Func<NormalizedSnapshotSpanCollection, SegmentedList<ITagSpan<IClassificationTag>>, TArg, Task> addSyntacticSpansAsync,
-        Func<NormalizedSnapshotSpanCollection, SegmentedList<ITagSpan<IClassificationTag>>, TArg, Task> addSemanticSpansAsync,
-        Func<NormalizedSnapshotSpanCollection, SegmentedList<ITagSpan<IClassificationTag>>, TArg, Task> addEmbeddedSpansAsync,
+        SegmentedList<TagSpan<IClassificationTag>> totalTags,
+        Func<NormalizedSnapshotSpanCollection, SegmentedList<TagSpan<IClassificationTag>>, TArg, Task> addSyntacticSpansAsync,
+        Func<NormalizedSnapshotSpanCollection, SegmentedList<TagSpan<IClassificationTag>>, TArg, Task> addSemanticSpansAsync,
+        Func<NormalizedSnapshotSpanCollection, SegmentedList<TagSpan<IClassificationTag>>, TArg, Task> addEmbeddedSpansAsync,
         TArg arg)
     {
         // First, get all the syntactic tags.  While they are generally overridden by semantic tags (since semantics
@@ -116,15 +117,15 @@ internal sealed class TotalClassificationAggregateTagger(
         // tags like 'Comments' and 'Excluded Code'.  In those cases we want the classification to 'snap' instantly to
         // the syntactic state, and we do not want things like semantic classifications showing up over that.
 
-        using var _1 = SegmentedListPool.GetPooledList<ITagSpan<IClassificationTag>>(out var stringLiterals);
-        using var _2 = SegmentedListPool.GetPooledList<ITagSpan<IClassificationTag>>(out var syntacticSpans);
-        using var _3 = SegmentedListPool.GetPooledList<ITagSpan<IClassificationTag>>(out var semanticSpans);
+        using var _1 = SegmentedListPool.GetPooledList<TagSpan<IClassificationTag>>(out var stringLiterals);
+        using var _2 = SegmentedListPool.GetPooledList<TagSpan<IClassificationTag>>(out var syntacticSpans);
+        using var _3 = SegmentedListPool.GetPooledList<TagSpan<IClassificationTag>>(out var semanticSpans);
 
         await addSyntacticSpansAsync(spans, syntacticSpans, arg).ConfigureAwait(false);
         await addSemanticSpansAsync(spans, semanticSpans, arg).ConfigureAwait(false);
 
-        syntacticSpans.Sort(s_spanComparison);
-        semanticSpans.Sort(s_spanComparison);
+        syntacticSpans.Sort(s_spanComparer);
+        semanticSpans.Sort(s_spanComparer);
 
         using var syntacticEnumerator = syntacticSpans.GetEnumerator();
         using var semanticEnumerator = semanticSpans.GetEnumerator();
@@ -231,7 +232,7 @@ internal sealed class TotalClassificationAggregateTagger(
                 return;
 
             // Only need to ask for the spans that overlapped the string literals.
-            using var _1 = SegmentedListPool.GetPooledList<ITagSpan<IClassificationTag>>(out var embeddedClassifications);
+            using var _1 = SegmentedListPool.GetPooledList<TagSpan<IClassificationTag>>(out var embeddedClassifications);
 
             var stringLiteralSpansFull = new NormalizedSnapshotSpanCollection(stringLiterals.Select(s => s.Span));
 
@@ -250,14 +251,14 @@ internal sealed class TotalClassificationAggregateTagger(
             }
 
             // ClassifierHelper.MergeParts requires these to be sorted.
-            stringLiterals.Sort(s_spanComparison);
-            embeddedClassifications.Sort(s_spanComparison);
+            stringLiterals.Sort(s_spanComparer);
+            embeddedClassifications.Sort(s_spanComparer);
 
             // Call into the helper to merge the string literals and embedded classifications into the final result.
             // The helper will add all the embedded classifications first, then add string literal classifications
             // in the the space between the embedded classifications that were originally classified as a string
             // literal.
-            ClassifierHelper.MergeParts<ITagSpan<IClassificationTag>, ClassificationTagSpanIntervalIntrospector>(
+            ClassifierHelper.MergeParts<TagSpan<IClassificationTag>, ClassificationTagSpanIntervalIntrospector>(
                 stringLiterals,
                 embeddedClassifications,
                 totalTags,
@@ -265,19 +266,25 @@ internal sealed class TotalClassificationAggregateTagger(
                 static (original, final) => new TagSpan<IClassificationTag>(new SnapshotSpan(original.Span.Snapshot, final.ToSpan()), original.Tag));
         }
 
-        ITagSpan<IClassificationTag>? GetNextSyntacticSpan()
+        TagSpan<IClassificationTag>? GetNextSyntacticSpan()
             => syntacticEnumerator.MoveNext() ? syntacticEnumerator.Current : null;
 
-        ITagSpan<IClassificationTag>? GetNextSemanticSpan()
+        TagSpan<IClassificationTag>? GetNextSemanticSpan()
             => semanticEnumerator.MoveNext() ? semanticEnumerator.Current : null;
     }
 
-    private readonly struct ClassificationTagSpanIntervalIntrospector : IIntervalIntrospector<ITagSpan<IClassificationTag>>
+    private sealed class TagSpanComparer : IComparer<TagSpan<IClassificationTag>>
     {
-        public int GetStart(ITagSpan<IClassificationTag> value)
+        public int Compare(TagSpan<IClassificationTag>? x, TagSpan<IClassificationTag>? y)
+            => x!.Span.Start.Position - y!.Span.Start.Position;
+    }
+
+    private readonly struct ClassificationTagSpanIntervalIntrospector : IIntervalIntrospector<TagSpan<IClassificationTag>>
+    {
+        public int GetStart(TagSpan<IClassificationTag> value)
             => value.Span.Start;
 
-        public int GetLength(ITagSpan<IClassificationTag> value)
+        public int GetLength(TagSpan<IClassificationTag> value)
             => value.Span.Length;
     }
 }

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -78,7 +78,7 @@ internal sealed class TotalClassificationAggregateTagger(
     EfficientTagger<IClassificationTag> embeddedTagger)
     : AbstractAggregateTagger<IClassificationTag>([syntacticTagger, semanticTagger, embeddedTagger])
 {
-    private static readonly IComparer<TagSpan<IClassificationTag>> s_spanComparer = new TagSpanComparer();
+    private static readonly Comparison<ITagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start.Position - s2.Span.Start.Position;
 
     public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<TagSpan<IClassificationTag>> totalTags)
     {
@@ -124,8 +124,8 @@ internal sealed class TotalClassificationAggregateTagger(
         await addSyntacticSpansAsync(spans, syntacticSpans, arg).ConfigureAwait(false);
         await addSemanticSpansAsync(spans, semanticSpans, arg).ConfigureAwait(false);
 
-        syntacticSpans.Sort(s_spanComparer);
-        semanticSpans.Sort(s_spanComparer);
+        syntacticSpans.Sort(s_spanComparison);
+        semanticSpans.Sort(s_spanComparison);
 
         using var syntacticEnumerator = syntacticSpans.GetEnumerator();
         using var semanticEnumerator = semanticSpans.GetEnumerator();
@@ -251,8 +251,8 @@ internal sealed class TotalClassificationAggregateTagger(
             }
 
             // ClassifierHelper.MergeParts requires these to be sorted.
-            stringLiterals.Sort(s_spanComparer);
-            embeddedClassifications.Sort(s_spanComparer);
+            stringLiterals.Sort(s_spanComparison);
+            embeddedClassifications.Sort(s_spanComparison);
 
             // Call into the helper to merge the string literals and embedded classifications into the final result.
             // The helper will add all the embedded classifications first, then add string literal classifications

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -78,7 +78,7 @@ internal sealed class TotalClassificationAggregateTagger(
     EfficientTagger<IClassificationTag> embeddedTagger)
     : AbstractAggregateTagger<IClassificationTag>([syntacticTagger, semanticTagger, embeddedTagger])
 {
-    private static readonly Comparison<ITagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start.Position - s2.Span.Start.Position;
+    private static readonly Comparison<TagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start.Position - s2.Span.Start.Position;
 
     public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<TagSpan<IClassificationTag>> totalTags)
     {

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -273,12 +273,6 @@ internal sealed class TotalClassificationAggregateTagger(
             => semanticEnumerator.MoveNext() ? semanticEnumerator.Current : null;
     }
 
-    private sealed class TagSpanComparer : IComparer<TagSpan<IClassificationTag>>
-    {
-        public int Compare(TagSpan<IClassificationTag>? x, TagSpan<IClassificationTag>? y)
-            => x!.Span.Start.Position - y!.Span.Start.Position;
-    }
-
     private readonly struct ClassificationTagSpanIntervalIntrospector : IIntervalIntrospector<TagSpan<IClassificationTag>>
     {
         public int GetStart(TagSpan<IClassificationTag> value)

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -77,7 +77,7 @@ internal sealed class TotalClassificationAggregateTagger(
     EfficientTagger<IClassificationTag> embeddedTagger)
     : AbstractAggregateTagger<IClassificationTag>([syntacticTagger, semanticTagger, embeddedTagger])
 {
-    private static readonly Comparison<ITagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start - s2.Span.Start;
+    private static readonly Comparison<ITagSpan<IClassificationTag>> s_spanComparison = static (s1, s2) => s1.Span.Start.Position - s2.Span.Start.Position;
 
     public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<IClassificationTag>> totalTags)
     {

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -51,8 +51,8 @@ internal partial class TagSpanIntervalTree<TTag> where TTag : ITag
         return _tree.HasIntervalThatContains(point.Position, length: 0, new IntervalIntrospector(snapshot));
     }
 
-    public IList<ITagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
-        => SegmentedListPool<ITagSpan<TTag>>.ComputeList(
+    public IList<TagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
+        => SegmentedListPool<TagSpan<TTag>>.ComputeList(
             static (args, tags) => args.@this.AppendIntersectingSpansInSortedOrder(args.snapshotSpan, tags),
             (@this: this, snapshotSpan));
 
@@ -61,7 +61,7 @@ internal partial class TagSpanIntervalTree<TTag> where TTag : ITag
     /// <paramref name="result"/>.  Note the sorted chunk of items are appended to <paramref name="result"/>.  This
     /// means that <paramref name="result"/> may not be sorted if there were already items in them.
     /// </summary>
-    private void AppendIntersectingSpansInSortedOrder(SnapshotSpan snapshotSpan, SegmentedList<ITagSpan<TTag>> result)
+    private void AppendIntersectingSpansInSortedOrder(SnapshotSpan snapshotSpan, SegmentedList<TagSpan<TTag>> result)
     {
         var snapshot = snapshotSpan.Snapshot;
         Debug.Assert(snapshot.TextBuffer == _textBuffer);
@@ -80,14 +80,14 @@ internal partial class TagSpanIntervalTree<TTag> where TTag : ITag
     public bool IsEmpty()
         => _tree.IsEmpty();
 
-    public void AddIntersectingTagSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<ITagSpan<TTag>> tags)
+    public void AddIntersectingTagSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
     {
         AddIntersectingTagSpansWorker(requestedSpans, tags);
         DebugVerifyTags(requestedSpans, tags);
     }
 
     [Conditional("DEBUG")]
-    private static void DebugVerifyTags(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<ITagSpan<TTag>> tags)
+    private static void DebugVerifyTags(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
     {
         if (tags == null)
         {
@@ -107,7 +107,7 @@ internal partial class TagSpanIntervalTree<TTag> where TTag : ITag
 
     private void AddIntersectingTagSpansWorker(
         NormalizedSnapshotSpanCollection requestedSpans,
-        SegmentedList<ITagSpan<TTag>> tags)
+        SegmentedList<TagSpan<TTag>> tags)
     {
         const int MaxNumberOfRequestedSpans = 100;
 
@@ -123,20 +123,20 @@ internal partial class TagSpanIntervalTree<TTag> where TTag : ITag
 
     private void AddTagsForSmallNumberOfSpans(
         NormalizedSnapshotSpanCollection requestedSpans,
-        SegmentedList<ITagSpan<TTag>> tags)
+        SegmentedList<TagSpan<TTag>> tags)
     {
         foreach (var span in requestedSpans)
             AppendIntersectingSpansInSortedOrder(span, tags);
     }
 
-    private void AddTagsForLargeNumberOfSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<ITagSpan<TTag>> tags)
+    private void AddTagsForLargeNumberOfSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
     {
         // we are asked with bunch of spans. rather than asking same question again and again, ask once with big span
         // which will return superset of what we want. and then filter them out in O(m+n) cost. 
         // m == number of requested spans, n = number of returned spans
         var mergedSpan = new SnapshotSpan(requestedSpans[0].Start, requestedSpans[^1].End);
 
-        using var _1 = SegmentedListPool.GetPooledList<ITagSpan<TTag>>(out var tempList);
+        using var _1 = SegmentedListPool.GetPooledList<TagSpan<TTag>>(out var tempList);
 
         AppendIntersectingSpansInSortedOrder(mergedSpan, tempList);
         if (tempList.Count == 0)

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -637,7 +637,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             return tags;
         }
 
-        public void AddTags(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<ITagSpan<TTag>> tags)
+        public void AddTags(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
         {
             _dataSource.ThreadingContext.ThrowIfNotOnUIThread();
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -35,7 +35,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
         public override void Dispose()
             => _tagSource.OnTaggerDisposed(this);
 
-        public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags)
+        public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<TagSpan<TTag>> tags)
             => _tagSource.AddTags(spans, tags);
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AggregateTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AggregateTagger.cs
@@ -56,7 +56,7 @@ internal sealed class SimpleAggregateTagger<TTag>(ImmutableArray<EfficientTagger
     : AbstractAggregateTagger<TTag>(taggers)
     where TTag : ITag
 {
-    public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags)
+    public override void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<TagSpan<TTag>> tags)
     {
         foreach (var tagger in this.Taggers)
             tagger.AddTags(spans, tags);

--- a/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
@@ -22,7 +22,7 @@ internal abstract class EfficientTagger<TTag> : ITagger<TTag>, IDisposable where
     /// <summary>
     /// Produce the set of tags with the requested <paramref name="spans"/>, adding those tags to <paramref name="tags"/>.
     /// </summary>
-    public abstract void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<ITagSpan<TTag>> tags);
+    public abstract void AddTags(NormalizedSnapshotSpanCollection spans, SegmentedList<TagSpan<TTag>> tags);
 
     public abstract void Dispose();
 
@@ -30,7 +30,7 @@ internal abstract class EfficientTagger<TTag> : ITagger<TTag>, IDisposable where
     /// Default impl of the core <see cref="ITagger{T}"/> interface.  Forces an allocation.
     /// </summary>
     public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
-        => SegmentedListPool<ITagSpan<TTag>>.ComputeList(
+        => SegmentedListPool<TagSpan<TTag>>.ComputeList(
             static (args, tags) => args.@this.AddTags(args.spans, tags),
             (@this: this, spans));
 

--- a/src/Workspaces/CSharp/Portable/Classification/CSharpClassificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/CSharpClassificationService.cs
@@ -13,14 +13,11 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.CSharp.Classification;
 
 [ExportLanguageService(typeof(IClassificationService), LanguageNames.CSharp), Shared]
-internal class CSharpEditorClassificationService : AbstractClassificationService
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpEditorClassificationService(
+    CSharpSyntaxClassificationService syntaxClassificationService) : AbstractClassificationService(syntaxClassificationService)
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public CSharpEditorClassificationService()
-    {
-    }
-
     public override void AddLexicalClassifications(SourceText text, TextSpan textSpan, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         => ClassificationHelpers.AddLexicalClassifications(text, textSpan, result, cancellationToken);
 

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/CSharpSyntaxClassificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/CSharpSyntaxClassificationService.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification;
 
-[ExportLanguageService(typeof(ISyntaxClassificationService), LanguageNames.CSharp), Shared]
+[ExportLanguageService(typeof(ISyntaxClassificationService), LanguageNames.CSharp), Export, Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class CSharpSyntaxClassificationService() : AbstractSyntaxClassificationService

--- a/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
@@ -20,8 +20,10 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Classification;
 
-internal abstract class AbstractClassificationService : IClassificationService
+internal abstract class AbstractClassificationService(ISyntaxClassificationService syntaxClassificationService) : IClassificationService
 {
+    private readonly ISyntaxClassificationService _syntaxClassificationService = syntaxClassificationService;
+
     public abstract void AddLexicalClassifications(SourceText text, TextSpan textSpan, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
     public abstract ClassifiedSpan AdjustStaleClassification(SourceText text, ClassifiedSpan classifiedSpan);
 
@@ -192,8 +194,7 @@ internal abstract class AbstractClassificationService : IClassificationService
         if (root is null)
             return;
 
-        var classificationService = services.GetLanguageServices(root.Language).GetRequiredService<ISyntaxClassificationService>();
-        classificationService.AddSyntacticClassifications(root, textSpans, result, cancellationToken);
+        _syntaxClassificationService.AddSyntacticClassifications(root, textSpans, result, cancellationToken);
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
@@ -16,10 +16,6 @@ namespace Microsoft.CodeAnalysis.Classification;
 
 internal abstract partial class AbstractSyntaxClassificationService : ISyntaxClassificationService
 {
-    protected AbstractSyntaxClassificationService()
-    {
-    }
-
     public abstract void AddLexicalClassifications(SourceText text, TextSpan textSpan, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
     public abstract void AddSyntacticClassifications(SyntaxNode root, ImmutableArray<TextSpan> textSpans, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
 

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/VisualBasicSyntaxClassificationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/VisualBasicSyntaxClassificationService.vb
@@ -9,12 +9,11 @@ Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Host.Mef
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
-    <ExportLanguageService(GetType(ISyntaxClassificationService), LanguageNames.VisualBasic), [Shared]>
+    <ExportLanguageService(GetType(ISyntaxClassificationService), LanguageNames.VisualBasic), Export, [Shared]>
     Partial Friend Class VisualBasicSyntaxClassificationService
         Inherits AbstractSyntaxClassificationService
 

--- a/src/Workspaces/VisualBasic/Portable/Classification/VisualBasicClassificationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/VisualBasicClassificationService.vb
@@ -16,7 +16,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
-        Public Sub New()
+        Public Sub New(syntaxClassificationService As VisualBasicSyntaxClassificationService)
+            MyBase.New(syntaxClassificationService)
         End Sub
 
         Public Overrides Sub AddLexicalClassifications(text As SourceText, textSpan As TextSpan, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken)


### PR DESCRIPTION
Takes us from: 

![image](https://github.com/dotnet/roslyn/assets/4564579/b4e5f1ec-91db-40ec-9c62-a009933956f1)

to

![image](https://github.com/dotnet/roslyn/assets/4564579/2cf647b1-4b7d-41d6-8b83-33f61ad2427d)
