### PR TITLE
Add test for F1 on "allows ref struct"

### DIFF
--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1475,6 +1475,19 @@ class C
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48392")]
+        public async Task TestAllowsRefStructAntiConstraint()
+        {
+            await Test_KeywordAsync(
+@"class C
+{ 
+    void M<T>()
+        where T : all[||]ows ref struct
+    {
+    }
+}", "allows");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48392")]
         public async Task TestUsingStaticOnUsingKeyword()
         {
             await Test_KeywordAsync(


### PR DESCRIPTION
It looks like this already detects this is a keyword and sends out a request for allows_CSharpKeyword, which matches the desired value per @BillWagner 