### PR TITLE
Reduce cost of syntactic classification by around 25% while paging down through a file (and around 50% while arrowing down).

### DIFF
--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.LastLineCache.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.LastLineCache.cs
@@ -44,7 +44,7 @@ internal partial class SyntacticClassificationTaggerProvider
 
             private readonly IThreadingContext _threadingContext = threadingContext;
 
-            // mutating state
+            // Mutating state.  No need for locks as we only execute on the UI thread (and throw if we're not on that thread).
 
             private ITextSnapshot? _snapshot;
 

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.LastLineCache.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.LastLineCache.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Classification;
 
@@ -14,52 +16,115 @@ internal partial class SyntacticClassificationTaggerProvider
     internal partial class TagComputer
     {
         /// <summary>
-        /// it is a helper class that encapsulates logic on holding onto last classification result
+        /// it is a helper class that encapsulates logic on holding onto last classification result.  This type has
+        /// thread affinity on the UI thread, so it doesn't need any synchronization.
         /// </summary>
-        private class LastLineCache(IThreadingContext threadingContext)
+        /// <remarks>
+        /// Empirical testing shows that when paging through a file, 25% of syntactic classification requests can be
+        /// returned from a simple LRU cache.  When arrowing up and down in a file, the cache hit rate is 85%.  This can
+        /// substantially speed up these requests, especially in large files, as it means we can avoid walking syntax
+        /// trees and reclassifying lines we just classified.
+        /// </remarks>
+        private sealed class ClassifiedLineCache(IThreadingContext threadingContext)
         {
-            // this helper class is primarily to improve active typing perf. don't bother to cache
-            // something very big. 
-            private const int MaxClassificationNumber = 32;
+            /// <summary>
+            /// Ensure that we don't cache incredibly long lines (for example, a minified JavaScript file).  This also
+            /// ensures if we were asked by some party to classify a large section of the file, that we don't attempt to
+            /// store that.  The primary purpose of this cache is for the common case of returning cached lines when the
+            /// editor calls into us to classify them.
+            /// </summary>
+            private const int MaxClassificationsCount = 1024;
 
-            // mutating state
-            private SnapshotSpan _span;
-            private readonly SegmentedList<ClassifiedSpan> _classifications = [];
+            /// <summary>
+            /// This number was picked as a reasonable number of lines to classify given regular screen sized.  This is
+            /// about 6x larger than a normal number of lines in VS at standard resolutions, and handles the case of
+            /// users with vertical monitors and small font/zoom settings..
+            /// </summary>
+            private const int CacheSize = 256;
+
             private readonly IThreadingContext _threadingContext = threadingContext;
 
-            private void Clear()
+            // mutating state
+
+            private ITextSnapshot? _snapshot;
+
+            private readonly LinkedList<Span> _spans = [];
+            private readonly Dictionary<Span, (LinkedListNode<Span> node, SegmentedList<ClassifiedSpan> classifiedSpans)> _spanToClassifiedSpansMap = [];
+
+            private void ClearIfDifferentSnapshot(ITextSnapshot snapshot)
             {
                 _threadingContext.ThrowIfNotOnUIThread();
 
-                _span = default;
-                _classifications.Clear();
-            }
-
-            public bool TryUseCache(SnapshotSpan span, SegmentedList<ClassifiedSpan> classifications)
-            {
-                _threadingContext.ThrowIfNotOnUIThread();
-
-                // currently, it is using SnapshotSpan even though holding onto it could be
-                // expensive. reason being it should be very soon sync-ed to latest snapshot.
-                if (_span.Equals(span))
+                if (_snapshot != snapshot)
                 {
-                    classifications.AddRange(_classifications);
-                    return true;
+                    _spans.Clear();
+                    _spanToClassifiedSpansMap.Clear();
+                    _snapshot = snapshot;
                 }
-
-                this.Clear();
-                return false;
             }
 
-            public void Update(SnapshotSpan span, SegmentedList<ClassifiedSpan> classifications)
+            public bool TryUseCache(SnapshotSpan snapshotSpan, SegmentedList<ClassifiedSpan> classifications)
             {
                 _threadingContext.ThrowIfNotOnUIThread();
-                this.Clear();
 
-                if (classifications.Count < MaxClassificationNumber)
+                ClearIfDifferentSnapshot(snapshotSpan.Snapshot);
+
+                if (!_spanToClassifiedSpansMap.TryGetValue(snapshotSpan.Span, out var tuple))
+                    return false;
+
+                // Move this node to the front of the LRU list.
+                _spans.Remove(tuple.node);
+                _spans.AddLast(tuple.node);
+
+                // AddRange is optimized to take a SegmentedList and copy directly from it into the result list.
+                classifications.AddRange(tuple.classifiedSpans);
+                return true;
+            }
+
+            public void Update(SnapshotSpan snapshotSpan, SegmentedList<ClassifiedSpan> classifications)
+            {
+                _threadingContext.ThrowIfNotOnUIThread();
+
+                if (classifications.Count > MaxClassificationsCount)
+                    return;
+
+                var span = snapshotSpan.Span;
+                ClearIfDifferentSnapshot(snapshotSpan.Snapshot);
+
+                if (_spanToClassifiedSpansMap.TryGetValue(span, out var tuple))
                 {
-                    _span = span;
-                    _classifications.AddRange(classifications);
+                    // Was in cache.  Update the cached classifications to the new ones, and move this span to the front
+                    // of end of the LRU list.
+
+                    var (existingNode, existingClassifications) = tuple;
+                    existingClassifications.Clear();
+
+                    // AddRange is optimized to take a SegmentedList and copy directly from it into the result list.
+                    existingClassifications.AddRange(classifications);
+
+                    _spans.Remove(existingNode);
+                    _spans.AddLast(existingNode);
+
+                    Contract.ThrowIfTrue(_spans.Count > CacheSize);
+                }
+                else
+                {
+                    // Not in cache.  Add to the cache, and remove the oldest entry if we're at capacity.
+                    var node = _spans.AddLast(span);
+
+                    // This constructor fast paths the case where we pass in another SegmentedList.
+                    var copy = new SegmentedList<ClassifiedSpan>(classifications);
+                    _spanToClassifiedSpansMap.Add(span, (node, copy));
+
+                    if (_spans.Count > CacheSize)
+                    {
+                        var first = _spans.First;
+                        Contract.ThrowIfNull(first);
+                        _spans.Remove(first);
+                        _spanToClassifiedSpansMap.Remove(first.Value);
+                    }
+
+                    Contract.ThrowIfTrue(_spans.Count > CacheSize);
                 }
             }
         }


### PR DESCRIPTION
Takes us from: 

![image](https://github.com/dotnet/roslyn/assets/4564579/67e081fb-8fd5-48b2-bd11-c6bd3fbe55d8)

To

![image](https://github.com/dotnet/roslyn/assets/4564579/6fa28337-6748-4a44-99f2-b1c2a6314cb8)

The simple idea here is to cache more classified lines that the editor asks us about.  Empirical testing showed that during page-down, we get asked for lines we were recently asked about 25% of the time, and arrowing down increased that to 85%.

By caching more (at a fixed, but larger size than the current cache), we dropped the number of times we actually have to go back to syntax by quite a bit.  This helped us avoid the expensive walks of the tree, which is the limiting factor currently in large files.  