### PR TITLE
Expose XAML IDiagnosticSourceProvider names

### DIFF
--- a/src/Tools/ExternalAccess/VisualDiagnostics/Contracts/Constants.cs
+++ b/src/Tools/ExternalAccess/VisualDiagnostics/Contracts/Constants.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VisualDiagnostics.Contracts;
+
+internal static class Constants
+{
+    public const string DiagnosticSourceProviderName = "HotReloadDiagnostics";
+}

--- a/src/Tools/ExternalAccess/VisualDiagnostics/Internal/HotReloadDiagnosticSourceProvider.cs
+++ b/src/Tools/ExternalAccess/VisualDiagnostics/Internal/HotReloadDiagnosticSourceProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VisualDiagnostics.Internal;
 
 internal abstract class HotReloadDiagnosticSourceProvider(IHotReloadDiagnosticManager diagnosticManager, bool isDocument) : IDiagnosticSourceProvider
 {
-    public string Name => "HotReloadDiagnostics";
+    public string Name => Constants.DiagnosticSourceProviderName;
     public bool IsDocument => isDocument;
 
     public bool IsEnabled(ClientCapabilities clientCapabilities) => true;

--- a/src/Tools/ExternalAccess/VisualDiagnostics/InternalAPI.Unshipped.txt
+++ b/src/Tools/ExternalAccess/VisualDiagnostics/InternalAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+const Microsoft.CodeAnalysis.ExternalAccess.VisualDiagnostics.Contracts.Constants.DiagnosticSourceProviderName = "HotReloadDiagnostics" -> string!
+Microsoft.CodeAnalysis.ExternalAccess.VisualDiagnostics.Contracts.Constants
 Microsoft.CodeAnalysis.ExternalAccess.VisualDiagnostics.Contracts.HotReloadRequestContext
 Microsoft.CodeAnalysis.ExternalAccess.VisualDiagnostics.Contracts.HotReloadRequestContext.ClientCapabilities.get -> Roslyn.LanguageServer.Protocol.ClientCapabilities!
 Microsoft.CodeAnalysis.ExternalAccess.VisualDiagnostics.Contracts.HotReloadRequestContext.HotReloadRequestContext(Microsoft.CodeAnalysis.LanguageServer.Handler.RequestContext context) -> void

--- a/src/Tools/ExternalAccess/Xaml/External/Constants.cs
+++ b/src/Tools/ExternalAccess/Xaml/External/Constants.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Xaml;
+
+internal static class Constants
+{
+    public const string DiagnosticSourceProviderName = "XamlDiagnostics";
+}

--- a/src/Tools/ExternalAccess/Xaml/Internal/XamlDiagnosticSourceProvider.cs
+++ b/src/Tools/ExternalAccess/Xaml/Internal/XamlDiagnosticSourceProvider.cs
@@ -21,7 +21,7 @@ internal sealed class XamlDiagnosticSourceProvider([Import(AllowDefault = true)]
 {
     bool IDiagnosticSourceProvider.IsDocument => true;
 
-    string IDiagnosticSourceProvider.Name => "XamlDiagnostics";
+    string IDiagnosticSourceProvider.Name => Constants.DiagnosticSourceProviderName;
 
     bool IDiagnosticSourceProvider.IsEnabled(ClientCapabilities clientCapabilities) => true;
 

--- a/src/Tools/ExternalAccess/Xaml/InternalAPI.Unshipped.txt
+++ b/src/Tools/ExternalAccess/Xaml/InternalAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 abstract Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerBase<TRequest, TResponse>.GetTextDocumentUri(TRequest request) -> System.Uri!
 abstract Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerFactoryBase<TRequest, TResponse>.CreateHandler(Microsoft.CodeAnalysis.ExternalAccess.Xaml.IXamlRequestHandler<TRequest, TResponse>? xamlRequestHandler, Microsoft.CodeAnalysis.ExternalAccess.Xaml.IResolveCachedDataService! resolveDataService) -> Microsoft.CodeAnalysis.ExternalAccess.Xaml.XamlRequestHandlerBase<TRequest, TResponse>!
+const Microsoft.CodeAnalysis.ExternalAccess.Xaml.Constants.DiagnosticSourceProviderName = "XamlDiagnostics" -> string!
 const Microsoft.CodeAnalysis.ExternalAccess.Xaml.StringConstants.FactoryMethodMessage = "This factory method only provides services for the MEF export provider." -> string!
 const Microsoft.CodeAnalysis.ExternalAccess.Xaml.StringConstants.ImportingConstructorMessage = "This exported object must be obtained through the MEF export provider." -> string!
 const Microsoft.CodeAnalysis.ExternalAccess.Xaml.StringConstants.XamlFileExtension = ".xaml" -> string!
@@ -9,6 +10,7 @@ Microsoft.CodeAnalysis.ExternalAccess.Xaml.ClientCapabilityProvider.ClientCapabi
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.ClientCapabilityProvider.IsDynamicRegistrationSupported(string! methodName) -> bool
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.ClientCapabilityProvider.SupportsCompletionListData.get -> bool
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.ClientCapabilityProvider.SupportsMarkdownDocumentation.get -> bool
+Microsoft.CodeAnalysis.ExternalAccess.Xaml.Constants
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.ConversionHelpers
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.DescriptionService
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.DescriptionService.DescriptionService(Microsoft.CodeAnalysis.Options.IGlobalOptionService! globalOptions) -> void


### PR DESCRIPTION
Expose names of XAML `IDiagnosticSourceProvider`'s so that they can be referenced during XAML Language Service registration