### PR TITLE
Convert interval-tree type to a struct

### DIFF
--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.TagNode.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.TagNode.cs
@@ -17,6 +17,9 @@ internal partial class TagSpanIntervalTree<TTag>
 
         public TTag Tag => _originalTagSpan.Tag;
 
+        public TagSpan<TTag> GetTranslatedTagSpan(ITextSnapshot textSnapshot)
+            => new(GetTranslatedSpan(textSnapshot), Tag);
+
         public SnapshotSpan GetTranslatedSpan(ITextSnapshot textSnapshot)
         {
             var localSpan = _originalTagSpan.Span;

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.TagNode.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.TagNode.cs
@@ -13,26 +13,23 @@ internal partial class TagSpanIntervalTree<TTag>
     private readonly struct TagNode(ITagSpan<TTag> tagSpan, SpanTrackingMode trackingMode)
     {
         private readonly ITagSpan<TTag> _originalTagSpan = tagSpan;
-        public readonly ITrackingSpan Span = tagSpan.Span.CreateTrackingSpan(trackingMode);
+        private readonly SpanTrackingMode _trackingMode = trackingMode;
 
         public TTag Tag => _originalTagSpan.Tag;
 
-        public int GetStart(ITextSnapshot textSnapshot)
+        public SnapshotSpan GetTranslatedSpan(ITextSnapshot textSnapshot)
         {
             var localSpan = _originalTagSpan.Span;
 
             return localSpan.Snapshot == textSnapshot
-                ? localSpan.Start
-                : this.Span.GetStartPoint(textSnapshot);
+                ? localSpan
+                : localSpan.TranslateTo(textSnapshot, _trackingMode);
         }
+
+        public int GetStart(ITextSnapshot textSnapshot)
+            => GetTranslatedSpan(textSnapshot).Start;
 
         public int GetLength(ITextSnapshot textSnapshot)
-        {
-            var localSpan = _originalTagSpan.Span;
-
-            return localSpan.Snapshot == textSnapshot
-                ? localSpan.Length
-                : this.Span.GetSpan(textSnapshot).Length;
-        }
+            => GetTranslatedSpan(textSnapshot).Length;
     }
 }

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.TagNode.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.TagNode.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -71,11 +71,11 @@ internal partial class TagSpanIntervalTree<TTag> where TTag : ITag
             snapshotSpan.Start, snapshotSpan.Length, ref intersectingIntervals.AsRef(), new IntervalIntrospector(snapshot));
 
         foreach (var tagNode in intersectingIntervals)
-            result.Add(new TagSpan<TTag>(tagNode.GetTranslatedSpan(snapshot), tagNode.Tag));
+            result.Add(tagNode.GetTranslatedTagSpan(snapshot));
     }
 
     public IEnumerable<ITagSpan<TTag>> GetSpans(ITextSnapshot snapshot)
-        => _tree.Select(tn => new TagSpan<TTag>(tn.GetTranslatedSpan(snapshot), tn.Tag));
+        => _tree.Select(tn => tn.GetTranslatedTagSpan(snapshot));
 
     public bool IsEmpty()
         => _tree.IsEmpty();

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -71,11 +71,11 @@ internal partial class TagSpanIntervalTree<TTag> where TTag : ITag
             snapshotSpan.Start, snapshotSpan.Length, ref intersectingIntervals.AsRef(), new IntervalIntrospector(snapshot));
 
         foreach (var tagNode in intersectingIntervals)
-            result.Add(new TagSpan<TTag>(tagNode.Span.GetSpan(snapshot), tagNode.Tag));
+            result.Add(new TagSpan<TTag>(tagNode.GetTranslatedSpan(snapshot), tagNode.Tag));
     }
 
     public IEnumerable<ITagSpan<TTag>> GetSpans(ITextSnapshot snapshot)
-        => _tree.Select(tn => new TagSpan<TTag>(tn.Span.GetSpan(snapshot), tn.Tag));
+        => _tree.Select(tn => new TagSpan<TTag>(tn.GetTranslatedSpan(snapshot), tn.Tag));
 
     public bool IsEmpty()
         => _tree.IsEmpty();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -71,9 +71,6 @@ internal partial class IntervalTree<T> : IEnumerable<T>
     private static bool IntersectsWith<TIntrospector>(T value, int start, int length, in TIntrospector introspector)
         where TIntrospector : struct, IIntervalIntrospector<T>
     {
-        var otherSpan = new TextSpan(start, length);
-        var thisSpan = GetSpan(value, in introspector);
-
         return thisSpan.IntersectsWith(otherSpan);
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -71,7 +71,13 @@ internal partial class IntervalTree<T> : IEnumerable<T>
     private static bool IntersectsWith<TIntrospector>(T value, int start, int length, in TIntrospector introspector)
         where TIntrospector : struct, IIntervalIntrospector<T>
     {
-        return thisSpan.IntersectsWith(otherSpan);
+        var otherStart = start;
+        var otherEnd = start + length;
+
+        var thisStart = introspector.GetStart(value);
+        var thisEnd = thisStart + introspector.GetLength(value);
+
+        return otherStart <= thisEnd && otherEnd >= thisStart;
     }
 
     private static bool OverlapsWith<TIntrospector>(T value, int start, int length, in TIntrospector introspector)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -373,10 +373,6 @@ internal partial class IntervalTree<T> : IEnumerable<T>
     IEnumerator IEnumerable.GetEnumerator()
         => this.GetEnumerator();
 
-    protected static TextSpan GetSpan<TIntrospector>(T value, in TIntrospector introspector)
-        where TIntrospector : struct, IIntervalIntrospector<T>
-        => new(introspector.GetStart(value), introspector.GetLength(value));
-
     protected static int GetEnd<TIntrospector>(T value, in TIntrospector introspector)
         where TIntrospector : struct, IIntervalIntrospector<T>
         => introspector.GetStart(value) + introspector.GetLength(value);


### PR DESCRIPTION
This drops us from a total of 4.7% of all allocations:

![image](https://github.com/dotnet/roslyn/assets/4564579/422ca40d-0867-4a5b-a26c-6e704864d9b5)

Down to just 2.1%

![image](https://github.com/dotnet/roslyn/assets/4564579/133bae2d-c138-49f2-807b-7c389784c797)

