### PR TITLE
Slow down the work navbar does, and cancel updating it when receiving a high volume of user events

### DIFF
--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
@@ -94,14 +94,14 @@ internal partial class NavigationBarController : IDisposable
         _asyncListener = asyncListener;
 
         _computeModelQueue = new AsyncBatchingWorkQueue<VoidResult, NavigationBarModel?>(
-            DelayTimeSpan.Medium,
+            DelayTimeSpan.Short,
             ComputeModelAndSelectItemAsync,
             EqualityComparer<VoidResult>.Default,
             asyncListener,
             _cancellationTokenSource.Token);
 
         _selectItemQueue = new AsyncBatchingWorkQueue(
-            DelayTimeSpan.Medium,
+            DelayTimeSpan.Short,
             SelectItemAsync,
             asyncListener,
             _cancellationTokenSource.Token);

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
@@ -61,8 +61,7 @@ internal partial class NavigationBarController : IDisposable
 
     /// <summary>
     /// Queue to batch up work to do to compute the current model.  Used so we can batch up a lot of events and only
-    /// compute the model once for every batch.  The <c>bool</c> type parameter isn't used, but is provided as this
-    /// type is generic.
+    /// compute the model once for every batch.
     /// </summary>
     private readonly AsyncBatchingWorkQueue<VoidResult, NavigationBarModel?> _computeModelQueue;
 


### PR DESCRIPTION
I couldn't perceive any issue changing this.  And it helps us not hit the UI thread too often while doing something like scrolling quickly.  There's little value in having the nav bars have to update that quickly, especially as it forces a UI thread switch that we're seeing in UI delays.