### PR TITLE
Final editor side changes for "allow ref struct" support

### DIFF
--- a/src/Features/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -21669,6 +21669,7 @@ class B : System.Attribute {}
     [InlineData("unmanaged")]
     [InlineData("System.IDisposable")]
     [InlineData("System.Delegate")]
+    [InlineData("allows ref struct")]
     public void TypeConstraint_Insert(string newConstraint)
     {
         var src1 = "class C<S,T> { }";
@@ -21691,6 +21692,7 @@ class B : System.Attribute {}
     [InlineData("unmanaged")]
     [InlineData("System.IDisposable")]
     [InlineData("System.Delegate")]
+    [InlineData("allows ref struct")]
     public void TypeConstraint_Delete(string oldConstraint)
     {
         var src1 = "class C<S,T> where T : " + oldConstraint + " { }";

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2355,6 +2355,7 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
         => TypesEquivalent(oldParameter.ConstraintTypes, newParameter.ConstraintTypes, exact) &&
            oldParameter.HasReferenceTypeConstraint == newParameter.HasReferenceTypeConstraint &&
            oldParameter.HasValueTypeConstraint == newParameter.HasValueTypeConstraint &&
+           oldParameter.AllowsRefLikeType == newParameter.AllowsRefLikeType &&
            oldParameter.HasConstructorConstraint == newParameter.HasConstructorConstraint &&
            oldParameter.HasNotNullConstraint == newParameter.HasNotNullConstraint &&
            oldParameter.HasUnmanagedTypeConstraint == newParameter.HasUnmanagedTypeConstraint &&

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -910,6 +910,7 @@ internal abstract partial class MethodExtractor<TSelectionResult, TStatementSynt
                     if (!parameter.HasConstructorConstraint &&
                         !parameter.HasReferenceTypeConstraint &&
                         !parameter.HasValueTypeConstraint &&
+                        !parameter.AllowsRefLikeType &&
                         parameter.ConstraintTypes.IsDefaultOrEmpty)
                     {
                         continue;


### PR DESCRIPTION
Per Tomas, the enc analyzer can be trivially changed for this support. Also, smal change where I missed one location in method extractor analyzer that needed a change