### PR TITLE
Do not serialize ProjectId.DebugName (in release builds)

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -109,7 +109,11 @@ public sealed class ProjectId : IEquatable<ProjectId>, IComparable<ProjectId>
     internal static ProjectId ReadFrom(ObjectReader reader)
     {
         var guid = reader.ReadGuid();
+#if DEBUG
         var debugName = reader.ReadString();
+#else
+        string? debugName = null;
+#endif
 
         return CreateFromSerialized(guid, debugName);
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -35,6 +35,7 @@ public sealed class ProjectId : IEquatable<ProjectId>, IComparable<ProjectId>
     [DataMember(Order = 0)]
     public Guid Id { get; }
 
+#if DEBUG
     /// <summary>
     /// An optional name to show <em>only</em> for debugger-display purposes.  This must not be used for any other
     /// purpose.  Importantly, it must not be part of the equality/hashing/comparable contract of this type (including
@@ -42,11 +43,14 @@ public sealed class ProjectId : IEquatable<ProjectId>, IComparable<ProjectId>
     /// </summary>
     [DataMember(Order = 1)]
     private readonly string? _debugName;
+#endif
 
     private ProjectId(Guid guid, string? debugName)
     {
         this.Id = guid;
+#if DEBUG
         _debugName = debugName;
+#endif
     }
 
     /// <summary>
@@ -66,10 +70,14 @@ public sealed class ProjectId : IEquatable<ProjectId>, IComparable<ProjectId>
         return new ProjectId(id, debugName);
     }
 
+#if DEBUG
     internal string? DebugName => _debugName;
+#else
+    internal string? DebugName => null;
+#endif
 
     private string GetDebuggerDisplay()
-        => string.Format("({0}, #{1} - {2})", this.GetType().Name, this.Id, _debugName);
+        => string.Format("({0}, #{1} - {2})", this.GetType().Name, this.Id, DebugName);
 
     public override string ToString()
         => GetDebuggerDisplay();
@@ -93,7 +101,9 @@ public sealed class ProjectId : IEquatable<ProjectId>, IComparable<ProjectId>
     internal void WriteTo(ObjectWriter writer)
     {
         writer.WriteGuid(Id);
+#if DEBUG
         writer.WriteString(DebugName);
+#endif
     }
 
     internal static ProjectId ReadFrom(ObjectReader reader)

--- a/src/Workspaces/Remote/Core/Serialization/MessagePackFormatters.cs
+++ b/src/Workspaces/Remote/Core/Serialization/MessagePackFormatters.cs
@@ -70,11 +70,12 @@ namespace Microsoft.CodeAnalysis.Remote
                         return null;
                     }
 
+#if DEBUG
                     Contract.ThrowIfFalse(reader.ReadArrayHeader() == 2);
                     var id = GuidFormatter.Instance.Deserialize(ref reader, options);
-#if DEBUG
                     var debugName = reader.ReadString();
 #else
+                    var id = GuidFormatter.Instance.Deserialize(ref reader, options);
                     string? debugName = null;
 #endif
 
@@ -107,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         GuidFormatter.Instance.Serialize(ref writer, value.Id, options);
                         writer.Write(value.DebugName);
 #else
-                        writer.WriteArrayHeader(1);
+                        // No need to write as an array if only serializing the id
                         GuidFormatter.Instance.Serialize(ref writer, value.Id, options);
 #endif
                     }

--- a/src/Workspaces/Remote/Core/Serialization/MessagePackFormatters.cs
+++ b/src/Workspaces/Remote/Core/Serialization/MessagePackFormatters.cs
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     var id = GuidFormatter.Instance.Deserialize(ref reader, options);
                     var debugName = reader.ReadString();
 #else
+                    // No need to read as an array if only deserializing the id
                     var id = GuidFormatter.Instance.Deserialize(ref reader, options);
                     string? debugName = null;
 #endif

--- a/src/Workspaces/Remote/Core/Serialization/MessagePackFormatters.cs
+++ b/src/Workspaces/Remote/Core/Serialization/MessagePackFormatters.cs
@@ -72,10 +72,14 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     Contract.ThrowIfFalse(reader.ReadArrayHeader() == 2);
                     var id = GuidFormatter.Instance.Deserialize(ref reader, options);
+#if DEBUG
                     var debugName = reader.ReadString();
+#else
+                    string? debugName = null;
+#endif
 
                     var previousId = _previousProjectId;
-                    if (previousId is not null && previousId.Id == id && previousId.DebugName == debugName)
+                    if (previousId is not null && previousId.Id == id)
                         return previousId;
 
                     var currentId = ProjectId.CreateFromSerialized(id, debugName);
@@ -98,9 +102,14 @@ namespace Microsoft.CodeAnalysis.Remote
                     }
                     else
                     {
+#if DEBUG
                         writer.WriteArrayHeader(2);
                         GuidFormatter.Instance.Serialize(ref writer, value.Id, options);
                         writer.Write(value.DebugName);
+#else
+                        writer.WriteArrayHeader(1);
+                        GuidFormatter.Instance.Serialize(ref writer, value.Id, options);
+#endif
                     }
                 }
                 catch (Exception e) when (e is not MessagePackSerializationException)


### PR DESCRIPTION
This value is only intended for debugger display purposes. Serialization of this showed up as ~3% of allocations in both VS and OOP in the find all references profile I'm looking at.

*** old Deserialize allocations (VS) ***
![image](https://github.com/dotnet/roslyn/assets/6785178/9729574d-dbc4-45f9-ad9d-e60c5d0e6591)

*** old Serialize allocations (OOP) ***
![image](https://github.com/dotnet/roslyn/assets/6785178/5bbb1ec0-6c99-407f-b536-d8fa26379689)
