### PR TITLE
Cache the getnode/gettoken classifiers retrieived from the extension manager.

### DIFF
--- a/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
@@ -43,7 +43,7 @@ internal abstract class AbstractClassificationService(ISyntaxClassificationServi
         return AddClassificationsAsync(document, textSpans, options, ClassificationType.EmbeddedLanguage, result, cancellationToken);
     }
 
-    private static async Task AddClassificationsAsync(
+    public async Task AddClassificationsAsync(
         Document document,
         ImmutableArray<TextSpan> textSpans,
         ClassificationOptions options,
@@ -134,21 +134,7 @@ internal abstract class AbstractClassificationService(ISyntaxClassificationServi
         return true;
     }
 
-    public static Task AddClassificationsInCurrentProcessAsync(
-        Document document,
-        ImmutableArray<TextSpan> textSpans,
-        ClassificationType type,
-        ClassificationOptions options,
-        SegmentedList<ClassifiedSpan> result,
-        CancellationToken cancellationToken)
-    {
-        if (document.GetRequiredLanguageService<IClassificationService>() is not AbstractClassificationService classificationService)
-            return Task.CompletedTask;
-
-        return classificationService.AddClassificationsInCurrentProcessWorkerAsync(document, textSpans, type, options, result, cancellationToken);
-    }
-
-    private async Task AddClassificationsInCurrentProcessWorkerAsync(
+    private async Task AddClassificationsInCurrentProcessAsync(
         Document document,
         ImmutableArray<TextSpan> textSpans,
         ClassificationType type,

--- a/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
@@ -180,21 +180,23 @@ internal abstract class AbstractClassificationService(ISyntaxClassificationServi
         {
             throw ExceptionUtilities.UnexpectedValue(type);
         }
-    }
 
-    private (Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>>, Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>>) GetExtensionClassifiers(
-        Document document, ISyntaxClassificationService classificationService)
-    {
-        if (_getNodeClassifiers == null || _getTokenClassifiers == null)
+        return;
+
+        (Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>>, Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>>) GetExtensionClassifiers(
+            Document document, ISyntaxClassificationService classificationService)
         {
-            var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
-            var classifiers = classificationService.GetDefaultSyntaxClassifiers();
+            if (_getNodeClassifiers == null || _getTokenClassifiers == null)
+            {
+                var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
+                var classifiers = classificationService.GetDefaultSyntaxClassifiers();
 
-            _getNodeClassifiers = extensionManager.CreateNodeExtensionGetter(classifiers, static c => c.SyntaxNodeTypes);
-            _getTokenClassifiers = extensionManager.CreateTokenExtensionGetter(classifiers, static c => c.SyntaxTokenKinds);
+                _getNodeClassifiers = extensionManager.CreateNodeExtensionGetter(classifiers, static c => c.SyntaxNodeTypes);
+                _getTokenClassifiers = extensionManager.CreateTokenExtensionGetter(classifiers, static c => c.SyntaxTokenKinds);
+            }
+
+            return (_getNodeClassifiers, _getTokenClassifiers);
         }
-
-        return (_getNodeClassifiers, _getTokenClassifiers);
     }
 
     public async Task AddSyntacticClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification.Classifiers;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Host;
@@ -24,8 +25,17 @@ internal abstract class AbstractClassificationService(ISyntaxClassificationServi
 {
     private readonly ISyntaxClassificationService _syntaxClassificationService = syntaxClassificationService;
 
-    private static Func<SyntaxNode, ImmutableArray<Classifiers.ISyntaxClassifier>>? s_getNodeClassifiers;
-    private static Func<SyntaxToken, ImmutableArray<Classifiers.ISyntaxClassifier>>? s_getTokenClassifiers;
+    private static ExtensionClassifierInfo? s_cachedExtensionClassifierInfo;
+
+    private class ExtensionClassifierInfo(
+        ISyntaxClassificationService classificationService,
+        Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
+        Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers)
+    {
+        public readonly ISyntaxClassificationService ClassificationService = classificationService;
+        public readonly Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> GetNodeClassifiers = getNodeClassifiers;
+        public readonly Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> GetTokenClassifiers = getTokenClassifiers;
+    }
 
     public abstract void AddLexicalClassifications(SourceText text, TextSpan textSpan, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
     public abstract ClassifiedSpan AdjustStaleClassification(SourceText text, ClassifiedSpan classifiedSpan);
@@ -145,17 +155,10 @@ internal abstract class AbstractClassificationService(ISyntaxClassificationServi
         {
             var classificationService = document.GetRequiredLanguageService<ISyntaxClassificationService>();
 
-            if (s_getNodeClassifiers == null || s_getTokenClassifiers == null)
-            {
-                var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
-                var classifiers = classificationService.GetDefaultSyntaxClassifiers();
-
-                s_getNodeClassifiers = extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes);
-                s_getTokenClassifiers = extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds);
-            }
+            GetExtensionClassifiers(document, classificationService, out var getNodeClassifiers, out var getTokenClassifiers);
 
             await classificationService.AddSemanticClassificationsAsync(
-                document, textSpans, options, s_getNodeClassifiers, s_getTokenClassifiers, result, cancellationToken).ConfigureAwait(false);
+                document, textSpans, options, getNodeClassifiers, getTokenClassifiers, result, cancellationToken).ConfigureAwait(false);
 
             if (options.ClassifyReassignedVariables)
             {
@@ -186,6 +189,30 @@ internal abstract class AbstractClassificationService(ISyntaxClassificationServi
         {
             throw ExceptionUtilities.UnexpectedValue(type);
         }
+    }
+
+    private static void GetExtensionClassifiers(
+        Document document,
+        ISyntaxClassificationService classificationService,
+        out Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
+        out Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers)
+    {
+        var cachedExtensionClassifierInfo = s_cachedExtensionClassifierInfo;
+
+        if (cachedExtensionClassifierInfo == null || cachedExtensionClassifierInfo.ClassificationService != classificationService)
+        {
+            var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
+            var classifiers = classificationService.GetDefaultSyntaxClassifiers();
+
+            cachedExtensionClassifierInfo = new ExtensionClassifierInfo(
+                classificationService,
+                extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes),
+                extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds));
+            s_cachedExtensionClassifierInfo = cachedExtensionClassifierInfo;
+        }
+
+        getNodeClassifiers = cachedExtensionClassifierInfo.GetNodeClassifiers;
+        getTokenClassifiers = cachedExtensionClassifierInfo.GetTokenClassifiers;
     }
 
     public async Task AddSyntacticClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -38,8 +39,12 @@ namespace Microsoft.CodeAnalysis.Remote
                 solution = document.Project.Solution;
 
                 using var _ = Classifier.GetPooledList(out var temp);
-                await AbstractClassificationService.AddClassificationsInCurrentProcessAsync(
-                    document, spans, type, options, temp, cancellationToken).ConfigureAwait(false);
+
+                // Safe to do this.  The remote classification service only runs for C#/VB.  So we know we'll always
+                // have this service and it will always be this type.
+                var classificationService = (AbstractClassificationService)document.GetRequiredLanguageService<IClassificationService>();
+                await classificationService.AddClassificationsAsync(
+                    document, spans, options, type, temp, cancellationToken).ConfigureAwait(false);
 
                 if (isFullyLoaded)
                 {


### PR DESCRIPTION
These showed up as ~6% of allocations in a find all references trace I'm looking at and it's trivial to cache these.

*** Previously ***
![image](https://github.com/dotnet/roslyn/assets/6785178/9470b903-ce91-43c5-8ba6-63406d08a2a1)

With my changes, these allocations are completely gone from the profile.