### PR TITLE
Move over to IDE using TagSpan uniformly

### DIFF
--- a/src/EditorFeatures/CSharpTest/InlineDiagnostics/InlineDiagnosticsTaggerProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDiagnostics/InlineDiagnosticsTaggerProviderTests.cs
@@ -34,13 +34,13 @@ public class InlineDiagnosticsTaggerProviderTests
         Assert.Equal(PredefinedErrorTypeNames.SyntaxError, firstSpan.Tag.ErrorType);
     }
 
-    private static async Task<ImmutableArray<ITagSpan<InlineDiagnosticsTag>>> GetTagSpansAsync(string content)
+    private static async Task<ImmutableArray<TagSpan<InlineDiagnosticsTag>>> GetTagSpansAsync(string content)
     {
         using var workspace = EditorTestWorkspace.CreateCSharp(content, composition: SquiggleUtilities.WpfCompositionWithSolutionCrawler);
         return await GetTagSpansAsync(workspace);
     }
 
-    private static async Task<ImmutableArray<ITagSpan<InlineDiagnosticsTag>>> GetTagSpansInSourceGeneratedDocumentAsync(string content)
+    private static async Task<ImmutableArray<TagSpan<InlineDiagnosticsTag>>> GetTagSpansInSourceGeneratedDocumentAsync(string content)
     {
         using var workspace = EditorTestWorkspace.CreateCSharp(
             files: [],
@@ -50,7 +50,7 @@ public class InlineDiagnosticsTaggerProviderTests
         return await GetTagSpansAsync(workspace);
     }
 
-    private static async Task<ImmutableArray<ITagSpan<InlineDiagnosticsTag>>> GetTagSpansAsync(EditorTestWorkspace workspace)
+    private static async Task<ImmutableArray<TagSpan<InlineDiagnosticsTag>>> GetTagSpansAsync(EditorTestWorkspace workspace)
     {
         workspace.GlobalOptions.SetGlobalOption(InlineDiagnosticsOptionsStorage.EnableInlineDiagnostics, LanguageNames.CSharp, true);
         return await TestDiagnosticTagProducer<InlineDiagnosticsTaggerProvider, InlineDiagnosticsTag>.GetTagSpansAsync(workspace);

--- a/src/EditorFeatures/CSharpTest/Interactive/BraceMatching/InteractiveBraceHighlightingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/BraceMatching/InteractiveBraceHighlightingTests.cs
@@ -30,7 +30,7 @@ public class InteractiveBraceHighlightingTests
     private static IEnumerable<T> Enumerable<T>(params T[] array)
         => array;
 
-    private static async Task<IEnumerable<ITagSpan<BraceHighlightTag>>> ProduceTagsAsync(
+    private static async Task<IEnumerable<TagSpan<BraceHighlightTag>>> ProduceTagsAsync(
         EditorTestWorkspace workspace,
         ITextBuffer buffer,
         int position)

--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -77,17 +77,10 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag> : ITagge
     protected virtual ImmutableArray<DiagnosticDataLocation> GetLocationsToTag(DiagnosticData diagnosticData)
         => diagnosticData.DataLocation is not null ? [diagnosticData.DataLocation] : [];
 
-    public ITagger<T>? CreateTagger<T>(ITextBuffer buffer) where T : ITag
+    ITagger<T>? ITaggerProvider.CreateTagger<T>(ITextBuffer buffer)
     {
-        using var taggers = TemporaryArray<EfficientTagger<TTag>>.Empty;
-        foreach (var taggerProvider in _diagnosticsTaggerProviders)
-        {
-            var innerTagger = taggerProvider.CreateTagger(buffer);
-            if (innerTagger != null)
-                taggers.Add(innerTagger);
-        }
+        var tagger = CreateTagger<T>(buffer);
 
-        var tagger = new SimpleAggregateTagger<TTag>(taggers.ToImmutableAndClear());
         if (tagger is not ITagger<T> genericTagger)
         {
             tagger.Dispose();
@@ -97,7 +90,20 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag> : ITagge
         return genericTagger;
     }
 
-    protected ITagSpan<TTag>? CreateTagSpan(Workspace workspace, SnapshotSpan span, DiagnosticData data)
+    public SimpleAggregateTagger<TTag> CreateTagger<T>(ITextBuffer buffer) where T : ITag
+    {
+        using var taggers = TemporaryArray<EfficientTagger<TTag>>.Empty;
+        foreach (var taggerProvider in _diagnosticsTaggerProviders)
+        {
+            var innerTagger = taggerProvider.CreateTagger(buffer);
+            if (innerTagger != null)
+                taggers.Add(innerTagger);
+        }
+
+        return new SimpleAggregateTagger<TTag>(taggers.ToImmutableAndClear());
+    }
+
+    protected TagSpan<TTag>? CreateTagSpan(Workspace workspace, SnapshotSpan span, DiagnosticData data)
     {
         var errorTag = CreateTag(workspace, data);
         if (errorTag == null)

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
         /// <summary>
         /// stores the parameter hint tags in a global location
         /// </summary>
-        private readonly List<(IMappingTagSpan<InlineHintDataTag> mappingTagSpan, ITagSpan<IntraTextAdornmentTag>? tagSpan)> _cache = [];
+        private readonly List<(IMappingTagSpan<InlineHintDataTag> mappingTagSpan, TagSpan<IntraTextAdornmentTag>? tagSpan)> _cache = [];
 
         /// <summary>
         /// Stores the snapshot associated with the cached tags in <see cref="_cache" />
@@ -138,9 +138,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             try
             {
                 if (spans.Count == 0)
-                {
-                    return Array.Empty<ITagSpan<IntraTextAdornmentTag>>();
-                }
+                    return [];
 
                 var snapshot = spans[0].Snapshot;
                 if (snapshot != _cacheSnapshot)
@@ -169,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                 var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
                 var classify = document != null && _taggerProvider.EditorOptionsService.GlobalOptions.GetOption(InlineHintsViewOptionsStorage.ColorHints, document.Project.Language);
 
-                var selectedSpans = new List<ITagSpan<IntraTextAdornmentTag>>();
+                var selectedSpans = new List<TagSpan<IntraTextAdornmentTag>>();
                 for (var i = 0; i < _cache.Count; i++)
                 {
                     var tagSpans = _cache[i].mappingTagSpan.Span.GetSpans(snapshot);

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -133,7 +133,10 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             _cache.Clear();
         }
 
-        public IEnumerable<ITagSpan<IntraTextAdornmentTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+        IEnumerable<ITagSpan<IntraTextAdornmentTag>> ITagger<IntraTextAdornmentTag>.GetTags(NormalizedSnapshotSpanCollection spans)
+            => GetTags(spans);
+
+        public IReadOnlyList<TagSpan<IntraTextAdornmentTag>> GetTags(NormalizedSnapshotSpanCollection spans)
         {
             try
             {

--- a/src/EditorFeatures/Core.Wpf/Preview/AbstractPreviewTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/AbstractPreviewTaggerProvider.cs
@@ -40,7 +40,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
                 _tagInstance = tagInstance;
             }
 
-            public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+            IEnumerable<ITagSpan<TTag>> ITagger<TTag>.GetTags(NormalizedSnapshotSpanCollection spans)
+                => GetTags(spans);
+
+            public IEnumerable<TagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
             {
                 if (_buffer.Properties.TryGetProperty(_key, out NormalizedSnapshotSpanCollection matchingSpans))
                 {

--- a/src/EditorFeatures/Core.Wpf/Preview/PreviewStaticClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/PreviewStaticClassificationTaggerProvider.cs
@@ -61,7 +61,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
             /// </summary>
             event EventHandler<SnapshotSpanEventArgs> ITagger<IClassificationTag>.TagsChanged { add { } remove { } }
 
-            public IEnumerable<ITagSpan<IClassificationTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+            IEnumerable<ITagSpan<IClassificationTag>> ITagger<IClassificationTag>.GetTags(NormalizedSnapshotSpanCollection spans)
+                => GetTags(spans);
+
+            public IEnumerable<TagSpan<IClassificationTag>> GetTags(NormalizedSnapshotSpanCollection spans)
             {
                 if (!_buffer.Properties.TryGetProperty(PredefinedPreviewTaggerKeys.StaticClassificationSpansKey, out ImmutableArray<ClassifiedSpan> classifiedSpans))
                 {

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -89,7 +89,7 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
             return [];
         }
 
-        private static IEnumerable<ITagSpan<IClassificationTag>> GetIntersectingTags(NormalizedSnapshotSpanCollection spans, TagSpanIntervalTree<IClassificationTag> cachedTags)
+        private static IEnumerable<TagSpan<IClassificationTag>> GetIntersectingTags(NormalizedSnapshotSpanCollection spans, TagSpanIntervalTree<IClassificationTag> cachedTags)
             => SegmentedListPool<TagSpan<IClassificationTag>>.ComputeList(
                 static (args, tags) => args.cachedTags.AddIntersectingTagSpans(args.spans, tags),
                 (cachedTags, spans));
@@ -125,7 +125,7 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
             }
         }
 
-        private IEnumerable<ITagSpan<IClassificationTag>> ComputeAndCacheAllTags(
+        private IEnumerable<TagSpan<IClassificationTag>> ComputeAndCacheAllTags(
             NormalizedSnapshotSpanCollection spans,
             ITextSnapshot snapshot,
             Document document,

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -89,12 +89,15 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
             return [];
         }
 
-        private static IEnumerable<TagSpan<IClassificationTag>> GetIntersectingTags(NormalizedSnapshotSpanCollection spans, TagSpanIntervalTree<IClassificationTag> cachedTags)
+        private static IReadOnlyList<TagSpan<IClassificationTag>> GetIntersectingTags(NormalizedSnapshotSpanCollection spans, TagSpanIntervalTree<IClassificationTag> cachedTags)
             => SegmentedListPool<TagSpan<IClassificationTag>>.ComputeList(
                 static (args, tags) => args.cachedTags.AddIntersectingTagSpans(args.spans, tags),
                 (cachedTags, spans));
 
-        public IEnumerable<ITagSpan<IClassificationTag>> GetAllTags(NormalizedSnapshotSpanCollection spans, CancellationToken cancellationToken)
+        IEnumerable<ITagSpan<IClassificationTag>> IAccurateTagger<IClassificationTag>.GetAllTags(NormalizedSnapshotSpanCollection spans, CancellationToken cancellationToken)
+            => GetAllTags(spans, cancellationToken);
+
+        public IEnumerable<TagSpan<IClassificationTag>> GetAllTags(NormalizedSnapshotSpanCollection spans, CancellationToken cancellationToken)
         {
             if (spans.Count == 0)
                 return [];

--- a/src/EditorFeatures/Core/InlineRename/Taggers/AbstractRenameTagger.cs
+++ b/src/EditorFeatures/Core/InlineRename/Taggers/AbstractRenameTagger.cs
@@ -90,7 +90,10 @@ internal abstract class AbstractRenameTagger<T> : ITagger<T>, IDisposable where 
 
     public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
 
-    public IEnumerable<ITagSpan<T>> GetTags(NormalizedSnapshotSpanCollection spans)
+    IEnumerable<ITagSpan<T>> ITagger<T>.GetTags(NormalizedSnapshotSpanCollection spans)
+        => GetTags(spans);
+
+    public IEnumerable<TagSpan<T>> GetTags(NormalizedSnapshotSpanCollection spans)
     {
         if (_renameService.ActiveSession == null)
         {

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.Tagger.cs
@@ -45,7 +45,7 @@ internal sealed partial class RenameTrackingTaggerProvider
         IEnumerable<ITagSpan<IErrorTag>> ITagger<IErrorTag>.GetTags(NormalizedSnapshotSpanCollection spans)
             => GetTags(spans, new ErrorTag(PredefinedErrorTypeNames.Suggestion));
 
-        private IEnumerable<ITagSpan<T>> GetTags<T>(NormalizedSnapshotSpanCollection spans, T tag) where T : ITag
+        private IEnumerable<TagSpan<T>> GetTags<T>(NormalizedSnapshotSpanCollection spans, T tag) where T : ITag
         {
             if (!_stateMachine.GlobalOptions.GetOption(RenameTrackingOptionsStorage.RenameTracking))
             {

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.IntervalIntrospector.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.IntervalIntrospector.cs
@@ -13,12 +13,12 @@ internal partial class TagSpanIntervalTree<TTag>
     private readonly struct IntervalIntrospector(
         ITextSnapshot snapshot,
         SpanTrackingMode trackingMode)
-        : IIntervalIntrospector<ITagSpan<TTag>>
+        : IIntervalIntrospector<TagSpan<TTag>>
     {
-        public int GetStart(ITagSpan<TTag> value)
+        public int GetStart(TagSpan<TTag> value)
             => GetTranslatedSpan(value, snapshot, trackingMode).Start;
 
-        public int GetLength(ITagSpan<TTag> value)
+        public int GetLength(TagSpan<TTag> value)
             => GetTranslatedSpan(value, snapshot, trackingMode).Length;
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -172,7 +172,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             _dataSource = dataSource;
             _asyncListener = asyncListener;
             _nonFrozenComputationCancellationSeries = new(_disposalTokenSource.Token);
-            _tagSpanSetPool = new ObjectPool<HashSet<ITagSpan<TTag>>>(() => new HashSet<ITagSpan<TTag>>(this), trimOnFree: false);
+            _tagSpanSetPool = new ObjectPool<HashSet<TagSpan<TTag>>>(() => new HashSet<TagSpan<TTag>>(this), trimOnFree: false);
 
             _workspaceRegistration = Workspace.GetWorkspaceRegistration(subjectBuffer.AsTextContainer());
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_IEqualityComparer.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_IEqualityComparer.cs
@@ -10,11 +10,11 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging;
 
 internal abstract partial class AbstractAsynchronousTaggerProvider<TTag>
 {
-    private partial class TagSource : IEqualityComparer<ITagSpan<TTag>>
+    private partial class TagSource : IEqualityComparer<TagSpan<TTag>>
     {
-        private readonly ObjectPool<HashSet<ITagSpan<TTag>>> _tagSpanSetPool;
+        private readonly ObjectPool<HashSet<TagSpan<TTag>>> _tagSpanSetPool;
 
-        public bool Equals(ITagSpan<TTag>? x, ITagSpan<TTag>? y)
+        public bool Equals(TagSpan<TTag>? x, TagSpan<TTag>? y)
         {
             if (x == y)
                 return true;
@@ -28,10 +28,10 @@ internal abstract partial class AbstractAsynchronousTaggerProvider<TTag>
         /// <summary>
         /// For the purposes of hashing, just hash spans.  This will prevent most collisions.  And the rare
         /// collision of two tag spans with the same span will be handled by checking if their tags are the same
-        /// through <see cref="Equals(ITagSpan{TTag}, ITagSpan{TTag})"/>.  This prevents us from having to
+        /// through <see cref="Equals(TagSpan{TTag}, TagSpan{TTag})"/>.  This prevents us from having to
         /// define a suitable hashing strategy for all our tags.
         /// </summary>
-        public int GetHashCode(ITagSpan<TTag> obj)
+        public int GetHashCode(TagSpan<TTag> obj)
             => obj.Span.Span.GetHashCode();
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -393,7 +393,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             foreach (var spanToTag in context.SpansToTag)
                 buffersToTag.Add(spanToTag.SnapshotSpan.Snapshot.TextBuffer);
 
-            using var _2 = ArrayBuilder<ITagSpan<TTag>>.GetInstance(out var newTagsInBuffer);
+            using var _2 = ArrayBuilder<TagSpan<TTag>>.GetInstance(out var newTagsInBuffer);
             using var _3 = ArrayBuilder<SnapshotSpan>.GetInstance(out var spansToInvalidateInBuffer);
 
             var newTagTrees = ImmutableDictionary.CreateBuilder<ITextBuffer, TagSpanIntervalTree<TTag>>();
@@ -427,7 +427,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
         private TagSpanIntervalTree<TTag>? ComputeNewTagTree(
             ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>> oldTagTrees,
             ITextBuffer textBuffer,
-            ArrayBuilder<ITagSpan<TTag>> newTags,
+            ArrayBuilder<TagSpan<TTag>> newTags,
             ArrayBuilder<SnapshotSpan> spansToInvalidate)
         {
             var noNewTags = newTags.IsEmpty;
@@ -469,7 +469,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
         private static void AddNonIntersectingTagSpans(
             ArrayBuilder<SnapshotSpan> spansToInvalidate,
             TagSpanIntervalTree<TTag> oldTagTree,
-            HashSet<ITagSpan<TTag>> nonIntersectingTagSpans)
+            HashSet<TagSpan<TTag>> nonIntersectingTagSpans)
         {
             var firstSpanToInvalidate = spansToInvalidate.First();
             var snapshot = firstSpanToInvalidate.Snapshot;
@@ -611,7 +611,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
 
             return new DiffResult(new(added), new(removed));
 
-            static ITagSpan<TTag>? NextOrNull(IEnumerator<ITagSpan<TTag>> enumerator)
+            static TagSpan<TTag>? NextOrNull(IEnumerator<TagSpan<TTag>> enumerator)
                 => enumerator.MoveNext() ? enumerator.Current : null;
         }
 

--- a/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
+++ b/src/EditorFeatures/Core/Tagging/EfficientTagger.cs
@@ -26,10 +26,13 @@ internal abstract class EfficientTagger<TTag> : ITagger<TTag>, IDisposable where
 
     public abstract void Dispose();
 
+    IEnumerable<ITagSpan<TTag>> ITagger<TTag>.GetTags(NormalizedSnapshotSpanCollection spans)
+        => GetTags(spans);
+
     /// <summary>
     /// Default impl of the core <see cref="ITagger{T}"/> interface.  Forces an allocation.
     /// </summary>
-    public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+    public IReadOnlyList<TagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection spans)
         => SegmentedListPool<TagSpan<TTag>>.ComputeList(
             static (args, tags) => args.@this.AddTags(args.spans, tags),
             (@this: this, spans));

--- a/src/EditorFeatures/Core/Tagging/TaggerContext.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerContext.cs
@@ -19,7 +19,7 @@ internal sealed class TaggerContext<TTag> where TTag : ITag
     private readonly ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>> _existingTags;
 
     internal ImmutableArray<SnapshotSpan> _spansTagged;
-    public readonly SegmentedList<ITagSpan<TTag>> TagSpans = [];
+    public readonly SegmentedList<TagSpan<TTag>> TagSpans = [];
 
     /// <summary>
     /// If the client should compute tags using frozen partial semantics.  This generally should have no effect if tags
@@ -73,7 +73,7 @@ internal sealed class TaggerContext<TTag> where TTag : ITag
         _existingTags = existingTags;
     }
 
-    public void AddTag(ITagSpan<TTag> tag)
+    public void AddTag(TagSpan<TTag> tag)
         => TagSpans.Add(tag);
 
     public void ClearTags()

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -247,7 +247,7 @@ public sealed class AsynchronousTaggerTests
 
     private sealed class TestTaggerProvider(
         IThreadingContext threadingContext,
-        Func<TaggerContext<TextMarkerTag>, DocumentSnapshotSpan, IEnumerable<ITagSpan<TextMarkerTag>>> callback,
+        Func<TaggerContext<TextMarkerTag>, DocumentSnapshotSpan, IEnumerable<TagSpan<TextMarkerTag>>> callback,
         ITaggerEventSource eventSource,
         IGlobalOptionService globalOptions,
         bool supportsFrozenPartialSemantics,

--- a/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.InlineDiagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         private readonly IThreadingContext _threadingContext;
         private readonly IAsynchronousOperationListenerProvider _listenerProvider;
 
-        private ITaggerProvider? _taggerProvider;
+        private AbstractDiagnosticsTaggerProvider<TTag>? _taggerProvider;
 
         public DiagnosticTaggerWrapper(
             EditorTestWorkspace workspace,
@@ -52,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
-        public ITaggerProvider TaggerProvider
+        public AbstractDiagnosticsTaggerProvider<TTag> TaggerProvider
         {
             get
             {
@@ -62,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
                     if (typeof(TProvider) == typeof(InlineDiagnosticsTaggerProvider))
                     {
-                        _taggerProvider = _workspace.ExportProvider.GetExportedValues<ITaggerProvider>()
+                        _taggerProvider = (AbstractDiagnosticsTaggerProvider<TTag>)(object)_workspace.ExportProvider.GetExportedValues<ITaggerProvider>()
                             .OfType<TProvider>()
                             .Single();
                     }

--- a/src/EditorFeatures/TestUtilities/Squiggles/SquiggleUtilities.cs
+++ b/src/EditorFeatures/TestUtilities/Squiggles/SquiggleUtilities.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
         internal static TestComposition WpfCompositionWithSolutionCrawler = EditorTestCompositions.EditorFeaturesWpf
             .RemoveParts(typeof(MockWorkspaceEventListenerProvider));
 
-        internal static async Task<ImmutableArray<ITagSpan<TTag>>> GetTagSpansAsync<TProvider, TTag>(
+        internal static async Task<ImmutableArray<TagSpan<TTag>>> GetTagSpansAsync<TProvider, TTag>(
             EditorTestWorkspace workspace,
             IReadOnlyDictionary<string, ImmutableArray<DiagnosticAnalyzer>> analyzerMap = null)
             where TProvider : AbstractDiagnosticsTaggerProvider<TTag>
@@ -37,9 +37,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
 
             var firstDocument = workspace.Documents.First();
             var textBuffer = firstDocument.GetTextBuffer();
-            var tagger = wrapper.TaggerProvider.CreateTagger<TTag>(textBuffer);
+            using var tagger = wrapper.TaggerProvider.CreateTagger<TTag>(textBuffer);
 
-            using var disposable = tagger as IDisposable;
             await wrapper.WaitForTags();
 
             var snapshot = textBuffer.CurrentSnapshot;

--- a/src/EditorFeatures/TestUtilities/Squiggles/TestDiagnosticTagProducer.cs
+++ b/src/EditorFeatures/TestUtilities/Squiggles/TestDiagnosticTagProducer.cs
@@ -17,7 +17,7 @@ internal sealed class TestDiagnosticTagProducer<TProvider, TTag>
     where TProvider : AbstractDiagnosticsTaggerProvider<TTag>
     where TTag : class, ITag
 {
-    internal static Task<ImmutableArray<ITagSpan<TTag>>> GetTagSpansAsync(
+    internal static Task<ImmutableArray<TagSpan<TTag>>> GetTagSpansAsync(
         EditorTestWorkspace workspace,
         IReadOnlyDictionary<string, ImmutableArray<DiagnosticAnalyzer>>? analyzerMap = null)
     {

--- a/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotExtensions.cs
@@ -85,11 +85,8 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         public static SnapshotSpan GetSpan(this ITextSnapshot snapshot, Span span)
             => new SnapshotSpan(snapshot, span);
 
-        public static ITagSpan<TTag> GetTagSpan<TTag>(this ITextSnapshot snapshot, Span span, TTag tag)
-            where TTag : ITag
-        {
-            return new TagSpan<TTag>(new SnapshotSpan(snapshot, span), tag);
-        }
+        public static TagSpan<TTag> GetTagSpan<TTag>(this ITextSnapshot snapshot, Span span, TTag tag) where TTag : ITag
+            => new(new SnapshotSpan(snapshot, span), tag);
 
         public static SnapshotSpan GetSpan(this ITextSnapshot snapshot, int startLine, int startIndex, int endLine, int endIndex)
             => TryGetSpan(snapshot, startLine, startIndex, endLine, endIndex) ?? throw new InvalidOperationException(TextEditorResources.The_snapshot_does_not_contain_the_specified_span);

--- a/src/VisualStudio/Core/Def/Preview/PreviewUpdater.Tagger.cs
+++ b/src/VisualStudio/Core/Def/Preview/PreviewUpdater.Tagger.cs
@@ -40,7 +40,10 @@ internal partial class PreviewUpdater
 
         public event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
 
-        public IEnumerable<ITagSpan<HighlightTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+        IEnumerable<ITagSpan<HighlightTag>> ITagger<HighlightTag>.GetTags(NormalizedSnapshotSpanCollection spans)
+            => GetTags(spans);
+
+        public IEnumerable<TagSpan<HighlightTag>> GetTags(NormalizedSnapshotSpanCollection spans)
         {
             var lines = _textBuffer.CurrentSnapshot.Lines.Where(line => line.Extent.OverlapsWith(_span));
 

--- a/src/VisualStudio/Core/Def/Preview/PreviewUpdater.Tagger.cs
+++ b/src/VisualStudio/Core/Def/Preview/PreviewUpdater.Tagger.cs
@@ -41,9 +41,9 @@ internal partial class PreviewUpdater
         public event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
 
         IEnumerable<ITagSpan<HighlightTag>> ITagger<HighlightTag>.GetTags(NormalizedSnapshotSpanCollection spans)
-            => GetTags(spans);
+            => GetTags();
 
-        public IEnumerable<TagSpan<HighlightTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+        public IEnumerable<TagSpan<HighlightTag>> GetTags()
         {
             var lines = _textBuffer.CurrentSnapshot.Lines.Where(line => line.Extent.OverlapsWith(_span));
 

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/VenusMargin/ProjectionSpanTagger.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/VenusMargin/ProjectionSpanTagger.cs
@@ -58,12 +58,13 @@ namespace Roslyn.Hosting.Diagnostics.VenusMargin
                 this.TagsChanged?.Invoke(this, args);
             }
 
-            public IEnumerable<ITagSpan<TextMarkerTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+            IEnumerable<ITagSpan<TextMarkerTag>> ITagger<TextMarkerTag>.GetTags(NormalizedSnapshotSpanCollection spans)
+                => GetTags(spans);
+
+            public IEnumerable<TagSpan<TextMarkerTag>> GetTags(NormalizedSnapshotSpanCollection spans)
             {
                 if (!_textView.Properties.TryGetProperty(PropertyName, out List<Span> allSpans))
-                {
-                    return null;
-                }
+                    return [];
 
                 return allSpans
                     .Where(s => spans.Any(ss => ss.IntersectsWith(s)))

--- a/src/Workspaces/Core/Portable/Utilities/SegmentedListPool.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SegmentedListPool.cs
@@ -39,7 +39,7 @@ internal static class SegmentedListPool
     /// are added to the list, then the <see cref="Array.Empty{T}"/> singleton will be returned.  Otherwise the 
     /// <see cref="SegmentedList{T}"/> instance will be returned.
     /// </summary>
-    public static IList<T> ComputeList<T, TArgs>(
+    public static IReadOnlyList<T> ComputeList<T, TArgs>(
         Action<TArgs, SegmentedList<T>> addItems,
         TArgs args,
         // Only used to allow type inference to work at callsite
@@ -63,10 +63,6 @@ internal static class SegmentedListPool
 
 internal static class SegmentedListPool<T>
 {
-    public static IList<T> ComputeList<TArgs>(
-        Action<TArgs, SegmentedList<T>> addItems,
-        TArgs args)
-    {
-        return SegmentedListPool.ComputeList<T, TArgs>(addItems, args, _: default);
-    }
+    public static IReadOnlyList<T> ComputeList<TArgs>(Action<TArgs, SegmentedList<T>> addItems, TArgs args)
+        => SegmentedListPool.ComputeList(addItems, args, _: default);
 }


### PR DESCRIPTION
In traces, calls through the interface members have actually shown up in traces.  This removes that entirely as everything is now a direct field call as this is now through non-virtual auto-properties.