### PR TITLE
Reduce lots of allocations in TagSpanIntervalTree

### DIFF
--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -159,8 +159,7 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
                     arg: default).ConfigureAwait(false);
             });
 
-            var cachedTags = new TagSpanIntervalTree<IClassificationTag>(snapshot.TextBuffer, SpanTrackingMode.EdgeExclusive, mergedTags);
-
+            var cachedTags = new TagSpanIntervalTree<IClassificationTag>(snapshot, SpanTrackingMode.EdgeExclusive, mergedTags);
             lock (_gate)
             {
                 _cachedTaggedSpan = spanToTag;

--- a/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -93,10 +93,10 @@ internal sealed class HighlighterViewTaggerProvider(
         var position = caretPosition.Value;
         var snapshot = snapshotSpan.Snapshot;
 
-        // See if the user is just moving their caret around in an existing tag.  If so, we don't
-        // want to actually go recompute things.  Note: this only works for containment.  If the
-        // user moves their caret to the end of a highlighted reference, we do want to recompute
-        // as they may now be at the start of some other reference that should be highlighted instead.
+        // See if the user is just moving their caret around in an existing tag.  If so, we don't want to actually go
+        // recompute things.  Note: this only works for containment.  If the user moves their caret to the end of a
+        // highlighted reference, we do want to recompute as they may now be at the start of some other reference that
+        // should be highlighted instead.
         var onExistingTags = context.HasExistingContainingTags(new SnapshotPoint(snapshot, position));
         if (onExistingTags)
         {

--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -122,10 +122,10 @@ internal sealed partial class ReferenceHighlightingViewTaggerProvider(
             return Task.CompletedTask;
         }
 
-        // See if the user is just moving their caret around in an existing tag.  If so, we don't
-        // want to actually go recompute things.  Note: this only works for containment.  If the
-        // user moves their caret to the end of a highlighted reference, we do want to recompute
-        // as they may now be at the start of some other reference that should be highlighted instead.
+        // See if the user is just moving their caret around in an existing tag.  If so, we don't want to actually go
+        // recompute things.  Note: this only works for containment.  If the user moves their caret to the end of a
+        // highlighted reference, we do want to recompute as they may now be at the start of some other reference that
+        // should be highlighted instead.
         var onExistingTags = context.HasExistingContainingTags(caretPosition);
         if (onExistingTags)
         {

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -79,6 +79,10 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
             result.Add(GetTranslatedTagSpan(tagSpan, snapshot, _spanTrackingMode));
     }
 
+    /// <summary>
+    /// Gets all the tag spans in this tree, remapped to <paramref name="snapshot"/>, and returns them as a <see
+    /// cref="NormalizedSnapshotSpanCollection"/>.
+    /// </summary>
     public NormalizedSnapshotSpanCollection GetSnapshotSpanCollection(ITextSnapshot snapshot)
     {
         using var _ = ArrayBuilder<SnapshotSpan>.GetInstance(out var spans);

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -62,7 +62,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
 
     public IReadOnlyList<TagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
         => SegmentedListPool<TagSpan<TTag>>.ComputeList(
-            static (args, tags) => args.@this.AppendIntersectingSpansInSortedOrder(args.snapshotSpan, tags),
+            static (args, tags) => args.@this.AddIntersectingTagSpans(args.snapshotSpan, tags),
             (@this: this, snapshotSpan));
 
     /// <summary>
@@ -70,7 +70,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
     /// <paramref name="result"/>.  Note the sorted chunk of items are appended to <paramref name="result"/>.  This
     /// means that <paramref name="result"/> may not be sorted if there were already items in them.
     /// </summary>
-    private void AppendIntersectingSpansInSortedOrder(SnapshotSpan snapshotSpan, SegmentedList<TagSpan<TTag>> result)
+    public void AddIntersectingTagSpans(SnapshotSpan snapshotSpan, SegmentedList<TagSpan<TTag>> result)
     {
         var snapshot = snapshotSpan.Snapshot;
 
@@ -174,12 +174,12 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
         // need to allocate any intermediate collections
         if (requestedSpans.Count == 1)
         {
-            AppendIntersectingSpansInSortedOrder(requestedSpans[0], tags);
+            AddIntersectingTagSpans(requestedSpans[0], tags);
         }
         else if (requestedSpans.Count < MaxNumberOfRequestedSpans)
         {
             foreach (var span in requestedSpans)
-                AppendIntersectingSpansInSortedOrder(span, tags);
+                AddIntersectingTagSpans(span, tags);
         }
         else
         {
@@ -197,7 +197,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
 
             using var _1 = SegmentedListPool.GetPooledList<TagSpan<TTag>>(out var tempList);
 
-            AppendIntersectingSpansInSortedOrder(mergedSpan, tempList);
+            AddIntersectingTagSpans(mergedSpan, tempList);
             if (tempList.Count == 0)
                 return;
 

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -55,11 +55,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
     public SpanTrackingMode SpanTrackingMode => _spanTrackingMode;
 
     public bool HasSpanThatContains(SnapshotPoint point)
-    {
-        var snapshot = point.Snapshot;
-
-        return _tree.HasIntervalThatContains(point.Position, length: 0, new IntervalIntrospector(snapshot, _spanTrackingMode));
-    }
+        => _tree.HasIntervalThatContains(point.Position, length: 0, new IntervalIntrospector(point.Snapshot, _spanTrackingMode));
 
     public IReadOnlyList<TagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
         => SegmentedListPool<TagSpan<TTag>>.ComputeList(

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -25,7 +25,8 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
     ITextBuffer textBuffer,
     SpanTrackingMode trackingMode,
     IEnumerable<TagSpan<TTag>>? values1 = null,
-    IEnumerable<TagSpan<TTag>>? values2 = null) where TTag : ITag
+    IEnumerable<TagSpan<TTag>>? values2 = null)
+    where TTag : ITag
 {
     private readonly SpanTrackingMode _spanTrackingMode = trackingMode;
     private readonly IntervalTree<TagSpan<TTag>> _tree = IntervalTree.Create(
@@ -42,16 +43,13 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
             : localSpan.TranslateTo(textSnapshot, trackingMode);
     }
 
-    private TagSpan<TTag> GetTranslatedITagSpan(TagSpan<TTag> originalTagSpan, ITextSnapshot textSnapshot)
-        // Avoid reallocating in the case where we're on the same snapshot.
-        => originalTagSpan.Span.Snapshot == textSnapshot
-            ? originalTagSpan
-            : GetTranslatedTagSpan(originalTagSpan, textSnapshot, _spanTrackingMode);
+    private TagSpan<TTag> GetTranslatedTagSpan(TagSpan<TTag> originalTagSpan, ITextSnapshot textSnapshot)
+        => GetTranslatedTagSpan(originalTagSpan, textSnapshot, _spanTrackingMode);
 
     private static TagSpan<TTag> GetTranslatedTagSpan(TagSpan<TTag> originalTagSpan, ITextSnapshot textSnapshot, SpanTrackingMode trackingMode)
         // Avoid reallocating in the case where we're on the same snapshot.
-        => originalTagSpan is TagSpan<TTag> tagSpan && tagSpan.Span.Snapshot == textSnapshot
-            ? tagSpan
+        => originalTagSpan.Span.Snapshot == textSnapshot
+            ? originalTagSpan
             : new(GetTranslatedSpan(originalTagSpan, textSnapshot, trackingMode), originalTagSpan.Tag);
 
     public SpanTrackingMode SpanTrackingMode => _spanTrackingMode;
@@ -88,7 +86,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
     }
 
     public IEnumerable<TagSpan<TTag>> GetSpans(ITextSnapshot snapshot)
-        => _tree.Select(tn => GetTranslatedITagSpan(tn, snapshot));
+        => _tree.Select(tn => GetTranslatedTagSpan(tn, snapshot));
 
     /// <summary>
     /// Adds all the tag spans in <see langword="this"/> to <paramref name="tagSpans"/>, translating them to the given
@@ -97,7 +95,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
     public void AddAllSpans(ITextSnapshot textSnapshot, HashSet<TagSpan<TTag>> tagSpans)
     {
         foreach (var tagSpan in _tree)
-            tagSpans.Add(GetTranslatedITagSpan(tagSpan, textSnapshot));
+            tagSpans.Add(GetTranslatedTagSpan(tagSpan, textSnapshot));
     }
 
     /// <summary>
@@ -121,7 +119,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
                 new IntervalIntrospector(textSnapshot, _spanTrackingMode));
 
             foreach (var tagSpan in buffer)
-                tagSpans.Remove(GetTranslatedITagSpan(tagSpan, textSnapshot));
+                tagSpans.Remove(GetTranslatedTagSpan(tagSpan, textSnapshot));
         }
     }
 

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -84,9 +84,6 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
             result.Add(GetTranslatedTagSpan(tagSpan, snapshot, _spanTrackingMode));
     }
 
-    public IEnumerable<TagSpan<TTag>> GetTagSpans(ITextSnapshot snapshot)
-        => _tree.Select(tn => GetTranslatedTagSpan(tn, snapshot));
-
     public NormalizedSnapshotSpanCollection GetSnapshotSpanCollection(ITextSnapshot snapshot)
     {
         using var _ = ArrayBuilder<SnapshotSpan>.GetInstance(out var spans);

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -85,6 +85,9 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
     /// </summary>
     public NormalizedSnapshotSpanCollection GetSnapshotSpanCollection(ITextSnapshot snapshot)
     {
+        if (this == Empty)
+            return NormalizedSnapshotSpanCollection.Empty;
+
         using var _ = ArrayBuilder<SnapshotSpan>.GetInstance(out var spans);
 
         foreach (var tagSpan in _tree)

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -77,8 +77,18 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
             result.Add(GetTranslatedTagSpan(tagSpan, snapshot, _spanTrackingMode));
     }
 
-    public IEnumerable<TagSpan<TTag>> GetSpans(ITextSnapshot snapshot)
+    public IEnumerable<TagSpan<TTag>> GetTagSpans(ITextSnapshot snapshot)
         => _tree.Select(tn => GetTranslatedTagSpan(tn, snapshot));
+
+    public NormalizedSnapshotSpanCollection GetSnapshotSpanCollection(ITextSnapshot snapshot)
+    {
+        using var _ = ArrayBuilder<SnapshotSpan>.GetInstance(out var spans);
+
+        foreach (var tagSpan in _tree)
+            spans.Add(GetTranslatedSpan(tagSpan, snapshot, _spanTrackingMode));
+
+        return new(spans);
+    }
 
     /// <summary>
     /// Adds all the tag spans in <see langword="this"/> to <paramref name="tagSpans"/>, translating them to the given

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -95,6 +95,14 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
             tagSpans.Add(GetTranslatedTagSpan(tagSpan, textSnapshot));
     }
 
+    /// <inheritdoc cref="AddAllSpans(ITextSnapshot, HashSet{TagSpan{TTag}})"/>
+    /// <remarks>Spans will be added in sorted order</remarks>
+    public void AddAllSpans(ITextSnapshot textSnapshot, ArrayBuilder<TagSpan<TTag>> tagSpans)
+    {
+        foreach (var tagSpan in _tree)
+            tagSpans.Add(GetTranslatedTagSpan(tagSpan, textSnapshot));
+    }
+
     /// <summary>
     /// Removes from <paramref name="tagSpans"/> all the tags spans in <see langword="this"/> that intersect with any of
     /// the spans in <paramref name="snapshotSpansToRemove"/>.

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -110,7 +110,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
 
     /// <inheritdoc cref="AddAllSpans(ITextSnapshot, HashSet{TagSpan{TTag}})"/>
     /// <remarks>Spans will be added in sorted order</remarks>
-    public void AddAllSpans(ITextSnapshot textSnapshot, ArrayBuilder<TagSpan<TTag>> tagSpans)
+    public void AddAllSpans(ITextSnapshot textSnapshot, SegmentedList<TagSpan<TTag>> tagSpans)
     {
         foreach (var tagSpan in _tree)
             tagSpans.Add(GetTranslatedTagSpan(tagSpan, textSnapshot));

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -128,9 +128,6 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
         }
     }
 
-    public bool IsEmpty()
-        => _tree.IsEmpty();
-
     public void AddIntersectingTagSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
     {
         AddIntersectingTagSpansWorker(requestedSpans, tags);

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -140,33 +140,6 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
 
     public void AddIntersectingTagSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
     {
-        AddIntersectingTagSpansWorker(requestedSpans, tags);
-        DebugVerifyTags(requestedSpans, tags);
-    }
-
-    [Conditional("DEBUG")]
-    private static void DebugVerifyTags(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
-    {
-        if (tags == null)
-        {
-            return;
-        }
-
-        foreach (var tag in tags)
-        {
-            var span = tag.Span;
-
-            if (!requestedSpans.Any(s => s.IntersectsWith(span)))
-            {
-                Contract.Fail(tag + " doesn't intersects with any requested span");
-            }
-        }
-    }
-
-    private void AddIntersectingTagSpansWorker(
-        NormalizedSnapshotSpanCollection requestedSpans,
-        SegmentedList<TagSpan<TTag>> tags)
-    {
         const int MaxNumberOfRequestedSpans = 100;
 
         // Special case the case where there is only one requested span.  In that case, we don't
@@ -185,6 +158,7 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
             AddTagsForLargeNumberOfSpans(requestedSpans, tags);
         }
 
+        DebugVerifyTags(requestedSpans, tags);
         return;
 
         void AddTagsForLargeNumberOfSpans(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
@@ -252,6 +226,25 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
 
                 if (!enumerator.MoveNext())
                     break;
+            }
+        }
+    }
+
+    [Conditional("DEBUG")]
+    private static void DebugVerifyTags(NormalizedSnapshotSpanCollection requestedSpans, SegmentedList<TagSpan<TTag>> tags)
+    {
+        if (tags == null)
+        {
+            return;
+        }
+
+        foreach (var tag in tags)
+        {
+            var span = tag.Span;
+
+            if (!requestedSpans.Any(s => s.IntersectsWith(span)))
+            {
+                Contract.Fail(tag + " doesn't intersects with any requested span");
             }
         }
     }

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -55,6 +55,9 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
     public bool HasSpanThatContains(SnapshotPoint point)
         => _tree.HasIntervalThatContains(point.Position, length: 0, new IntervalIntrospector(point.Snapshot, _spanTrackingMode));
 
+    public bool HasSpanThatIntersects(SnapshotPoint point)
+        => _tree.HasIntervalThatIntersectsWith(point.Position, new IntervalIntrospector(point.Snapshot, _spanTrackingMode));
+
     public IReadOnlyList<TagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
         => SegmentedListPool<TagSpan<TTag>>.ComputeList(
             static (args, tags) => args.@this.AppendIntersectingSpansInSortedOrder(args.snapshotSpan, tags),

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -52,8 +52,6 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
             ? originalTagSpan
             : new(GetTranslatedSpan(originalTagSpan, textSnapshot, trackingMode), originalTagSpan.Tag);
 
-    public SpanTrackingMode SpanTrackingMode => _spanTrackingMode;
-
     public bool HasSpanThatContains(SnapshotPoint point)
         => _tree.HasIntervalThatContains(point.Position, length: 0, new IntervalIntrospector(point.Snapshot, _spanTrackingMode));
 

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -29,19 +29,14 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
     where TTag : ITag
 {
     private readonly SpanTrackingMode _spanTrackingMode = trackingMode;
+
     private readonly IntervalTree<TagSpan<TTag>> _tree = IntervalTree.Create(
         new IntervalIntrospector(textBuffer.CurrentSnapshot, trackingMode),
         values1, values2);
 
-    private static SnapshotSpan GetTranslatedSpan(
-        TagSpan<TTag> originalTagSpan, ITextSnapshot textSnapshot, SpanTrackingMode trackingMode)
-    {
-        var localSpan = originalTagSpan.Span;
-
-        return localSpan.Snapshot == textSnapshot
-            ? localSpan
-            : localSpan.TranslateTo(textSnapshot, trackingMode);
-    }
+    private static SnapshotSpan GetTranslatedSpan(TagSpan<TTag> originalTagSpan, ITextSnapshot textSnapshot, SpanTrackingMode trackingMode)
+        // SnapshotSpan no-ops if you pass it the same snapshot that it is holding onto.
+        => originalTagSpan.Span.TranslateTo(textSnapshot, trackingMode);
 
     private TagSpan<TTag> GetTranslatedTagSpan(TagSpan<TTag> originalTagSpan, ITextSnapshot textSnapshot)
         => GetTranslatedTagSpan(originalTagSpan, textSnapshot, _spanTrackingMode);

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -27,7 +27,6 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
     IEnumerable<TagSpan<TTag>>? values1 = null,
     IEnumerable<TagSpan<TTag>>? values2 = null) where TTag : ITag
 {
-    private readonly ITextBuffer _textBuffer = textBuffer;
     private readonly SpanTrackingMode _spanTrackingMode = trackingMode;
     private readonly IntervalTree<TagSpan<TTag>> _tree = IntervalTree.Create(
         new IntervalIntrospector(textBuffer.CurrentSnapshot, trackingMode),
@@ -55,14 +54,11 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
             ? tagSpan
             : new(GetTranslatedSpan(originalTagSpan, textSnapshot, trackingMode), originalTagSpan.Tag);
 
-    public ITextBuffer Buffer => _textBuffer;
-
     public SpanTrackingMode SpanTrackingMode => _spanTrackingMode;
 
     public bool HasSpanThatContains(SnapshotPoint point)
     {
         var snapshot = point.Snapshot;
-        Debug.Assert(snapshot.TextBuffer == _textBuffer);
 
         return _tree.HasIntervalThatContains(point.Position, length: 0, new IntervalIntrospector(snapshot, _spanTrackingMode));
     }
@@ -80,7 +76,6 @@ internal sealed partial class TagSpanIntervalTree<TTag>(
     private void AppendIntersectingSpansInSortedOrder(SnapshotSpan snapshotSpan, SegmentedList<TagSpan<TTag>> result)
     {
         var snapshot = snapshotSpan.Snapshot;
-        Debug.Assert(snapshot.TextBuffer == _textBuffer);
 
         using var intersectingIntervals = TemporaryArray<TagSpan<TTag>>.Empty;
         _tree.FillWithIntervalsThatIntersectWith(

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -60,11 +60,6 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
     public bool HasSpanThatIntersects(SnapshotPoint point)
         => _tree.HasIntervalThatIntersectsWith(point.Position, new IntervalIntrospector(point.Snapshot, _spanTrackingMode));
 
-    public IReadOnlyList<TagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
-        => SegmentedListPool<TagSpan<TTag>>.ComputeList(
-            static (args, tags) => args.@this.AddIntersectingTagSpans(args.snapshotSpan, tags),
-            (@this: this, snapshotSpan));
-
     /// <summary>
     /// Gets all the spans that intersect with <paramref name="snapshotSpan"/> in sorted order and adds them to
     /// <paramref name="result"/>.  Note the sorted chunk of items are appended to <paramref name="result"/>.  This

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 /// </summary>
 internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTrackingMode) where TTag : ITag
 {
+    // Tracking mode passed in here doesn't matter (since the tree is empty).
     public static readonly TagSpanIntervalTree<TTag> Empty = new(SpanTrackingMode.EdgeInclusive);
 
     private readonly SpanTrackingMode _spanTrackingMode = spanTrackingMode;
@@ -93,7 +94,9 @@ internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTra
         foreach (var tagSpan in _tree)
             spans.Add(GetTranslatedSpan(tagSpan, snapshot, _spanTrackingMode));
 
-        return new(spans);
+        return spans.Count == 0
+            ? NormalizedSnapshotSpanCollection.Empty
+            : new(spans);
     }
 
     /// <summary>

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -21,18 +21,24 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 /// tracked. That way you can query for intersecting/overlapping spans in a different snapshot
 /// than the one for the tag spans that were added.
 /// </summary>
-internal sealed partial class TagSpanIntervalTree<TTag>(
-    ITextBuffer textBuffer,
-    SpanTrackingMode trackingMode,
-    IEnumerable<TagSpan<TTag>>? values1 = null,
-    IEnumerable<TagSpan<TTag>>? values2 = null)
-    where TTag : ITag
+internal sealed partial class TagSpanIntervalTree<TTag>(SpanTrackingMode spanTrackingMode) where TTag : ITag
 {
-    private readonly SpanTrackingMode _spanTrackingMode = trackingMode;
+    public static readonly TagSpanIntervalTree<TTag> Empty = new(SpanTrackingMode.EdgeInclusive);
 
-    private readonly IntervalTree<TagSpan<TTag>> _tree = IntervalTree.Create(
-        new IntervalIntrospector(textBuffer.CurrentSnapshot, trackingMode),
-        values1, values2);
+    private readonly SpanTrackingMode _spanTrackingMode = spanTrackingMode;
+    private readonly IntervalTree<TagSpan<TTag>> _tree = IntervalTree<TagSpan<TTag>>.Empty;
+
+    public TagSpanIntervalTree(
+        ITextSnapshot textSnapshot,
+        SpanTrackingMode trackingMode,
+        IEnumerable<TagSpan<TTag>>? values1 = null,
+        IEnumerable<TagSpan<TTag>>? values2 = null)
+        : this(trackingMode)
+    {
+        _tree = IntervalTree.Create(
+            new IntervalIntrospector(textSnapshot, trackingMode),
+            values1, values2);
+    }
 
     private static SnapshotSpan GetTranslatedSpan(TagSpan<TTag> originalTagSpan, ITextSnapshot textSnapshot, SpanTrackingMode trackingMode)
         // SnapshotSpan no-ops if you pass it the same snapshot that it is holding onto.

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Options;
@@ -50,6 +51,9 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
         /// Internal for testing purposes.
         /// </summary>
         private const int CoalesceDifferenceCount = 10;
+
+        private static readonly ObjectPool<SegmentedList<TagSpan<TTag>>> s_tagSpanListPool = new(() => new(), trimOnFree: false);
+        private readonly ObjectPool<HashSet<TagSpan<TTag>>> _tagSpanSetPool;
 
         #region Fields that can be accessed from either thread
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_IEqualityComparer.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_IEqualityComparer.cs
@@ -12,8 +12,6 @@ internal abstract partial class AbstractAsynchronousTaggerProvider<TTag>
 {
     private partial class TagSource : IEqualityComparer<TagSpan<TTag>>
     {
-        private readonly ObjectPool<HashSet<TagSpan<TTag>>> _tagSpanSetPool;
-
         public bool Equals(TagSpan<TTag>? x, TagSpan<TTag>? y)
         {
             if (x == y)

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -142,7 +142,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             RaiseTagsChanged(buffer, difference);
         }
 
-        private TagSpanIntervalTree<TTag> GetTagTree(ITextSnapshot snapshot, ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>> tagTrees)
+        private static TagSpanIntervalTree<TTag> GetTagTree(ITextSnapshot snapshot, ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>> tagTrees)
         {
             return tagTrees.TryGetValue(snapshot.TextBuffer, out var tagTree)
                 ? tagTree

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -513,7 +513,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                     else
                     {
                         // It's a new buffer, so report all spans are changed
-                        bufferToChanges[latestBuffer] = new DiffResult(added: new(latestSpans.GetTagSpans(snapshot).Select(t => t.Span)), removed: null);
+                        bufferToChanges[latestBuffer] = new DiffResult(added: latestSpans.GetSnapshotSpanCollection(snapshot), removed: null);
                     }
                 }
 
@@ -522,7 +522,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                     if (!newTagTrees.ContainsKey(oldBuffer))
                     {
                         // This buffer disappeared, so let's notify that the old tags are gone
-                        bufferToChanges[oldBuffer] = new DiffResult(added: null, removed: new(previousSpans.GetTagSpans(oldBuffer.CurrentSnapshot).Select(t => t.Span)));
+                        bufferToChanges[oldBuffer] = new DiffResult(added: null, removed: previousSpans.GetSnapshotSpanCollection(oldBuffer.CurrentSnapshot));
                     }
                 }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -109,7 +109,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                             var allTags = treeForBuffer.GetSpans(e.After).ToList();
                             var newTagTree = new TagSpanIntervalTree<TTag>(
                                 buffer,
-                                treeForBuffer.SpanTrackingMode,
+                                this._dataSource.SpanTrackingMode,
                                 allTags.Except(tagsToRemove, comparer: this));
                             return new(oldTagTrees.SetItem(buffer, newTagTree));
                         }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -40,11 +40,8 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             {
                 // If it changed position and we're still in a tag, there's nothing more to do
                 var currentTags = TryGetTagIntervalTreeForBuffer(caret.Value.Snapshot.TextBuffer);
-                if (currentTags != null && currentTags.GetIntersectingSpans(new SnapshotSpan(caret.Value, 0)).Count > 0)
-                {
-                    // Caret is inside a tag.  No need to do anything.
+                if (currentTags != null && currentTags.HasSpanThatIntersects(caret.Value))
                     return;
-                }
             }
 
             RemoveAllTags();

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -543,13 +543,17 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             TagSpanIntervalTree<TTag> latestTree,
             TagSpanIntervalTree<TTag> previousTree)
         {
-            var latestSpans = latestTree.GetSpans(snapshot);
-            var previousSpans = previousTree.GetSpans(snapshot);
+            using var _1 = ArrayBuilder<TagSpan<TTag>>.GetInstance(out var latestSpans);
+            using var _2 = ArrayBuilder<TagSpan<TTag>>.GetInstance(out var previousSpans);
 
-            using var _1 = ArrayBuilder<SnapshotSpan>.GetInstance(out var added);
-            using var _2 = ArrayBuilder<SnapshotSpan>.GetInstance(out var removed);
-            using var latestEnumerator = latestSpans.GetEnumerator();
-            using var previousEnumerator = previousSpans.GetEnumerator();
+            using var _3 = ArrayBuilder<SnapshotSpan>.GetInstance(out var added);
+            using var _4 = ArrayBuilder<SnapshotSpan>.GetInstance(out var removed);
+
+            latestTree.AddAllSpans(snapshot, latestSpans);
+            previousTree.AddAllSpans(snapshot, previousSpans);
+
+            var latestEnumerator = latestSpans.GetEnumerator();
+            var previousEnumerator = previousSpans.GetEnumerator();
 
             var latest = NextOrNull(latestEnumerator);
             var previous = NextOrNull(previousEnumerator);
@@ -608,7 +612,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
 
             return new DiffResult(new(added), new(removed));
 
-            static TagSpan<TTag>? NextOrNull(IEnumerator<TagSpan<TTag>> enumerator)
+            static TagSpan<TTag>? NextOrNull(ArrayBuilder<TagSpan<TTag>>.Enumerator enumerator)
                 => enumerator.MoveNext() ? enumerator.Current : null;
         }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -450,9 +450,13 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             {
                 // If we have no spans to invalidate, then we can just keep the old tags and add the new tags.
                 var snapshot = newTags.First().Span.Snapshot;
-                var oldTagsToKeep = oldTagTree.GetTagSpans(snapshot);
+
+                // For efficiency, just grab the old tags, remap them to the current snapshot, and place them in the
+                // newTags buffer.  This is a safe mutation of this buffer as the caller doesn't use it after this point
+                // and instead immediately clears it.
+                oldTagTree.AddAllSpans(snapshot, newTags);
                 return new TagSpanIntervalTree<TTag>(
-                    snapshot, _dataSource.SpanTrackingMode, oldTagsToKeep, newTags);
+                    snapshot, _dataSource.SpanTrackingMode, newTags);
             }
             else
             {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -58,7 +58,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             var oldTagTree = GetTagTree(snapshot, oldTagTrees);
 
             // everything from old tree is removed.
-            RaiseTagsChanged(snapshot.TextBuffer, new DiffResult(added: null, removed: new(oldTagTree.GetSpans(snapshot).Select(s => s.Span))));
+            RaiseTagsChanged(snapshot.TextBuffer, new DiffResult(added: null, removed: oldTagTree.GetSnapshotSpanCollection(snapshot)));
         }
 
         private void OnSubjectBufferChanged(object? _, TextContentChangedEventArgs e)
@@ -103,7 +103,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                         var tagsToRemove = e.Changes.SelectMany(c => treeForBuffer.GetIntersectingSpans(new SnapshotSpan(snapshot, c.NewSpan)));
                         if (tagsToRemove.Any())
                         {
-                            var allTags = treeForBuffer.GetSpans(e.After).ToList();
+                            var allTags = treeForBuffer.GetTagSpans(e.After).ToList();
                             var newTagTree = new TagSpanIntervalTree<TTag>(
                                 buffer,
                                 this._dataSource.SpanTrackingMode,
@@ -449,7 +449,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             if (noSpansToInvalidate)
             {
                 // If we have no spans to invalidate, then we can just keep the old tags and add the new tags.
-                var oldTagsToKeep = oldTagTree.GetSpans(newTags.First().Span.Snapshot);
+                var oldTagsToKeep = oldTagTree.GetTagSpans(newTags.First().Span.Snapshot);
                 return new TagSpanIntervalTree<TTag>(
                     textBuffer, _dataSource.SpanTrackingMode, oldTagsToKeep, newTags);
             }
@@ -518,7 +518,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                     else
                     {
                         // It's a new buffer, so report all spans are changed
-                        bufferToChanges[latestBuffer] = new DiffResult(added: new(latestSpans.GetSpans(snapshot).Select(t => t.Span)), removed: null);
+                        bufferToChanges[latestBuffer] = new DiffResult(added: new(latestSpans.GetTagSpans(snapshot).Select(t => t.Span)), removed: null);
                     }
                 }
 
@@ -527,7 +527,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                     if (!newTagTrees.ContainsKey(oldBuffer))
                     {
                         // This buffer disappeared, so let's notify that the old tags are gone
-                        bufferToChanges[oldBuffer] = new DiffResult(added: null, removed: new(previousSpans.GetSpans(oldBuffer.CurrentSnapshot).Select(t => t.Span)));
+                        bufferToChanges[oldBuffer] = new DiffResult(added: null, removed: new(previousSpans.GetTagSpans(oldBuffer.CurrentSnapshot).Select(t => t.Span)));
                     }
                 }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -562,8 +562,8 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             var latestEnumerator = latestSpans.GetEnumerator();
             var previousEnumerator = previousSpans.GetEnumerator();
 
-            var latest = NextOrNull(latestEnumerator);
-            var previous = NextOrNull(previousEnumerator);
+            var latest = NextOrNull(ref latestEnumerator);
+            var previous = NextOrNull(ref previousEnumerator);
 
             while (latest != null && previous != null)
             {
@@ -573,12 +573,12 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                 if (latestSpan.Start < previousSpan.Start)
                 {
                     added.Add(latestSpan);
-                    latest = NextOrNull(latestEnumerator);
+                    latest = NextOrNull(ref latestEnumerator);
                 }
                 else if (previousSpan.Start < latestSpan.Start)
                 {
                     removed.Add(previousSpan);
-                    previous = NextOrNull(previousEnumerator);
+                    previous = NextOrNull(ref previousEnumerator);
                 }
                 else
                 {
@@ -587,20 +587,20 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                     if (previousSpan.End > latestSpan.End)
                     {
                         removed.Add(previousSpan);
-                        latest = NextOrNull(latestEnumerator);
+                        latest = NextOrNull(ref latestEnumerator);
                     }
                     else if (latestSpan.End > previousSpan.End)
                     {
                         added.Add(latestSpan);
-                        previous = NextOrNull(previousEnumerator);
+                        previous = NextOrNull(ref previousEnumerator);
                     }
                     else
                     {
                         if (!_dataSource.TagEquals(latest.Tag, previous.Tag))
                             added.Add(latestSpan);
 
-                        latest = NextOrNull(latestEnumerator);
-                        previous = NextOrNull(previousEnumerator);
+                        latest = NextOrNull(ref latestEnumerator);
+                        previous = NextOrNull(ref previousEnumerator);
                     }
                 }
             }
@@ -608,18 +608,18 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             while (latest != null)
             {
                 added.Add(latest.Span);
-                latest = NextOrNull(latestEnumerator);
+                latest = NextOrNull(ref latestEnumerator);
             }
 
             while (previous != null)
             {
                 removed.Add(previous.Span);
-                previous = NextOrNull(previousEnumerator);
+                previous = NextOrNull(ref previousEnumerator);
             }
 
             return new DiffResult(new(added), new(removed));
 
-            static TagSpan<TTag>? NextOrNull(ArrayBuilder<TagSpan<TTag>>.Enumerator enumerator)
+            static TagSpan<TTag>? NextOrNull(ref ArrayBuilder<TagSpan<TTag>>.Enumerator enumerator)
                 => enumerator.MoveNext() ? enumerator.Current : null;
         }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -56,7 +56,9 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                 ref _cachedTagTrees_mayChangeFromAnyThread, ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>>.Empty);
 
             var snapshot = _subjectBuffer.CurrentSnapshot;
-            var oldTagTree = GetTagTree(snapshot, oldTagTrees);
+            var oldTagTree = oldTagTrees.TryGetValue(snapshot.TextBuffer, out var tagTree)
+                ? tagTree
+                : TagSpanIntervalTree<TTag>.Empty;
 
             // everything from old tree is removed.
             RaiseTagsChanged(snapshot.TextBuffer, new DiffResult(added: null, removed: oldTagTree.GetSnapshotSpanCollection(snapshot)));
@@ -140,13 +142,6 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             var difference = ComputeDifference(snapshot, newTagTrees[buffer], oldTagTrees[buffer]);
 
             RaiseTagsChanged(buffer, difference);
-        }
-
-        private static TagSpanIntervalTree<TTag> GetTagTree(ITextSnapshot snapshot, ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>> tagTrees)
-        {
-            return tagTrees.TryGetValue(snapshot.TextBuffer, out var tagTree)
-                ? tagTree
-                : TagSpanIntervalTree<TTag>.Empty;
         }
 
         private void OnEventSourceChanged(object? _1, TaggerEventArgs _2)

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -469,7 +469,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
             else
             {
                 // We do have spans to invalidate. Get the set of old tags that don't intersect with those and add the new tags.
-                using var _1 = _tagSpanSetPool.GetPooledObject(out var nonIntersectingTagSpans);
+                using var _1 = _tagSpanSetPool.GetPooledObject(out var nonIntersectingOldTags);
 
                 var firstSpanToInvalidate = spansToInvalidate.First();
                 var snapshot = firstSpanToInvalidate.Snapshot;
@@ -478,12 +478,12 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                 // full snapshot is being invalidated.
                 if (firstSpanToInvalidate.Length != snapshot.Length)
                 {
-                    oldTagTree.AddAllSpans(snapshot, nonIntersectingTagSpans);
-                    oldTagTree.RemoveIntersectingTagSpans(spansToInvalidate, nonIntersectingTagSpans);
+                    oldTagTree.AddAllSpans(snapshot, nonIntersectingOldTags);
+                    oldTagTree.RemoveIntersectingTagSpans(spansToInvalidate, nonIntersectingOldTags);
                 }
 
                 return new TagSpanIntervalTree<TTag>(
-                    snapshot, _dataSource.SpanTrackingMode, nonIntersectingTagSpans, newTags);
+                    snapshot, _dataSource.SpanTrackingMode, nonIntersectingOldTags, newTags);
             }
         }
 

--- a/src/EditorFeatures/Test/Tagging/TagSpanIntervalTreeTests.cs
+++ b/src/EditorFeatures/Test/Tagging/TagSpanIntervalTreeTests.cs
@@ -30,7 +30,7 @@ public class TagSpanIntervalTreeTests
     {
         var (tree, buffer) = CreateTree(string.Empty);
 
-        Assert.Empty(tree.GetSpans(buffer.CurrentSnapshot));
+        Assert.Empty(tree.GetTagSpans(buffer.CurrentSnapshot));
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class TagSpanIntervalTreeTests
     {
         var (tree, buffer) = CreateTree("Hello, World", new Span(0, 5));
 
-        Assert.Equal(new Span(0, 5), tree.GetSpans(buffer.CurrentSnapshot).Single().Span);
+        Assert.Equal(new Span(0, 5), tree.GetTagSpans(buffer.CurrentSnapshot).Single().Span);
     }
 
     [Fact]

--- a/src/EditorFeatures/Test/Tagging/TagSpanIntervalTreeTests.cs
+++ b/src/EditorFeatures/Test/Tagging/TagSpanIntervalTreeTests.cs
@@ -7,6 +7,7 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Test.EditorUtilities;
@@ -30,7 +31,7 @@ public class TagSpanIntervalTreeTests
     {
         var (tree, buffer) = CreateTree(string.Empty);
 
-        Assert.Empty(tree.GetTagSpans(buffer.CurrentSnapshot));
+        Assert.Empty(tree.GetIntersectingSpans(buffer.CurrentSnapshot.GetFullSpan()));
     }
 
     [Fact]
@@ -38,7 +39,7 @@ public class TagSpanIntervalTreeTests
     {
         var (tree, buffer) = CreateTree("Hello, World", new Span(0, 5));
 
-        Assert.Equal(new Span(0, 5), tree.GetTagSpans(buffer.CurrentSnapshot).Single().Span);
+        Assert.Equal(new Span(0, 5), tree.GetIntersectingSpans(buffer.CurrentSnapshot.GetFullSpan()).Single().Span);
     }
 
     [Fact]

--- a/src/EditorFeatures/Test/Tagging/TagSpanIntervalTreeTests.cs
+++ b/src/EditorFeatures/Test/Tagging/TagSpanIntervalTreeTests.cs
@@ -22,7 +22,7 @@ public class TagSpanIntervalTreeTests
         var exportProvider = EditorTestCompositions.Editor.ExportProviderFactory.CreateExportProvider();
         var buffer = EditorFactory.CreateBuffer(exportProvider, text);
         var tags = spans.Select(s => new TagSpan<ITextMarkerTag>(new SnapshotSpan(buffer.CurrentSnapshot, s), new TextMarkerTag(string.Empty)));
-        return (new TagSpanIntervalTree<ITextMarkerTag>(buffer, SpanTrackingMode.EdgeInclusive, tags), buffer);
+        return (new TagSpanIntervalTree<ITextMarkerTag>(buffer.CurrentSnapshot, SpanTrackingMode.EdgeInclusive, tags), buffer);
     }
 
     [Fact]

--- a/src/EditorFeatures/Test/Tagging/TagSpanIntervalTreeTests.cs
+++ b/src/EditorFeatures/Test/Tagging/TagSpanIntervalTreeTests.cs
@@ -17,49 +17,49 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Tagging;
 [UseExportProvider]
 public class TagSpanIntervalTreeTests
 {
-    private static TagSpanIntervalTree<ITextMarkerTag> CreateTree(string text, params Span[] spans)
+    private static (TagSpanIntervalTree<ITextMarkerTag>, ITextBuffer) CreateTree(string text, params Span[] spans)
     {
         var exportProvider = EditorTestCompositions.Editor.ExportProviderFactory.CreateExportProvider();
         var buffer = EditorFactory.CreateBuffer(exportProvider, text);
         var tags = spans.Select(s => new TagSpan<ITextMarkerTag>(new SnapshotSpan(buffer.CurrentSnapshot, s), new TextMarkerTag(string.Empty)));
-        return new TagSpanIntervalTree<ITextMarkerTag>(buffer, SpanTrackingMode.EdgeInclusive, tags);
+        return (new TagSpanIntervalTree<ITextMarkerTag>(buffer, SpanTrackingMode.EdgeInclusive, tags), buffer);
     }
 
     [Fact]
     public void TestEmptyTree()
     {
-        var tree = CreateTree(string.Empty);
+        var (tree, buffer) = CreateTree(string.Empty);
 
-        Assert.Empty(tree.GetSpans(tree.Buffer.CurrentSnapshot));
+        Assert.Empty(tree.GetSpans(buffer.CurrentSnapshot));
     }
 
     [Fact]
     public void TestSingleSpan()
     {
-        var tree = CreateTree("Hello, World", new Span(0, 5));
+        var (tree, buffer) = CreateTree("Hello, World", new Span(0, 5));
 
-        Assert.Equal(new Span(0, 5), tree.GetSpans(tree.Buffer.CurrentSnapshot).Single().Span);
+        Assert.Equal(new Span(0, 5), tree.GetSpans(buffer.CurrentSnapshot).Single().Span);
     }
 
     [Fact]
     public void TestSingleIntersectingSpanAtStartWithEdit()
     {
-        var tree = CreateTree("Hello, World", new Span(7, 5));
-        tree.Buffer.Insert(0, new string('c', 100));
+        var (tree, buffer) = CreateTree("Hello, World", new Span(7, 5));
+        buffer.Insert(0, new string('c', 100));
 
         // The span should start at 107
-        var spans = tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 107, 0));
+        var spans = tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 107, 0));
         Assert.Equal(new Span(107, 5), spans.Single().Span);
     }
 
     [Fact]
     public void TestSingleIntersectingSpanAtEndWithEdit()
     {
-        var tree = CreateTree("Hello, World", new Span(7, 5));
-        tree.Buffer.Insert(0, new string('c', 100));
+        var (tree, buffer) = CreateTree("Hello, World", new Span(7, 5));
+        buffer.Insert(0, new string('c', 100));
 
         // The span should end at 112
-        var spans = tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 112, 0));
+        var spans = tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 112, 0));
         Assert.Equal(new Span(107, 5), spans.Single().Span);
     }
 
@@ -67,67 +67,67 @@ public class TagSpanIntervalTreeTests
     public void TestManySpansWithEdit()
     {
         // Create a buffer with the second half of the buffer covered with spans
-        var tree = CreateTree(new string('c', 100), Enumerable.Range(50, count: 50).Select(s => new Span(s, 1)).ToArray());
-        tree.Buffer.Insert(0, new string('c', 100));
+        var (tree, buffer) = CreateTree(new string('c', 100), Enumerable.Range(50, count: 50).Select(s => new Span(s, 1)).ToArray());
+        buffer.Insert(0, new string('c', 100));
 
         // We should have 50 spans if we start looking at just the end
-        Assert.Equal(50, tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 150, 50)).Count());
+        Assert.Equal(50, tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 150, 50)).Count());
 
         // And we should have 26 here. We directly cover 25 spans, and we touch one more
-        Assert.Equal(26, tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 175, 25)).Count());
+        Assert.Equal(26, tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 175, 25)).Count());
     }
 
     [Fact]
     public void TestManySpansWithEdit2()
     {
         // Cover the full buffer with spans
-        var tree = CreateTree(new string('c', 100), Enumerable.Range(0, count: 100).Select(s => new Span(s, 1)).ToArray());
-        tree.Buffer.Insert(0, new string('c', 100));
+        var (tree, buffer) = CreateTree(new string('c', 100), Enumerable.Range(0, count: 100).Select(s => new Span(s, 1)).ToArray());
+        buffer.Insert(0, new string('c', 100));
 
         // We should see one span anywhere in the beginning of the buffer, since this is edge inclusive
-        Assert.Equal(1, tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 0, 1)).Count());
-        Assert.Equal(1, tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 50, 1)).Count());
+        Assert.Equal(1, tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 0, 1)).Count());
+        Assert.Equal(1, tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 50, 1)).Count());
 
         // We should see two at position 100 (the first span that is now expanded, and the second of width 1)
-        Assert.Equal(2, tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 100, 1)).Count());
+        Assert.Equal(2, tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 100, 1)).Count());
     }
 
     [Fact]
     public void TestManySpansWithDeleteAndEditAtStart()
     {
         // Cover the full buffer with spans
-        var tree = CreateTree(new string('c', 100), Enumerable.Range(0, count: 100).Select(s => new Span(s, 1)).ToArray());
+        var (tree, buffer) = CreateTree(new string('c', 100), Enumerable.Range(0, count: 100).Select(s => new Span(s, 1)).ToArray());
 
-        tree.Buffer.Delete(new Span(0, 50));
-        tree.Buffer.Insert(0, new string('c', 50));
+        buffer.Delete(new Span(0, 50));
+        buffer.Insert(0, new string('c', 50));
 
         // We should see 51 spans intersecting the start. When we did the delete, we contracted 50 spans to size
         // zero, and then the insert will have expanded all of those, plus the span right next to it.
-        Assert.Equal(51, tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 0, 1)).Count());
+        Assert.Equal(51, tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 0, 1)).Count());
     }
 
     [Fact]
     public void TestManySpansWithDeleteAndEditAtEnd()
     {
         // Cover the full buffer with spans
-        var tree = CreateTree(new string('c', 100), Enumerable.Range(0, count: 100).Select(s => new Span(s, 1)).ToArray());
+        var (tree, buffer) = CreateTree(new string('c', 100), Enumerable.Range(0, count: 100).Select(s => new Span(s, 1)).ToArray());
 
-        tree.Buffer.Delete(new Span(50, 50));
-        tree.Buffer.Insert(50, new string('c', 50));
+        buffer.Delete(new Span(50, 50));
+        buffer.Insert(50, new string('c', 50));
 
         // We should see 51 spans intersecting the end. When we did the delete, we contracted 50 spans to size zero,
         // and then the insert will have expanded all of those, plus the span right next to it.
-        Assert.Equal(51, tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 99, 1)).Count());
+        Assert.Equal(51, tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 99, 1)).Count());
     }
 
     [Fact]
     public void TestTagSpanOrdering()
     {
         // Cover the full buffer with spans
-        var tree = CreateTree(new string('c', 100), Enumerable.Range(0, count: 100).Select(s => new Span(s, 1)).ToArray());
+        var (tree, buffer) = CreateTree(new string('c', 100), Enumerable.Range(0, count: 100).Select(s => new Span(s, 1)).ToArray());
 
         var lastStart = -1;
-        foreach (var tag in tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, 0, tree.Buffer.CurrentSnapshot.Length)))
+        foreach (var tag in tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)))
         {
             Assert.True(lastStart < tag.Span.Start.Position);
             lastStart = tag.Span.Start.Position;
@@ -137,40 +137,40 @@ public class TagSpanIntervalTreeTests
     [Fact]
     public void TestEmptySpanIntersects1()
     {
-        var tree = CreateTree("goo", new Span(0, 0));
-        var spans = tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, new Span(0, 0)));
+        var (tree, buffer) = CreateTree("goo", new Span(0, 0));
+        var spans = tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, new Span(0, 0)));
         Assert.Single(spans);
     }
 
     [Fact]
     public void TestEmptySpanIntersects2()
     {
-        var tree = CreateTree("goo", new Span(0, 0));
-        var spans = tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, new Span(0, "goo".Length)));
+        var (tree, buffer) = CreateTree("goo", new Span(0, 0));
+        var spans = tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, new Span(0, "goo".Length)));
         Assert.Single(spans);
     }
 
     [Fact]
     public void TestEmptySpanIntersects3()
     {
-        var tree = CreateTree("goo", new Span(1, 0));
-        var spans = tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, new Span(0, 1)));
+        var (tree, buffer) = CreateTree("goo", new Span(1, 0));
+        var spans = tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, new Span(0, 1)));
         Assert.Single(spans);
     }
 
     [Fact]
     public void TestEmptySpanIntersects4()
     {
-        var tree = CreateTree("goo", new Span(1, 0));
-        var spans = tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, new Span(1, 0)));
+        var (tree, buffer) = CreateTree("goo", new Span(1, 0));
+        var spans = tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, new Span(1, 0)));
         Assert.Single(spans);
     }
 
     [Fact]
     public void TestEmptySpanIntersects5()
     {
-        var tree = CreateTree("goo", new Span(1, 0));
-        var spans = tree.GetIntersectingSpans(new SnapshotSpan(tree.Buffer.CurrentSnapshot, new Span(1, 1)));
+        var (tree, buffer) = CreateTree("goo", new Span(1, 0));
+        var spans = tree.GetIntersectingSpans(new SnapshotSpan(buffer.CurrentSnapshot, new Span(1, 1)));
         Assert.Single(spans);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -10,7 +10,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Collections;
@@ -352,30 +351,33 @@ internal partial class IntervalTree<T> : IEnumerable<T>
 
     public IEnumerator<T> GetEnumerator()
     {
-        if (root == null)
-        {
-            yield break;
-        }
+        return this == Empty ? SpecializedCollections.EmptyEnumerator<T>() : GetEnumeratorWorker();
 
-        using var _ = ArrayBuilder<(Node? node, bool firstTime)>.GetInstance(out var candidates);
-        candidates.Push((root, firstTime: true));
-        while (candidates.TryPop(out var tuple))
+        IEnumerator<T> GetEnumeratorWorker()
         {
-            var (currentNode, firstTime) = tuple;
-            if (currentNode != null)
+            if (root == null)
+                yield break;
+
+            using var _ = ArrayBuilder<(Node? node, bool firstTime)>.GetInstance(out var candidates);
+            candidates.Push((root, firstTime: true));
+            while (candidates.TryPop(out var tuple))
             {
-                if (firstTime)
+                var (currentNode, firstTime) = tuple;
+                if (currentNode != null)
                 {
-                    // First time seeing this node.  Mark that we've been seen and recurse
-                    // down the left side.  The next time we see this node we'll yield it
-                    // out.
-                    candidates.Push((currentNode.Right, firstTime: true));
-                    candidates.Push((currentNode, firstTime: false));
-                    candidates.Push((currentNode.Left, firstTime: true));
-                }
-                else
-                {
-                    yield return currentNode.Value;
+                    if (firstTime)
+                    {
+                        // First time seeing this node.  Mark that we've been seen and recurse
+                        // down the left side.  The next time we see this node we'll yield it
+                        // out.
+                        candidates.Push((currentNode.Right, firstTime: true));
+                        candidates.Push((currentNode, firstTime: false));
+                        candidates.Push((currentNode.Left, firstTime: true));
+                    }
+                    else
+                    {
+                        yield return currentNode.Value;
+                    }
                 }
             }
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
@@ -50,6 +50,13 @@ internal static class SharedPoolExtensions
         return pooledObject;
     }
 
+    public static PooledObject<SegmentedList<TItem>> GetPooledObject<TItem>(this ObjectPool<SegmentedList<TItem>> pool, out SegmentedList<TItem> list)
+    {
+        var pooledObject = PooledObject<SegmentedList<TItem>>.Create(pool);
+        list = pooledObject.Object;
+        return pooledObject;
+    }
+
     public static PooledObject<HashSet<TItem>> GetPooledObject<TItem>(this ObjectPool<HashSet<TItem>> pool, out HashSet<TItem> list)
     {
         var pooledObject = PooledObject<HashSet<TItem>>.Create(pool);


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/73713.

Moved to pooled collections, and callers pass in the collections they want to fill. 

Before: 

![image](https://github.com/dotnet/roslyn/assets/4564579/6441e958-392d-4352-9073-e62b05d89b31)

After:

![image](https://github.com/dotnet/roslyn/assets/4564579/f118146b-9768-4233-94dc-3a3a09b926e7)
