### PR TITLE
Avoid unnecessary tree walk when hitting non-relevant directives

### DIFF
--- a/src/Features/Core/Portable/BraceMatching/AbstractDirectiveTriviaBraceMatcher.cs
+++ b/src/Features/Core/Portable/BraceMatching/AbstractDirectiveTriviaBraceMatcher.cs
@@ -37,16 +37,21 @@ internal abstract class AbstractDirectiveTriviaBraceMatcher<TDirectiveTriviaSynt
         }
 
         TDirectiveTriviaSyntax? matchingDirective = null;
-        if (IsConditionalDirective(directive))
+        if (directive
+                is TIfDirectiveTriviaSyntax
+                or TElseIfDirectiveTriviaSyntax
+                or TElseDirectiveTriviaSyntax
+                or TEndIfDirectiveTriviaSyntax)
         {
             // #if/#elif/#else/#endif directive cases.
             var matchingDirectives = GetMatchingConditionalDirectives(directive, cancellationToken);
             if (matchingDirectives.Length > 0)
                 matchingDirective = matchingDirectives[(matchingDirectives.IndexOf(directive) + 1) % matchingDirectives.Length];
         }
-        else
+        else if (directive
+                is TRegionDirectiveTriviaSyntax
+                or TEndRegionDirectiveTriviaSyntax)
         {
-            // #region/#endregion or other directive cases.
             matchingDirective = GetMatchingDirective(directive, cancellationToken);
         }
 
@@ -60,10 +65,4 @@ internal abstract class AbstractDirectiveTriviaBraceMatcher<TDirectiveTriviaSynt
             LeftSpan: GetSpanForTagging(directive),
             RightSpan: GetSpanForTagging(matchingDirective));
     }
-
-    private static bool IsConditionalDirective(TDirectiveTriviaSyntax directive)
-        => directive is TIfDirectiveTriviaSyntax or
-               TElseIfDirectiveTriviaSyntax or
-               TElseDirectiveTriviaSyntax or
-               TEndIfDirectiveTriviaSyntax;
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/DirectiveSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/DirectiveSyntaxExtensions.vb
@@ -9,7 +9,6 @@ Imports Microsoft.CodeAnalysis.VisualBasic.LanguageService
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
-
     Friend Module DirectiveSyntaxExtensions
         Private ReadOnly s_rootToDirectiveInfo As New ConditionalWeakTable(Of SyntaxNode, DirectiveInfo(Of DirectiveTriviaSyntax))()
 


### PR DESCRIPTION
Addresses cost during typing, even when the caret is not on a directive that has a matching brace:

![image](https://github.com/dotnet/roslyn/assets/4564579/903371cd-dcde-4df6-8227-a28dc3907568)
