### PR TITLE
Don't run code in the async/await highlighter unless on one of those keywords.

### DIFF
--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/AsyncAwaitHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/AsyncAwaitHighlighter.cs
@@ -14,22 +14,22 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Highlighting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting.KeywordHighlighters;
 
 [ExportHighlighter(LanguageNames.CSharp), Shared]
-internal class AsyncAwaitHighlighter : AbstractKeywordHighlighter
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class AsyncAwaitHighlighter() : AbstractKeywordHighlighter(findInsideTrivia: false)
 {
     private static readonly ObjectPool<Stack<SyntaxNode>> s_stackPool
         = SharedPools.Default<Stack<SyntaxNode>>();
 
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public AsyncAwaitHighlighter()
-    {
-    }
+    protected override bool ContainsHighlightableToken(ref TemporaryArray<SyntaxToken> tokens)
+        => tokens.Any(t => t.Kind() is SyntaxKind.AwaitKeyword or SyntaxKind.AsyncKeyword);
 
     protected override bool IsHighlightableNode(SyntaxNode node)
         => node.IsReturnableConstructOrTopLevelCompilationUnit();

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/ConditionalPreprocessorHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/ConditionalPreprocessorHighlighter.cs
@@ -17,12 +17,8 @@ namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting.KeywordHighlighters;
 [ExportHighlighter(LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class ConditionalPreprocessorHighlighter : AbstractKeywordHighlighter<DirectiveTriviaSyntax>
+internal sealed class ConditionalPreprocessorHighlighter() : AbstractKeywordHighlighter<DirectiveTriviaSyntax>
 {
-    public ConditionalPreprocessorHighlighter()
-    {
-    }
-
     protected override void AddHighlights(
         DirectiveTriviaSyntax directive, List<TextSpan> highlights, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/ConditionalPreprocessorHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/ConditionalPreprocessorHighlighter.cs
@@ -15,10 +15,10 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting.KeywordHighlighters;
 
 [ExportHighlighter(LanguageNames.CSharp), Shared]
-internal class ConditionalPreprocessorHighlighter : AbstractKeywordHighlighter<DirectiveTriviaSyntax>
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class ConditionalPreprocessorHighlighter : AbstractKeywordHighlighter<DirectiveTriviaSyntax>
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public ConditionalPreprocessorHighlighter()
     {
     }

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/IfStatementHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/IfStatementHighlighter.cs
@@ -14,18 +14,18 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Highlighting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting;
 
 [ExportHighlighter(LanguageNames.CSharp), Shared]
-internal class IfStatementHighlighter : AbstractKeywordHighlighter<IfStatementSyntax>
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class IfStatementHighlighter() : AbstractKeywordHighlighter<IfStatementSyntax>(findInsideTrivia: false)
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public IfStatementHighlighter()
-    {
-    }
+    protected override bool ContainsHighlightableToken(ref TemporaryArray<SyntaxToken> tokens)
+        => tokens.Any(static t => t.Kind() is SyntaxKind.IfKeyword or SyntaxKind.ElseKeyword);
 
     protected override void AddHighlights(
         IfStatementSyntax ifStatement, List<TextSpan> highlights, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/LoopHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/LoopHighlighter.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Highlighting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting.KeywordHighlighters;
@@ -20,6 +21,16 @@ namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting.KeywordHighlighters;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class LoopHighlighter() : AbstractKeywordHighlighter(findInsideTrivia: false)
 {
+    protected override bool ContainsHighlightableToken(ref TemporaryArray<SyntaxToken> tokens)
+        => tokens.Any(static t => t.Kind()
+            is SyntaxKind.DoKeyword
+            or SyntaxKind.ForKeyword
+            or SyntaxKind.ForEachKeyword
+            or SyntaxKind.WhileKeyword
+            or SyntaxKind.BreakKeyword
+            or SyntaxKind.ContinueKeyword
+            or SyntaxKind.SemicolonToken);
+
     protected override bool IsHighlightableNode(SyntaxNode node)
         => node.IsContinuableConstruct();
 

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/LoopHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/LoopHighlighter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;
@@ -18,14 +16,10 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting.KeywordHighlighters;
 
 [ExportHighlighter(LanguageNames.CSharp), Shared]
-internal class LoopHighlighter : AbstractKeywordHighlighter
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class LoopHighlighter() : AbstractKeywordHighlighter(findInsideTrivia: false)
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public LoopHighlighter()
-    {
-    }
-
     protected override bool IsHighlightableNode(SyntaxNode node)
         => node.IsContinuableConstruct();
 

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Highlighting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting.KeywordHighlighters;
@@ -67,7 +68,7 @@ internal sealed class SwitchStatementHighlighter() : AbstractKeywordHighlighter<
             // but if the label is missing, we do highlight 'goto' assuming it's more likely that
             // the user is in the middle of typing 'goto case' or 'goto default'.
             if (gotoStatement.Kind() is SyntaxKind.GotoCaseStatement or SyntaxKind.GotoDefaultStatement ||
-                gotoStatement.Expression.IsMissing)
+                gotoStatement is { Expression.IsMissing: true })
             {
                 var start = gotoStatement.GotoKeyword.SpanStart;
                 var end = !gotoStatement.CaseOrDefaultKeyword.IsKind(SyntaxKind.None)
@@ -82,10 +83,9 @@ internal sealed class SwitchStatementHighlighter() : AbstractKeywordHighlighter<
         {
             foreach (var childNodeOrToken in node.ChildNodesAndTokens())
             {
-                if (childNodeOrToken.IsToken)
+                if (!childNodeOrToken.AsNode(out var child))
                     continue;
 
-                var child = childNodeOrToken.AsNode();
                 var highlightBreaksForChild = highlightBreaks && !child.IsBreakableConstruct();
                 var highlightGotosForChild = highlightGotos && !child.IsKind(SyntaxKind.SwitchStatement);
 

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
@@ -29,7 +29,8 @@ internal sealed class SwitchStatementHighlighter() : AbstractKeywordHighlighter<
             or SyntaxKind.DefaultKeyword
             or SyntaxKind.SemicolonToken
             or SyntaxKind.BreakKeyword
-            or SyntaxKind.GotoKeyword);
+            or SyntaxKind.GotoKeyword
+            or SyntaxKind.ColonToken);
 
     protected override void AddHighlights(
         SwitchStatementSyntax switchStatement, List<TextSpan> spans, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
@@ -13,18 +13,24 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Highlighting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.KeywordHighlighting.KeywordHighlighters;
 
 [ExportHighlighter(LanguageNames.CSharp), Shared]
-internal class SwitchStatementHighlighter : AbstractKeywordHighlighter<SwitchStatementSyntax>
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class SwitchStatementHighlighter() : AbstractKeywordHighlighter<SwitchStatementSyntax>(findInsideTrivia: false)
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public SwitchStatementHighlighter()
-    {
-    }
+    protected override bool ContainsHighlightableToken(ref TemporaryArray<SyntaxToken> tokens)
+        => tokens.Any(static t => t.Kind()
+            is SyntaxKind.SwitchKeyword
+            or SyntaxKind.CaseKeyword
+            or SyntaxKind.DefaultKeyword
+            or SyntaxKind.SemicolonToken
+            or SyntaxKind.BreakKeyword
+            or SyntaxKind.GotoKeyword);
 
     protected override void AddHighlights(
         SwitchStatementSyntax switchStatement, List<TextSpan> spans, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/SyntacticChangeRangeComputer.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/SyntacticChangeRangeComputer.cs
@@ -119,11 +119,8 @@ internal static class SyntacticChangeRangeComputer
             if (oldRoot.IsIncrementallyIdenticalTo(newRoot))
                 return null;
 
-            using var leftOldStack = s_enumeratorPool.GetPooledObject();
-            using var leftNewStack = s_enumeratorPool.GetPooledObject();
-
-            var oldStack = leftOldStack.Object;
-            var newStack = leftNewStack.Object;
+            using var _1 = s_enumeratorPool.GetPooledObject(out var oldStack);
+            using var _2 = s_enumeratorPool.GetPooledObject(out var newStack);
 
             oldStack.Push(oldRoot.ChildNodesAndTokens().GetEnumerator());
             newStack.Push(newRoot.ChildNodesAndTokens().GetEnumerator());

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -338,9 +338,7 @@ internal static class ParenthesizedExpressionSyntaxExtensions
         // they include any : or :: tokens. If they do, we can't remove the parentheses because
         // the parser would assume that the first : would begin the format clause of the interpolation.
 
-        using var pooledStack = s_nodeStackPool.GetPooledObject();
-        var stack = pooledStack.Object;
-
+        using var _ = s_nodeStackPool.GetPooledObject(out var stack);
         stack.Push(node.Expression);
 
         while (stack.TryPop(out var expression))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -24,8 +24,7 @@ internal partial class IntervalTree<T> : IEnumerable<T>
 {
     public static readonly IntervalTree<T> Empty = new();
 
-    private static readonly ObjectPool<Stack<(Node node, bool firstTime)>> s_stackPool
-        = SharedPools.Default<Stack<(Node node, bool firstTime)>>();
+    private static readonly ObjectPool<Stack<(Node node, bool firstTime)>> s_stackPool = new(() => new(), trimOnFree: false);
 
     /// <summary>
     /// Keep around a fair number of these as we often use them in parallel algorithms.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/IntervalTree`1.cs
@@ -158,8 +158,7 @@ internal partial class IntervalTree<T> : IEnumerable<T>
         if (root is null)
             return false;
 
-        using var pooledObject = s_nodePool.GetPooledObject();
-        var candidates = pooledObject.Object;
+        using var _ = s_nodePool.GetPooledObject(out var candidates);
 
         var end = start + length;
 
@@ -202,8 +201,7 @@ internal partial class IntervalTree<T> : IEnumerable<T>
         if (root == null)
             return 0;
 
-        using var pooledObject = s_stackPool.GetPooledObject();
-        var candidates = pooledObject.Object;
+        using var _ = s_stackPool.GetPooledObject(out var candidates);
 
         var matches = 0;
         var end = start + length;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
@@ -861,11 +861,8 @@ internal static partial class SyntaxNodeExtensions
             var conditionalMap = new Dictionary<TDirectiveTriviaSyntax, ImmutableArray<TDirectiveTriviaSyntax>>(
                 DirectiveSyntaxEqualityComparer.Instance);
 
-            using var pooledRegionStack = s_stackPool.GetPooledObject();
-            using var pooledIfStack = s_stackPool.GetPooledObject();
-
-            var regionStack = pooledRegionStack.Object;
-            var ifStack = pooledIfStack.Object;
+            using var _1 = s_stackPool.GetPooledObject(out var regionStack);
+            using var _2 = s_stackPool.GetPooledObject(out var ifStack);
 
             foreach (var token in root.DescendantTokens(descendIntoChildren: static node => node.ContainsDirectives))
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
@@ -43,6 +43,13 @@ internal static class SharedPoolExtensions
     public static PooledObject<SegmentedList<TItem>> GetPooledObject<TItem>(this ObjectPool<SegmentedList<TItem>> pool)
         => PooledObject<SegmentedList<TItem>>.Create(pool);
 
+    public static PooledObject<Stack<TItem>> GetPooledObject<TItem>(this ObjectPool<Stack<TItem>> pool, out Stack<TItem> stack)
+    {
+        var pooledObject = PooledObject<Stack<TItem>>.Create(pool);
+        stack = pooledObject.Object;
+        return pooledObject;
+    }
+
     public static PooledObject<List<TItem>> GetPooledObject<TItem>(this ObjectPool<List<TItem>> pool, out List<TItem> list)
     {
         var pooledObject = PooledObject<List<TItem>>.Create(pool);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
@@ -36,8 +36,7 @@ internal static class ISyntaxFactsExtensions
         // and all the trivia on each token.  If full-span is false we'll examine all tokens
         // but we'll ignore the leading trivia on the very first trivia and the trailing trivia
         // on the very last token.
-        using var pooledObject = s_stackPool.GetPooledObject();
-        var stack = pooledObject.Object;
+        using var _ = s_stackPool.GetPooledObject(out var stack);
         stack.Push((node, leading: fullSpan, trailing: fullSpan));
 
         var result = IsOnSingleLine(syntaxFacts, stack);


### PR DESCRIPTION
Addresses about half the cost of keyword highlighting.

![image](https://github.com/dotnet/roslyn/assets/4564579/ca73c9ca-94f1-4350-9657-a2f01abcb7b0)
