### PR TITLE
Avoid any sort of work converting from Span to TextSpan

### DIFF
--- a/src/EditorFeatures/Core/Shared/Extensions/SpanExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/SpanExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
@@ -18,7 +19,7 @@ internal static class SpanExtensions
     /// <param name="span"></param>
     /// <returns></returns>
     public static TextSpan ToTextSpan(this Span span)
-        => new(span.Start, span.Length);
+        => Unsafe.As<Span, TextSpan>(ref span);
 
     public static bool IntersectsWith(this Span span, int position)
         => position >= span.Start && position <= span.End;

--- a/src/EditorFeatures/Core/Shared/Extensions/SpanExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/SpanExtensions.cs
@@ -18,6 +18,7 @@ internal static class SpanExtensions
     /// </summary>
     /// <param name="span"></param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static TextSpan ToTextSpan(this Span span)
         => Unsafe.As<Span, TextSpan>(ref span);
 

--- a/src/EditorFeatures/Core/Shared/Extensions/SpanExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/SpanExtensions.cs
@@ -20,7 +20,12 @@ internal static class SpanExtensions
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static TextSpan ToTextSpan(this Span span)
-        => Unsafe.As<Span, TextSpan>(ref span);
+    {
+        // this is a terribly ugly hack.  It depends on the fact that the Span and TextSpan both are just two adjacent
+        // ints, and that neither the editor or roslyn will realistically ever change the layout of these types. If
+        // either does, we will blow up immediately, so this is somewhat ok for us to take a dependency on.
+        return Unsafe.As<Span, TextSpan>(ref span);
+    }
 
     public static bool IntersectsWith(this Span span, int position)
         => position >= span.Start && position <= span.End;


### PR DESCRIPTION
Addresses:

![image](https://github.com/dotnet/roslyn/assets/4564579/2192552c-9d3d-45f1-aec7-6c1d554f6d96)

We really do not want any overhead here at all.  Given a Span, we shoul dbe able to view that as a TextSpan freely.