### PR TITLE
Lower allocations in tagging

### DIFF
--- a/src/Compilers/Core/Portable/Collections/TemporaryArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/TemporaryArrayExtensions.cs
@@ -107,6 +107,17 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             return result;
         }
 
+        public static T? FirstOrDefault<T, TArg>(this in TemporaryArray<T> array, Func<T, TArg, bool> predicate, TArg arg)
+        {
+            foreach (var item in array)
+            {
+                if (predicate(item, arg))
+                    return item;
+            }
+
+            return default;
+        }
+
         public static void AddIfNotNull<T>(this ref TemporaryArray<T> array, T? value)
             where T : struct
         {

--- a/src/EditorFeatures/Core/Copilot/CopilotTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Copilot/CopilotTaggerProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Workspaces;
@@ -58,13 +59,14 @@ internal sealed class CopilotTaggerProvider(
             TaggerEventSources.OnTextChanged(subjectBuffer));
     }
 
-    protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView? textView, ITextBuffer subjectBuffer)
+    protected override void AddSpansToTag(ITextView? textView, ITextBuffer subjectBuffer, ref TemporaryArray<SnapshotSpan> result)
     {
         this.ThreadingContext.ThrowIfNotOnUIThread();
         Contract.ThrowIfNull(textView);
 
         // We only care about the cases where we have caret.
-        return textView.GetCaretPoint(subjectBuffer) is { } caret ? [new SnapshotSpan(caret, 0)] : [];
+        if (textView.GetCaretPoint(subjectBuffer) is { } caret)
+            result.Add(new SnapshotSpan(caret, 0));
     }
 
     protected override async Task ProduceTagsAsync(TaggerContext<ITextMarkerTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.InlineHints;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -77,7 +78,7 @@ internal partial class InlineHintsDataTaggerProvider(
             TaggerEventSources.OnGlobalOptionChanged(GlobalOptions, InlineHintsOptionsStorage.ForImplicitObjectCreation));
     }
 
-    protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView? textView, ITextBuffer subjectBuffer)
+    protected override void AddSpansToTag(ITextView? textView, ITextBuffer subjectBuffer, ref TemporaryArray<SnapshotSpan> result)
     {
         this.ThreadingContext.ThrowIfNotOnUIThread();
         Contract.ThrowIfNull(textView);
@@ -88,10 +89,11 @@ internal partial class InlineHintsDataTaggerProvider(
         if (visibleSpanOpt == null)
         {
             // Couldn't find anything visible, just fall back to tagging all hint locations
-            return base.GetSpansToTag(textView, subjectBuffer);
+            base.AddSpansToTag(textView, subjectBuffer, ref result);
+            return;
         }
 
-        return [visibleSpanOpt.Value];
+        result.Add(visibleSpanOpt.Value);
     }
 
     protected override async Task ProduceTagsAsync(

--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.ReferenceHighlighting;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -86,13 +87,12 @@ internal sealed partial class ReferenceHighlightingViewTaggerProvider(
         return textViewOpt.BufferGraph.MapDownToFirstMatch(textViewOpt.Selection.Start.Position, PointTrackingMode.Positive, b => IsSupportedContentType(b.ContentType), PositionAffinity.Successor);
     }
 
-    protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textViewOpt, ITextBuffer subjectBuffer)
+    protected override void AddSpansToTag(ITextView textViewOpt, ITextBuffer subjectBuffer, ref TemporaryArray<SnapshotSpan> result)
     {
         // Note: this may return no snapshot spans.  We have to be resilient to that
         // when processing the TaggerContext<>.SpansToTag below.
-        return textViewOpt.BufferGraph.GetTextBuffers(b => IsSupportedContentType(b.ContentType))
-                          .Select(b => b.CurrentSnapshot.GetFullSpan())
-                          .ToList();
+        foreach (var buffer in textViewOpt.BufferGraph.GetTextBuffers(b => IsSupportedContentType(b.ContentType)))
+            result.Add(buffer.CurrentSnapshot.GetFullSpan());
     }
 
     protected override Task ProduceTagsAsync(

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Tagging;
 using Microsoft.CodeAnalysis.Text;
@@ -214,10 +215,11 @@ internal abstract partial class AbstractAsynchronousTaggerProvider<TTag> where T
     /// and will asynchronously call into <see cref="ProduceTagsAsync(TaggerContext{TTag}, CancellationToken)"/> at some point in
     /// the future to produce tags for these spans.
     /// </summary>
-    protected virtual IEnumerable<SnapshotSpan> GetSpansToTag(ITextView? textView, ITextBuffer subjectBuffer)
+    protected virtual void AddSpansToTag(
+        ITextView? textView, ITextBuffer subjectBuffer, ref TemporaryArray<SnapshotSpan> result)
     {
         // For a standard tagger, the spans to tag is the span of the entire snapshot.
-        return [subjectBuffer.CurrentSnapshot.GetFullSpan()];
+        result.Add(subjectBuffer.CurrentSnapshot.GetFullSpan());
     }
 
     /// <summary>

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.SingleViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.SingleViewportTaggerProvider.cs
@@ -59,7 +59,7 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> where T
             // looked at.
             => _viewPortToTag == ViewPortToTag.InView ? _callback.EventChangeDelay : TaggerDelay.NonFocus;
 
-        protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView? textView, ITextBuffer subjectBuffer)
+        protected override void AddSpansToTag(ITextView? textView, ITextBuffer subjectBuffer, ref TemporaryArray<SnapshotSpan> result)
         {
             this.ThreadingContext.ThrowIfNotOnUIThread();
             Contract.ThrowIfNull(textView);
@@ -71,16 +71,20 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> where T
             {
                 // couldn't figure out the visible span.  So the InView tagger will need to tag everything, and the
                 // above/below tagger should tag nothing.
-                return _viewPortToTag == ViewPortToTag.InView
-                    ? base.GetSpansToTag(textView, subjectBuffer)
-                    : [];
+                if (_viewPortToTag == ViewPortToTag.InView)
+                    base.AddSpansToTag(textView, subjectBuffer, ref result);
+
+                return;
             }
 
             var visibleSpan = visibleSpanOpt.Value;
 
             // If we're the 'InView' tagger, tag what was visible. 
             if (_viewPortToTag is ViewPortToTag.InView)
-                return [visibleSpan];
+            {
+                result.Add(visibleSpan);
+                return;
+            }
 
             // For the above/below tagger, broaden the span to to the requested portion above/below what's visible, then
             // subtract out the visible range.
@@ -89,8 +93,6 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> where T
 
             var widenedSpan = widenedSpanOpt.Value;
             Contract.ThrowIfFalse(widenedSpan.Span.Contains(visibleSpan.Span), "The widened span must be at least as large as the visible one.");
-
-            using var result = TemporaryArray<SnapshotSpan>.Empty;
 
             if (_viewPortToTag is ViewPortToTag.Above)
             {
@@ -101,12 +103,9 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> where T
             else if (_viewPortToTag is ViewPortToTag.Below)
             {
                 var belowSpan = new SnapshotSpan(visibleSpan.Snapshot, Span.FromBounds(visibleSpan.Span.End, widenedSpan.Span.End));
-
                 if (!belowSpan.IsEmpty)
                     result.Add(belowSpan);
             }
-
-            return result.ToImmutableAndClear();
         }
 
         protected override async Task ProduceTagsAsync(


### PR DESCRIPTION
Avoids unnecessary linq in tagging:

![image](https://github.com/dotnet/roslyn/assets/4564579/4d11ecff-d2b7-4eee-a5eb-64f784de05cd)
