### PR TITLE
Change the DocumentationCommentId to use a PooledStringBuilder

### DIFF
--- a/src/Compilers/Core/Portable/DocumentationCommentId.cs
+++ b/src/Compilers/Core/Portable/DocumentationCommentId.cs
@@ -54,11 +54,11 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(symbol));
             }
 
-            var builder = new StringBuilder();
+            var builder = PooledStringBuilder.GetInstance();
             var generator = new PrefixAndDeclarationGenerator(builder);
             generator.Visit(symbol);
 
-            return generator.Failed ? null : builder.ToString();
+            return generator.Failed ? null : builder.ToStringAndFree();
         }
 
         /// <summary>
@@ -86,10 +86,10 @@ namespace Microsoft.CodeAnalysis
                 return result;
             }
 
-            var builder = new StringBuilder();
+            var builder = PooledStringBuilder.GetInstance();
             var generator = new ReferenceGenerator(builder, typeParameterContext: null);
             generator.Visit(symbol);
-            return builder.ToString();
+            return builder.ToStringAndFree();
         }
 
         /// <summary>


### PR DESCRIPTION
This shows as about 1% of allocations in OOP in a find references profile I'm looking at.

*** old profile snippet ***
![image](https://github.com/dotnet/roslyn/assets/6785178/bcf7134f-d147-45f3-8c4f-2223f37b2c5a)