### PR TITLE
Align sort implementation with reference from dotnet/runtime

### DIFF
--- a/src/Dependencies/Collections/SegmentedArray.cs
+++ b/src/Dependencies/Collections/SegmentedArray.cs
@@ -394,22 +394,6 @@ namespace Microsoft.CodeAnalysis.Collections
             }
         }
 
-        public static void Sort<T>(SegmentedArray<T> array, int index, int length, Comparison<T> comparison)
-        {
-            if (index < 0)
-                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
-            if (length < 0)
-                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
-            if (array.Length - index < length)
-                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
-
-            if (length > 1)
-            {
-                var segment = new SegmentedArraySegment<T>(array, index, length);
-                SegmentedArraySortHelper<T>.Sort(segment, comparison);
-            }
-        }
-
         public static void Sort<T>(SegmentedArray<T> array, Comparison<T> comparison)
         {
             if (comparison is null)

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -1198,7 +1198,8 @@ namespace Microsoft.CodeAnalysis.Collections
 
             if (_size > 1)
             {
-                SegmentedArray.Sort(_items, 0, _size, comparison);
+                var segment = new SegmentedArraySegment<T>(_items, 0, _size);
+                SegmentedArraySortHelper<T>.Sort(segment, comparison);
             }
             _version++;
         }


### PR DESCRIPTION
Remove an overload from `SegmentedArray` that does not have a corresponding method in `System.Array` in favor of directly interacting with `SegmentedArraySortHelper<T>`.

Addresses feedback in #73648 (specifically https://github.com/dotnet/roslyn/pull/73648#discussion_r1617539643)