### PR TITLE
Fix issue where we were querying a linq expression over and over

### DIFF
--- a/src/EditorFeatures/Core/Shared/Extensions/HostWorkspaceServicesExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/HostWorkspaceServicesExtensions.cs
@@ -25,12 +25,10 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
         public static CodeAnalysis.Host.LanguageServices? GetProjectServices(
             this SolutionServices workspaceServices, IContentType contentType)
         {
-            foreach (var language in workspaceServices.SupportedLanguages)
+            foreach (var language in workspaceServices.SupportedLanguagesArray)
             {
                 if (LanguageMatches(language, contentType, workspaceServices))
-                {
                     return workspaceServices.GetLanguageServices(language);
-                }
             }
 
             return null;

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Host;
@@ -86,7 +87,9 @@ public abstract class HostWorkspaceServices
     /// <summary>
     /// A list of language names for supported language services.
     /// </summary>
-    public virtual IEnumerable<string> SupportedLanguages => [];
+    public virtual IEnumerable<string> SupportedLanguages => SupportedLanguagesArray;
+
+    internal virtual ImmutableArray<string> SupportedLanguagesArray => [];
 
     /// <summary>
     /// Returns true if the language is supported.

--- a/src/Workspaces/Core/Portable/Workspace/Host/SolutionServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SolutionServices.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Host;
@@ -42,6 +43,9 @@ public sealed class SolutionServices
     /// <inheritdoc cref="HostWorkspaceServices.SupportedLanguages"/>
     public IEnumerable<string> SupportedLanguages
         => _services.SupportedLanguages;
+
+    internal ImmutableArray<string> SupportedLanguagesArray
+        => _services.SupportedLanguagesArray;
 
     /// <inheritdoc cref="HostWorkspaceServices.IsSupported"/>
     public bool IsSupported(string languageName)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
@@ -8,7 +8,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Roslyn.Utilities;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
 #endif
 
         public override bool IsSupported(string languageName)
-            => this.ComputeSupportedLanguages().Contains(languageName);
+            => this.SupportedLanguagesArray.Contains(languageName);
 
         public override HostLanguageServices GetLanguageServices(string languageName)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
@@ -105,7 +105,9 @@ namespace Microsoft.CodeAnalysis.Host.Mef
 
         public override IEnumerable<string> SupportedLanguages => ComputeSupportedLanguages();
 
-#if !CODE_STYLE
+#if CODE_STYLE
+        internal ImmutableArray<string> SupportedLanguagesArray => ComputeSupportedLanguages();
+#else
         internal override ImmutableArray<string> SupportedLanguagesArray => ComputeSupportedLanguages();
 #endif
 
@@ -135,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
 
         public override IEnumerable<TLanguageService> FindLanguageServices<TLanguageService>(MetadataFilter filter)
         {
-            foreach (var language in this.SupportedLanguages)
+            foreach (var language in SupportedLanguagesArray)
             {
 #pragma warning disable RS0030 // Do not used banned API 'GetLanguageServices', use 'GetExtendedLanguageServices' instead - allowed in this context.
                 var services = (MefLanguageServices)this.GetLanguageServices(language);


### PR DESCRIPTION
Fixes 0.3% of allocs:

![image](https://github.com/dotnet/roslyn/assets/4564579/eec4f04e-e18e-4bc9-ab42-bf3f52428058)
