### PR TITLE
Remove poison attributes

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -499,7 +499,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get
             {
                 ObsoleteAttributeHelpers.InitializeObsoleteDataFromMetadata(ref _lazyObsoleteAttributeData, _handle, (PEModuleSymbol)(this.ContainingModule),
-                    ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false, ignoreExtensionMarker: false);
+                    ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false);
 
                 return _lazyObsoleteAttributeData;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -669,7 +669,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get
             {
                 ObsoleteAttributeHelpers.InitializeObsoleteDataFromMetadata(ref _lazyObsoleteAttributeData, _handle, (PEModuleSymbol)(this.ContainingModule),
-                    ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false, ignoreExtensionMarker: false);
+                    ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false);
 
                 return _lazyObsoleteAttributeData;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -1548,7 +1548,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 if (!_packedFlags.IsObsoleteAttributePopulated)
                 {
                     var result = ObsoleteAttributeHelpers.GetObsoleteDataFromMetadata(_handle, (PEModuleSymbol)ContainingModule,
-                        ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: MethodKind == MethodKind.Constructor, ignoreExtensionMarker: false);
+                        ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: MethodKind == MethodKind.Constructor);
 
                     if (result != null)
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2505,10 +2505,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 allowedFeatures |= CompilerFeatureRequiredFeatures.RefStructs;
             }
-            else if (IsExtension)
-            {
-                allowedFeatures |= CompilerFeatureRequiredFeatures.RefStructs | CompilerFeatureRequiredFeatures.ExtensionTypes;
-            }
 
             var diag = PEUtilities.DeriveCompilerFeatureRequiredAttributeDiagnostic(this, ContainingPEModule, Handle, allowedFeatures, decoder);
 
@@ -2737,10 +2733,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
 
                 bool ignoreByRefLikeMarker = this.IsRefLikeType;
-                bool ignoreExtensionMarker = this.IsExtension;
 
                 ObsoleteAttributeHelpers.InitializeObsoleteDataFromMetadata(ref uncommon.lazyObsoleteAttributeData, _handle, ContainingPEModule,
-                    ignoreByRefLikeMarker, ignoreRequiredMemberMarker: false, ignoreExtensionMarker);
+                    ignoreByRefLikeMarker, ignoreRequiredMemberMarker: false);
 
                 return uncommon.lazyObsoleteAttributeData;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -868,7 +868,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get
             {
                 ObsoleteAttributeHelpers.InitializeObsoleteDataFromMetadata(ref _lazyObsoleteAttributeData, _handle, (PEModuleSymbol)(this.ContainingModule),
-                    ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false, ignoreExtensionMarker: false);
+                    ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false);
 
                 return _lazyObsoleteAttributeData;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
@@ -29,11 +29,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// done for Metadata symbol easily whereas trying to do this for source symbols could result in cycles.
         /// </summary>
         internal static void InitializeObsoleteDataFromMetadata(ref ObsoleteAttributeData data, EntityHandle token, PEModuleSymbol containingModule,
-            bool ignoreByRefLikeMarker, bool ignoreRequiredMemberMarker, bool ignoreExtensionMarker)
+            bool ignoreByRefLikeMarker, bool ignoreRequiredMemberMarker)
         {
             if (ReferenceEquals(data, ObsoleteAttributeData.Uninitialized))
             {
-                ObsoleteAttributeData obsoleteAttributeData = GetObsoleteDataFromMetadata(token, containingModule, ignoreByRefLikeMarker, ignoreRequiredMemberMarker, ignoreExtensionMarker);
+                ObsoleteAttributeData obsoleteAttributeData = GetObsoleteDataFromMetadata(token, containingModule, ignoreByRefLikeMarker, ignoreRequiredMemberMarker);
                 Interlocked.CompareExchange(ref data, obsoleteAttributeData, ObsoleteAttributeData.Uninitialized);
             }
         }
@@ -42,10 +42,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Get the ObsoleteAttributeData by fetching attributes and decoding ObsoleteAttributeData. This can be 
         /// done for Metadata symbol easily whereas trying to do this for source symbols could result in cycles.
         /// </summary>
-        internal static ObsoleteAttributeData GetObsoleteDataFromMetadata(EntityHandle token, PEModuleSymbol containingModule, bool ignoreByRefLikeMarker, bool ignoreRequiredMemberMarker, bool ignoreExtensionMarker)
+        internal static ObsoleteAttributeData GetObsoleteDataFromMetadata(EntityHandle token, PEModuleSymbol containingModule, bool ignoreByRefLikeMarker, bool ignoreRequiredMemberMarker)
         {
             var obsoleteAttributeData = containingModule.Module.TryGetDeprecatedOrExperimentalOrObsoleteAttribute(token, new MetadataDecoder(containingModule),
-                ignoreByRefLikeMarker, ignoreRequiredMemberMarker, ignoreExtensionMarker);
+                ignoreByRefLikeMarker, ignoreRequiredMemberMarker);
 
             Debug.Assert(obsoleteAttributeData == null || !obsoleteAttributeData.IsUninitialized);
             return obsoleteAttributeData;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1822,7 +1822,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var location = GetFirstLocation();
             var compilation = DeclaringCompilation;
 
-            if (this.IsRefLikeType || this.IsExtension)
+            if (this.IsRefLikeType)
             {
                 compilation.EnsureIsByRefLikeAttributeExists(diagnostics, location, modifyCompilation: true);
             }
@@ -2650,12 +2650,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // The required members list for the base type '{0}' is malformed and cannot be interpreted. To use this constructor, apply the 'SetsRequiredMembers' attribute.
                     diagnostics.Add(ErrorCode.ERR_RequiredMembersBaseTypeInvalid, method.GetFirstLocation(), BaseTypeNoUseSiteDiagnostics);
                 }
-            }
-
-            if (this.IsExtension)
-            {
-                _ = Binder.GetWellKnownTypeMember(DeclaringCompilation, WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor, diagnostics, GetFirstLocation());
-                _ = Binder.GetWellKnownTypeMember(DeclaringCompilation, WellKnownMember.System_ObsoleteAttribute__ctor, diagnostics, GetFirstLocation());
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1728,11 +1728,6 @@ next:;
                         PEModule.ByRefLikeMarker, nameof(CompilerFeatureRequiredFeatures.RefStructs), isOptionalUse: true);
                 }
             }
-            else if (this.IsExtension)
-            {
-                addPoisonAttributes(ref attributes, compilation, hasObsolete,
-                    PEModule.ExtensionMarker, nameof(CompilerFeatureRequiredFeatures.ExtensionTypes), isOptionalUse: false);
-            }
 
             if (this.IsReadOnly)
             {

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_IsByRefLike.cs
@@ -1045,7 +1045,7 @@ namespace System
             var peModule = (PEModuleSymbol)peType.ContainingModule;
             var decoder = new MetadataDecoder(peModule);
             var obsoleteAttribute = peModule.Module.TryGetDeprecatedOrExperimentalOrObsoleteAttribute(peType.Handle, decoder,
-                ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false, ignoreExtensionMarker: false);
+                ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false);
 
             if (hasObsolete)
             {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -79,7 +79,7 @@ public class RequiredMembersTests : CSharpTestBase
                 var peMethod = (PEMethodSymbol)ctor;
                 var decoder = new MetadataDecoder(peModule, peMethod);
                 var obsoleteAttribute = peModule.Module.TryGetDeprecatedOrExperimentalOrObsoleteAttribute(peMethod.Handle, decoder,
-                    ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false, ignoreExtensionMarker: false);
+                    ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false);
 
                 string? unsupportedCompilerFeatureToken = peModule.Module.GetFirstUnsupportedCompilerFeatureFromToken(peMethod.Handle, decoder, CompilerFeatureRequiredFeatures.None);
 

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1196,15 +1196,13 @@ namespace Microsoft.CodeAnalysis
 
         internal const string ByRefLikeMarker = "Types with embedded references are not supported in this version of your compiler.";
         internal const string RequiredMembersMarker = "Constructors of types with required members are not supported in this version of your compiler.";
-        internal const string ExtensionMarker = "Extension types are not supported in this version of your compiler.";
 
         /// <remarks>Should be kept in sync with <see cref="IsMoreImportantObsoleteKind(ObsoleteAttributeKind, ObsoleteAttributeKind)"/></remarks>
         internal ObsoleteAttributeData TryGetDeprecatedOrExperimentalOrObsoleteAttribute(
             EntityHandle token,
             IAttributeNamedArgumentDecoder decoder,
             bool ignoreByRefLikeMarker,
-            bool ignoreRequiredMemberMarker,
-            bool ignoreExtensionMarker)
+            bool ignoreRequiredMemberMarker)
         {
             AttributeInfo info;
 
@@ -1223,8 +1221,6 @@ namespace Microsoft.CodeAnalysis
                     case ByRefLikeMarker when ignoreByRefLikeMarker:
                         return null;
                     case RequiredMembersMarker when ignoreRequiredMemberMarker:
-                        return null;
-                    case ExtensionMarker when ignoreExtensionMarker:
                         return null;
                 }
                 return obsoleteData;
@@ -1251,7 +1247,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Indicates whether the first attribute should be prioritized over the second one.
         /// Same order of priority as
-        ///   <see cref="TryGetDeprecatedOrExperimentalOrObsoleteAttribute(EntityHandle, IAttributeNamedArgumentDecoder, bool, bool, bool)"/>
+        ///   <see cref="TryGetDeprecatedOrExperimentalOrObsoleteAttribute(EntityHandle, IAttributeNamedArgumentDecoder, bool, bool)"/>
         /// </summary>
         internal static bool IsMoreImportantObsoleteKind(ObsoleteAttributeKind firstKind, ObsoleteAttributeKind secondKind)
         {
@@ -1386,7 +1382,6 @@ namespace Microsoft.CodeAnalysis
                 {
                     nameof(CompilerFeatureRequiredFeatures.RefStructs) => CompilerFeatureRequiredFeatures.RefStructs,
                     nameof(CompilerFeatureRequiredFeatures.RequiredMembers) => CompilerFeatureRequiredFeatures.RequiredMembers,
-                    nameof(CompilerFeatureRequiredFeatures.ExtensionTypes) => CompilerFeatureRequiredFeatures.ExtensionTypes,
                     _ => CompilerFeatureRequiredFeatures.None,
                 };
         }

--- a/src/Compilers/Core/Portable/Symbols/CompilerFeatureRequiredFeatures.cs
+++ b/src/Compilers/Core/Portable/Symbols/CompilerFeatureRequiredFeatures.cs
@@ -12,5 +12,4 @@ internal enum CompilerFeatureRequiredFeatures
     None = 0,
     RefStructs = 1 << 0,
     RequiredMembers = 1 << 1,
-    ExtensionTypes = 1 << 2,
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim obsoleteAttributeData As ObsoleteAttributeData = Nothing
             ' ignoreByRefLikeMarker := False, since VB does not support ref-like types
             obsoleteAttributeData = containingModule.Module.TryGetDeprecatedOrExperimentalOrObsoleteAttribute(token, New MetadataDecoder(containingModule),
-                ignoreByRefLikeMarker:=False, ignoreRequiredMemberMarker:=True, ignoreExtensionMarker:=False)
+                ignoreByRefLikeMarker:=False, ignoreRequiredMemberMarker:=True)
 
             Debug.Assert(obsoleteAttributeData Is Nothing OrElse Not obsoleteAttributeData.IsUninitialized)
             Return obsoleteAttributeData


### PR DESCRIPTION
This allows executing on Desktop framework (the PR updates the tests).

For the test change, I removed all usages of the special obsolete message (used in various IL tests). I also removed all usages of `TargetFramework.Net70`, `FailsPEVerify` and `IncludeExpectedOutput` and then restored only the places that need those.

Relates to test plan https://github.com/dotnet/roslyn/issues/66722