### PR TITLE
Run providers in parallel when determining if we should show the lightbulb icon

### DIFF
--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -136,7 +136,7 @@ internal sealed class CodeRefactoringService(
                     return true;
                 }
 
-                return true;
+                return false;
             },
             args: (this, document, state, options, linkedTokenSource),
             // intentionally using the outer token here.  The linked token is only used to cancel the inner operations.

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -89,18 +89,58 @@ internal sealed class CodeRefactoringService(
         CodeActionOptionsProvider options,
         CancellationToken cancellationToken)
     {
-        foreach (var provider in GetProviders(document))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+        // A token for controlling the inner work we do calling out to each provider.  Once we have a single provider
+        // that returns a refactoring, we can cancel the work we're doing with all other providers.
+        using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            var refactoring = await GetRefactoringFromProviderAsync(
-                document, state, provider, options, cancellationToken).ConfigureAwait(false);
+        // This await will not complete until all providers have been called (though we'll attempt to bail out of any of
+        // them once we have a single refactoring found).  So there's no concern here about produceItems running after
+        // linkedTokenSource has been diposed.
+        return await ProducerConsumer<VoidResult>.RunParallelAsync(
+            source: this.GetProviders(document),
+            produceItems: static async (provider, callback, args, cancellationToken) =>
+            {
+                var (@this, document, state, options, linkedTokenSource) = args;
 
-            if (refactoring != null)
+                // Do no work if either the outer request canceled, or another provider already found a refactoring.
+                if (cancellationToken.IsCancellationRequested || linkedTokenSource.Token.IsCancellationRequested)
+                    return;
+
+                try
+                {
+                    // We want to pass linkedTokenSource.Token here so that we can cancel the inner operation once the
+                    // outer ProducerConsumer sees a single refactoring returned by any provider.
+                    var refactoring = await @this.GetRefactoringFromProviderAsync(
+                        document, state, provider, options, linkedTokenSource.Token).ConfigureAwait(false);
+
+                    // If we have a refactoring, send a single VoidResult value to the consumer so it can cancel the
+                    // other concurrent operations, and can return 'true' to the caller to indicate that there are
+                    // refactorings.
+                    if (refactoring != null)
+                        callback(default(VoidResult));
+                }
+                catch (OperationCanceledException)
+                {
+                    // Ensure that the cancellation of the inner token doesn't bubble outside.  We are not canceling the
+                    // entire operation just because one provider succeeded and canceled the rest.
+                }
+            },
+            consumeItems: static async (items, args, cancellationToken) =>
+            {
+                // Try to consume from the results that produceItems is sending us.  The moment we get a single result,
+                // we know we're done and we have at least one refactoring.
+                await foreach (var unused in items)
+                {
+                    // Cancel all the other items that are still running (or are asked to run in the future).
+                    args.linkedTokenSource.Cancel();
+                    return true;
+                }
+
                 return true;
-        }
-
-        return false;
+            },
+            args: (this, document, state, options, linkedTokenSource),
+            // intentionally using the outer token here.  The linked token is only used to cancel the inner operations.
+            cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(


### PR DESCRIPTION
Right now when determining if the lightbulb shoudl appear, we run providers serially, ending up with a long serial chain of costs like so:

![image](https://github.com/dotnet/roslyn/assets/4564579/26ca95f3-06be-4a53-9e2e-40f38076a381)

individually providers aren't that expensive.  But when we have dozens to hundreds of them, this adds up.

This PR switches to running them in parallel, canceling either whne we are told to stop, or the moment we find one that has a refactoring. 