### PR TITLE
Support 'use primary constructor' on no-parameter constructors with attributes

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
@@ -189,7 +189,7 @@ internal sealed class CSharpUsePrimaryConstructorDiagnosticAnalyzer()
                 _primaryConstructorDeclaration.Identifier.GetLocation(),
                 _styleOption.Notification,
                 context.Options,
-                ImmutableArray.Create(_primaryConstructorDeclaration.GetLocation()),
+                [_primaryConstructorDeclaration.GetLocation()],
                 properties));
 
             _candidateMembersToRemove.Free();
@@ -288,7 +288,12 @@ internal sealed class CSharpUsePrimaryConstructorDiagnosticAnalyzer()
                 if (!TryFindPrimaryConstructorCandidate(namedType, out var primaryConstructor, out var primaryConstructorDeclaration))
                     return null;
 
-                if (primaryConstructor.Parameters.Length == 0)
+                // If we have no parameters and no attributes, then this is a trivial constructor.  We don't want to
+                // spam the user to convert this to a primary constructor.  What would likely be better would be to
+                // offer to remove the constructor entirely.  We do offer when there are attributes to help with cases
+                // like simple DI constructors that have no parameters, but would still be nicer with the attributes
+                // moved to the type instead.
+                if (primaryConstructor.Parameters.Length == 0 && primaryConstructorDeclaration.AttributeLists.Count == 0)
                     return null;
 
                 // protected constructor in an abstract type is fine.  It will stay protected even as a primary constructor.

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -4071,4 +4071,33 @@ public partial class UsePrimaryConstructorTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestAttributeOnEmptyConstructor()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    [CLSCompliant(true)]
+                    public [|C|]()
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                [method: CLSCompliant(true)]
+                class C()
+                {
+                }
+                """,
+            CodeActionIndex = 0,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -4072,7 +4072,7 @@ public partial class UsePrimaryConstructorTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73695")]
     public async Task TestAttributeOnEmptyConstructor()
     {
         await new VerifyCS.Test


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/73695