### PR TITLE
Improve AddImport conflict detection performance

### DIFF
--- a/src/Features/CSharpTest/GenerateMethod/GenerateMethodTests.cs
+++ b/src/Features/CSharpTest/GenerateMethod/GenerateMethodTests.cs
@@ -8508,6 +8508,8 @@ new TestParameters(Options.Regular));
             }
             """,
             """
+            using System;
+
             class Class
             {
                 void M(nint i, nuint i2)
@@ -8517,7 +8519,7 @@ new TestParameters(Options.Regular));
 
                 private (nint, nuint) NewMethod(nint i, nuint i2)
                 {
-                    throw new System.NotImplementedException();
+                    throw new NotImplementedException();
                 }
             }
             """);

--- a/src/Features/VisualBasicTest/GenerateMethod/GenerateMethodTests.vb
+++ b/src/Features/VisualBasicTest/GenerateMethod/GenerateMethodTests.vb
@@ -1347,14 +1347,16 @@ End Class")
  [|[Me]|]([string])
     End Sub
 End Module",
-"Module Program
+"Imports System
+
+Module Program
     Sub Main(args As String())
         Dim [string] As String = ""hello"" 
  [Me]([string])
     End Sub
 
     Private Sub [Me]([string] As String)
-        Throw New System.NotImplementedException()
+        Throw New NotImplementedException()
     End Sub
 End Module")
         End Function

--- a/src/Workspaces/CSharp/Portable/Editing/CSharpImportAdder.cs
+++ b/src/Workspaces/CSharp/Portable/Editing/CSharpImportAdder.cs
@@ -7,12 +7,15 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Editing;
@@ -39,20 +42,19 @@ internal class CSharpImportAdder : ImportAdderService
         return null;
     }
 
-    protected override void AddPotentiallyConflictingImports(
+    protected override Task AddPotentiallyConflictingImportsAsync(
         SemanticModel model,
         SyntaxNode container,
         ImmutableArray<INamespaceSymbol> namespaceSymbols,
         HashSet<INamespaceSymbol> conflicts,
         CancellationToken cancellationToken)
     {
-        var rewriter = new ConflictWalker(model, namespaceSymbols, conflicts, cancellationToken);
-        rewriter.Visit(container);
+        var conflictFinder = new ConflictFinder(model, namespaceSymbols);
+        return conflictFinder.AddPotentiallyConflictingImportsAsync(container, conflicts, cancellationToken);
     }
 
     private static INamespaceSymbol? GetExplicitNamespaceSymbol(ExpressionSyntax fullName, ExpressionSyntax namespacePart, SemanticModel model)
     {
-
         // name must refer to something that is not a namespace, but be qualified with a namespace.
         var symbol = model.GetSymbolInfo(fullName).Symbol;
         if (symbol != null && symbol.Kind != SymbolKind.Namespace && model.GetSymbolInfo(namespacePart).Symbol is INamespaceSymbol)
@@ -76,10 +78,9 @@ internal class CSharpImportAdder : ImportAdderService
     /// no users being hit, then that's far less important than if we have a reasonable coding pattern that would be
     /// impacted by adding an import to a normal namespace.
     /// </summary>
-    private class ConflictWalker : CSharpSyntaxWalker
+    private class ConflictFinder
     {
         private readonly SemanticModel _model;
-        private readonly CancellationToken _cancellationToken;
 
         /// <summary>
         /// A mapping containing the simple names and arity of all imported types, mapped to the import that they're
@@ -99,25 +100,11 @@ internal class CSharpImportAdder : ImportAdderService
         /// </remarks>
         private readonly MultiDictionary<string, INamespaceSymbol> _importedExtensionMethods = [];
 
-        private readonly HashSet<INamespaceSymbol> _conflictNamespaces;
-
-        /// <summary>
-        /// Track if we're in an anonymous method or not.  If so, because of how the language binds lambdas and
-        /// overloads, we'll assume any method access we see inside (instance or otherwise) could end up conflicting
-        /// with an extension method we might pull in.
-        /// </summary>
-        private bool _inAnonymousMethod;
-
-        public ConflictWalker(
+        public ConflictFinder(
             SemanticModel model,
-            ImmutableArray<INamespaceSymbol> namespaceSymbols,
-            HashSet<INamespaceSymbol> conflictNamespaces,
-            CancellationToken cancellationToken)
-            : base(SyntaxWalkerDepth.StructuredTrivia)
+            ImmutableArray<INamespaceSymbol> namespaceSymbols)
         {
             _model = model;
-            _cancellationToken = cancellationToken;
-            _conflictNamespaces = conflictNamespaces;
 
             AddImportedMembers(namespaceSymbols);
         }
@@ -142,91 +129,137 @@ internal class CSharpImportAdder : ImportAdderService
             }
         }
 
-        public override void VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax node)
+        public async Task AddPotentiallyConflictingImportsAsync(SyntaxNode container, HashSet<INamespaceSymbol> conflicts, CancellationToken cancellationToken)
         {
-            // lambdas are interesting.  Say you have:
-            //
-            //      Goo(x => x.M());
-            //
-            //      void Goo(Action<C> act) { }
-            //      void Goo(Action<int> act) { }
-            //
-            //      class C { public void M() { } }
-            //
-            // This is legal code where the lambda body is calling the instance method.  However, if we introduce a
-            // using that brings in an extension method 'M' on 'int', then the above will become ambiguous.  This is
-            // because lambda binding will try each interpretation separately and eliminate the ones that fail.
-            // Adding the import will make the int form succeed, causing ambiguity.
-            //
-            // To deal with that, we keep track of if we're in a lambda, and we conservatively assume that a method
-            // access (even to a non-extension method) could conflict with an extension method brought in.
+            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var nodes);
 
-            var previousInAnonymousMethod = _inAnonymousMethod;
-            _inAnonymousMethod = true;
-            base.VisitSimpleLambdaExpression(node);
-            _inAnonymousMethod = previousInAnonymousMethod;
+            CollectInfoFromContainer(container, nodes, out var containsAnonymousMethods);
+
+            await ProducerConsumer<INamespaceSymbol>.RunParallelAsync(
+                source: nodes,
+                produceItems: static (node, onItemsFound, args, cancellationToken) =>
+                {
+                    var (self, containsAnonymousMethods, _) = args;
+                    if (node is SimpleNameSyntax nameSyntaxNode)
+                        self.ProduceConflicts(nameSyntaxNode, onItemsFound, cancellationToken);
+                    else if (node is MemberAccessExpressionSyntax memberAccessExpressionNode)
+                        self.ProduceConflicts(memberAccessExpressionNode, containsAnonymousMethods, onItemsFound, cancellationToken);
+                    else
+                        throw ExceptionUtilities.Unreachable();
+
+                    return Task.CompletedTask;
+                },
+                consumeItems: static async (items, args, cancellationToken) =>
+                {
+                    var (_, _, conflicts) = args;
+                    await foreach (var conflict in items)
+                        conflicts.Add(conflict);
+                },
+                args: (self: this, containsAnonymousMethods, conflicts),
+                cancellationToken).ConfigureAwait(false);
         }
 
-        public override void VisitParenthesizedLambdaExpression(ParenthesizedLambdaExpressionSyntax node)
+        private void CollectInfoFromContainer(SyntaxNode container, ArrayBuilder<SyntaxNode> nodes, out bool containsAnonymousMethods)
         {
-            var previousInAnonymousMethod = _inAnonymousMethod;
-            _inAnonymousMethod = true;
-            base.VisitParenthesizedLambdaExpression(node);
-            _inAnonymousMethod = previousInAnonymousMethod;
+            containsAnonymousMethods = false;
+
+            foreach (var node in container.DescendantNodesAndSelf())
+            {
+                switch (node.Kind())
+                {
+                    case SyntaxKind.IdentifierName:
+                    case SyntaxKind.GenericName:
+                        if (IsPotentialConflictWithImportedType((SimpleNameSyntax)node))
+                            nodes.Add(node);
+                        break;
+                    case SyntaxKind.SimpleMemberAccessExpression:
+                    case SyntaxKind.PointerMemberAccessExpression:
+                        if (IsPotentialConflictWithImportedExtensionMethod((MemberAccessExpressionSyntax)node))
+                            nodes.Add(node);
+                        break;
+                    case SyntaxKind.SimpleLambdaExpression:
+                    case SyntaxKind.ParenthesizedLambdaExpression:
+                    case SyntaxKind.AnonymousMethodExpression:
+                        // Track if we've seen an anonymous method or not.  If so, because of how the language binds lambdas and
+                        // overloads, we'll assume any method access we see inside (instance or otherwise) could end up conflicting
+                        // with an extension method we might pull in.
+                        containsAnonymousMethods = true;
+                        break;
+                }
+            }
         }
 
-        public override void VisitAnonymousMethodExpression(AnonymousMethodExpressionSyntax node)
-        {
-            var previousInAnonymousMethod = _inAnonymousMethod;
-            _inAnonymousMethod = true;
-            base.VisitAnonymousMethodExpression(node);
-            _inAnonymousMethod = previousInAnonymousMethod;
-        }
-
-        private void CheckName(NameSyntax node)
+        private bool IsPotentialConflictWithImportedType(SimpleNameSyntax node)
         {
             // Check to see if we have an standalone identifier (or identifier on the left of a dot). If so, if that
             // identifier binds to a type, then we don't want to bring in any imports that would bring in the same
             // name and could then potentially conflict here.
 
             if (node.IsRightSideOfDotOrArrowOrColonColon())
-                return;
+                return false;
 
             // Check to see if we have a var. If so, then nothing assigned to a var
             // would bring any imports that could cause a potential conflict.
             if (node.IsVar)
-                return;
+                return false;
 
-            var symbol = _model.GetSymbolInfo(node, _cancellationToken).GetAnySymbol();
+            // Drastically reduce the number of nodes that need to be inspected by filtering
+            // out nodes whose identifier isn't a potential conflict.
+            if (!_importedTypes.ContainsKey((node.Identifier.Text, node.Arity)))
+                return false;
+
+            return true;
+        }
+
+        private bool IsPotentialConflictWithImportedExtensionMethod(MemberAccessExpressionSyntax node)
+            => _importedExtensionMethods.ContainsKey(node.Name.Identifier.Text);
+
+        private void ProduceConflicts(SimpleNameSyntax node, Action<INamespaceSymbol> addConflict, CancellationToken cancellationToken)
+        {
+            var symbol = _model.GetSymbolInfo(node, cancellationToken).GetAnySymbol();
             if (symbol?.Kind == SymbolKind.NamedType)
-                _conflictNamespaces.AddRange(_importedTypes[(symbol.Name, node.Arity)]);
+            {
+                foreach (var conflictingSymbol in _importedTypes[(symbol.Name, node.Arity)])
+                    addConflict(conflictingSymbol);
+            }
         }
 
-        public override void VisitIdentifierName(IdentifierNameSyntax node)
+        private void ProduceConflicts(MemberAccessExpressionSyntax node, bool containsAnonymousMethods, Action<INamespaceSymbol> addConflict, CancellationToken cancellationToken)
         {
-            base.VisitIdentifierName(node);
-            CheckName(node);
-        }
-
-        public override void VisitGenericName(GenericNameSyntax node)
-        {
-            base.VisitGenericName(node);
-            CheckName(node);
-        }
-
-        public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
-        {
-            base.VisitMemberAccessExpression(node);
-
             // Check to see if we have a reference to an extension method.  If so, then pulling in an import could
             // bring in an extension that conflicts with that.
 
-            var symbol = _model.GetSymbolInfo(node.Name, _cancellationToken).GetAnySymbol();
+            var symbol = _model.GetSymbolInfo(node.Name, cancellationToken).GetAnySymbol();
             if (symbol is IMethodSymbol method)
             {
-                // see explanation in VisitSimpleLambdaExpression for the _inAnonymousMethod check
-                if (method.IsReducedExtension() || _inAnonymousMethod)
-                    _conflictNamespaces.AddRange(_importedExtensionMethods[method.Name]);
+                var isConflicting = method.IsReducedExtension();
+
+                if (!isConflicting && containsAnonymousMethods)
+                {
+                    // lambdas are interesting.  Say you have:
+                    //
+                    //      Goo(x => x.M());
+                    //
+                    //      void Goo(Action<C> act) { }
+                    //      void Goo(Action<int> act) { }
+                    //
+                    //      class C { public void M() { } }
+                    //
+                    // This is legal code where the lambda body is calling the instance method.  However, if we introduce a
+                    // using that brings in an extension method 'M' on 'int', then the above will become ambiguous.  This is
+                    // because lambda binding will try each interpretation separately and eliminate the ones that fail.
+                    // Adding the import will make the int form succeed, causing ambiguity.
+                    //
+                    // To deal with that, we keep track of if we're in a lambda, and we conservatively assume that a method
+                    // access (even to a non-extension method) could conflict with an extension method brought in.
+                    isConflicting = node.HasAncestor<AnonymousFunctionExpressionSyntax>();
+                }
+
+                if (isConflicting)
+                {
+                    foreach (var conflictingSymbol in _importedExtensionMethods[method.Name])
+                        addConflict(conflictingSymbol);
+                }
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
+++ b/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
@@ -44,8 +44,6 @@ internal abstract class ImportAdderService : ILanguageService
         // Create a simple interval tree for simplification spans.
         var spansTree = new TextSpanIntervalTree(spans);
 
-        Func<SyntaxNode, bool> overlapsWithSpan = n => spansTree.HasIntervalThatOverlapsWith(n.FullSpan.Start, n.FullSpan.Length);
-
         // Only dive deeper into nodes that actually overlap with the span we care about.  And also only include
         // those child nodes that themselves overlap with the span.  i.e. if we have:
         //
@@ -55,7 +53,7 @@ internal abstract class ImportAdderService : ILanguageService
         //
         // We'll dive under the parent because it overlaps with the span.  But we only want to include (and dive
         // into) B and C not A and D.
-        var nodes = root.DescendantNodesAndSelf(overlapsWithSpan).Where(overlapsWithSpan);
+        var nodes = root.DescendantNodesAndSelf(OverlapsWithSpan).Where(OverlapsWithSpan);
 
         if (strategy == Strategy.AddImportsFromSymbolAnnotations)
             return await AddImportDirectivesFromSymbolAnnotationsAsync(document, nodes, addImportsService, generator, options, cancellationToken).ConfigureAwait(false);
@@ -64,19 +62,21 @@ internal abstract class ImportAdderService : ILanguageService
             return await AddImportDirectivesFromSyntaxesAsync(document, nodes, addImportsService, generator, options, cancellationToken).ConfigureAwait(false);
 
         throw ExceptionUtilities.UnexpectedValue(strategy);
+
+        bool OverlapsWithSpan(SyntaxNode n) => spansTree.HasIntervalThatOverlapsWith(n.FullSpan.Start, n.FullSpan.Length);
     }
 
     protected abstract INamespaceSymbol? GetExplicitNamespaceSymbol(SyntaxNode node, SemanticModel model);
 
-    private ISet<INamespaceSymbol> GetSafeToAddImports(
+    private async Task<ISet<INamespaceSymbol>> GetSafeToAddImportsAsync(
         ImmutableArray<INamespaceSymbol> namespaceSymbols,
         SyntaxNode container,
         SemanticModel model,
         CancellationToken cancellationToken)
     {
         using var _ = PooledHashSet<INamespaceSymbol>.GetInstance(out var conflicts);
-        AddPotentiallyConflictingImports(
-            model, container, namespaceSymbols, conflicts, cancellationToken);
+        await AddPotentiallyConflictingImportsAsync(
+            model, container, namespaceSymbols, conflicts, cancellationToken).ConfigureAwait(false);
         return namespaceSymbols.Except(conflicts).ToSet();
     }
 
@@ -86,7 +86,7 @@ internal abstract class ImportAdderService : ILanguageService
     /// <paramref name="container"/> is the node that the import will be added to.  This will either be the
     /// compilation-unit node, or one of the namespace-blocks in the file.
     /// </summary>
-    protected abstract void AddPotentiallyConflictingImports(
+    protected abstract Task AddPotentiallyConflictingImportsAsync(
         SemanticModel model,
         SyntaxNode container,
         ImmutableArray<INamespaceSymbol> namespaceSymbols,
@@ -174,7 +174,7 @@ internal abstract class ImportAdderService : ILanguageService
         using var _ = PooledDictionary<INamespaceSymbol, SyntaxNode>.GetInstance(out var importToSyntax);
 
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var model = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var model = await document.GetRequiredNullableDisabledSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
         SyntaxNode? first = null, last = null;
         var annotatedNodes = syntaxNodes.Where(x => x.HasAnnotations(SymbolAnnotation.Kind));
@@ -183,7 +183,7 @@ internal abstract class ImportAdderService : ILanguageService
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (annotatedNode.GetAnnotations(DoNotAddImportsAnnotation.Kind).Any())
+            if (annotatedNode.HasAnnotations(DoNotAddImportsAnnotation.Kind))
                 continue;
 
             var annotations = annotatedNode.GetAnnotations(SymbolAnnotation.Kind);
@@ -228,7 +228,11 @@ internal abstract class ImportAdderService : ILanguageService
         var importContainer = addImportsService.GetImportContainer(root, context, importToSyntax.First().Value, options);
 
         // Now remove any imports we think can cause conflicts in that container.
-        var safeImportsToAdd = GetSafeToAddImports([.. importToSyntax.Keys], importContainer, model, cancellationToken);
+        var safeImportsToAdd = await GetSafeToAddImportsAsync(
+            [.. importToSyntax.Keys],
+            importContainer,
+            model,
+            cancellationToken).ConfigureAwait(false);
 
         var importsToAdd = importToSyntax.Where(kvp => safeImportsToAdd.Contains(kvp.Key)).Select(kvp => kvp.Value).ToImmutableArray();
         if (importsToAdd.Length == 0)

--- a/src/Workspaces/VisualBasic/Portable/Editing/VisualBasicImportAdder.vb
+++ b/src/Workspaces/VisualBasic/Portable/Editing/VisualBasicImportAdder.vb
@@ -203,16 +203,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Editing
             End Function
 
             Private Sub ProduceConflicts(node As SimpleNameSyntax, addConflict As Action(Of INamespaceSymbol), cancellationToken As CancellationToken)
-                Dim Symbol = _model.GetSymbolInfo(node, cancellationToken).GetAnySymbol()
-                If (Symbol?.Kind = SymbolKind.NamedType) Then
-                    For Each conflictingSymbol In _importedTypesAndNamespaces.Item((Symbol.Name, node.Arity))
-                        addConflict(conflictingSymbol)
-                    Next
+                For Each conflictingSymbol In _importedTypesAndNamespaces.Item((node.Identifier.ValueText, node.Arity))
+                    addConflict(conflictingSymbol)
+                Next
 
-                    For Each conflictingSymbol In _importedMembers.Item(Symbol.Name)
-                        addConflict(conflictingSymbol)
-                    Next
-                End If
+                For Each conflictingSymbol In _importedMembers.Item(node.Identifier.ValueText)
+                    addConflict(conflictingSymbol)
+                Next
             End Sub
 
             Private Sub ProduceConflicts(node As MemberAccessExpressionSyntax, containsAnonymousMethods As Boolean, addConflict As Action(Of INamespaceSymbol), cancellationToken As CancellationToken)

--- a/src/Workspaces/VisualBasic/Portable/Editing/VisualBasicImportAdder.vb
+++ b/src/Workspaces/VisualBasic/Portable/Editing/VisualBasicImportAdder.vb
@@ -149,9 +149,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Editing
                     args:=Me,
                     cancellationToken).ConfigureAwait(False)
 
-                For Each conflict In items
-                    conflicts.Add(conflict)
-                Next
+                conflicts.AddRange(items)
             End Function
 
             Private Sub CollectInfoFromContainer(container As SyntaxNode, nodes As ArrayBuilder(Of SyntaxNode), ByRef containsAnonymousMethods As Boolean)

--- a/src/Workspaces/VisualBasic/Portable/Editing/VisualBasicImportAdder.vb
+++ b/src/Workspaces/VisualBasic/Portable/Editing/VisualBasicImportAdder.vb
@@ -8,6 +8,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageService
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -35,14 +36,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Editing
             Return Nothing
         End Function
 
-        Protected Overrides Sub AddPotentiallyConflictingImports(model As SemanticModel,
-                container As SyntaxNode,
-                namespaceSymbols As ImmutableArray(Of INamespaceSymbol),
-                conflicts As HashSet(Of INamespaceSymbol),
-                cancellationToken As CancellationToken)
-            Dim walker = New ConflictWalker(model, namespaceSymbols, conflicts, cancellationToken)
-            walker.Visit(container)
-        End Sub
+        Protected Overrides Function AddPotentiallyConflictingImportsAsync(model As SemanticModel, container As SyntaxNode, namespaceSymbols As ImmutableArray(Of INamespaceSymbol), conflicts As HashSet(Of INamespaceSymbol), cancellationToken As CancellationToken) As Task
+            Dim conflictFinder = New ConflictFinder(model, namespaceSymbols)
+            Return conflictFinder.AddPotentiallyConflictingImportsAsync(container, conflicts, cancellationToken)
+        End Function
 
         Private Overloads Shared Function GetExplicitNamespaceSymbol(fullName As ExpressionSyntax, namespacePart As ExpressionSyntax, model As SemanticModel) As INamespaceSymbol
             ' name must refer to something that is not a namespace, but be qualified with a namespace.
@@ -60,11 +57,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Editing
             Return Nothing
         End Function
 
-        Private Class ConflictWalker
+        Private Class ConflictFinder
             Inherits VisualBasicSyntaxWalker
             Implements IEqualityComparer(Of (name As String, arity As Integer))
 
-            Private ReadOnly _cancellationToken As CancellationToken
             Private ReadOnly _model As SemanticModel
 
             ''' <summary>
@@ -86,24 +82,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Editing
             ''' </summary>
             Private ReadOnly _importedExtensionMethods As MultiDictionary(Of String, INamespaceSymbol)
 
-            Private ReadOnly _conflictNamespaces As HashSet(Of INamespaceSymbol)
-
-            ''' <summary>
-            ''' Track if we're in an anonymous method or not.  If so, because of how the language binds lambdas and
-            ''' overloads, we'll assume any method access we see inside (instance or otherwise) could end up conflicting
-            ''' with an extension method we might pull in.
-            ''' </summary>
-            Private _inAnonymousMethod As Boolean
-
             Public Sub New(
                     model As SemanticModel,
-                    namespaceSymbols As ImmutableArray(Of INamespaceSymbol),
-                    conflictNamespaces As HashSet(Of INamespaceSymbol),
-                    cancellationToken As CancellationToken)
+                    namespaceSymbols As ImmutableArray(Of INamespaceSymbol))
                 MyBase.New(SyntaxWalkerDepth.StructuredTrivia)
                 _model = model
-                _cancellationToken = cancellationToken
-                _conflictNamespaces = conflictNamespaces
 
                 _importedTypesAndNamespaces = New MultiDictionary(Of (name As String, arity As Integer), INamespaceSymbol)(Me)
                 _importedMembers = New MultiDictionary(Of String, INamespaceSymbol)(VisualBasicSyntaxFacts.Instance.StringComparer)
@@ -142,72 +125,130 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Editing
                 Next
             End Sub
 
-            Public Overrides Sub VisitMultiLineLambdaExpression(node As MultiLineLambdaExpressionSyntax)
+            Public Async Function AddPotentiallyConflictingImportsAsync(container As SyntaxNode, conflicts As HashSet(Of INamespaceSymbol), cancellationToken As CancellationToken) As Task
+                Dim nodes = ArrayBuilder(Of SyntaxNode).GetInstance()
+                Dim containsAnonymousMethods = False
 
-                ' lambdas are interesting.  Say you have
-                '
-                '      Goo(sub (x) x.M())
-                '
-                '      sub Goo(act as Action(of C))
-                '      sub Goo(act as Action(of integer))
-                '
-                '      class C : public sub M()
-                '
-                ' This Is legal code where the lambda body Is calling the instance method.  However, if we introduce a
-                ' using that brings in an extension method 'M' on 'int', then the above will become ambiguous.  This is
-                ' because lambda binding will try each interpretation separately And eliminate the ones that fail.
-                ' Adding the import will make the int form succeed, causing ambiguity.
-                '
-                ' To deal with that, we keep track of if we're in a lambda, and we conservatively assume that a method
-                ' access (even to a non-extension method) could conflict with an extension method brought in.
+                CollectInfoFromContainer(container, nodes, containsAnonymousMethods)
 
-                Dim previousInAnonymousMethod = _inAnonymousMethod
-                _inAnonymousMethod = True
-                MyBase.VisitMultiLineLambdaExpression(node)
-                _inAnonymousMethod = previousInAnonymousMethod
+                Dim produceItems =
+                    Function(node As SyntaxNode, onItemsFound As Action(Of INamespaceSymbol), conflictFinder As ConflictFinder, cancellationToken1 As CancellationToken) As Task
+                        If TypeOf node Is SimpleNameSyntax Then
+                            Me.ProduceConflicts(TryCast(node, SimpleNameSyntax), onItemsFound, cancellationToken)
+                        ElseIf TypeOf node Is MemberAccessExpressionSyntax Then
+                            Me.ProduceConflicts(TryCast(node, MemberAccessExpressionSyntax), containsAnonymousMethods, onItemsFound, cancellationToken)
+                        Else
+                            Throw ExceptionUtilities.Unreachable()
+                        End If
+                        Return Task.CompletedTask
+                    End Function
+
+                Dim items = Await ProducerConsumer(Of INamespaceSymbol).RunParallelAsync(
+                    source:=nodes,
+                    produceItems:=produceItems,
+                    args:=Me,
+                    cancellationToken).ConfigureAwait(False)
+
+                For Each conflict In items
+                    conflicts.Add(conflict)
+                Next
+            End Function
+
+            Private Sub CollectInfoFromContainer(container As SyntaxNode, nodes As ArrayBuilder(Of SyntaxNode), ByRef containsAnonymousMethods As Boolean)
+                For Each node In container.DescendantNodesAndSelf()
+                    Select Case node.Kind()
+                        Case SyntaxKind.IdentifierName,
+                             SyntaxKind.GenericName
+                            If IsPotentialConflictWithImportedTypeNamespaceOrMember(TryCast(node, SimpleNameSyntax)) Then
+                                nodes.Add(node)
+                            End If
+                        Case SyntaxKind.SimpleMemberAccessExpression,
+                             SyntaxKind.DictionaryAccessExpression
+                            If IsPotentialConflictWithImportedExtensionMethod(TryCast(node, MemberAccessExpressionSyntax)) Then
+                                nodes.Add(node)
+                            End If
+                        Case SyntaxKind.MultiLineFunctionLambdaExpression,
+                             SyntaxKind.MultiLineSubLambdaExpression,
+                             SyntaxKind.SingleLineFunctionLambdaExpression,
+                             SyntaxKind.SingleLineSubLambdaExpression
+                            ' Track if we've seen an anonymous method or not.  If so, because of how the language binds lambdas and
+                            ' overloads, we'll assume any method access we see inside (instance or otherwise) could end up conflicting
+                            ' with an extension method we might pull in.
+                            containsAnonymousMethods = True
+                    End Select
+                Next
             End Sub
 
-            Public Overrides Sub VisitSingleLineLambdaExpression(node As SingleLineLambdaExpressionSyntax)
-                Dim previousInAnonymousMethod = _inAnonymousMethod
-                _inAnonymousMethod = True
-                MyBase.VisitSingleLineLambdaExpression(node)
-                _inAnonymousMethod = previousInAnonymousMethod
-            End Sub
-
-            Private Sub CheckName(node As NameSyntax, name As String)
+            Private Function IsPotentialConflictWithImportedTypeNamespaceOrMember(node As SimpleNameSyntax) As Boolean
                 ' Check to see if we have an standalone identifier (Or identifier on the left of a dot). If so, then we
                 ' don't want to bring in any imports that would bring in the same name And could then potentially
                 ' conflict here.
-
                 If node.IsRightSideOfDotOrBang Then
-                    Return
+                    Return False
                 End If
 
-                _conflictNamespaces.AddRange(_importedTypesAndNamespaces((name, node.Arity)))
-                _conflictNamespaces.AddRange(_importedMembers(name))
+                ' Drastically reduce the number of nodes that need to be inspected by filtering
+                ' out nodes whose identifier isn't a potential conflict.
+                If _importedTypesAndNamespaces.ContainsKey((node.Identifier.Text, node.Arity)) Then
+                    Return True
+                End If
+
+                If _importedMembers.ContainsKey(node.Identifier.Text) Then
+                    Return True
+                End If
+
+                Return False
+            End Function
+
+            Private Function IsPotentialConflictWithImportedExtensionMethod(node As MemberAccessExpressionSyntax) As Boolean
+                Return _importedExtensionMethods.ContainsKey(node.Name.Identifier.Text)
+            End Function
+
+            Private Sub ProduceConflicts(node As SimpleNameSyntax, addConflict As Action(Of INamespaceSymbol), cancellationToken As CancellationToken)
+                Dim Symbol = _model.GetSymbolInfo(node, cancellationToken).GetAnySymbol()
+                If (Symbol?.Kind = SymbolKind.NamedType) Then
+                    For Each conflictingSymbol In _importedTypesAndNamespaces.Item((Symbol.Name, node.Arity))
+                        addConflict(conflictingSymbol)
+                    Next
+
+                    For Each conflictingSymbol In _importedMembers.Item(Symbol.Name)
+                        addConflict(conflictingSymbol)
+                    Next
+                End If
             End Sub
 
-            Public Overrides Sub VisitIdentifierName(node As IdentifierNameSyntax)
-                MyBase.VisitIdentifierName(node)
-                CheckName(node, node.Identifier.ValueText)
-            End Sub
-
-            Public Overrides Sub VisitGenericName(node As GenericNameSyntax)
-                MyBase.VisitGenericName(node)
-                CheckName(node, node.Identifier.ValueText)
-            End Sub
-
-            Public Overrides Sub VisitMemberAccessExpression(node As MemberAccessExpressionSyntax)
-                MyBase.VisitMemberAccessExpression(node)
-
+            Private Sub ProduceConflicts(node As MemberAccessExpressionSyntax, containsAnonymousMethods As Boolean, addConflict As Action(Of INamespaceSymbol), cancellationToken As CancellationToken)
                 ' Check to see if we have a reference to an extension method.  If so, then pulling in an import could
                 ' bring in an extension that conflicts with that.
-
-                Dim method = TryCast(_model.GetSymbolInfo(node.Name, _cancellationToken).GetAnySymbol(), IMethodSymbol)
+                Dim method = TryCast(_model.GetSymbolInfo(node.Name, cancellationToken).GetAnySymbol(), IMethodSymbol)
                 If method IsNot Nothing Then
-                    ' see explanation in VisitSimpleLambdaExpression for the _inAnonymousMethod check
-                    If method.IsReducedExtension() OrElse _inAnonymousMethod Then
-                        _conflictNamespaces.AddRange(_importedExtensionMethods(method.Name))
+                    Dim isConflicting = method.IsReducedExtension()
+
+                    If Not isConflicting And containsAnonymousMethods Then
+                        ' lambdas are interesting.  Say you have
+                        '
+                        '      Goo(sub (x) x.M())
+                        '
+                        '      sub Goo(act as Action(of C))
+                        '      sub Goo(act as Action(of integer))
+                        '
+                        '      class C : public sub M()
+                        '
+                        ' This Is legal code where the lambda body Is calling the instance method.  However, if we introduce a
+                        ' using that brings in an extension method 'M' on 'int', then the above will become ambiguous.  This is
+                        ' because lambda binding will try each interpretation separately And eliminate the ones that fail.
+                        ' Adding the import will make the int form succeed, causing ambiguity.
+                        '
+                        ' To deal with that, we keep track of if we're in a lambda, and we conservatively assume that a method
+                        ' access (even to a non-extension method) could conflict with an extension method brought in.
+
+                        isConflicting = node.HasAncestor(Of LambdaExpressionSyntax)()
+                    End If
+
+                    If isConflicting Then
+                        For Each conflictingSymbol In _importedExtensionMethods.Item(method.Name)
+                            addConflict(conflictingSymbol)
+                        Next
                     End If
                 End If
             End Sub


### PR DESCRIPTION
We've recently obtained some traces from customers around UI delays during completion commit in C# files. The first profile I took a look at indicated that the delay was due to a snippet commit, in particular during the code used to prevent adding conflicting imports.

This code has been improved in 3 ways, all relating to accessing the semantic model (where the *vast* majority of the time was spent):

1) Reduce the number of nodes for which semantic information need be obtained. The code already collects a couple dictionaries keyed on type names which could cause conflicts. This simply changes the code to filter syntax nodes based on this.

2) Change the kind of semantic model used. About half the time used during binding was due to the model dealing with work around nullability. We don't need that information, so we're good to use the much faster NullableDisabled semantic model.

3) Process binding nodes to their semantic information in parallel. This does a simple collection of nodes of interest, then uses the ProducerConsumer mechanism to obtain semantic information in parallel.

As a minor tweak, I also did away with the TreeWalker derivation, instead just doing a simple walk over the results of GetDescendantNodes. Should be more performant, and I find it a bit easier to understand when the needs are this simple.