### PR TITLE
Perform nav bar computation in two passes

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractEditorNavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractEditorNavigationBarItemService.cs
@@ -30,12 +30,12 @@ internal abstract class AbstractEditorNavigationBarItemService : INavigationBarI
     public async Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(
         Document document,
         bool workspaceSupportsDocumentChanges,
-        bool forceFrozenPartialSemanticsForCrossProcessOperations,
+        bool frozenPartialSemantics,
         ITextVersion textVersion,
         CancellationToken cancellationToken)
     {
         var service = document.GetRequiredLanguageService<CodeAnalysis.NavigationBar.INavigationBarItemService>();
-        var items = await service.GetItemsAsync(document, workspaceSupportsDocumentChanges, forceFrozenPartialSemanticsForCrossProcessOperations, cancellationToken).ConfigureAwait(false);
+        var items = await service.GetItemsAsync(document, workspaceSupportsDocumentChanges, frozenPartialSemantics, cancellationToken).ConfigureAwait(false);
         return items.SelectAsArray(v => (NavigationBarItem)new WrappedNavigationBarItem(textVersion, v));
     }
 

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/INavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/INavigationBarItemService.cs
@@ -16,7 +16,7 @@ internal interface INavigationBarItemService : ILanguageService
     Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(
         Document document,
         bool workspaceSupportsDocumentChanges,
-        bool forceFrozenPartialSemanticsForCrossProcessOperations,
+        bool frozenPartialSemantics,
         ITextVersion textVersion,
         CancellationToken cancellationToken);
     bool ShowItemGrayedIfNear(NavigationBarItem item);

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptNavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptNavigationBarItemService.cs
@@ -33,7 +33,7 @@ internal class VSTypeScriptNavigationBarItemService(
         Document document, ITextVersion textVersion, CancellationToken cancellationToken)
     {
         return ((INavigationBarItemService)this).GetItemsAsync(
-            document, workspaceSupportsDocumentChanges: true, forceFrozenPartialSemanticsForCrossProcessOperations: false, textVersion, cancellationToken);
+            document, workspaceSupportsDocumentChanges: true, frozenPartialSemantics: false, textVersion, cancellationToken);
     }
 
     async Task<ImmutableArray<NavigationBarItem>> INavigationBarItemService.GetItemsAsync(

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
@@ -87,13 +87,6 @@ internal partial class NavigationBarController : IDisposable
     /// </summary>
     private bool _paused = false;
 
-    /// <param name="FrozenPartialSemantics">Indicates if we should compute with frozen partial semantics or
-    /// not.</param>
-    /// <param name="NonFrozenComputationToken">If <paramref name="FrozenPartialSemantics"/> is false, then this is a
-    /// cancellation token that can cancel the expensive work being done if new frozen-partial work is
-    /// requested.</param>
-    private readonly record struct NavigationBarQueueItem(bool FrozenPartialSemantics, CancellationToken? NonFrozenComputationToken);
-
     public NavigationBarController(
         IThreadingContext threadingContext,
         INavigationBarPresenter presenter,
@@ -111,7 +104,7 @@ internal partial class NavigationBarController : IDisposable
         _nonFrozenComputationCancellationSeries = new(threadingContext.DisposalToken);
 
         _computeModelQueue = new AsyncBatchingWorkQueue<NavigationBarQueueItem, NavigationBarModel?>(
-            DelayTimeSpan.Short,
+            DelayTimeSpan.Medium,
             ComputeModelAndSelectItemAsync,
             EqualityComparer<NavigationBarQueueItem>.Default,
             asyncListener,

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,7 +65,15 @@ internal partial class NavigationBarController : IDisposable
     /// Queue to batch up work to do to compute the current model.  Used so we can batch up a lot of events and only
     /// compute the model once for every batch.
     /// </summary>
-    private readonly AsyncBatchingWorkQueue<VoidResult, NavigationBarModel?> _computeModelQueue;
+    private readonly AsyncBatchingWorkQueue<NavigationBarQueueItem, NavigationBarModel?> _computeModelQueue;
+
+    /// <summary>
+    /// This cancellation series controls the non-frozen nav-bar computation pass.  We want this to be separately
+    /// cancellable so that if new events come in that we cancel the expensive non-frozen nav-bar pass (which might be
+    /// computing skeletons, SG docs, etc.), do the next cheap frozen-nav-bar-pass, and then push the
+    /// expensive-nonfrozen-nav-bar-pass to the end again.
+    /// </summary>
+    private readonly CancellationSeries _nonFrozenComputationCancellationSeries;
 
     /// <summary>
     /// Queue to batch up work to do to determine the selected item.  Used so we can batch up a lot of events and only
@@ -77,6 +86,13 @@ internal partial class NavigationBarController : IDisposable
     /// cref="_visibilityTracker"/>.
     /// </summary>
     private bool _paused = false;
+
+    /// <param name="FrozenPartialSemantics">Indicates if we should compute with frozen partial semantics or
+    /// not.</param>
+    /// <param name="NonFrozenComputationToken">If <paramref name="FrozenPartialSemantics"/> is false, then this is a
+    /// cancellation token that can cancel the expensive work being done if new frozen-partial work is
+    /// requested.</param>
+    private readonly record struct NavigationBarQueueItem(bool FrozenPartialSemantics, CancellationToken? NonFrozenComputationToken);
 
     public NavigationBarController(
         IThreadingContext threadingContext,
@@ -92,11 +108,12 @@ internal partial class NavigationBarController : IDisposable
         _visibilityTracker = visibilityTracker;
         _uiThreadOperationExecutor = uiThreadOperationExecutor;
         _asyncListener = asyncListener;
+        _nonFrozenComputationCancellationSeries = new(threadingContext.DisposalToken);
 
-        _computeModelQueue = new AsyncBatchingWorkQueue<VoidResult, NavigationBarModel?>(
+        _computeModelQueue = new AsyncBatchingWorkQueue<NavigationBarQueueItem, NavigationBarModel?>(
             DelayTimeSpan.Short,
             ComputeModelAndSelectItemAsync,
-            EqualityComparer<VoidResult>.Default,
+            EqualityComparer<NavigationBarQueueItem>.Default,
             asyncListener,
             _cancellationTokenSource.Token);
 
@@ -196,7 +213,13 @@ internal partial class NavigationBarController : IDisposable
         if (_disconnected)
             return;
 
-        _computeModelQueue.AddWork(default(VoidResult));
+        // Cancel any expensive, in-flight, nav--bar work as there's now a request to perform lightweight tagging. Note:
+        // intentionally ignoring the return value here.  We're enqueuing normal work here, so it has no associated
+        // token with it.
+        _ = _nonFrozenComputationCancellationSeries.CreateNext();
+        _computeModelQueue.AddWork(
+            new NavigationBarQueueItem(FrozenPartialSemantics: true, NonFrozenComputationToken: null),
+            cancelExistingWork: true);
     }
 
     private void OnCaretMovedOrActiveViewChanged(object? sender, EventArgs e)

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
@@ -206,7 +206,7 @@ internal partial class NavigationBarController : IDisposable
         if (_disconnected)
             return;
 
-        // Cancel any expensive, in-flight, nav--bar work as there's now a request to perform lightweight tagging. Note:
+        // Cancel any expensive, in-flight, nav-bar work as there's now a request to perform lightweight tagging. Note:
         // intentionally ignoring the return value here.  We're enqueuing normal work here, so it has no associated
         // token with it.
         _ = _nonFrozenComputationCancellationSeries.CreateNext();

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
@@ -101,7 +101,7 @@ internal partial class NavigationBarController : IDisposable
         _visibilityTracker = visibilityTracker;
         _uiThreadOperationExecutor = uiThreadOperationExecutor;
         _asyncListener = asyncListener;
-        _nonFrozenComputationCancellationSeries = new(threadingContext.DisposalToken);
+        _nonFrozenComputationCancellationSeries = new(_cancellationTokenSource.Token);
 
         _computeModelQueue = new AsyncBatchingWorkQueue<NavigationBarQueueItem, NavigationBarModel?>(
             DelayTimeSpan.Medium,

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -102,14 +102,6 @@ internal partial class NavigationBarController
 
         async Task<NavigationBarModel?> ComputeModelAsync()
         {
-            // When computing items just get the partial semantics workspace.  This will ensure we can get data for this
-            // file, and hopefully have enough loaded to get data for other files in the case of partial types.  In the
-            // event the other files aren't available, then partial-type information won't be correct.  That's ok though
-            // as this is just something that happens during solution load and will pass once that is over.  By using
-            // partial semantics, we can ensure we don't spend an inordinate amount of time computing and using full
-            // compilation data (like skeleton assemblies).
-            var forceFrozenPartialSemanticsForCrossProcessOperations = true;
-
             var workspace = textSnapshot.TextBuffer.GetWorkspace();
             if (workspace is null)
                 return null;

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -57,8 +57,7 @@ internal partial class NavigationBarController
         }
         else
         {
-            // Normal request to either compute frozen partial tags, or compute normal tags in a tagger that does
-            // *not* support frozen partial tagging.
+            // Normal request to either compute nav-bar items using frozen partial semantics.
             return await ComputeModelAndSelectItemAsync(frozenPartialSemantics, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -8,12 +8,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 
@@ -24,7 +22,52 @@ internal partial class NavigationBarController
     /// <summary>
     /// Starts a new task to compute the model based on the current text.
     /// </summary>
-    private async ValueTask<NavigationBarModel?> ComputeModelAndSelectItemAsync(ImmutableSegmentedList<VoidResult> _, CancellationToken cancellationToken)
+    private async ValueTask<NavigationBarModel?> ComputeModelAndSelectItemAsync(
+        ImmutableSegmentedList<NavigationBarQueueItem> queueItems, CancellationToken cancellationToken)
+    {
+        // If any of the requests are for frozen partial, then we do compute with frozen partial semantics.  We
+        // always want these "fast but inaccurate" passes to happen first.  That pass will then enqueue the work
+        // to do the slow-but-accurate pass.
+        var frozenPartialSemantics = queueItems.Any(t => t.FrozenPartialSemantics);
+
+        if (!frozenPartialSemantics)
+        {
+            // We're asking for the expensive nav-bar-pass, Kick off the work to do that, but attach ourselves to the
+            // requested cancellation token so this expensive work can be canceled if new requests for frozen partial
+            // work come in.
+
+            // Since we're not frozen-partial, all requests must have an associated cancellation token.  And all but
+            // the last *must* be already canceled (since each is canceled as new work is added).
+            Contract.ThrowIfFalse(queueItems.All(t => !t.FrozenPartialSemantics));
+            Contract.ThrowIfFalse(queueItems.All(t => t.NonFrozenComputationToken != null));
+            Contract.ThrowIfFalse(queueItems.Take(queueItems.Count - 1).All(t => t.NonFrozenComputationToken!.Value.IsCancellationRequested));
+
+            var lastNonFrozenComputationToken = queueItems[^1].NonFrozenComputationToken!.Value;
+
+            // Need a dedicated try/catch here since we're operating on a different token than the queue's token.
+            using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(lastNonFrozenComputationToken, cancellationToken);
+            try
+            {
+                return await ComputeModelAndSelectItemAsync(frozenPartialSemantics, linkedTokenSource.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (ExceptionUtilities.IsCurrentOperationBeingCancelled(ex, linkedTokenSource.Token))
+            {
+                return null;
+            }
+        }
+        else
+        {
+            // Normal request to either compute frozen partial tags, or compute normal tags in a tagger that does
+            // *not* support frozen partial tagging.
+            return await ComputeModelAndSelectItemAsync(frozenPartialSemantics, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Starts a new task to compute the model based on the current text.
+    /// </summary>
+    private async ValueTask<NavigationBarModel?> ComputeModelAndSelectItemAsync(
+        bool frozenPartialSemantics, CancellationToken cancellationToken)
     {
         // Jump back to the UI thread to determine what snapshot the user is processing.
         await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken).NoThrowAwaitable();
@@ -42,6 +85,12 @@ internal partial class NavigationBarController
         await TaskScheduler.Default;
 
         var model = await ComputeModelAsync().ConfigureAwait(false);
+
+        // If we were computing with frozen partial semantics here, enqueue work to compute *without* frozen
+        // partial snapshots so we move to accurate results shortly. Create and pass along a new cancellation
+        // token for this expensive work so that it can be canceled by future lightweight work.
+        if (frozenPartialSemantics)
+            _computeModelQueue.AddWork(new NavigationBarQueueItem(FrozenPartialSemantics: false, _nonFrozenComputationCancellationSeries.CreateNext(default)));
 
         // Now, enqueue work to select the right item in this new model. Note: we don't want to cancel existing items in
         // the queue as it may be the case that the user moved between us capturing the initial caret point and now, and
@@ -65,7 +114,9 @@ internal partial class NavigationBarController
             if (workspace is null)
                 return null;
 
-            var document = textSnapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
+            var document = frozenPartialSemantics
+                ? textSnapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken)
+                : textSnapshot.AsText().GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
                 return null;
 
@@ -90,7 +141,7 @@ internal partial class NavigationBarController
                 var items = await itemService.GetItemsAsync(
                     document,
                     workspace.CanApplyChange(ApplyChangesKind.ChangeDocument),
-                    forceFrozenPartialSemanticsForCrossProcessOperations,
+                    frozenPartialSemantics,
                     textSnapshot.Version,
                     cancellationToken).ConfigureAwait(false);
                 return new NavigationBarModel(itemService, items);

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarQueueItem.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarQueueItem.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 
-namespace Microsoft.CodeAnalysis.NavigationBar;
+namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar;
 
 /// <param name="FrozenPartialSemantics">Indicates if we should compute with frozen partial semantics or
 /// not.</param>

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarQueueItem.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarQueueItem.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis.NavigationBar;
+
+/// <param name="FrozenPartialSemantics">Indicates if we should compute with frozen partial semantics or
+/// not.</param>
+/// <param name="NonFrozenComputationToken">If <paramref name="FrozenPartialSemantics"/> is false, then this is a
+/// cancellation token that can cancel the expensive work being done if new frozen-partial work is
+/// requested.</param>
+internal readonly record struct NavigationBarQueueItem(
+    bool FrozenPartialSemantics,
+    CancellationToken? NonFrozenComputationToken);

--- a/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
 
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
                 Dim actualItems = Await service.GetItemsAsync(
-                    document, workspaceSupportsDocumentChanges:=True, forceFrozenPartialSemanticsForCrossProcessOperations:=False, snapshot.Version, Nothing)
+                    document, workspaceSupportsDocumentChanges:=True, frozenPartialSemantics:=False, snapshot.Version, Nothing)
 
                 AssertEqual(expectedItems, actualItems, document.GetLanguageService(Of ISyntaxFactsService)().IsCaseSensitive)
             End Using
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
 
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
                 Dim items = Await service.GetItemsAsync(
-                    document, workspaceSupportsDocumentChanges:=True, forceFrozenPartialSemanticsForCrossProcessOperations:=False, snapshot.Version, Nothing)
+                    document, workspaceSupportsDocumentChanges:=True, frozenPartialSemantics:=False, snapshot.Version, Nothing)
 
                 Dim hostDocument = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
                 Dim model As New NavigationBarModel(service, items)
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
 
                 Dim items = Await service.GetItemsAsync(
-                    document, workspaceSupportsDocumentChanges:=True, forceFrozenPartialSemanticsForCrossProcessOperations:=False, snapshot.Version, Nothing)
+                    document, workspaceSupportsDocumentChanges:=True, frozenPartialSemantics:=False, snapshot.Version, Nothing)
 
                 Dim leftItem = items.Single(Function(i) i.Text = leftItemToSelectText)
                 Dim rightItem = selectRightItem(leftItem.ChildItems)
@@ -121,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
 
                 Dim service = DirectCast(sourceDocument.GetLanguageService(Of INavigationBarItemService)(), AbstractEditorNavigationBarItemService)
                 Dim items = Await service.GetItemsAsync(
-                    sourceDocument, workspaceSupportsDocumentChanges:=True, forceFrozenPartialSemanticsForCrossProcessOperations:=False, snapshot.Version, Nothing)
+                    sourceDocument, workspaceSupportsDocumentChanges:=True, frozenPartialSemantics:=False, snapshot.Version, Nothing)
 
                 Dim leftItem = items.Single(Function(i) i.Text = leftItemToSelectText)
                 Dim rightItem = leftItem.ChildItems.Single(Function(i) i.Text = rightItemToSelectText)

--- a/src/Features/Core/Portable/NavigationBar/AbstractNavigationBarItemService.cs
+++ b/src/Features/Core/Portable/NavigationBar/AbstractNavigationBarItemService.cs
@@ -18,7 +18,7 @@ internal abstract class AbstractNavigationBarItemService : INavigationBarItemSer
 {
     protected abstract Task<ImmutableArray<RoslynNavigationBarItem>> GetItemsInCurrentProcessAsync(Document document, bool supportsCodeGeneration, CancellationToken cancellationToken);
 
-    public async Task<ImmutableArray<RoslynNavigationBarItem>> GetItemsAsync(Document document, bool supportsCodeGeneration, bool forceFrozenPartialSemanticsForCrossProcessOperations, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<RoslynNavigationBarItem>> GetItemsAsync(Document document, bool supportsCodeGeneration, bool frozenPartialSemantics, CancellationToken cancellationToken)
     {
         var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
         if (client != null)
@@ -28,7 +28,7 @@ internal abstract class AbstractNavigationBarItemService : INavigationBarItemSer
             var documentId = document.Id;
             var result = await client.TryInvokeAsync<IRemoteNavigationBarItemService, ImmutableArray<SerializableNavigationBarItem>>(
                 document.Project,
-                (service, solutionInfo, cancellationToken) => service.GetItemsAsync(solutionInfo, documentId, supportsCodeGeneration, forceFrozenPartialSemanticsForCrossProcessOperations, cancellationToken),
+                (service, solutionInfo, cancellationToken) => service.GetItemsAsync(solutionInfo, documentId, supportsCodeGeneration, frozenPartialSemantics, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
 
             return result.HasValue

--- a/src/Features/Core/Portable/NavigationBar/INavigationBarItemService.cs
+++ b/src/Features/Core/Portable/NavigationBar/INavigationBarItemService.cs
@@ -11,5 +11,5 @@ namespace Microsoft.CodeAnalysis.NavigationBar;
 
 internal interface INavigationBarItemService : ILanguageService
 {
-    Task<ImmutableArray<RoslynNavigationBarItem>> GetItemsAsync(Document document, bool supportsCodeGeneration, bool forceFrozenPartialSemanticsForCrossProcessOperations, CancellationToken cancellationToken);
+    Task<ImmutableArray<RoslynNavigationBarItem>> GetItemsAsync(Document document, bool supportsCodeGeneration, bool frozenPartialSemantics, CancellationToken cancellationToken);
 }

--- a/src/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var clientCapabilities = context.GetRequiredClientCapabilities();
 
             var navBarService = document.Project.Services.GetRequiredService<INavigationBarItemService>();
-            var navBarItems = await navBarService.GetItemsAsync(document, supportsCodeGeneration: false, forceFrozenPartialSemanticsForCrossProcessOperations: false, cancellationToken).ConfigureAwait(false);
+            var navBarItems = await navBarService.GetItemsAsync(document, supportsCodeGeneration: false, frozenPartialSemantics: false, cancellationToken).ConfigureAwait(false);
             if (navBarItems.IsEmpty)
                 return [];
 

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         public Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(Document document, ITextVersion textVersion, CancellationToken cancellationToken)
         {
             return ((INavigationBarItemService)this).GetItemsAsync(
-                document, workspaceSupportsDocumentChanges: true, forceFrozenPartialSemanticsForCrossProcessOperations: false, textVersion, cancellationToken);
+                document, workspaceSupportsDocumentChanges: true, frozenPartialSemantics: false, textVersion, cancellationToken);
         }
 
         async Task<ImmutableArray<NavigationBarItem>> INavigationBarItemService.GetItemsAsync(


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2065682

This follows the same change made in taggers back in https://github.com/dotnet/roslyn/pull/72878.

The idea is fairly simple.  When computing nav bar items, we always first try a simple and quick pass using frozen-partial semantics.  This allows the nav bars to be reasonably up to date with whatever the user jsut types, as well as with the last contents of SG documents and skeleton references.

As long as new changes are coming in, we keep performing those cheap computation passes.

When a cheap computation pass finishes, we then enqueue a request to do one final expensive pass that will actually update hte navbars with non-frozen data.  Thus, ensuring that we always finally get into a final, correct, state.  That expensive pass will be pre-empted by more cheap requests that come in.  But we'll always eventually run that expensive/correct pass as the final thing we do.