### PR TITLE
Reduce Linq usage in SymbolDisplayVisitor.CreateAliasMap

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.cs
@@ -196,26 +196,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             // NOTE(cyrusn): If we're currently in a block of usings, then we want to collect the
             // aliases that are higher up than this block.  Using aliases declared in a block of
             // usings are not usable from within that same block.
-            var usingDirective = GetAncestorOrThis<UsingDirectiveSyntax>(startNode);
-            if (usingDirective != null)
+            while (startNode != null)
             {
-                startNode = usingDirective.Parent!.Parent!;
+                if (startNode is UsingDirectiveSyntax)
+                {
+                    startNode = startNode.Parent!.Parent!;
+                    break;
+                }
+
+                startNode = startNode.Parent;
             }
 
-            var usingAliases = GetAncestorsOrThis<BaseNamespaceDeclarationSyntax>(startNode)
-                .SelectMany(n => n.Usings)
-                .Concat(GetAncestorsOrThis<CompilationUnitSyntax>(startNode).SelectMany(c => c.Usings))
-                .Where(u => u.Alias != null)
-                .Select(u => semanticModel.GetDeclaredSymbol(u) as IAliasSymbol)
-                .WhereNotNull();
+            startNode ??= token.Parent;
 
             var builder = ImmutableDictionary.CreateBuilder<INamespaceOrTypeSymbol, IAliasSymbol>();
-            foreach (var alias in usingAliases)
+            while (startNode != null)
             {
-                if (!builder.ContainsKey(alias.Target))
+                var usings = (startNode as BaseNamespaceDeclarationSyntax)?.Usings;
+                usings ??= (startNode as CompilationUnitSyntax)?.Usings;
+
+                if (usings != null)
                 {
-                    builder.Add(alias.Target, alias);
+                    foreach (var u in usings)
+                    {
+                        if (u.Alias != null
+                            && semanticModel.GetDeclaredSymbol(u) is IAliasSymbol aliasSymbol
+                            && !builder.ContainsKey(aliasSymbol.Target))
+                        {
+                            builder.Add(aliasSymbol.Target, aliasSymbol);
+                        }
+                    }
                 }
+
+                startNode = startNode.Parent;
             }
 
             return builder.ToImmutable();
@@ -285,18 +298,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return symbolName;
-        }
-
-        private static T? GetAncestorOrThis<T>(SyntaxNode node) where T : SyntaxNode
-        {
-            return GetAncestorsOrThis<T>(node).FirstOrDefault();
-        }
-
-        private static IEnumerable<T> GetAncestorsOrThis<T>(SyntaxNode node) where T : SyntaxNode
-        {
-            return node == null
-                ? SpecializedCollections.EmptyEnumerable<T>()
-                : node.AncestorsAndSelf().OfType<T>();
         }
 
         private IDictionary<INamespaceOrTypeSymbol, IAliasSymbol> AliasMap

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.cs
@@ -195,7 +195,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // NOTE(cyrusn): If we're currently in a block of usings, then we want to collect the
             // aliases that are higher up than this block.  Using aliases declared in a block of
-            // usings are not usable from within that same block.
+            // usings are not usable from within that same block. This loop moves us outside of the
+            // immediately enclosing using directive, if any.
             while (startNode != null)
             {
                 if (startNode is UsingDirectiveSyntax)


### PR DESCRIPTION
This method showed up in a customer profile, and I was able to reproduce locally. Local repro was open Roslyn.sln, wait for CPU to settle, in SyntaxTokenParser.cs, set caret inside cref="" value and invoke completion 10 times.

*** old memory allocations ***
![image](https://github.com/dotnet/roslyn/assets/6785178/e465efa9-4333-4d32-96d7-8f362b7c98f5)

*** new memory allocations ***
![image](https://github.com/dotnet/roslyn/assets/6785178/05efff4e-77d9-48c2-8d07-9a41dd3bbf4c)