### PR TITLE
Reduce allocations in PENamespaceSymbol.GetMembers()

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 ImmutableInterlocked.InterlockedExchange(ref _lazyFlattenedNamespacesAndTypes, calculateMembers());
             }
 
-            return StaticCast<Symbol>.From(_lazyFlattenedNamespacesAndTypes);
+            return _lazyFlattenedNamespacesAndTypes;
 
             ImmutableArray<Symbol> calculateMembers()
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -77,23 +77,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             if (_lazyFlattenedNamespacesAndTypes.IsDefault)
             {
+                var flattenedTypes = StaticCast<NamespaceOrTypeSymbol>.From(GetMemberTypesPrivate());
+
                 if (lazyNamespaces.Count == 0)
                 {
-                    var flattenedTypes = StaticCast<NamespaceOrTypeSymbol>.From(GetMemberTypesPrivate());
                     ImmutableInterlocked.InterlockedExchange(ref _lazyFlattenedNamespacesAndTypes, flattenedTypes);
                 }
                 else
                 {
-                    ArrayBuilder<NamespaceOrTypeSymbol> builder = ArrayBuilder<NamespaceOrTypeSymbol>.GetInstance();
+                    ArrayBuilder<NamespaceOrTypeSymbol> builder = ArrayBuilder<NamespaceOrTypeSymbol>.GetInstance(lazyNamespaces.Count + flattenedTypes.Length);
+
+                    builder.AddRange(flattenedTypes);
 
                     foreach (var kvp in lazyNamespaces)
                     {
                         builder.Add(kvp.Value);
-                    }
-
-                    foreach (var kvp in lazyTypes)
-                    {
-                        builder.AddRange(kvp.Value);
                     }
 
                     ImmutableInterlocked.InterlockedExchange(ref _lazyFlattenedNamespacesAndTypes, builder.ToImmutableAndFree());

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Public NotOverridable Overloads Overrides Function GetMembers() As ImmutableArray(Of Symbol)
             If _lazyFlattenedNamespacesAndTypes.IsDefault Then
                 EnsureAllMembersLoaded()
-                _lazyFlattenedNamespacesAndTypes = m_lazyMembers.Flatten()
+                ImmutableInterlocked.InterlockedExchange(_lazyFlattenedNamespacesAndTypes, m_lazyMembers.Flatten())
             End If
 
             Return _lazyFlattenedNamespacesAndTypes

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
@@ -44,6 +44,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         ' Lazily filled in collection of all contained types.
         Private _lazyFlattenedTypes As ImmutableArray(Of NamedTypeSymbol)
 
+        ' Lazily filled in collection of all contained namespaces and types.
+        Private _lazyFlattenedNamespacesAndTypes As ImmutableArray(Of Symbol)
+
         Friend NotOverridable Overrides ReadOnly Property Extent As NamespaceExtent
             Get
                 Return New NamespaceExtent(Me.ContainingPEModule)
@@ -71,9 +74,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Function
 
         Public NotOverridable Overloads Overrides Function GetMembers() As ImmutableArray(Of Symbol)
-            EnsureAllMembersLoaded()
+            If _lazyFlattenedNamespacesAndTypes.IsDefault Then
+                EnsureAllMembersLoaded()
+                _lazyFlattenedNamespacesAndTypes = m_lazyMembers.Flatten()
+            End If
 
-            Return m_lazyMembers.Flatten()
+            Return _lazyFlattenedNamespacesAndTypes
         End Function
 
         Friend Overrides ReadOnly Property EmbeddedSymbolKind As EmbeddedSymbolKind


### PR DESCRIPTION
This method commonly shows up in profiles, and this change is very similar to an optimization made to make GetTypeMembers more efficient.

Just opening roslyn.sln and bringing up completion once in a file ends up hitting this codepath about 5,000 times in VS and about 50,000 times OOP. With these changes, I see about 60% of those requests in VS hit the cache, and about 95% of those OOP hit the cache. This is about worst case for hits in this cache too, as PENamespaceSymbol object seemed to be reused quite well. 
 