### PR TITLE
Check duplicate interfaces only for metadata

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -9,11 +9,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
-using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -723,7 +723,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // metadata and be instantiated in C#.  We check to see if that's happened.
         private static bool HasDuplicateInterfaces(NamedTypeSymbol type, ConsList<TypeSymbol> basesBeingResolved)
         {
-            if (type.OriginalDefinition is SourceNamedTypeSymbol)
+            if (type.OriginalDefinition is not PENamedTypeSymbol)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -723,6 +723,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // metadata and be instantiated in C#.  We check to see if that's happened.
         private static bool HasDuplicateInterfaces(NamedTypeSymbol type, ConsList<TypeSymbol> basesBeingResolved)
         {
+            if (type.OriginalDefinition is SourceNamedTypeSymbol)
+            {
+                return false;
+            }
+
             // PERF: avoid instantiating all interfaces here
             //       Ex: if class implements just IEnumerable<> and IComparable<> it cannot have conflicting implementations
             var array = type.OriginalDefinition.InterfacesNoUseSiteDiagnostics(basesBeingResolved);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/40538.
Fixes https://github.com/dotnet/razor/issues/9837.

First commit extracted out of https://github.com/dotnet/roslyn/pull/73730.