### PR TITLE
Cancel classification work for the portions of the view outside of hte viewport.

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.SingleViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.SingleViewportTaggerProvider.cs
@@ -54,6 +54,14 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> where T
             // looked at.
             => _viewPortToTag == ViewPortToTag.InView ? _callback.EventChangeDelay : TaggerDelay.NonFocus;
 
+        protected override bool CancelOnNewWork
+            // For what's in view, we don't want to cancel work when changes come in.  That way we still finish
+            // computing whatever was in progress, which we can map forward to the latest snapshot.  This helps ensure
+            // that colors come in quickly, even as the user is typing fast.  For what's above/below, we don't want to
+            // do the same.  We can just cancel that work entirely, pushing things out until the next lull in typing. 
+            // This can save a lot of CPU time for things that may never even be looked at.
+            => _viewPortToTag != ViewPortToTag.InView;
+
         protected override void AddSpansToTag(ITextView? textView, ITextBuffer subjectBuffer, ref TemporaryArray<SnapshotSpan> result)
         {
             this.ThreadingContext.ThrowIfNotOnUIThread();


### PR DESCRIPTION
In general, taggers like to compute their work till completion, then delay some cadence, then do the next compute pass after an event comes in (and repeat that continuously).  The idea here is that once we've started computing, we might as well finish.  That way the work isn't wasted, and so that we have tags that are never too stale.

This is great for what's in view.  Ensuring that even if a typer is very fast, everything in view is still catching up to them at a reasonable cadence, without them having to pause.  

However, this really isn't necessary for the portions of tagging we do outside of the main viewport.  We do this work so that if the goes up/down by a page or so, they don't see snap in of tags (which you can still observe if you go up/down by quite a lot).  But the goal is to prevent the snap in.  As long as the tags are reasonably accurate (which they generally are) based on the last time we actually tagged then spending the work to recompute those sections *continuously* is excessive.  Note: we still compute them after a few seconds of no activity.  But this change us from:

`tag->event->delay->tag->event->delay->tag->event->delay->tag->event->delay->tag`   into
`tag->event->delay->event->delay->event->delay->event->delay->event->delay->tag`

which avoids lots of unnecessary computation.

Drops CPU usage from:

![image](https://github.com/dotnet/roslyn/assets/4564579/4171126f-71ba-44aa-a6b9-60dafbab5713)

to

![image](https://github.com/dotnet/roslyn/assets/4564579/f2528e41-30ed-4f29-abce-1aacbbc5621b)
