### PR TITLE
Fix build host when only the .net 6 SDK is installed

### DIFF
--- a/src/Tools/TestDiscoveryWorker/Program.cs
+++ b/src/Tools/TestDiscoveryWorker/Program.cs
@@ -24,76 +24,85 @@ if (args.Length != 1)
     return ExitFailure;
 }
 
-using var pipeClient = new AnonymousPipeClientStream(PipeDirection.In, args[0]);
-using var sr = new StreamReader(pipeClient);
-string? output;
-
-// Wait for 'sync message' from the server.
-do
+try
 {
-    output = await sr.ReadLineAsync().ConfigureAwait(false);
-}
-while (!(output?.StartsWith("ASSEMBLY", StringComparison.OrdinalIgnoreCase) == true));
+    using var pipeClient = new AnonymousPipeClientStream(PipeDirection.In, args[0]);
+    using var sr = new StreamReader(pipeClient);
+    string? output;
 
-if ((output = await sr.ReadLineAsync().ConfigureAwait(false)) is not null)
-{
-    var assemblyFileName = output;
-
-#if NET6_0_OR_GREATER   
-    var resolver = new System.Runtime.Loader.AssemblyDependencyResolver(assemblyFileName);
-    System.Runtime.Loader.AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
+    // Wait for 'sync message' from the server.
+    do
     {
-        var assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
-        if (assemblyPath is not null)
-        {
-            return context.LoadFromAssemblyPath(assemblyPath);
-        }
+        output = await sr.ReadLineAsync().ConfigureAwait(false);
+    }
+    while (!(output?.StartsWith("ASSEMBLY", StringComparison.OrdinalIgnoreCase) == true));
 
-        return null;
-    };
+    if ((output = await sr.ReadLineAsync().ConfigureAwait(false)) is not null)
+    {
+        var assemblyFileName = output;
+
+#if NET6_0_OR_GREATER
+        var resolver = new System.Runtime.Loader.AssemblyDependencyResolver(assemblyFileName);
+        System.Runtime.Loader.AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
+        {
+            var assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
+            if (assemblyPath is not null)
+            {
+                return context.LoadFromAssemblyPath(assemblyPath);
+            }
+
+            return null;
+        };
 #endif
 
-    string testDescriptor = Path.GetFileName(assemblyFileName);
+        string testDescriptor = Path.GetFileName(assemblyFileName);
 #if NET
-    testDescriptor += " (.NET Core)";
+        testDescriptor += " (.NET Core)";
 #else
     testDescriptor += " (.NET Framework)";
 #endif
 
-    await Console.Out.WriteLineAsync($"Discovering tests in {testDescriptor}...").ConfigureAwait(false);
+        await Console.Out.WriteLineAsync($"Discovering tests in {testDescriptor}...").ConfigureAwait(false);
 
-    using var xunit = new XunitFrontController(AppDomainSupport.IfAvailable, assemblyFileName, shadowCopy: false);
-    var configuration = ConfigReader.Load(assemblyFileName);
-    var sink = new Sink();
-    xunit.Find(includeSourceInformation: false,
-               messageSink: sink,
-               discoveryOptions: TestFrameworkOptions.ForDiscovery(configuration));
+        using var xunit = new XunitFrontController(AppDomainSupport.IfAvailable, assemblyFileName, shadowCopy: false);
+        var configuration = ConfigReader.Load(assemblyFileName);
+        var sink = new Sink();
+        xunit.Find(includeSourceInformation: false,
+                   messageSink: sink,
+                   discoveryOptions: TestFrameworkOptions.ForDiscovery(configuration));
 
-    var testsToWrite = new HashSet<string>();
-    await foreach (var fullyQualifiedName in sink.GetTestCaseNamesAsync())
-    {
-        testsToWrite.Add(fullyQualifiedName);
-    }
+        var testsToWrite = new HashSet<string>();
+        await foreach (var fullyQualifiedName in sink.GetTestCaseNamesAsync())
+        {
+            testsToWrite.Add(fullyQualifiedName);
+        }
 
-    if (sink.AnyWriteFailures)
-    {
-        await Console.Error.WriteLineAsync($"Channel failed to write for '{assemblyFileName}'").ConfigureAwait(false);
-        return ExitFailure;
-    }
+        if (sink.AnyWriteFailures)
+        {
+            await Console.Error.WriteLineAsync($"Channel failed to write for '{assemblyFileName}'").ConfigureAwait(false);
+            return ExitFailure;
+        }
 
 #if NET6_0_OR_GREATER
-    await Console.Out.WriteLineAsync($"Discovered {testsToWrite.Count} tests in {testDescriptor}").ConfigureAwait(false);
+        await Console.Out.WriteLineAsync($"Discovered {testsToWrite.Count} tests in {testDescriptor}").ConfigureAwait(false);
 #else
-    await Console.Out.WriteLineAsync($"Discovered {testsToWrite.Count} tests in {testDescriptor}").ConfigureAwait(false);
+        await Console.Out.WriteLineAsync($"Discovered {testsToWrite.Count} tests in {testDescriptor}").ConfigureAwait(false);
 #endif
 
-    var directory = Path.GetDirectoryName(assemblyFileName);
-    using var fileStream = File.Create(Path.Combine(directory!, "testlist.json"));
-    await JsonSerializer.SerializeAsync(fileStream, testsToWrite).ConfigureAwait(false);
-    return ExitSuccess;
-}
+        var directory = Path.GetDirectoryName(assemblyFileName);
+        using var fileStream = File.Create(Path.Combine(directory!, "testlist.json"));
+        await JsonSerializer.SerializeAsync(fileStream, testsToWrite).ConfigureAwait(false);
+        return ExitSuccess;
+    }
 
-return ExitFailure;
+    return ExitFailure;
+}
+catch (Exception ex)
+{
+    // Write the exception details to stderr so the host process can pick it up.
+    await Console.Error.WriteLineAsync(ex.ToString()).ConfigureAwait(false);
+    return 1;
+}
 
 file class Sink : IMessageSink
 {

--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\*.cs" Link="InternalUtilities\%(FileName).cs" />

--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="17.3.2" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Was caught by integration tests
```
[Error - 12:58:15 AM] [BuildHost PID 3252] The BuildHost process exited with -532462766. Process output:
Unhandled exception. System.IO.FileLoadException: Could not load file or assembly 'System.Collections.Immutable, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)
File name: 'System.Collections.Immutable, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at Microsoft.CodeAnalysis.MSBuild.Program.Main(String[] args)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.CodeAnalysis.MSBuild.Program.Main(String[] args)
   at Microsoft.CodeAnalysis.MSBuild.Program.<Main>(String[] args)
```

SCI was not getting shipped in the output, so when using a .net6 runtime (.net6 SDK only installed, launch server via .exe instead of .dll) it failed to find the 8.0 dependency.
Adding an explicit reference seems to fix the issue