### PR TITLE
Workaround issue with invalid diagnostics reported via TS workspace diagnostics

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractWorkspacePullDiagnosticsHandler.cs
@@ -242,7 +242,22 @@ internal abstract class AbstractWorkspacePullDiagnosticsHandler<TDiagnosticsPara
 
         // Do not attempt to get workspace diagnostics for Razor files, Razor will directly ask us for document diagnostics
         // for any razor file they are interested in.
-        return document.IsRazorDocument();
+        if (document.IsRazorDocument())
+        {
+            return true;
+        }
+
+        // Temporary workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2021832
+        // LSP workspace diagnostics are incorrectly returning diagnostics for the backing generated JS file.
+        // Razor is responsible for handling diagnostics for the virtual JS file and should not be returned here.
+        // This workaround should be removed in 17.11 as JS diagnostics are no longer returned via Roslyn in 17.11
+        if (context.ServerKind == WellKnownLspServerKinds.RoslynTypeScriptLspServer &&
+            (document.FilePath?.EndsWith("__virtual.js") == true || document.FilePath?.EndsWith(".razor") == true))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     internal abstract TestAccessor GetTestAccessor();


### PR DESCRIPTION
Diagnostics for TS diagnostics in Razor files should only ever come from Razor, not through Roslyn, so we avoid reporting them.

This is a workaround for 17.10 that will be removed in 17.11 (we no longer report TS diagnostics through roslyn in 17.11).

![image](https://github.com/dotnet/roslyn/assets/5749229/9d91b08d-825b-4f67-9bcd-92b7127028e6)
