### PR TITLE
Reduce project forks on solution open

### DIFF
--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/DocumentBasedFixAllProviderHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/DocumentBasedFixAllProviderHelpers.cs
@@ -103,8 +103,8 @@ internal static class DocumentBasedFixAllProviderHelpers
             // expensive as we'd fork, produce semantics, fork, produce semantics, etc. etc.). Instead, by
             // adding all the changed documents to one solution, and then cleaning *those* we only perform
             // cleanup semantics on one forked solution.
-            var changedRoots = changedRootsAndTexts.SelectAsArray(t => t.Item2.node != null, t => (t.documentId, t.Item2.node!, PreservationMode.PreserveValue));
-            var changedTexts = changedRootsAndTexts.SelectAsArray(t => t.Item2.text != null, t => (t.documentId, t.Item2.text!, PreservationMode.PreserveValue));
+            var changedRoots = changedRootsAndTexts.SelectAsArray(t => t.Item2.node != null, t => (t.documentId, t.Item2.node!));
+            var changedTexts = changedRootsAndTexts.SelectAsArray(t => t.Item2.text != null, t => (t.documentId, t.Item2.text!));
 
             return originalSolution
                 .WithDocumentSyntaxRoots(changedRoots)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1181,14 +1181,11 @@ public partial class Solution
     /// specified.
     /// </summary>
     public Solution WithDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
-        => WithDocumentTexts([(documentId, text, mode)]);
+        => WithDocumentTexts([(documentId, text)], mode);
 
-    internal Solution WithDocumentTexts(ImmutableArray<(DocumentId documentId, SourceText text)> texts)
-        => WithDocumentTexts(texts.SelectAsArray(t => (t.documentId, t.text, PreservationMode.PreserveValue)));
-
-    internal Solution WithDocumentTexts(ImmutableArray<(DocumentId documentId, SourceText text, PreservationMode mode)> texts)
+    internal Solution WithDocumentTexts(ImmutableArray<(DocumentId documentId, SourceText text)> texts, PreservationMode mode = PreservationMode.PreserveValue)
     {
-        foreach (var (documentId, text, mode) in texts)
+        foreach (var (documentId, text) in texts)
         {
             CheckContainsDocument(documentId);
 
@@ -1199,7 +1196,7 @@ public partial class Solution
                 throw new ArgumentOutOfRangeException(nameof(mode));
         }
 
-        return WithCompilationState(_compilationState.WithDocumentTexts(texts));
+        return WithCompilationState(_compilationState.WithDocumentTexts(texts, mode));
     }
 
     /// <summary>
@@ -1312,31 +1309,30 @@ public partial class Solution
     /// rooted by the specified syntax node.
     /// </summary>
     public Solution WithDocumentSyntaxRoot(DocumentId documentId, SyntaxNode root, PreservationMode mode = PreservationMode.PreserveValue)
-        => WithDocumentSyntaxRoots([(documentId, root, mode)]);
+        => WithDocumentSyntaxRoots([(documentId, root)], mode);
 
     /// <inheritdoc cref="WithDocumentSyntaxRoot"/>.
-    internal Solution WithDocumentSyntaxRoots(ImmutableArray<(DocumentId documentId, SyntaxNode root)> syntaxRoots)
-        => WithDocumentSyntaxRoots(syntaxRoots.SelectAsArray(t => (t.documentId, t.root, PreservationMode.PreserveValue)));
-
-    /// <inheritdoc cref="WithDocumentSyntaxRoot"/>.
-    internal Solution WithDocumentSyntaxRoots(ImmutableArray<(DocumentId documentId, SyntaxNode root, PreservationMode mode)> syntaxRoots)
+    internal Solution WithDocumentSyntaxRoots(ImmutableArray<(DocumentId documentId, SyntaxNode root)> syntaxRoots, PreservationMode mode = PreservationMode.PreserveValue)
     {
-        foreach (var (documentId, root, mode) in syntaxRoots)
+        if (!mode.IsValid())
+            throw new ArgumentOutOfRangeException(nameof(mode));
+
+        foreach (var (documentId, root) in syntaxRoots)
         {
             CheckContainsDocument(documentId);
 
             if (root == null)
                 throw new ArgumentNullException(nameof(root));
-
-            if (!mode.IsValid())
-                throw new ArgumentOutOfRangeException(nameof(mode));
         }
 
-        return WithCompilationState(_compilationState.WithDocumentSyntaxRoots(syntaxRoots));
+        return WithCompilationState(_compilationState.WithDocumentSyntaxRoots(syntaxRoots, mode));
     }
 
     internal Solution WithDocumentContentsFrom(DocumentId documentId, DocumentState documentState, bool forceEvenIfTreesWouldDiffer)
-        => WithCompilationState(_compilationState.WithDocumentContentsFrom(documentId, documentState, forceEvenIfTreesWouldDiffer));
+        => WithCompilationState(_compilationState.WithDocumentContentsFrom([(documentId, documentState)], forceEvenIfTreesWouldDiffer));
+
+    internal Solution WithDocumentContentsFrom(ImmutableArray<(DocumentId documentId, DocumentState documentState)> documentIdsAndStates, bool forceEvenIfTreesWouldDiffer)
+        => WithCompilationState(_compilationState.WithDocumentContentsFrom(documentIdsAndStates, forceEvenIfTreesWouldDiffer));
 
     /// <summary>
     /// Creates a new solution instance with the document specified updated to have the source

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -708,18 +708,20 @@ internal sealed partial class SolutionCompilationState
             this.SolutionState.WithDocumentFilePath(documentId, filePath), documentId);
     }
 
-    internal SolutionCompilationState WithDocumentTexts(ImmutableArray<(DocumentId documentId, SourceText text, PreservationMode mode)> texts)
+    internal SolutionCompilationState WithDocumentTexts(ImmutableArray<(DocumentId documentId, SourceText text)> texts, PreservationMode mode)
         => WithDocumentContents(
             texts, SourceTextIsUnchanged,
-            static (documentState, text, mode) => documentState.UpdateText(text, mode));
+            static (documentState, text, mode) => documentState.UpdateText(text, mode),
+            data: mode);
 
-    private static bool SourceTextIsUnchanged(DocumentState oldDocument, SourceText text)
+    private static bool SourceTextIsUnchanged(DocumentState oldDocument, SourceText text, PreservationMode mode)
         => oldDocument.TryGetText(out var oldText) && text == oldText;
 
-    private SolutionCompilationState WithDocumentContents<TContent>(
-        ImmutableArray<(DocumentId documentId, TContent content, PreservationMode mode)> texts,
-        Func<DocumentState, TContent, bool> isUnchanged,
-        Func<DocumentState, TContent, PreservationMode, DocumentState> updateContent)
+    private SolutionCompilationState WithDocumentContents<TContent, TData>(
+        ImmutableArray<(DocumentId documentId, TContent content)> texts,
+        Func<DocumentState, TContent, TData, bool> isUnchanged,
+        Func<DocumentState, TContent, TData, DocumentState> updateContent,
+        TData data)
     {
         return UpdateDocumentsInMultipleProjects(
              texts.GroupBy(d => d.documentId.ProjectId).Select(g =>
@@ -728,13 +730,13 @@ internal sealed partial class SolutionCompilationState
                  var projectState = this.SolutionState.GetRequiredProjectState(projectId);
 
                  using var _ = ArrayBuilder<DocumentState>.GetInstance(out var newDocumentStates);
-                 foreach (var (documentId, content, mode) in g)
+                 foreach (var (documentId, content) in g)
                  {
                      var documentState = projectState.DocumentStates.GetRequiredState(documentId);
-                     if (isUnchanged(documentState, content))
+                     if (isUnchanged(documentState, content, data))
                          continue;
 
-                     newDocumentStates.Add(updateContent(documentState, content, mode));
+                     newDocumentStates.Add(updateContent(documentState, content, data));
                  }
 
                  return (projectId, newDocumentStates.ToImmutableAndClear());
@@ -794,14 +796,15 @@ internal sealed partial class SolutionCompilationState
             this.SolutionState.WithAnalyzerConfigDocumentText(documentId, textAndVersion, mode));
     }
 
-    /// <inheritdoc cref="Solution.WithDocumentSyntaxRoots(ImmutableArray{ValueTuple{DocumentId, SyntaxNode, PreservationMode}})"/>
-    public SolutionCompilationState WithDocumentSyntaxRoots(ImmutableArray<(DocumentId documentId, SyntaxNode root, PreservationMode mode)> syntaxRoots)
+    /// <inheritdoc cref="Solution.WithDocumentSyntaxRoots(ImmutableArray{ValueTuple{DocumentId, SyntaxNode}}, PreservationMode)"/>
+    public SolutionCompilationState WithDocumentSyntaxRoots(ImmutableArray<(DocumentId documentId, SyntaxNode root)> syntaxRoots, PreservationMode mode)
     {
         return WithDocumentContents(
             syntaxRoots, IsUnchanged,
-            static (documentState, root, mode) => documentState.UpdateTree(root, mode));
+            static (documentState, root, mode) => documentState.UpdateTree(root, mode),
+            data: mode);
 
-        static bool IsUnchanged(DocumentState oldDocument, SyntaxNode root)
+        static bool IsUnchanged(DocumentState oldDocument, SyntaxNode root, PreservationMode _)
         {
             return oldDocument.TryGetSyntaxTree(out var oldTree) &&
                 oldTree.TryGetRoot(out var oldRoot) &&
@@ -810,10 +813,21 @@ internal sealed partial class SolutionCompilationState
     }
 
     public SolutionCompilationState WithDocumentContentsFrom(
-        DocumentId documentId, DocumentState documentState, bool forceEvenIfTreesWouldDiffer)
+        ImmutableArray<(DocumentId documentId, DocumentState documentState)> documentIdsAndStates, bool forceEvenIfTreesWouldDiffer)
     {
-        return UpdateDocumentState(
-            this.SolutionState.WithDocumentContentsFrom(documentId, documentState, forceEvenIfTreesWouldDiffer), documentId);
+        return WithDocumentContents(
+            documentIdsAndStates,
+            isUnchanged: static (oldDocumentState, documentState, forceEvenIfTreesWouldDiffer) =>
+            {
+                if (oldDocumentState == documentState)
+                    return true;
+
+                return oldDocumentState.TextAndVersionSource == documentState.TextAndVersionSource
+                    && oldDocumentState.TreeSource == documentState.TreeSource;
+            },
+            static (oldDocumentState, documentState, forceEvenIfTreesWouldDiffer) =>
+                oldDocumentState.UpdateTextAndTreeContents(documentState.TextAndVersionSource, documentState.TreeSource, forceEvenIfTreesWouldDiffer),
+            data: forceEvenIfTreesWouldDiffer);
     }
 
     /// <inheritdoc cref="SolutionState.WithDocumentSourceCodeKind"/>
@@ -1391,8 +1405,8 @@ internal sealed partial class SolutionCompilationState
         // compilation state instance.  So in the case where there are no linked documents, there is no cost here.  And
         // there is no additional cost processing the initiating document in this loop.
         var allDocumentIds = this.SolutionState.GetRelatedDocumentIds(documentId);
-        foreach (var siblingId in allDocumentIds)
-            currentCompilationState = currentCompilationState.WithDocumentContentsFrom(siblingId, currentDocumentState, forceEvenIfTreesWouldDiffer: true);
+        var allDocumentIdsWithCurrentDocumentState = allDocumentIds.SelectAsArray(static (docId, currentDocumentState) => (docId, currentDocumentState), currentDocumentState);
+        currentCompilationState = currentCompilationState.WithDocumentContentsFrom(allDocumentIdsWithCurrentDocumentState, forceEvenIfTreesWouldDiffer: true);
 
         return WithFrozenPartialCompilationIncludingSpecificDocumentWorker(currentCompilationState, documentId, cancellationToken);
 
@@ -1651,7 +1665,7 @@ internal sealed partial class SolutionCompilationState
     /// </summary>
     public SolutionCompilationState WithDocumentText(IEnumerable<DocumentId?> documentIds, SourceText text, PreservationMode mode)
     {
-        using var _ = ArrayBuilder<(DocumentId, SourceText, PreservationMode)>.GetInstance(out var changedDocuments);
+        using var _ = ArrayBuilder<(DocumentId, SourceText)>.GetInstance(out var changedDocuments);
 
         foreach (var documentId in documentIds)
         {
@@ -1670,15 +1684,15 @@ internal sealed partial class SolutionCompilationState
                 // the same text (for example, when GetOpenDocumentInCurrentContextWithChanges) is called.
                 //
                 // The use of GetRequiredState mirrors what happens in WithDocumentTexts
-                if (!SourceTextIsUnchanged(documentState, text))
-                    changedDocuments.Add((documentId, text, mode));
+                if (!SourceTextIsUnchanged(documentState, text, mode))
+                    changedDocuments.Add((documentId, text));
             }
         }
 
         if (changedDocuments.Count == 0)
             return this;
 
-        return this.WithDocumentTexts(changedDocuments.ToImmutableAndClear());
+        return this.WithDocumentTexts(changedDocuments.ToImmutableAndClear(), mode);
     }
 
     internal TestAccessor GetTestAccessor()

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -819,9 +819,6 @@ internal sealed partial class SolutionCompilationState
             documentIdsAndStates,
             isUnchanged: static (oldDocumentState, documentState, forceEvenIfTreesWouldDiffer) =>
             {
-                if (oldDocumentState == documentState)
-                    return true;
-
                 return oldDocumentState.TextAndVersionSource == documentState.TextAndVersionSource
                     && oldDocumentState.TreeSource == documentState.TreeSource;
             },

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -988,33 +988,6 @@ internal sealed partial class SolutionState
         return UpdateAnalyzerConfigDocumentState(oldDocument.UpdateText(textAndVersion, mode));
     }
 
-    /// <param name="forceEvenIfTreesWouldDiffer">Whether or not the specified document is forced to have the same text and
-    /// green-tree-root from <paramref name="documentState"/>.  If <see langword="true"/>, then they will share
-    /// these values.  If <see langword="false"/>, then they will only be shared when safe to do so (for example,
-    /// when parse-options and pp-directives would not cause issues.</param>
-    /// <remarks>
-    /// Forcing should only happen in frozen-partial snapshots, where we are ok with inaccuracies in the trees we
-    /// get back and want perf to be very high.  Any codepaths from frozen-partial should pass <see
-    /// langword="true"/> for this.  Any codepaths from Workspace.UnifyLinkedDocumentContents should pass <see
-    /// langword="false"/>.</remarks>
-    public StateChange WithDocumentContentsFrom(DocumentId documentId, DocumentState documentState, bool forceEvenIfTreesWouldDiffer)
-    {
-        var oldDocument = GetRequiredDocumentState(documentId);
-        var oldProject = GetRequiredProjectState(documentId.ProjectId);
-        if (oldDocument == documentState)
-            return new(this, oldProject, oldProject);
-
-        if (oldDocument.TextAndVersionSource == documentState.TextAndVersionSource &&
-            oldDocument.TreeSource == documentState.TreeSource)
-        {
-            return new(this, oldProject, oldProject);
-        }
-
-        return UpdateDocumentState(
-            oldDocument.UpdateTextAndTreeContents(documentState.TextAndVersionSource, documentState.TreeSource, forceEvenIfTreesWouldDiffer),
-            contentChanged: true);
-    }
-
     /// <summary>
     /// Creates a new solution instance with the document specified updated to have the source
     /// code kind specified.

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -284,6 +284,9 @@ public abstract partial class Workspace : IDisposable
 
             var changes = newSolution.GetChanges(oldSolution);
 
+            using var _1 = PooledHashSet<DocumentId>.GetInstance(out var changedDocumentIds);
+            using var _2 = ArrayBuilder<DocumentId>.GetInstance(out var addedDocumentIds);
+
             // For all added documents, see if they link to an existing document.  If so, use that existing documents text/tree.
             foreach (var addedProject in changes.GetAddedProjects())
             {
@@ -291,15 +294,8 @@ public abstract partial class Workspace : IDisposable
                 if (!addedProject.SupportsCompilation)
                     continue;
 
-                // It's likely when adding files that if we link them to files in another project, that we will do the
-                // same for other sibling files being added.  Keep that information around so help speed up the linked
-                // file search as we process siblings.
-                ProjectId? relatedProjectIdHint = null;
-                foreach (var addedDocument in addedProject.Documents)
-                    (newSolution, relatedProjectIdHint) = UpdateAddedDocumentToExistingContentsInSolution(newSolution, addedDocument.Id, relatedProjectIdHint);
+                addedDocumentIds.AddRange(addedProject.DocumentIds);
             }
-
-            using var _ = PooledHashSet<DocumentId>.GetInstance(out var seenChangedDocuments);
 
             foreach (var projectChanges in changes.GetProjectChanges())
             {
@@ -307,67 +303,90 @@ public abstract partial class Workspace : IDisposable
                 if (!projectChanges.NewProject.SupportsCompilation)
                     continue;
 
-                // Now do the same for all added documents in a project.
-                ProjectId? relatedProjectIdHint = null;
-                foreach (var addedDocument in projectChanges.GetAddedDocuments())
-                    (newSolution, relatedProjectIdHint) = UpdateAddedDocumentToExistingContentsInSolution(newSolution, addedDocument, relatedProjectIdHint);
-
-                // now, for any changed document, ensure we go and make all links to it have the same text/tree.
-                foreach (var changedDocumentId in projectChanges.GetChangedDocuments())
-                    newSolution = UpdateExistingDocumentsToChangedDocumentContents(newSolution, changedDocumentId, seenChangedDocuments);
+                // Now do the same for all added and changed documents in a project.
+                addedDocumentIds.AddRange(projectChanges.GetAddedDocuments());
+                changedDocumentIds.AddRange(projectChanges.GetChangedDocuments());
             }
+
+            newSolution = UpdateAddedDocumentToExistingContentsInSolution(newSolution, addedDocumentIds);
+
+            // now, for any changed document, ensure we go and make all links to it have the same text/tree.
+            newSolution = UpdateExistingDocumentsToChangedDocumentContents(newSolution, changedDocumentIds);
 
             return newSolution;
         }
 
-        static (Solution newSolution, ProjectId? relatedProjectId) UpdateAddedDocumentToExistingContentsInSolution(
-            Solution solution, DocumentId addedDocumentId, ProjectId? relatedProjectIdHint)
+        static Solution UpdateAddedDocumentToExistingContentsInSolution(
+            Solution solution, ArrayBuilder<DocumentId> addedDocumentIds)
         {
-            Contract.ThrowIfTrue(addedDocumentId.ProjectId == relatedProjectIdHint);
+            ProjectId? relatedProjectIdHint = null;
+            using var _ = ArrayBuilder<(DocumentId, DocumentState)>.GetInstance(out var relatedDocumentIdsAndStates);
 
-            // Look for a related document we can create our contents from.  We only have to look for a single related
-            // doc as we'll be done once we update our contents to theirs.  Note: GetFirstRelatedDocumentId will also
-            // not search the project that addedDocumentId came from.  So this will help ensure we don't repeatedly add
-            // documents to a project, then look for related docs *within that project*, forcing the file-path map in it
-            // to be recreated for each document.
-            var relatedDocumentId = solution.GetFirstRelatedDocumentId(addedDocumentId, relatedProjectIdHint);
+            foreach (var addedDocumentId in addedDocumentIds)
+            {
+                // Ensure we don't search in addedDocumentId's project for the related document
+                if (addedDocumentId.ProjectId == relatedProjectIdHint)
+                    relatedProjectIdHint = null;
 
-            // Couldn't find a related document.  Keep the same solution, and keep track of the best related project we
-            // found while processing this project.
-            if (relatedDocumentId is null)
-                return (solution, relatedProjectIdHint);
+                // Look for a related document we can create our contents from.  We only have to look for a single related
+                // doc as we'll be done once we update our contents to theirs.  Note: GetFirstRelatedDocumentId will also
+                // not search the project that addedDocumentId came from.  So this will help ensure we don't repeatedly add
+                // documents to a project, then look for related docs *within that project*, forcing the file-path map in it
+                // to be recreated for each document.
+                var relatedDocumentId = solution.GetFirstRelatedDocumentId(addedDocumentId, relatedProjectIdHint);
 
-            var relatedDocument = solution.GetRequiredDocument(relatedDocumentId);
+                // Couldn't find a related document.
+                if (relatedDocumentId is null)
+                    continue;
 
-            // Should never return a file as its own related document
-            Contract.ThrowIfTrue(relatedDocumentId == addedDocumentId);
+                var relatedDocument = solution.GetRequiredDocument(relatedDocumentId);
 
-            // Related document must come from a distinct project.
-            Contract.ThrowIfTrue(relatedDocumentId.ProjectId == addedDocumentId.ProjectId);
+                // Should never return a file as its own related document
+                Contract.ThrowIfTrue(relatedDocumentId == addedDocumentId);
 
-            var newSolution = solution.WithDocumentContentsFrom(addedDocumentId, relatedDocument.DocumentState, forceEvenIfTreesWouldDiffer: false);
-            return (newSolution, relatedProjectId: relatedDocumentId.ProjectId);
+                // Related document must come from a distinct project.
+                Contract.ThrowIfTrue(relatedDocumentId.ProjectId == addedDocumentId.ProjectId);
+
+                relatedProjectIdHint = relatedDocumentId.ProjectId;
+                relatedDocumentIdsAndStates.Add((addedDocumentId, relatedDocument.DocumentState));
+            }
+
+            if (relatedDocumentIdsAndStates.IsEmpty)
+                return solution;
+
+            return solution.WithDocumentContentsFrom(relatedDocumentIdsAndStates.ToImmutableAndClear(), forceEvenIfTreesWouldDiffer: false);
         }
 
-        static Solution UpdateExistingDocumentsToChangedDocumentContents(Solution solution, DocumentId changedDocumentId, HashSet<DocumentId> processedDocuments)
+        static Solution UpdateExistingDocumentsToChangedDocumentContents(Solution solution, HashSet<DocumentId> changedDocumentIds)
         {
             // Changing a document in a linked-doc-chain will end up producing N changed documents.  We only want to
             // process that chain once.
-            if (processedDocuments.Add(changedDocumentId))
+            using var _ = PooledDictionary<DocumentId, DocumentState>.GetInstance(out var documentIdsToUpdate);
+
+            foreach (var changedDocumentId in changedDocumentIds)
             {
-                var changedDocument = solution.GetRequiredDocument(changedDocumentId);
+                Document? changedDocument = null;
                 var relatedDocumentIds = solution.GetRelatedDocumentIds(changedDocumentId);
+
                 foreach (var relatedDocumentId in relatedDocumentIds)
                 {
                     if (relatedDocumentId == changedDocumentId)
                         continue;
 
-                    if (processedDocuments.Add(relatedDocumentId))
-                        solution = solution.WithDocumentContentsFrom(relatedDocumentId, changedDocument.DocumentState, forceEvenIfTreesWouldDiffer: false);
+                    if (!changedDocumentIds.Contains(relatedDocumentId))
+                    {
+                        changedDocument ??= solution.GetRequiredDocument(changedDocumentId);
+                        documentIdsToUpdate[relatedDocumentId] = changedDocument.DocumentState;
+                    }
                 }
             }
 
-            return solution;
+            if (documentIdsToUpdate.Count == 0)
+                return solution;
+
+            var toProcessRelatedDocumentIds = documentIdsToUpdate.SelectAsArray(kvp => (kvp.Key, kvp.Value));
+
+            return solution.WithDocumentContentsFrom(toProcessRelatedDocumentIds, forceEvenIfTreesWouldDiffer: false);
         }
     }
 
@@ -1193,8 +1212,6 @@ public abstract partial class Workspace : IDisposable
                     {
                         // Have the linked documents point *into* the same instance data that the initial document
                         // points at.  This way things like tree data can be shared across docs.
-
-                        var options = oldSolution.Services.GetRequiredService<IWorkspaceConfigurationService>().Options;
 
                         var newDocument = newSolution.GetRequiredDocument(documentId);
                         foreach (var linkedDocumentId in linkedDocumentIds)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -361,7 +361,7 @@ public abstract partial class Workspace : IDisposable
         {
             // Changing a document in a linked-doc-chain will end up producing N changed documents.  We only want to
             // process that chain once.
-            using var _ = PooledDictionary<DocumentId, DocumentState>.GetInstance(out var documentIdsToUpdate);
+            using var _ = PooledDictionary<DocumentId, DocumentState>.GetInstance(out var relatedDocumentIdsAndStates);
 
             foreach (var changedDocumentId in changedDocumentIds)
             {
@@ -376,17 +376,17 @@ public abstract partial class Workspace : IDisposable
                     if (!changedDocumentIds.Contains(relatedDocumentId))
                     {
                         changedDocument ??= solution.GetRequiredDocument(changedDocumentId);
-                        documentIdsToUpdate[relatedDocumentId] = changedDocument.DocumentState;
+                        relatedDocumentIdsAndStates[relatedDocumentId] = changedDocument.DocumentState;
                     }
                 }
             }
 
-            if (documentIdsToUpdate.Count == 0)
+            if (relatedDocumentIdsAndStates.Count == 0)
                 return solution;
 
-            var toProcessRelatedDocumentIds = documentIdsToUpdate.SelectAsArray(kvp => (kvp.Key, kvp.Value));
+            var relatedDocumentIdsAndStatesArray = relatedDocumentIdsAndStates.SelectAsArray(static kvp => (kvp.Key, kvp.Value));
 
-            return solution.WithDocumentContentsFrom(toProcessRelatedDocumentIds, forceEvenIfTreesWouldDiffer: false);
+            return solution.WithDocumentContentsFrom(relatedDocumentIdsAndStatesArray, forceEvenIfTreesWouldDiffer: false);
         }
     }
 


### PR DESCRIPTION
This doesn't have a huge impact on solution open time, so I'm on the fence about whether this is worth the churn. I *think* the new code is better, but I'm flexible about whether to pursue this.

*** CPU from forks (before) ***
![image](https://github.com/dotnet/roslyn/assets/6785178/48a53afc-9a66-4ac5-9834-88199a65c777)

*** CPU from forks (after) ***
![image](https://github.com/dotnet/roslyn/assets/6785178/fa93fd0a-edd5-415f-8e74-f8de4029a85e)