### PR TITLE
Use a serialization compatible marker

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -225,6 +225,9 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
 #endif
 
+        // We use a Guid for the marker because it is used as a key in an exceptions Data dictionary, so we must make sure
+        // it's serializable if the exception crosses an RPC boundary. In particular System.Text.Json doesn't like plain
+        // object dictionary keys.
         private static readonly object s_reportedMarker = Guid.NewGuid();
 
         // Do not allow this method to be inlined.  That way when we have a dump we can see this frame in the stack and

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
 #endif
 
-        private static readonly Guid s_reportedMarker = Guid.NewGuid();
+        private static readonly object s_reportedMarker = Guid.NewGuid();
 
         // Do not allow this method to be inlined.  That way when we have a dump we can see this frame in the stack and
         // can examine things like s_reportedExceptionMessage.  Without this, it's a lot tricker as FatalError is linked

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
 #endif
 
-        private static readonly object s_reportedMarker = new();
+        private static readonly Guid s_reportedMarker = Guid.NewGuid();
 
         // Do not allow this method to be inlined.  That way when we have a dump we can see this frame in the stack and
         // can examine things like s_reportedExceptionMessage.  Without this, it's a lot tricker as FatalError is linked

--- a/src/Workspaces/CoreTest/UtilityTest/ExceptionHelpersTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/ExceptionHelpersTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Text.Json;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -54,6 +55,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
 
             Assert.True(false, "Should have returned in the catch block before this point.");
+        }
+
+        [Fact]
+        public void ErrorReporting_SerializesException()
+        {
+            FatalError.SetHandlers(delegate { }, delegate { });
+
+            var e = new Exception("Hello");
+            FatalError.ReportNonFatalError(e);
+
+            Assert.NotEmpty(e.Data);
+            Assert.NotNull(JsonSerializer.Serialize(e));
+            Assert.NotNull(Newtonsoft.Json.JsonConvert.SerializeObject(e));
         }
     }
 }


### PR DESCRIPTION
FatalError tries to tag exceptions so that they don't get reported twice, but it uses a plain object which fails serialization/deserialization if that exception ever crosses a json rpc boundary that uses System.Text.Json. This PR changes it to something serializable.