### PR TITLE
Add tsx/jsx as recognized extensions for TS

### DIFF
--- a/src/LanguageServer/Protocol/LanguageInfoProvider.cs
+++ b/src/LanguageServer/Protocol/LanguageInfoProvider.cs
@@ -33,9 +33,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             { ".razor", s_razorLanguageInformation },
             { ".xaml", s_xamlLanguageInformation },
             { ".ts", s_typeScriptLanguageInformation },
-            { ".js", s_typeScriptLanguageInformation },
+            { ".d.ts", s_typeScriptLanguageInformation },
             { ".tsx", s_typeScriptLanguageInformation },
+            { ".js", s_typeScriptLanguageInformation },
             { ".jsx", s_typeScriptLanguageInformation },
+            { ".cjs", s_typeScriptLanguageInformation },
+            { ".mjs", s_typeScriptLanguageInformation },
+            { ".cts", s_typeScriptLanguageInformation },
         };
 
         public LanguageInformation GetLanguageInformation(string documentPath, string? lspLanguageId)

--- a/src/LanguageServer/Protocol/LanguageInfoProvider.cs
+++ b/src/LanguageServer/Protocol/LanguageInfoProvider.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             { ".xaml", s_xamlLanguageInformation },
             { ".ts", s_typeScriptLanguageInformation },
             { ".js", s_typeScriptLanguageInformation },
+            { ".tsx", s_typeScriptLanguageInformation },
+            { ".jsx", s_typeScriptLanguageInformation },
         };
 
         public LanguageInformation GetLanguageInformation(string documentPath, string? lspLanguageId)


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2078456

This issue precedes 17.10, however it is exacerbated there because we switched to pull diagnostics (for TS as well).  A combination of bugs lead to the problem here
1.  The client is sending us incorrect language ids.  They send us the [content type display name](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient?path=/src/product/RemoteLanguage/Impl/Infrastructure/TextSynchronization/TextDocumentDidOpenNotificationFactory.cs&version=GBdevelop&line=88&lineEnd=89&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents), which has almost no relation to the language ids that are defined by the LSP spec - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
2.  We were missing the fallback when no languageId is specified for .tsx and .jsx (and others)
3.  The work to support different language handlers made all of this worse (as we now care upfront what the language is).

This change resolves 2).  I'm talking to the client about 1 (but we should fallback correctly for the no id case regardless).

3) will be improved once we switch Razor/XAML to our LSP types and can do upfront deserialization.

Tagging @MariaSolOs