### PR TITLE
Disable automatic test discovery for Roslyn in DevKit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,6 @@
     // ms-azure-devops.azure-pipelines settings
     "azure-pipelines.customSchemaFile": ".vscode/dnceng-schema.json",
     "dotnet.defaultSolution": "Roslyn.sln",
-    "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true
+    "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+    "dotnet.testWindow.disableAutoDiscovery": true
 }


### PR DESCRIPTION
Keep hitting the same issue @jaredpar hit a while back - where the testhost locks files and causes the build to fail.

This disables automatic discovery using the option added in https://github.com/microsoft/vscode-dotnettools/issues/1089

Discovery can be run manually by hitting the refresh button in the test explorer.