### PR TITLE
Support offering 'use collection' expr when assigning a List<T> to an IList<T>

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -197,6 +197,16 @@ internal static class UseCollectionExpressionHelpers
             if (s_tupleNamesCanDifferComparer.Equals(type, convertedType))
                 return true;
 
+            // It's always safe to convert List<X> to ICollection<X> or IList<X> as the language guarantees that it will
+            // continue emitting a List<X> for those target types.
+            var isWellKnownCollectionReadWriteInterface = IsWellKnownCollectionReadWriteInterface(convertedType);
+            if (isWellKnownCollectionReadWriteInterface &&
+                Equals(type.OriginalDefinition, compilation.ListOfTType()) &&
+                Equals(type.GetTypeArguments()[0], convertedType.GetTypeArguments()[0]))
+            {
+                return true;
+            }
+
             // Before this point are all the changes that we can detect that are always safe to make.
             if (!allowSemanticsChange)
                 return false;
@@ -208,7 +218,7 @@ internal static class UseCollectionExpressionHelpers
 
             // In the case of a singleton (like `Array.Empty<T>()`) we don't want to convert to `IList<T>` as that
             // will replace the code with code that now always allocates.
-            if (isSingletonInstance && IsWellKnownCollectionReadWriteInterface(convertedType))
+            if (isSingletonInstance && isWellKnownCollectionReadWriteInterface)
                 return false;
 
             // Ok to convert in cases like:


### PR DESCRIPTION
The language explicitly states that a collection expression will produce a `List<T>` in this case.  So it's always safe to offer, no matter which feature setting a user has on.