### PR TITLE
Follow up on added ability to rewrite symbol references in BoundTreeRewriter.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -885,7 +885,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return statement;
             }
 
-            return new BoundBlock(statement.Syntax, locals, localFunctions, hasUnsafeModifier: false, instrumentation: null,
+            return new BoundBlock(statement.Syntax, locals, ImmutableArray<MethodSymbol>.CastUp(localFunctions), hasUnsafeModifier: false, instrumentation: null,
                                   ImmutableArray.Create(statement))
             { WasCompilerGenerated = true };
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1891,7 +1891,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundBlock(
                 node,
                 locals,
-                GetDeclaredLocalFunctionsForScope(node),
+                ImmutableArray<MethodSymbol>.CastUp(GetDeclaredLocalFunctionsForScope(node)),
                 hasUnsafeModifier: node.Parent?.Kind() == SyntaxKind.UnsafeStatement,
                 instrumentation: null,
                 boundStatements);

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 syntax: node,
                 expression: boundSwitchGoverningExpression,
                 innerLocals: locals,
-                innerLocalFunctions: functions,
+                innerLocalFunctions: ImmutableArray<MethodSymbol>.CastUp(functions),
                 switchSections: switchSections,
                 defaultLabel: defaultLabel,
                 breakLabel: this.BreakLabel,

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1026,7 +1026,7 @@
   -->
   <Node Name="BoundBlock" Base="BoundStatementList">
     <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
-    <Field Name="LocalFunctions" Type="ImmutableArray&lt;LocalFunctionSymbol&gt;"/>
+    <Field Name="LocalFunctions" Type="ImmutableArray&lt;MethodSymbol&gt;"/>
     <Field Name="HasUnsafeModifier" Type="bool" Null="NotApplicable"/>
     
     <!-- Optional block-level instrumentation info -->
@@ -1167,7 +1167,7 @@
 
     <!-- Locals declared immediately within the switch block. -->
     <Field Name="InnerLocals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
-    <Field Name="InnerLocalFunctions" Type="ImmutableArray&lt;LocalFunctionSymbol&gt;"/>
+    <Field Name="InnerLocalFunctions" Type="ImmutableArray&lt;MethodSymbol&gt;"/>
     <Field Name="SwitchSections" Type="ImmutableArray&lt;BoundSwitchSection&gt;"/>
     <Field Name="ReachabilityDecisionDag" Type="BoundDecisionDag" Null="disallow" SkipInVisitor="true"/>
     <Field Name="DefaultLabel" Type="BoundSwitchLabel?"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundTreeRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundTreeRewriter.cs
@@ -192,6 +192,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return builder is null ? symbols : builder.ToImmutableAndFree();
         }
+
+        protected virtual ImmutableArray<LocalSymbol> VisitLocals(ImmutableArray<LocalSymbol> locals) => locals;
+
+        protected virtual ImmutableArray<MethodSymbol> VisitDeclaredLocalFunctions(ImmutableArray<MethodSymbol> localFunctions) => localFunctions;
     }
 
     internal abstract class BoundTreeRewriterWithStackGuard : BoundTreeRewriter

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal partial class BoundBlock
     {
         public BoundBlock(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundStatement> statements, bool hasErrors = false)
-            : this(syntax, locals, ImmutableArray<LocalFunctionSymbol>.Empty, hasUnsafeModifier: false, instrumentation: null, statements, hasErrors)
+            : this(syntax, locals, ImmutableArray<MethodSymbol>.Empty, hasUnsafeModifier: false, instrumentation: null, statements, hasErrors)
         {
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -2284,7 +2284,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void ReportUnusedVariables(ImmutableArray<LocalFunctionSymbol> locals)
+        private void ReportUnusedVariables(ImmutableArray<MethodSymbol> locals)
         {
             foreach (var symbol in locals)
             {
@@ -2292,7 +2292,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void ReportIfUnused(LocalFunctionSymbol symbol)
+        private void ReportIfUnused(MethodSymbol symbol)
         {
             if (!_usedLocalFunctions.Contains(symbol))
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 builder.AddRange(statements, n - 1);
                 builder.Add(AppendImplicitReturn((BoundBlock)statements[n - 1], method));
 
-                return body.Update(body.Locals, ImmutableArray<LocalFunctionSymbol>.Empty, body.HasUnsafeModifier, body.Instrumentation, builder.ToImmutableAndFree());
+                return body.Update(body.Locals, ImmutableArray<MethodSymbol>.Empty, body.HasUnsafeModifier, body.Instrumentation, builder.ToImmutableAndFree());
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/BoundTreeToDifferentEnclosingContextRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/BoundTreeToDifferentEnclosingContextRewriter.cs
@@ -1,0 +1,188 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// a bound node rewriter that rewrites types properly (which in some cases the automatically-generated
+    /// base class does not).  This is used in the lambda rewriter, the iterator rewriter, and the async rewriter.
+    /// </summary>
+    internal abstract class BoundTreeToDifferentEnclosingContextRewriter : BoundTreeRewriterWithStackGuard
+    {
+        // A mapping from every local variable to its replacement local variable.  Local variables are replaced when
+        // their types change due to being inside of a generic method.  Otherwise we reuse the original local (even
+        // though its containing method is not correct because the code is moved into another method)
+        private readonly Dictionary<LocalSymbol, LocalSymbol> localMap = new Dictionary<LocalSymbol, LocalSymbol>();
+
+        // A mapping for types in the original method to types in its replacement.  This is mainly necessary
+        // when the original method was generic, as type parameters in the original method are mapping into
+        // type parameters of the resulting class.
+        protected abstract TypeMap TypeMap { get; }
+
+        protected abstract MethodSymbol CurrentMethod { get; }
+
+        public override BoundNode DefaultVisit(BoundNode node)
+        {
+            Debug.Fail($"Override the visitor for {node.Kind}");
+            return base.DefaultVisit(node);
+        }
+
+        protected void RewriteLocals(ImmutableArray<LocalSymbol> locals, ArrayBuilder<LocalSymbol> newLocals)
+        {
+            foreach (var local in locals)
+            {
+                if (TryRewriteLocal(local, out LocalSymbol? newLocal))
+                {
+                    newLocals.Add(newLocal);
+                }
+            }
+        }
+
+        protected virtual bool TryRewriteLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? newLocal)
+        {
+            if (localMap.TryGetValue(local, out newLocal))
+            {
+                return true;
+            }
+
+            var newType = VisitType(local.Type);
+            if (TypeSymbol.Equals(newType, local.Type, TypeCompareKind.ConsiderEverything2))
+            {
+                newLocal = local;
+            }
+            else
+            {
+                newLocal = new TypeSubstitutedLocalSymbol(local, TypeWithAnnotations.Create(newType), CurrentMethod);
+                localMap.Add(local, newLocal);
+            }
+
+            return true;
+        }
+
+        protected sealed override ImmutableArray<LocalSymbol> VisitLocals(ImmutableArray<LocalSymbol> locals)
+        {
+            if (locals.IsEmpty) return locals;
+            var newLocals = ArrayBuilder<LocalSymbol>.GetInstance();
+            RewriteLocals(locals, newLocals);
+            return newLocals.ToImmutableAndFree();
+        }
+
+        protected sealed override LocalSymbol VisitLocalSymbol(LocalSymbol local)
+        {
+            if (!TryRewriteLocal(local, out var newLocal))
+            {
+                throw ExceptionUtilities.UnexpectedValue(local);
+            }
+
+            return newLocal;
+        }
+
+        protected bool TryGetRewrittenLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? localToUse)
+        {
+            return localMap.TryGetValue(local, out localToUse);
+        }
+
+        public override BoundNode VisitBlock(BoundBlock node)
+            => VisitBlock(node, removeInstrumentation: false);
+
+        protected BoundBlock VisitBlock(BoundBlock node, bool removeInstrumentation)
+        {
+            // Note: Instrumentation variable is intentionally not rewritten. It should never be lifted.
+
+            var newLocals = this.VisitLocals(node.Locals);
+            var newLocalFunctions = this.VisitDeclaredLocalFunctions(node.LocalFunctions);
+            var newStatements = VisitList(node.Statements);
+            var newInstrumentation = removeInstrumentation ? null : (BoundBlockInstrumentation?)Visit(node.Instrumentation);
+            return node.Update(newLocals, newLocalFunctions, node.HasUnsafeModifier, newInstrumentation, newStatements);
+        }
+
+        [return: NotNullIfNotNull(nameof(type))]
+        public sealed override TypeSymbol? VisitType(TypeSymbol? type)
+        {
+            return TypeMap.SubstituteType(type).Type;
+        }
+
+        public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        {
+            // Local rewriter should have already rewritten interpolated strings into their final form of calls and gotos
+            Debug.Assert(node.InterpolatedStringHandlerData is null);
+
+            return node.Update(
+                node.OperatorKind,
+                node.ConstantValueOpt,
+                VisitMethodSymbol(node.Method),
+                VisitType(node.ConstrainedToType),
+                node.ResultKind,
+                (BoundExpression)Visit(node.Left),
+                (BoundExpression)Visit(node.Right),
+                VisitType(node.Type));
+        }
+
+        public override BoundNode? VisitConversion(BoundConversion node)
+        {
+            var conversion = node.Conversion;
+
+            if (conversion.Method is not null)
+            {
+                conversion = conversion.SetConversionMethod(VisitMethodSymbol(conversion.Method));
+            }
+
+            return node.Update(
+                (BoundExpression)Visit(node.Operand),
+                conversion,
+                node.IsBaseConversion,
+                node.Checked,
+                node.ExplicitCastInCode,
+                node.ConstantValueOpt,
+                node.ConversionGroupOpt,
+                VisitType(node.Type));
+        }
+
+        [return: NotNullIfNotNull(nameof(method))]
+        protected override MethodSymbol? VisitMethodSymbol(MethodSymbol? method)
+        {
+            if (method is null)
+            {
+                return null;
+            }
+
+            if (method.ContainingType.IsAnonymousType)
+            {
+                //  Method of an anonymous type
+                var newType = (NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly();
+                if (ReferenceEquals(newType, method.ContainingType))
+                {
+                    //  Anonymous type symbol was not rewritten
+                    return method;
+                }
+
+                //  get a new method by name
+                foreach (var member in newType.GetMembers(method.Name))
+                {
+                    if (member.Kind == SymbolKind.Method)
+                    {
+                        return (MethodSymbol)member;
+                    }
+                }
+
+                throw ExceptionUtilities.Unreachable();
+            }
+            else
+            {
+                //  Method of a regular type
+                return ((MethodSymbol)method.OriginalDefinition)
+                    .AsMember((NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly())
+                    .ConstructIfGeneric(TypeMap.SubstituteTypes(method.TypeArgumentsWithAnnotations));
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
@@ -765,7 +765,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         LocalSymbol localToUse;
-                        if (!localMap.TryGetValue(local, out localToUse))
+                        if (!TryGetRewrittenLocal(local, out localToUse))
                         {
                             localToUse = local;
                         }
@@ -1191,17 +1191,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitScope(BoundScope node)
         {
             Debug.Assert(!node.Locals.IsEmpty);
-            var newLocals = ArrayBuilder<LocalSymbol>.GetInstance();
-            RewriteLocals(node.Locals, newLocals);
+            var newLocals = VisitLocals(node.Locals);
 
             var statements = VisitList(node.Statements);
-            if (newLocals.Count == 0)
+            if (newLocals.Length == 0)
             {
-                newLocals.Free();
                 return new BoundStatementList(node.Syntax, statements);
             }
 
-            return node.Update(newLocals.ToImmutableAndFree(), statements);
+            return node.Update(newLocals, statements);
         }
 
         public override BoundNode VisitCatchBlock(BoundCatchBlock node)

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -13,11 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    /// <summary>
-    /// a bound node rewriter that rewrites types properly (which in some cases the automatically-generated
-    /// base class does not).  This is used in the lambda rewriter, the iterator rewriter, and the async rewriter.
-    /// </summary>
-    internal abstract partial class MethodToClassRewriter : BoundTreeRewriterWithStackGuard
+    internal abstract partial class MethodToClassRewriter : BoundTreeToDifferentEnclosingContextRewriter
     {
         // For each captured variable, information about its replacement.  May be populated lazily (that is, not all
         // upfront) by subclasses.  Specifically, the async rewriter produces captured symbols for temps, including
@@ -27,20 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // created in the first pass.
         protected Dictionary<Symbol, CapturedSymbolReplacement> proxies = new Dictionary<Symbol, CapturedSymbolReplacement>();
 
-        // A mapping from every local variable to its replacement local variable.  Local variables are replaced when
-        // their types change due to being inside of a generic method.  Otherwise we reuse the original local (even
-        // though its containing method is not correct because the code is moved into another method)
-        protected readonly Dictionary<LocalSymbol, LocalSymbol> localMap = new Dictionary<LocalSymbol, LocalSymbol>();
-
-        // A mapping for types in the original method to types in its replacement.  This is mainly necessary
-        // when the original method was generic, as type parameters in the original method are mapping into
-        // type parameters of the resulting class.
-        protected abstract TypeMap TypeMap { get; }
-
         // Subclasses override this method to fetch a frame pointer.
         protected abstract BoundExpression FramePointer(SyntaxNode syntax, NamedTypeSymbol frameClass);
-
-        protected abstract MethodSymbol CurrentMethod { get; }
 
         // Containing type for any synthesized members.
         protected abstract NamedTypeSymbol ContainingType { get; }
@@ -65,30 +49,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this._placeholderMap = new Dictionary<BoundValuePlaceholderBase, BoundExpression>();
         }
 
-        public override BoundNode DefaultVisit(BoundNode node)
-        {
-            Debug.Fail($"Override the visitor for {node.Kind}");
-            return base.DefaultVisit(node);
-        }
-
         /// <summary>
         /// Returns true if the specified local/parameter needs to be hoisted to a field.
         /// Variable may be hoisted even if it is not captured, to improve debugging experience.
         /// </summary>
         protected abstract bool NeedsProxy(Symbol localOrParameter);
 
-        protected void RewriteLocals(ImmutableArray<LocalSymbol> locals, ArrayBuilder<LocalSymbol> newLocals)
-        {
-            foreach (var local in locals)
-            {
-                if (TryRewriteLocal(local, out LocalSymbol? newLocal))
-                {
-                    newLocals.Add(newLocal);
-                }
-            }
-        }
-
-        protected bool TryRewriteLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? newLocal)
+        protected sealed override bool TryRewriteLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? newLocal)
         {
             if (NeedsProxy(local))
             {
@@ -97,126 +64,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            if (localMap.TryGetValue(local, out newLocal))
-            {
-                return true;
-            }
-
-            var newType = VisitType(local.Type);
-            if (TypeSymbol.Equals(newType, local.Type, TypeCompareKind.ConsiderEverything2))
-            {
-                newLocal = local;
-            }
-            else
-            {
-                newLocal = new TypeSubstitutedLocalSymbol(local, TypeWithAnnotations.Create(newType), CurrentMethod);
-                localMap.Add(local, newLocal);
-            }
-
-            return true;
-        }
-
-        private ImmutableArray<LocalSymbol> RewriteLocals(ImmutableArray<LocalSymbol> locals)
-        {
-            if (locals.IsEmpty) return locals;
-            var newLocals = ArrayBuilder<LocalSymbol>.GetInstance();
-            RewriteLocals(locals, newLocals);
-            return newLocals.ToImmutableAndFree();
-        }
-
-        public override BoundNode VisitCatchBlock(BoundCatchBlock node)
-        {
-            if (!node.Locals.IsDefaultOrEmpty)
-            {
-                // Yield/await aren't supported in catch block atm, but we need to rewrite the type 
-                // of the variables owned by the catch block. Note that one of these variables might be a closure frame reference.
-                var newLocals = RewriteLocals(node.Locals);
-
-                return node.Update(
-                    newLocals,
-                    (BoundExpression?)this.Visit(node.ExceptionSourceOpt),
-                    this.VisitType(node.ExceptionTypeOpt),
-                    (BoundStatementList?)this.Visit(node.ExceptionFilterPrologueOpt),
-                    (BoundExpression?)this.Visit(node.ExceptionFilterOpt),
-                    (BoundBlock?)this.Visit(node.Body)!,
-                    node.IsSynthesizedAsyncCatchAll);
-            }
-
-            return base.VisitCatchBlock(node)!;
-        }
-
-        public override BoundNode VisitBlock(BoundBlock node)
-            => VisitBlock(node, removeInstrumentation: false);
-
-        protected BoundBlock VisitBlock(BoundBlock node, bool removeInstrumentation)
-        {
-            // Note: Instrumentation variable is intentionally not rewritten. It should never be lifted.
-
-            var newLocals = RewriteLocals(node.Locals);
-            var newLocalFunctions = node.LocalFunctions;
-            var newStatements = VisitList(node.Statements);
-            var newInstrumentation = removeInstrumentation ? null : (BoundBlockInstrumentation?)Visit(node.Instrumentation);
-            return node.Update(newLocals, newLocalFunctions, node.HasUnsafeModifier, newInstrumentation, newStatements);
+            return base.TryRewriteLocal(local, out newLocal);
         }
 
         public abstract override BoundNode VisitScope(BoundScope node);
 
-        public override BoundNode VisitSequence(BoundSequence node)
-        {
-            var newLocals = RewriteLocals(node.Locals);
-            var newSideEffects = VisitList<BoundExpression>(node.SideEffects);
-            var newValue = (BoundExpression)this.Visit(node.Value);
-            var newType = this.VisitType(node.Type);
-            return node.Update(newLocals, newSideEffects, newValue, newType);
-        }
-
         public override BoundNode VisitForStatement(BoundForStatement node)
         {
-            var newOuterLocals = RewriteLocals(node.OuterLocals);
-            var initializer = (BoundStatement?)this.Visit(node.Initializer);
-            var newInnerLocals = RewriteLocals(node.InnerLocals);
-            var condition = (BoundExpression?)this.Visit(node.Condition);
-            var increment = (BoundStatement?)this.Visit(node.Increment);
-            var body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newOuterLocals, initializer, newInnerLocals, condition, increment, body, node.BreakLabel, node.ContinueLabel);
+            throw ExceptionUtilities.Unreachable();
         }
 
         public override BoundNode VisitDoStatement(BoundDoStatement node)
         {
-            var newLocals = RewriteLocals(node.Locals);
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newLocals, condition, body, node.BreakLabel, node.ContinueLabel);
+            throw ExceptionUtilities.Unreachable();
         }
 
         public override BoundNode VisitWhileStatement(BoundWhileStatement node)
         {
-            var newLocals = RewriteLocals(node.Locals);
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newLocals, condition, body, node.BreakLabel, node.ContinueLabel);
+            throw ExceptionUtilities.Unreachable();
         }
 
         public override BoundNode VisitUsingStatement(BoundUsingStatement node)
         {
-            var newLocals = RewriteLocals(node.Locals);
-            var declarations = (BoundMultipleLocalDeclarations?)this.Visit(node.DeclarationsOpt);
-            var expression = (BoundExpression?)this.Visit(node.ExpressionOpt);
-            var body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newLocals, declarations, expression, body, node.AwaitOpt, node.PatternDisposeInfoOpt);
-        }
-
-        [return: NotNullIfNotNull(nameof(type))]
-        public sealed override TypeSymbol? VisitType(TypeSymbol? type)
-        {
-            return TypeMap.SubstituteType(type).Type;
-        }
-
-        public override BoundNode VisitMethodInfo(BoundMethodInfo node)
-        {
-            var rewrittenMethod = VisitMethodSymbol(node.Method);
-            // No need to rewrite the node's type, because it is always System.Reflection.MethodInfo
-            return node.Update(rewrittenMethod, node.GetMethodFromHandle, node.Type);
+            throw ExceptionUtilities.Unreachable();
         }
 
         public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)
@@ -257,64 +127,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 node.ResultKind,
                 rewrittenType);
         }
-
-        public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
-        {
-            // Local rewriter should have already rewritten interpolated strings into their final form of calls and gotos
-            Debug.Assert(node.InterpolatedStringHandlerData is null);
-
-            return node.Update(
-                node.OperatorKind,
-                node.ConstantValueOpt,
-                VisitMethodSymbol(node.Method),
-                VisitType(node.ConstrainedToType),
-                node.ResultKind,
-                (BoundExpression)Visit(node.Left),
-                (BoundExpression)Visit(node.Right),
-                VisitType(node.Type));
-        }
-
-        public override BoundNode VisitUnaryOperator(BoundUnaryOperator node)
-            => node.Update(
-                node.OperatorKind,
-                (BoundExpression)Visit(node.Operand),
-                node.ConstantValueOpt,
-                VisitMethodSymbol(node.MethodOpt),
-                VisitType(node.ConstrainedToTypeOpt),
-                node.ResultKind,
-                VisitType(node.Type));
-
-        public override BoundNode? VisitConversion(BoundConversion node)
-        {
-            var conversion = node.Conversion;
-
-            if (conversion.Method is not null)
-            {
-                conversion = conversion.SetConversionMethod(VisitMethodSymbol(conversion.Method));
-            }
-
-            return node.Update(
-                (BoundExpression)Visit(node.Operand),
-                conversion,
-                node.IsBaseConversion,
-                node.Checked,
-                node.ExplicitCastInCode,
-                node.ConstantValueOpt,
-                node.ConversionGroupOpt,
-                VisitType(node.Type));
-        }
-
-        public override BoundNode? VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
-            => node.Update(
-                node.OperatorKind,
-                VisitMethodSymbol(node.LogicalOperator),
-                VisitMethodSymbol(node.TrueOperator),
-                VisitMethodSymbol(node.FalseOperator),
-                VisitType(node.ConstrainedToTypeOpt),
-                node.ResultKind,
-                (BoundExpression)Visit(node.Left),
-                (BoundExpression)Visit(node.Right),
-                VisitType(node.Type));
 
         private MethodSymbol GetMethodWrapperForBaseNonVirtualCall(MethodSymbol methodBeingCalled, SyntaxNode syntax)
         {
@@ -403,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // if a local needs a proxy it should have been allocated by its declaration node.
             Debug.Assert(!NeedsProxy(node.LocalSymbol));
 
-            return VisitUnhoistedLocal(node);
+            return base.VisitLocal(node)!;
         }
 
         public override BoundNode? VisitLocalId(BoundLocalId node)
@@ -432,16 +244,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             field = null;
             return false;
-        }
-
-        private BoundNode VisitUnhoistedLocal(BoundLocal node)
-        {
-            if (this.localMap.TryGetValue(node.LocalSymbol, out LocalSymbol? replacementLocal))
-            {
-                return new BoundLocal(node.Syntax, replacementLocal, node.ConstantValueOpt, replacementLocal.Type, node.HasErrors);
-            }
-
-            return base.VisitLocal(node)!;
         }
 
         public override BoundNode VisitAwaitableInfo(BoundAwaitableInfo node)
@@ -550,29 +352,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return node.Update(receiverOpt, fieldSymbol, node.ConstantValueOpt, node.ResultKind, type);
         }
 
-        public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)
-        {
-            var rewritten = (BoundObjectCreationExpression?)base.VisitObjectCreationExpression(node);
-            Debug.Assert(rewritten != null);
-            if (!TypeSymbol.Equals(rewritten.Type, node.Type, TypeCompareKind.ConsiderEverything2) && (object)node.Constructor != null)
-            {
-                MethodSymbol ctor = VisitMethodSymbol(node.Constructor);
-                rewritten = rewritten.Update(
-                    ctor,
-                    rewritten.Arguments,
-                    rewritten.ArgumentNamesOpt,
-                    rewritten.ArgumentRefKindsOpt,
-                    rewritten.Expanded,
-                    rewritten.ArgsToParamsOpt,
-                    rewritten.DefaultArguments,
-                    rewritten.ConstantValueOpt,
-                    rewritten.InitializerExpressionOpt,
-                    rewritten.Type);
-            }
-
-            return rewritten;
-        }
-
         public override BoundNode VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
         {
             BoundExpression originalArgument = node.Argument;
@@ -588,58 +367,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             method = VisitMethodSymbol(method);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(rewrittenArgument, method, node.IsExtensionMethod, node.WasTargetTyped, type);
-        }
-
-        public override BoundNode VisitFunctionPointerLoad(BoundFunctionPointerLoad node)
-        {
-            return node.Update(VisitMethodSymbol(node.TargetMethod), VisitType(node.ConstrainedToTypeOpt), VisitType(node.Type));
-        }
-
-        public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
-        {
-            var receiver = (BoundExpression)this.Visit(node.Receiver);
-            var whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
-            var whenNullOpt = (BoundExpression?)this.Visit(node.WhenNullOpt);
-            TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(receiver, VisitMethodSymbol(node.HasValueMethodOpt), whenNotNull, whenNullOpt, node.Id, node.ForceCopyOfNullableValueType, type);
-        }
-
-        [return: NotNullIfNotNull(nameof(method))]
-        protected new MethodSymbol? VisitMethodSymbol(MethodSymbol? method)
-        {
-            if (method is null)
-            {
-                return null;
-            }
-
-            if (method.ContainingType.IsAnonymousType)
-            {
-                //  Method of an anonymous type
-                var newType = (NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly();
-                if (ReferenceEquals(newType, method.ContainingType))
-                {
-                    //  Anonymous type symbol was not rewritten
-                    return method;
-                }
-
-                //  get a new method by name
-                foreach (var member in newType.GetMembers(method.Name))
-                {
-                    if (member.Kind == SymbolKind.Method)
-                    {
-                        return (MethodSymbol)member;
-                    }
-                }
-
-                throw ExceptionUtilities.Unreachable();
-            }
-            else
-            {
-                //  Method of a regular type
-                return ((MethodSymbol)method.OriginalDefinition)
-                    .AsMember((NamedTypeSymbol)TypeMap.SubstituteType(method.ContainingType).AsTypeSymbolOnly())
-                    .ConstructIfGeneric(TypeMap.SubstituteTypes(method.TypeArgumentsWithAnnotations));
-            }
         }
 
         [return: NotNullIfNotNull(nameof(property))]
@@ -704,14 +431,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return node.Update(member, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ResultKind, receiverType, type);
-        }
-
-        public override BoundNode VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
-        {
-            BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
-            MethodSymbol method = VisitMethodSymbol(node.ConversionMethod);
-            TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(operand, method, type);
         }
 
         private static bool BaseReferenceInReceiverWasRewritten([NotNullWhen(true)] BoundExpression? originalReceiver, [NotNullWhen(true)] BoundExpression? rewrittenReceiver)

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -521,6 +521,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundBlock Block(ImmutableArray<LocalSymbol> locals, ImmutableArray<LocalFunctionSymbol> localFunctions, ImmutableArray<BoundStatement> statements)
         {
+            return Block(locals, ImmutableArray<MethodSymbol>.CastUp(localFunctions), statements);
+        }
+
+        public BoundBlock Block(ImmutableArray<LocalSymbol> locals, ImmutableArray<MethodSymbol> localFunctions, ImmutableArray<BoundStatement> statements)
+        {
             return new BoundBlock(Syntax, locals, localFunctions, hasUnsafeModifier: false, instrumentation: null, statements) { WasCompilerGenerated = true };
         }
 


### PR DESCRIPTION
- Extract common reusable functionality from MethodToClassRewriter into a new base class
- Remove some redundant overrides
- Adjust bound nodes and BoundTreeRewriter in preparation for extension method rewrite.