### PR TITLE
Upgrade MicrosoftCodeAnalysisTestingVersion to 1.1.2-beta1.24121.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
     <!-- Versions used by several individual references below -->
     <RoslynDiagnosticsNugetPackageVersion>3.3.4-beta1.22579.2</RoslynDiagnosticsNugetPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview1.23111.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23163.2</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.24121.1</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.149-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
     <!-- CodeStyleAnalyzerVersion should we updated together with version of dotnet-format in dotnet-tools.json -->
     <CodeStyleAnalyzerVersion>4.3.0-1.final</CodeStyleAnalyzerVersion>

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "8.0.100-preview.1.23115.2",
     "allowPrerelease": false,
-    "rollForward": "latestPatch"
+    "rollForward": "disable"
   },
   "tools": {
     "dotnet": "8.0.100-preview.1.23115.2",

--- a/src/EditorFeatures/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
@@ -4542,37 +4542,23 @@ namespace N
 
         #endregion
 
-        private static void AddSolutionTransform(List<Func<Solution, ProjectId, Solution>> solutionTransforms)
-        {
-            solutionTransforms.Add((solution, projectId) =>
-            {
-                var project = solution.GetProject(projectId)!;
-
-                var compilationOptions = (CSharpCompilationOptions)project.CompilationOptions!;
-                // enable nullable
-                compilationOptions = compilationOptions.WithNullableContextOptions(NullableContextOptions.Enable);
-                solution = solution
-                    .WithProjectCompilationOptions(projectId, compilationOptions)
-                    .WithProjectMetadataReferences(projectId, TargetFrameworkUtil.GetReferences(TargetFramework.Net60));
-
-                return solution;
-            });
-        }
-
         private class RefactoringTest : VerifyCSRefactoring.Test
         {
             public RefactoringTest()
             {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
                 LanguageVersion = LanguageVersion.CSharp10;
-                AddSolutionTransform(SolutionTransforms);
                 MarkupOptions = MarkupOptions.UseFirstDescriptor;
             }
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override CompilationOptions CreateCompilationOptions()
             {
-                var workspace = new AdhocWorkspace();
+                var compilationOptions = (CSharpCompilationOptions)base.CreateCompilationOptions();
 
-                return workspace;
+                // enable nullable
+                compilationOptions = compilationOptions.WithNullableContextOptions(NullableContextOptions.Enable);
+
+                return compilationOptions;
             }
         }
 
@@ -4596,8 +4582,18 @@ namespace N
         {
             public CodeFixTest()
             {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
                 LanguageVersion = LanguageVersion.CSharp10;
-                AddSolutionTransform(SolutionTransforms);
+            }
+
+            protected override CompilationOptions CreateCompilationOptions()
+            {
+                var compilationOptions = (CSharpCompilationOptions)base.CreateCompilationOptions();
+
+                // enable nullable
+                compilationOptions = compilationOptions.WithNullableContextOptions(NullableContextOptions.Enable);
+
+                return compilationOptions;
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -47,11 +47,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
                 return SpecializedCollections.SingletonEnumerable(new CSharpExtractClassCodeRefactoringProvider(service));
             }
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 var unusedCompilationOptions = new CSharpCompilationOptions(OutputKind.NetModule);
                 var unusedParseOptions = new CSharpParseOptions(LanguageVersion.CSharp1);
-                return TestWorkspace.Create(WorkspaceKind, LanguageNames.CSharp, unusedCompilationOptions, unusedParseOptions);
+                return Task.FromResult<Workspace>(TestWorkspace.Create(WorkspaceKind, LanguageNames.CSharp, unusedCompilationOptions, unusedParseOptions));
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateEqualsAndGetHas
             public ImmutableArray<string> MemberNames;
             public Action<ImmutableArray<PickMembersOption>> OptionsCallback;
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 // If we're a dialog test, then mixin our mock and initialize its values to the ones the test asked for.
                 var workspace = new AdhocWorkspace(s_composition.GetHostServices());
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateEqualsAndGetHas
                 service.MemberNames = MemberNames;
                 service.OptionsCallback = OptionsCallback;
 
-                return workspace;
+                return Task.FromResult<Workspace>(workspace);
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -3420,7 +3420,7 @@ static int Do[||]Something()
 
             private readonly bool _testPreselection;
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 var hostServices = s_testServices.GetHostServices();
 
@@ -3432,7 +3432,7 @@ static int Do[||]Something()
                 testOptionsService.CreateNew = _createNew;
                 testOptionsService.ExpectedPrecheckedMembers = _testPreselection ? _selection : ImmutableArray<string>.Empty;
 
-                return workspace;
+                return Task.FromResult<Workspace>(workspace);
             }
         }
 

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
@@ -113,16 +113,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             protected override FixAllContext CreateFixAllContext(
                 Document? document,
+                TextSpan? diagnosticSpan,
                 Project project,
                 CodeFixProvider codeFixProvider,
                 FixAllScope scope,
                 string? codeActionEquivalenceKey,
                 IEnumerable<string> diagnosticIds,
+                DiagnosticSeverity minimumSeverity,
                 FixAllContext.DiagnosticProvider fixAllDiagnosticProvider,
                 CancellationToken cancellationToken)
                 => new(new FixAllState(
                     fixAllProvider: NoOpFixAllProvider.Instance,
-                    diagnosticSpan: null,
+                    diagnosticSpan,
                     document,
                     project,
                     codeFixProvider,

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -124,14 +124,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             private static readonly TestComposition s_editorFeaturesOOPComposition = EditorTestCompositions.EditorFeatures.WithTestHostParts(TestHost.OutOfProcess);
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 if (TestHost == TestHost.InProcess)
-                    return base.CreateWorkspaceImpl();
+                    return base.CreateWorkspaceImplAsync();
 
                 var hostServices = s_editorFeaturesOOPComposition.GetHostServices();
                 var workspace = new AdhocWorkspace(hostServices);
-                return workspace;
+                return Task.FromResult<Workspace>(workspace);
             }
 #endif
         }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
@@ -110,14 +110,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             private static readonly TestComposition s_editorFeaturesOOPComposition = EditorTestCompositions.EditorFeatures.WithTestHostParts(TestHost.OutOfProcess);
 
-            protected override Workspace CreateWorkspaceImpl()
+            protected override Task<Workspace> CreateWorkspaceImplAsync()
             {
                 if (TestHost == TestHost.InProcess)
-                    return base.CreateWorkspaceImpl();
+                    return base.CreateWorkspaceImplAsync();
 
                 var hostServices = s_editorFeaturesOOPComposition.GetHostServices();
                 var workspace = new AdhocWorkspace(hostServices);
-                return workspace;
+                return Task.FromResult<Workspace>(workspace);
             }
 
 #endif

--- a/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
@@ -3065,7 +3065,7 @@ End Namespace"
 
             Private ReadOnly _newType As Boolean
 
-            Protected Overrides Function CreateWorkspaceImpl() As Workspace
+            Protected Overrides Function CreateWorkspaceImplAsync() As Task(Of Workspace)
                 Dim hostServices = s_testServices.GetHostServices()
                 Dim workspace = New AdhocWorkspace(hostServices)
                 Dim optionsService = DirectCast(workspace.Services.GetRequiredService(Of IMoveStaticMembersOptionsService)(), TestMoveStaticMembersService)
@@ -3079,7 +3079,7 @@ End Namespace"
                 End If
                 optionsService.CreateNew = _newType
 
-                Return workspace
+                Return Task.FromResult(Of Workspace)(workspace)
             End Function
         End Class
 


### PR DESCRIPTION
Disabled roll-forward in global.json to prevent source-breaking changes in later releases from affecting the build of this servicing branch.