### PR TITLE
[cherry-pick] Use separate async tracker for SG work instad of reusing workspace async tracker

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/TaskScheduler/IWorkspaceAsynchronousOperationListenerProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TaskScheduler/IWorkspaceAsynchronousOperationListenerProvider.cs
@@ -12,4 +12,5 @@ namespace Microsoft.CodeAnalysis.Host;
 internal interface IWorkspaceAsynchronousOperationListenerProvider : IWorkspaceService
 {
     IAsynchronousOperationListener GetListener();
+    IAsynchronousOperationListener GetListener(string featureName);
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/TaskScheduler/WorkspaceAsynchronousOperationListenerProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TaskScheduler/WorkspaceAsynchronousOperationListenerProvider.cs
@@ -19,4 +19,7 @@ internal sealed class WorkspaceAsynchronousOperationListenerProvider(IAsynchrono
 
     public IAsynchronousOperationListener GetListener()
         => _listener;
+
+    public IAsynchronousOperationListener GetListener(string featureName)
+        => listenerProvider.GetListener(featureName);
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -92,7 +93,7 @@ public abstract partial class Workspace : IDisposable
             TimeSpan.FromMilliseconds(1500),
             ProcessUpdateSourceGeneratorRequestAsync,
             EqualityComparer<(ProjectId? projectId, bool forceRegeneration)>.Default,
-            listenerProvider.GetListener(),
+            listenerProvider.GetListener(FeatureAttribute.SourceGenerators),
             _updateSourceGeneratorsQueueTokenSource.Token);
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_SourceGeneration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_SourceGeneration.cs
@@ -43,10 +43,6 @@ public partial class Workspace
                 return;
         }
 
-        // Ensure we're fully loaded before rerunning generators.
-        var workspaceStatusService = this.Services.GetRequiredService<IWorkspaceStatusService>();
-        await workspaceStatusService.WaitUntilFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
-
         await this.SetCurrentSolutionAsync(
             useAsync: true,
             oldSolution =>


### PR DESCRIPTION
Cherry-pick 73880 to main, to expedite the fix for the SG issue.