### PR TITLE
Throw when there is a syntax version mismatch in codelens

### DIFF
--- a/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveHandler.cs
@@ -52,7 +52,7 @@ internal sealed class CodeLensResolveHandler : ILspServiceDocumentRequestHandler
         // If the request is for an older version of the document, throw an exception so the client knows to re-query us.
         if (resolveData.SyntaxVersion != currentDocumentSyntaxVersion.ToString())
         {
-            throw new LocalRpcException($"Resolve version {resolveData.SyntaxVersion} does not match current version {currentDocumentSyntaxVersion}")
+            throw new LocalRpcException($"Resolve version '{resolveData.SyntaxVersion}' does not match current version '{currentDocumentSyntaxVersion}'")
             {
                 ErrorCode = LspErrorCodes.ContentModified
             };

--- a/src/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
@@ -395,8 +395,8 @@ public class CSharpCodeLensTests : AbstractCodeLensTests
         await testLspServer.InsertTextAsync(documentUri, (0, 0, "A"));
 
         // Assert that we don't crash when sending an old request to a new document
-        var firstDocumentResult2 = await testLspServer.ExecuteRequestAsync<LSP.CodeLens, LSP.CodeLens>(LSP.Methods.CodeLensResolveName, firstCodeLens, CancellationToken.None);
-        Assert.NotNull(firstDocumentResult2?.Command?.Title);
+        var firstDocumentResult2 = Assert.ThrowsAsync<StreamJsonRpc.RemoteInvocationException>(async () => await testLspServer.ExecuteRequestAsync<LSP.CodeLens, LSP.CodeLens>(LSP.Methods.CodeLensResolveName, firstCodeLens, CancellationToken.None));
+        Assert.False(testLspServer.GetServerAccessor().HasShutdownStarted());
     }
 
     [Theory, CombinatorialData]


### PR DESCRIPTION
Noticed in integration tests that sometimes we would get silent failures.  We should be throwing here with a specific exception that will tell the client to re-request the codelens items.

This also matches how inlay hints behaves.