### PR TITLE
Include wrapping options in editorconfig formatting options

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -48,15 +48,15 @@ internal static class CSharpCollectionExpressionRewriter
         var document = await ParsedDocument.CreateAsync(workspaceDocument, cancellationToken).ConfigureAwait(false);
 
 #if CODE_STYLE
-        var formattingOptions = SyntaxFormattingOptions.CommonDefaults;
+        var formattingOptions = CSharpSyntaxFormattingOptions.Default;
 #else
-        var formattingOptions = await workspaceDocument.GetSyntaxFormattingOptionsAsync(
+        var formattingOptions = (CSharpSyntaxFormattingOptions)await workspaceDocument.GetSyntaxFormattingOptionsAsync(
             fallbackOptions, cancellationToken).ConfigureAwait(false);
 #endif
 
         var indentationOptions = new IndentationOptions(formattingOptions);
 
-        var wrappingLength = ((CSharpSyntaxFormattingOptions)formattingOptions).CollectionExpressionWrappingLength;
+        var wrappingLength = formattingOptions.CollectionExpressionWrappingLength;
 
         var initializer = getInitializer(expressionToReplace);
         var endOfLine = DetermineEndOfLine(document, expressionToReplace, formattingOptions);

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Indentation;
@@ -55,12 +56,7 @@ internal static class CSharpCollectionExpressionRewriter
 
         var indentationOptions = new IndentationOptions(formattingOptions);
 
-        // the option is currently not an editorconfig option, so not available in code style layer
-#if CODE_STYLE
-        var wrappingLength = CodeActionOptions.DefaultCollectionExpressionWrappingLength;
-#else
-        var wrappingLength = fallbackOptions.GetOptions(document.LanguageServices).CollectionExpressionWrappingLength;
-#endif
+        var wrappingLength = ((CSharpSyntaxFormattingOptions)formattingOptions).CollectionExpressionWrappingLength;
 
         var initializer = getInitializer(expressionToReplace);
         var endOfLine = DetermineEndOfLine(document, expressionToReplace, formattingOptions);

--- a/src/Analyzers/Core/CodeFixes/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
@@ -2,22 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
-using static Microsoft.CodeAnalysis.UseConditionalExpression.UseConditionalExpressionHelpers;
 using static Microsoft.CodeAnalysis.UseConditionalExpression.UseConditionalExpressionCodeFixHelpers;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.UseConditionalExpression;
 
@@ -59,7 +57,7 @@ internal abstract class AbstractUseConditionalExpressionForAssignmentCodeFixProv
     /// </summary>
     protected override async Task FixOneAsync(
         Document document, Diagnostic diagnostic,
-        SyntaxEditor editor, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
+        SyntaxEditor editor, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken)
     {
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
         var ifStatement = diagnostic.AdditionalLocations[0].FindNode(cancellationToken);
@@ -81,7 +79,7 @@ internal abstract class AbstractUseConditionalExpressionForAssignmentCodeFixProv
             trueAssignment?.Value ?? trueStatement,
             falseAssignment?.Value ?? falseStatement,
             isRef,
-            fallbackOptions,
+            formattingOptions,
             cancellationToken).ConfigureAwait(false);
 
         // See if we're assigning to a variable declared directly above the if statement. If so,

--- a/src/Analyzers/Core/CodeFixes/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnCodeFixProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -45,7 +46,7 @@ internal abstract class AbstractUseConditionalExpressionForReturnCodeFixProvider
 
     protected override async Task FixOneAsync(
         Document document, Diagnostic diagnostic,
-        SyntaxEditor editor, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
+        SyntaxEditor editor, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken)
     {
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
         var ifStatement = (TIfStatementSyntax)diagnostic.AdditionalLocations[0].FindNode(cancellationToken);
@@ -69,7 +70,7 @@ internal abstract class AbstractUseConditionalExpressionForReturnCodeFixProvider
             trueReturn?.ReturnedValue ?? trueStatement,
             falseReturn?.ReturnedValue ?? falseStatement,
             isRef,
-            fallbackOptions,
+            formattingOptions,
             cancellationToken).ConfigureAwait(false);
 
         var generatorInternal = document.GetRequiredLanguageService<SyntaxGeneratorInternal>();

--- a/src/EditorFeatures/TestUtilities/Utilities/VisualBasicCodeActionOptions.cs
+++ b/src/EditorFeatures/TestUtilities/Utilities/VisualBasicCodeActionOptions.cs
@@ -24,9 +24,6 @@ internal static class VisualBasicCodeActionOptions
         CodeStyleOptions = VisualBasicIdeCodeStyleOptions.Default
     };
 
-    public static CodeActionOptions WithWrappingColumn(this CodeActionOptions options, int value)
-        => options with { WrappingColumn = value };
-
     public static CodeActionOptions With(this CodeActionOptions options, VisualBasicSyntaxFormattingOptions value)
         => options with { CleanupOptions = options.CleanupOptions with { FormattingOptions = value } };
 

--- a/src/Features/CSharp/Portable/Wrapping/CSharpSyntaxWrappingOptions.cs
+++ b/src/Features/CSharp/Portable/Wrapping/CSharpSyntaxWrappingOptions.cs
@@ -12,9 +12,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping;
 
 internal sealed class CSharpSyntaxWrappingOptions(
     CSharpSyntaxFormattingOptions formattingOptions,
-    int wrappingColumn,
     OperatorPlacementWhenWrappingPreference operatorPlacement,
-    bool newLinesForBracesInObjectCollectionArrayInitializers) : SyntaxWrappingOptions(formattingOptions, wrappingColumn, operatorPlacement)
+    bool newLinesForBracesInObjectCollectionArrayInitializers) : SyntaxWrappingOptions(formattingOptions, operatorPlacement)
 {
     public readonly bool NewLinesForBracesInObjectCollectionArrayInitializers = newLinesForBracesInObjectCollectionArrayInitializers;
 }
@@ -28,7 +27,6 @@ internal static class CSharpSyntaxWrappingOptionsProviders
         return new(
             new CSharpSyntaxFormattingOptions(options, (CSharpSyntaxFormattingOptions)fallbackOptions.CleanupOptions.FormattingOptions),
             operatorPlacement: options.GetOption(CodeStyleOptions2.OperatorPlacementWhenWrapping, fallbackOptions.CodeStyleOptions.OperatorPlacementWhenWrapping),
-            wrappingColumn: fallbackOptions.WrappingColumn,
             newLinesForBracesInObjectCollectionArrayInitializers: options.GetOption(CSharpFormattingOptions2.NewLineBeforeOpenBrace, newLineBeforeOpenBraceDefault).HasFlag(NewLineBeforeOpenBracePlacement.ObjectCollectionArrayInitializers));
     }
 }

--- a/src/Features/CSharpTest/Wrapping/AbstractWrappingTests.cs
+++ b/src/Features/CSharpTest/Wrapping/AbstractWrappingTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Wrapping;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping;
@@ -23,7 +24,7 @@ public abstract class AbstractWrappingTests : AbstractCSharpCodeActionTest_NoEdi
         => FlattenActions(actions);
 
     private protected TestParameters GetIndentionColumn(int column)
-        => new(globalOptions: Option(CodeActionOptionsStorage.WrappingColumn, column));
+        => new(options: Option(FormattingOptions2.WrappingColumn, column));
 
     protected Task TestAllWrappingCasesAsync(
         string input,

--- a/src/Features/Core/Portable/Wrapping/SyntaxWrappingOptions.cs
+++ b/src/Features/Core/Portable/Wrapping/SyntaxWrappingOptions.cs
@@ -10,20 +10,18 @@ namespace Microsoft.CodeAnalysis.Wrapping;
 internal abstract class SyntaxWrappingOptions
 {
     public readonly SyntaxFormattingOptions FormattingOptions;
-    public readonly int WrappingColumn;
     public readonly OperatorPlacementWhenWrappingPreference OperatorPlacement;
 
     protected SyntaxWrappingOptions(
         SyntaxFormattingOptions formattingOptions,
-        int wrappingColumn,
         OperatorPlacementWhenWrappingPreference operatorPlacement)
     {
         FormattingOptions = formattingOptions;
-        WrappingColumn = wrappingColumn;
         OperatorPlacement = operatorPlacement;
     }
 
     public bool UseTabs => FormattingOptions.UseTabs;
     public int TabSize => FormattingOptions.TabSize;
     public string NewLine => FormattingOptions.NewLine;
+    public int WrappingColumn => FormattingOptions.WrappingColumn;
 }

--- a/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
@@ -55,7 +55,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             /// editorconfig options.
             /// </summary>
             internal readonly OptionsCollectionAlias options;
-            internal readonly OptionsCollectionAlias globalOptions;
             internal readonly TestHost testHost;
             internal readonly string workspaceKind;
             internal readonly object fixProviderData;
@@ -195,10 +194,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 MakeProjectsAndDocumentsRooted(workspace);
                 AddAnalyzerConfigDocumentWithOptions(workspace, parameters.options);
             }
-
-#if !CODE_STYLE
-            parameters.globalOptions?.SetGlobalOptions(workspace.GlobalOptions);
-#endif
             return workspace;
         }
 

--- a/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
@@ -55,6 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             /// editorconfig options.
             /// </summary>
             internal readonly OptionsCollectionAlias options;
+            internal readonly OptionsCollectionAlias globalOptions;
             internal readonly TestHost testHost;
             internal readonly string workspaceKind;
             internal readonly object fixProviderData;

--- a/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
@@ -195,6 +195,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 MakeProjectsAndDocumentsRooted(workspace);
                 AddAnalyzerConfigDocumentWithOptions(workspace, parameters.options);
             }
+
+#if !CODE_STYLE
+            parameters.globalOptions?.SetGlobalOptions(workspace.GlobalOptions);
+#endif
             return workspace;
         }
 

--- a/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionTest_NoEditor.cs
@@ -106,10 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             using var _ = ArrayBuilder<(CodeAction, TextSpan?)>.GetInstance(out var actions);
 
-            var codeActionOptionsProvider = parameters.globalOptions?.IsEmpty() == false
-                ? CodeActionOptionsStorage.GetCodeActionOptionsProvider(workspace.GlobalOptions)
-                : CodeActionOptions.DefaultProvider;
-
+            var codeActionOptionsProvider = CodeActionOptions.DefaultProvider;
             var context = new CodeRefactoringContext(document, selectedOrAnnotatedSpan, (a, t) => actions.Add((a, t)), codeActionOptionsProvider, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);
             var result = actions.Count > 0 ? new CodeRefactoring(provider, actions.ToImmutable(), FixAllProviderInfo.Create(provider), codeActionOptionsProvider) : null;

--- a/src/Features/VisualBasic/Portable/Wrapping/VisualBasicSyntaxWrappingOptions.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/VisualBasicSyntaxWrappingOptions.vb
@@ -16,17 +16,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping
 
         Public Sub New(
             formattingOptions As VisualBasicSyntaxFormattingOptions,
-            wrappingColumn As Integer,
             operatorPlacement As OperatorPlacementWhenWrappingPreference)
 
-            MyBase.New(formattingOptions, wrappingColumn, operatorPlacement)
+            MyBase.New(formattingOptions, operatorPlacement)
         End Sub
 
         Public Shared Function Create(options As IOptionsReader, fallbackOptions As CodeActionOptions) As VisualBasicSyntaxWrappingOptions
             Return New VisualBasicSyntaxWrappingOptions(
                 formattingOptions:=New VisualBasicSyntaxFormattingOptions(options, DirectCast(fallbackOptions.CleanupOptions.FormattingOptions, VisualBasicSyntaxFormattingOptions)),
-                operatorPlacement:=options.GetOption(CodeStyleOptions2.OperatorPlacementWhenWrapping, fallbackOptions.CodeStyleOptions.OperatorPlacementWhenWrapping),
-                wrappingColumn:=fallbackOptions.WrappingColumn)
+                operatorPlacement:=options.GetOption(CodeStyleOptions2.OperatorPlacementWhenWrapping, fallbackOptions.CodeStyleOptions.OperatorPlacementWhenWrapping))
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasicTest/Wrapping/AbstractParameterWrappingTests.vb
+++ b/src/Features/VisualBasicTest/Wrapping/AbstractParameterWrappingTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.VisualBasic.Wrapping
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Wrapping
@@ -22,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Wrapping
         End Function
 
         Private Protected Function GetIndentionColumn(column As Integer) As TestParameters
-            Return New TestParameters(globalOptions:=[Option](CodeActionOptionsStorage.WrappingColumn, column))
+            Return New TestParameters(options:=[Option](FormattingOptions2.WrappingColumn, column))
         End Function
 
         Protected Function TestAllWrappingCasesAsync(

--- a/src/LanguageServer/Protocol/Features/Options/CodeActionOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/Features/Options/CodeActionOptionsStorage.cs
@@ -17,9 +17,6 @@ namespace Microsoft.CodeAnalysis.CodeActions
 {
     internal static class CodeActionOptionsStorage
     {
-        public static readonly PerLanguageOption2<int> WrappingColumn =
-            new("FormattingOptions_WrappingColumn", CodeActionOptions.DefaultWrappingColumn);
-
         public static CodeActionOptions GetCodeActionOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
             => new()
             {
@@ -30,9 +27,6 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 ImplementTypeOptions = globalOptions.GetImplementTypeOptions(languageServices.Language),
                 ExtractMethodOptions = globalOptions.GetExtractMethodOptions(languageServices.Language),
                 HideAdvancedMembers = globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, languageServices.Language),
-                WrappingColumn = globalOptions.GetOption(WrappingColumn, languageServices.Language),
-                ConditionalExpressionWrappingLength = globalOptions.GetOption(ConditionalExpressionWrappingLength, languageServices.Language),
-                CollectionExpressionWrappingLength = globalOptions.GetOption(CollectionExpressionWrappingLength, languageServices.Language),
             };
 
         internal static CodeActionOptionsProvider GetCodeActionOptionsProvider(this IGlobalOptionService globalOptions)
@@ -40,11 +34,5 @@ namespace Microsoft.CodeAnalysis.CodeActions
             var cache = ImmutableDictionary<string, CodeActionOptions>.Empty;
             return new DelegatingCodeActionOptionsProvider(languageService => ImmutableInterlocked.GetOrAdd(ref cache, languageService.Language, (_, options) => GetCodeActionOptions(options, languageService), globalOptions));
         }
-
-        public static readonly PerLanguageOption2<int> ConditionalExpressionWrappingLength = new(
-            "dotnet_conditional_expression_wrapping_length", CodeActionOptions.DefaultConditionalExpressionWrappingLength);
-
-        public static readonly PerLanguageOption2<int> CollectionExpressionWrappingLength = new(
-            "dotnet_collection_expression_wrapping_length", CodeActionOptions.DefaultCollectionExpressionWrappingLength);
     }
 }

--- a/src/VisualStudio/CSharp/Test/EditorConfigSettings/DataProvider/DataProviderTests.cs
+++ b/src/VisualStudio/CSharp/Test/EditorConfigSettings/DataProvider/DataProviderTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Da
 
             // We need to substract for string options that are not yet supported.
             // https://github.com/dotnet/roslyn/issues/62937
-            var optionsWithUI = CodeStyleOptions2.AllOptions
+            var optionsWithUI = CodeStyleOptions2.EditorConfigOptions
                 .Remove(CodeStyleOptions2.OperatorPlacementWhenWrapping)
                 .Remove(CodeStyleOptions2.FileHeaderTemplate)
                 .Remove(CodeStyleOptions2.RemoveUnnecessarySuppressionExclusions)
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Da
             var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
 
             // We don't support PreferredModifierOrder yet:
-            var optionsWithUI = CSharpCodeStyleOptions.AllOptions
+            var optionsWithUI = CSharpCodeStyleOptions.EditorConfigOptions
                 .Remove(CSharpCodeStyleOptions.PreferredModifierOrder);
 
             AssertEx.SetEqual(optionsWithUI, dataSnapShot.Select(setting => setting.Key.Option));

--- a/src/VisualStudio/CSharp/Test/EditorConfigSettings/DataProvider/DataProviderTests.cs
+++ b/src/VisualStudio/CSharp/Test/EditorConfigSettings/DataProvider/DataProviderTests.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Da
 
             // multiple settings may share the same option (e.g. settings representing flags of an enum):
             var optionsForSettings = dataSnapshot.GroupBy(s => s.Key.Option).Select(g => g.Key).ToArray();
-            AssertEx.SetEqual(CSharpFormattingOptions2.AllOptions, optionsForSettings);
+            AssertEx.SetEqual(CSharpFormattingOptions2.EditorConfigOptions, optionsForSettings);
         }
 
         [Fact]

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -413,7 +413,7 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_compute_task_list_items_for_closed_files", new RoamingProfileStorage("TextEditor.Specific.ComputeTaskListItemsForClosedFiles")},
         {"dotnet_task_list_storage_descriptors", new RoamingProfileStorage("Microsoft.VisualStudio.ErrorListPkg.Shims.TaskListOptions.CommentTokens")},
         {"dotnet_unsupported_conditional_expression_wrapping_length", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ConditionalExpressionWrappingLength")},
-        {"csharp_unsupported_collection_expression_wrapping_length", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.CollectionExpressionWrappingLength")},
+        {"csharp_unsupported_collection_expression_wrapping_length", new RoamingProfileStorage("TextEditor.CSharp.Specific.CollectionExpressionWrappingLength")},
         {"dotnet_report_invalid_placeholders_in_string_dot_format_calls", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.WarnOnInvalidStringDotFormatCalls")},
         {"visual_basic_preferred_modifier_order", new RoamingProfileStorage("TextEditor.VisualBasic.Specific.PreferredModifierOrder")},
         {"visual_basic_style_prefer_isnot_expression", new RoamingProfileStorage("TextEditor.VisualBasic.Specific.PreferIsNotExpression")},

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -412,8 +412,8 @@ internal abstract class VisualStudioOptionStorage
 #pragma warning restore
         {"dotnet_compute_task_list_items_for_closed_files", new RoamingProfileStorage("TextEditor.Specific.ComputeTaskListItemsForClosedFiles")},
         {"dotnet_task_list_storage_descriptors", new RoamingProfileStorage("Microsoft.VisualStudio.ErrorListPkg.Shims.TaskListOptions.CommentTokens")},
-        {"dotnet_conditional_expression_wrapping_length", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ConditionalExpressionWrappingLength")},
-        {"dotnet_collection_expression_wrapping_length", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.CollectionExpressionWrappingLength")},
+        {"dotnet_unsupported_conditional_expression_wrapping_length", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ConditionalExpressionWrappingLength")},
+        {"csharp_unsupported_collection_expression_wrapping_length", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.CollectionExpressionWrappingLength")},
         {"dotnet_report_invalid_placeholders_in_string_dot_format_calls", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.WarnOnInvalidStringDotFormatCalls")},
         {"visual_basic_preferred_modifier_order", new RoamingProfileStorage("TextEditor.VisualBasic.Specific.PreferredModifierOrder")},
         {"visual_basic_style_prefer_isnot_expression", new RoamingProfileStorage("TextEditor.VisualBasic.Specific.PreferIsNotExpression")},

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -25,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         internal AbstractOptionPreviewViewModel ViewModel;
         private readonly IServiceProvider _serviceProvider;
         private readonly Func<OptionStore, IServiceProvider, AbstractOptionPreviewViewModel> _createViewModel;
-        private readonly ImmutableArray<(string feature, ImmutableArray<IOption2> options)> _groupedEditorConfigOptions;
+        private readonly IEnumerable<(string feature, ImmutableArray<IOption2> options)> _groupedEditorConfigOptions;
         private readonly string _language;
 
         public static readonly Uri CodeStylePageHeaderLearnMoreUri = new Uri(UseEditorConfigUrl);
@@ -41,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             OptionStore optionStore,
             Func<OptionStore, IServiceProvider,
             AbstractOptionPreviewViewModel> createViewModel,
-            ImmutableArray<(string feature, ImmutableArray<IOption2> options)> groupedEditorConfigOptions,
+            IEnumerable<(string feature, ImmutableArray<IOption2> options)> groupedEditorConfigOptions,
             string language)
             : base(optionStore)
         {

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -235,9 +235,7 @@ public class VisualStudioOptionStorageTests
             "FeatureOnOffOptions_RefactoringVerification",                                  // TODO: remove? https://github.com/dotnet/roslyn/issues/66063 
             "FeatureOnOffOptions_RenameTracking",                                           // TODO: remove? https://github.com/dotnet/roslyn/issues/66063
             "file_header_template",                                                         // repository specific
-            "dotnet_internal_wrapping_column",                                              // TODO: https://github.com/dotnet/roslyn/issues/66062
-            "dotnet_internal_conditional_expression_wrapping_length",                       // TODO: https://github.com/dotnet/roslyn/issues/66062
-            "csharp_internal_collection_expression_wrapping_length",                        // TODO: https://github.com/dotnet/roslyn/issues/66062
+            "dotnet_unsupported_wrapping_column",                                           // TODO: https://github.com/dotnet/roslyn/issues/66062
             "insert_final_newline",                                                         // TODO: https://github.com/dotnet/roslyn/issues/66062
             "RazorDesignTimeDocumentFormattingOptions_TabSize",                             // TODO: remove once Razor removes design-time documents
             "RazorDesignTimeDocumentFormattingOptions_UseTabs",                             // TODO: remove once Razor removes design-time documents

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -235,7 +235,9 @@ public class VisualStudioOptionStorageTests
             "FeatureOnOffOptions_RefactoringVerification",                                  // TODO: remove? https://github.com/dotnet/roslyn/issues/66063 
             "FeatureOnOffOptions_RenameTracking",                                           // TODO: remove? https://github.com/dotnet/roslyn/issues/66063
             "file_header_template",                                                         // repository specific
-            "FormattingOptions_WrappingColumn",                                             // TODO: https://github.com/dotnet/roslyn/issues/66062
+            "dotnet_internal_wrapping_column",                                              // TODO: https://github.com/dotnet/roslyn/issues/66062
+            "dotnet_internal_conditional_expression_wrapping_length",                       // TODO: https://github.com/dotnet/roslyn/issues/66062
+            "csharp_internal_collection_expression_wrapping_length",                        // TODO: https://github.com/dotnet/roslyn/issues/66062
             "insert_final_newline",                                                         // TODO: https://github.com/dotnet/roslyn/issues/66062
             "RazorDesignTimeDocumentFormattingOptions_TabSize",                             // TODO: remove once Razor removes design-time documents
             "RazorDesignTimeDocumentFormattingOptions_UseTabs",                             // TODO: remove once Razor removes design-time documents

--- a/src/Workspaces/CSharp/Portable/Options/CSharpEditorConfigOptionsEnumerator.cs
+++ b/src/Workspaces/CSharp/Portable/Options/CSharpEditorConfigOptionsEnumerator.cs
@@ -18,14 +18,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Options;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class CSharpEditorConfigOptionsEnumerator() : IEditorConfigOptionsEnumerator
 {
-    public IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions()
+    public IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(bool includeUndocumented)
     {
-        foreach (var entry in EditorConfigOptionsEnumerator.GetLanguageAgnosticEditorConfigOptions())
+        foreach (var entry in EditorConfigOptionsEnumerator.GetLanguageAgnosticEditorConfigOptions(includeUndocumented))
         {
             yield return entry;
         }
 
-        yield return (CSharpWorkspaceResources.CSharp_Coding_Conventions, CSharpCodeStyleOptions.AllOptions);
-        yield return (CSharpWorkspaceResources.CSharp_Formatting_Rules, CSharpFormattingOptions2.AllOptions);
+        yield return (CSharpWorkspaceResources.CSharp_Coding_Conventions, CSharpCodeStyleOptions.EditorConfigOptions);
+        yield return (CSharpWorkspaceResources.CSharp_Formatting_Rules, CSharpFormattingOptions2.EditorConfigOptions);
+
+        if (includeUndocumented)
+        {
+            yield return (CSharpWorkspaceResources.CSharp_Formatting_Rules, CSharpFormattingOptions2.UndocumentedOptions);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Options/CSharpEditorConfigOptionsEnumerator.cs
+++ b/src/Workspaces/CSharp/Portable/Options/CSharpEditorConfigOptionsEnumerator.cs
@@ -18,9 +18,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Options;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class CSharpEditorConfigOptionsEnumerator() : IEditorConfigOptionsEnumerator
 {
-    public IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(bool includeUndocumented)
+    public IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(bool includeUnsupported)
     {
-        foreach (var entry in EditorConfigOptionsEnumerator.GetLanguageAgnosticEditorConfigOptions(includeUndocumented))
+        foreach (var entry in EditorConfigOptionsEnumerator.GetLanguageAgnosticEditorConfigOptions(includeUnsupported))
         {
             yield return entry;
         }
@@ -28,7 +28,7 @@ internal sealed class CSharpEditorConfigOptionsEnumerator() : IEditorConfigOptio
         yield return (CSharpWorkspaceResources.CSharp_Coding_Conventions, CSharpCodeStyleOptions.EditorConfigOptions);
         yield return (CSharpWorkspaceResources.CSharp_Formatting_Rules, CSharpFormattingOptions2.EditorConfigOptions);
 
-        if (includeUndocumented)
+        if (includeUnsupported)
         {
             yield return (CSharpWorkspaceResources.CSharp_Formatting_Rules, CSharpFormattingOptions2.UndocumentedOptions);
         }

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
@@ -9,6 +9,10 @@ using System.Xml.Linq;
 
 namespace Microsoft.CodeAnalysis.CodeStyle;
 
+/// <summary>
+/// Public representation of a code style option value. Should only be used for public API.
+/// Internally the value is represented by <see cref="ICodeStyleOption2"/>.
+/// </summary>
 internal interface ICodeStyleOption
 {
     XElement ToXElement();

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Options;
 internal static partial class EditorConfigFileGenerator
 {
     public static string Generate(
-        ImmutableArray<(string feature, ImmutableArray<IOption2> options)> groupedOptions,
+        IEnumerable<(string feature, ImmutableArray<IOption2> options)> groupedOptions,
         IOptionsReader configOptions,
         string language)
     {

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigOptionsEnumerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigOptionsEnumerator.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
@@ -20,24 +21,20 @@ namespace Microsoft.CodeAnalysis.Options;
 internal sealed class EditorConfigOptionsEnumerator(
     [ImportMany] IEnumerable<Lazy<IEditorConfigOptionsEnumerator, LanguageMetadata>> optionEnumerators)
 {
-    public ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetOptions(string language)
-    {
-        var builder = ArrayBuilder<(string, ImmutableArray<IOption2>)>.GetInstance();
+    public IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(string language, bool includeUndocumented = false)
+        => optionEnumerators
+            .Where(e => e.Metadata.Language == language)
+            .SelectMany(e => e.Value.GetOptions(includeUndocumented));
 
-        foreach (var generator in optionEnumerators)
+    internal static IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetLanguageAgnosticEditorConfigOptions(bool includeUndocumented)
+    {
+        yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.EditorConfigOptions);
+
+        if (includeUndocumented)
         {
-            if (generator.Metadata.Language == language)
-            {
-                builder.AddRange(generator.Value.GetOptions());
-            }
+            yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.UndocumentedOptions);
         }
 
-        return builder.ToImmutableAndFree();
-    }
-
-    internal static IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetLanguageAgnosticEditorConfigOptions()
-    {
-        yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.Options);
-        yield return (WorkspacesResources.dot_NET_Coding_Conventions, GenerationOptions.AllOptions.AddRange(CodeStyleOptions2.AllOptions));
+        yield return (WorkspacesResources.dot_NET_Coding_Conventions, GenerationOptions.EditorConfigOptions.AddRange(CodeStyleOptions2.EditorConfigOptions));
     }
 }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigOptionsEnumerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigOptionsEnumerator.cs
@@ -21,16 +21,16 @@ namespace Microsoft.CodeAnalysis.Options;
 internal sealed class EditorConfigOptionsEnumerator(
     [ImportMany] IEnumerable<Lazy<IEditorConfigOptionsEnumerator, LanguageMetadata>> optionEnumerators)
 {
-    public IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(string language, bool includeUndocumented = false)
+    public IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(string language, bool includeUnsupported = false)
         => optionEnumerators
             .Where(e => e.Metadata.Language == language)
-            .SelectMany(e => e.Value.GetOptions(includeUndocumented));
+            .SelectMany(e => e.Value.GetOptions(includeUnsupported));
 
-    internal static IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetLanguageAgnosticEditorConfigOptions(bool includeUndocumented)
+    internal static IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetLanguageAgnosticEditorConfigOptions(bool includeUnsupported)
     {
         yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.EditorConfigOptions);
 
-        if (includeUndocumented)
+        if (includeUnsupported)
         {
             yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.UndocumentedOptions);
         }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/IEditorConfigOptionsEnumerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/IEditorConfigOptionsEnumerator.cs
@@ -12,5 +12,6 @@ internal interface IEditorConfigOptionsEnumerator
     /// <summary>
     /// Returns all editorconfig options defined by the implementing language, grouped by feature.
     /// </summary>
-    public abstract IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions();
+    /// <param name="includeUndocumented">True to include undocumented options that the user can set in editorconfig file but we provide no support for them.</param>
+    public abstract IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(bool includeUndocumented);
 }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/IEditorConfigOptionsEnumerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/IEditorConfigOptionsEnumerator.cs
@@ -12,6 +12,6 @@ internal interface IEditorConfigOptionsEnumerator
     /// <summary>
     /// Returns all editorconfig options defined by the implementing language, grouped by feature.
     /// </summary>
-    /// <param name="includeUndocumented">True to include undocumented options that the user can set in editorconfig file but we provide no support for them.</param>
-    public abstract IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(bool includeUndocumented);
+    /// <param name="includeUnsupported">True to include undocumented options that the user can set in editorconfig file but we provide no support for them.</param>
+    public abstract IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetOptions(bool includeUnsupported);
 }

--- a/src/Workspaces/CoreTest/Options/OptionKeyTests.cs
+++ b/src/Workspaces/CoreTest/Options/OptionKeyTests.cs
@@ -178,9 +178,12 @@ namespace Microsoft.CodeAnalysis.UnitTests.Options
         public void IsEditorConfigOption()
         {
             Assert.All(FormattingOptions2.EditorConfigOptions, o => Assert.True(o.Definition.IsEditorConfigOption));
+            Assert.All(FormattingOptions2.UndocumentedOptions, o => Assert.True(o.Definition.IsEditorConfigOption));
+
             Assert.False(FormattingOptions2.SmartIndent.Definition.IsEditorConfigOption);
 
-            Assert.All(CSharpFormattingOptions2.AllOptions, o => Assert.True(o.Definition.IsEditorConfigOption));
+            Assert.All(CSharpFormattingOptions2.EditorConfigOptions, o => Assert.True(o.Definition.IsEditorConfigOption));
+            Assert.All(CSharpFormattingOptions2.UndocumentedOptions, o => Assert.True(o.Definition.IsEditorConfigOption));
 
             Assert.True(NamingStyleOptions.NamingPreferences.Definition.IsEditorConfigOption);
             Assert.True(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess.Definition.IsEditorConfigOption);

--- a/src/Workspaces/CoreTest/Options/OptionKeyTests.cs
+++ b/src/Workspaces/CoreTest/Options/OptionKeyTests.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Options
         [Fact]
         public void IsEditorConfigOption()
         {
-            Assert.All(FormattingOptions2.Options, o => Assert.True(o.Definition.IsEditorConfigOption));
+            Assert.All(FormattingOptions2.EditorConfigOptions, o => Assert.True(o.Definition.IsEditorConfigOption));
             Assert.False(FormattingOptions2.SmartIndent.Definition.IsEditorConfigOption);
 
             Assert.All(CSharpFormattingOptions2.AllOptions, o => Assert.True(o.Definition.IsEditorConfigOption));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpCodeStyleOptions.cs
@@ -14,14 +14,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle;
 
 internal static partial class CSharpCodeStyleOptions
 {
-    private static readonly ImmutableArray<IOption2>.Builder s_allOptionsBuilder = ImmutableArray.CreateBuilder<IOption2>();
+    private static readonly ImmutableArray<IOption2>.Builder s_editorConfigOptionsBuilder = ImmutableArray.CreateBuilder<IOption2>();
 
     private static Option2<CodeStyleOption2<T>> CreateOption<T>(
         OptionGroup group,
         string name,
         CodeStyleOption2<T> defaultValue,
         Func<CodeStyleOption2<T>, EditorConfigValueSerializer<CodeStyleOption2<T>>>? serializerFactory = null)
-        => s_allOptionsBuilder.CreateEditorConfigOption(name, defaultValue, group, LanguageNames.CSharp, serializerFactory);
+        => s_editorConfigOptionsBuilder.CreateEditorConfigOption(name, defaultValue, group, LanguageNames.CSharp, serializerFactory);
 
     public static readonly Option2<CodeStyleOption2<bool>> VarForBuiltInTypes = CreateOption(
         CSharpCodeStyleOptionGroups.VarPreferences, "csharp_style_var_for_built_in_types",
@@ -261,7 +261,10 @@ internal static partial class CSharpCodeStyleOptions
         "csharp_style_prefer_primary_constructors",
         CSharpIdeCodeStyleOptions.Default.PreferPrimaryConstructors);
 
-    internal static readonly ImmutableArray<IOption2> AllOptions = s_allOptionsBuilder.ToImmutable();
+    /// <summary>
+    /// Options that we expect the user to set in editorconfig.
+    /// </summary>
+    internal static readonly ImmutableArray<IOption2> EditorConfigOptions = s_editorConfigOptionsBuilder.ToImmutable();
 }
 
 internal static class CSharpCodeStyleOptionGroups

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpFormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpFormattingOptions2.cs
@@ -276,8 +276,8 @@ internal static partial class CSharpFormattingOptions2
     /// Internal option -- not exposed to editorconfig tooling via <see cref="EditorConfigOptions"/>.
     /// </summary>
     public static readonly Option2<int> CollectionExpressionWrappingLength = new(
-        $"csharp_internal_collection_expression_wrapping_length",
-        defaultValue: 120,
+        $"csharp_unsupported_collection_expression_wrapping_length",
+        defaultValue: CSharpSyntaxFormattingOptions.Default.CollectionExpressionWrappingLength,
         languageName: LanguageNames.CSharp,
         isEditorConfigOption: true);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpFormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpFormattingOptions2.cs
@@ -19,7 +19,7 @@ internal static partial class CSharpFormattingOptions2
 {
     private const string PublicFeatureName = "CSharpFormattingOptions";
 
-    private static readonly ImmutableArray<IOption2>.Builder s_allOptionsBuilder = ImmutableArray.CreateBuilder<IOption2>();
+    private static readonly ImmutableArray<IOption2>.Builder s_editorConfigOptionsBuilder = ImmutableArray.CreateBuilder<IOption2>();
 
     // Maps to store mapping between special option kinds and the corresponding editor config string representations.
     #region Editor Config maps
@@ -65,12 +65,10 @@ internal static partial class CSharpFormattingOptions2
         ]);
     #endregion
 
-    internal static ImmutableArray<IOption2> AllOptions { get; }
-
     private static Option2<T> CreateOption<T>(OptionGroup group, string name, T defaultValue, EditorConfigValueSerializer<T>? serializer = null)
     {
         var option = new Option2<T>(name, defaultValue, group, LanguageNames.CSharp, isEditorConfigOption: true, serializer: serializer);
-        s_allOptionsBuilder.Add(option);
+        s_editorConfigOptionsBuilder.Add(option);
         return option;
     }
 
@@ -274,13 +272,24 @@ internal static partial class CSharpFormattingOptions2
         CSharpSyntaxFormattingOptions.NewLinesDefault.HasFlag(NewLinePlacement.BetweenQueryExpressionClauses))
         .WithPublicOption(PublicFeatureName, "NewLineForClausesInQuery");
 
-    static CSharpFormattingOptions2()
-    {
-        // Note that the static constructor executes after all the static field initializers for the options have executed,
-        // and each field initializer adds the created option to the following builders.
+    /// <summary>
+    /// Internal option -- not exposed to editorconfig tooling via <see cref="EditorConfigOptions"/>.
+    /// </summary>
+    public static readonly Option2<int> CollectionExpressionWrappingLength = new(
+        $"csharp_internal_collection_expression_wrapping_length",
+        defaultValue: 120,
+        languageName: LanguageNames.CSharp,
+        isEditorConfigOption: true);
 
-        AllOptions = s_allOptionsBuilder.ToImmutable();
-    }
+    /// <summary>
+    /// Options that we expect the user to set in editorconfig.
+    /// </summary>
+    internal static readonly ImmutableArray<IOption2> EditorConfigOptions = s_editorConfigOptionsBuilder.ToImmutable();
+
+    /// <summary>
+    /// Options that can be set via editorconfig but we do not provide tooling support.
+    /// </summary>
+    internal static readonly ImmutableArray<IOption2> UndocumentedOptions = [CollectionExpressionWrappingLength];
 }
 
 #if CODE_STYLE

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormattingOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormattingOptions.cs
@@ -61,6 +61,7 @@ internal sealed record class CSharpSyntaxFormattingOptions : SyntaxFormattingOpt
     [DataMember] public bool WrappingPreserveSingleLine { get; init; } = true;
     [DataMember] public CodeStyleOption2<NamespaceDeclarationPreference> NamespaceDeclarations { get; init; } = s_defaultNamespaceDeclarations;
     [DataMember] public CodeStyleOption2<bool> PreferTopLevelStatements { get; init; } = s_trueWithSilentEnforcement;
+    [DataMember] public int CollectionExpressionWrappingLength { get; init; } = 120;
 
     public CSharpSyntaxFormattingOptions()
     {
@@ -111,5 +112,6 @@ internal sealed record class CSharpSyntaxFormattingOptions : SyntaxFormattingOpt
         WrappingPreserveSingleLine = options.GetOption(CSharpFormattingOptions2.WrappingPreserveSingleLine, fallbackOptions.WrappingPreserveSingleLine);
         NamespaceDeclarations = options.GetOption(CSharpCodeStyleOptions.NamespaceDeclarations, fallbackOptions.NamespaceDeclarations);
         PreferTopLevelStatements = options.GetOption(CSharpCodeStyleOptions.PreferTopLevelStatements, fallbackOptions.PreferTopLevelStatements);
+        CollectionExpressionWrappingLength = options.GetOption(CSharpFormattingOptions2.CollectionExpressionWrappingLength, fallbackOptions.CollectionExpressionWrappingLength);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOption2`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOption2`1.cs
@@ -10,6 +10,10 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CodeStyle;
 
+/// <summary>
+/// Internal representation of a code style option value. Should be used throughout Roslyn.
+/// The internal values are translated to the public ones (ICodeStyleOption) at the public entry points.
+/// </summary>
 internal interface ICodeStyleOption2
 {
     XElement ToXElement();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOptions2.cs
@@ -18,19 +18,19 @@ internal static class CodeStyleOptions2
 {
     private const string PublicFeatureName = "CodeStyleOptions";
 
-    private static readonly ImmutableArray<IOption2>.Builder s_allOptionsBuilder = ImmutableArray.CreateBuilder<IOption2>();
+    private static readonly ImmutableArray<IOption2>.Builder s_editorConfigOptionsBuilder = ImmutableArray.CreateBuilder<IOption2>();
 
     private static PerLanguageOption2<CodeStyleOption2<T>> CreatePerLanguageOption<T>(
         OptionGroup group, string name, CodeStyleOption2<T> defaultValue, Func<CodeStyleOption2<T>, EditorConfigValueSerializer<CodeStyleOption2<T>>>? serializerFactory = null)
-        => s_allOptionsBuilder.CreatePerLanguageEditorConfigOption(name, defaultValue, group, serializerFactory);
+        => s_editorConfigOptionsBuilder.CreatePerLanguageEditorConfigOption(name, defaultValue, group, serializerFactory);
 
     private static Option2<CodeStyleOption2<T>> CreateOption<T>(
         OptionGroup group, string name, CodeStyleOption2<T> defaultValue, Func<CodeStyleOption2<T>, EditorConfigValueSerializer<CodeStyleOption2<T>>>? serializerFactory = null)
-        => s_allOptionsBuilder.CreateEditorConfigOption(name, defaultValue, group, languageName: null, serializerFactory);
+        => s_editorConfigOptionsBuilder.CreateEditorConfigOption(name, defaultValue, group, languageName: null, serializerFactory);
 
     private static Option2<T> CreateOption<T>(
         OptionGroup group, string name, T defaultValue, EditorConfigValueSerializer<T>? serializer = null)
-        => s_allOptionsBuilder.CreateEditorConfigOption(name, defaultValue, group, serializer);
+        => s_editorConfigOptionsBuilder.CreateEditorConfigOption(name, defaultValue, group, serializer);
 
     private static PerLanguageOption2<CodeStyleOption2<bool>> CreateQualifyAccessOption(string name)
         => CreatePerLanguageOption(CodeStyleOptionGroups.ThisOrMe, name, defaultValue: SimplifierOptions.DefaultQualifyAccess);
@@ -342,7 +342,10 @@ internal static class CodeStyleOptions2
         "dotnet_style_allow_statement_immediately_after_block_experimental",
         IdeCodeStyleOptions.CommonDefaults.AllowStatementImmediatelyAfterBlock);
 
-    internal static readonly ImmutableArray<IOption2> AllOptions = s_allOptionsBuilder.ToImmutable();
+    /// <summary>
+    /// Options that we expect the user to set in editorconfig.
+    /// </summary>
+    internal static readonly ImmutableArray<IOption2> EditorConfigOptions = s_editorConfigOptionsBuilder.ToImmutable();
 }
 
 internal static class CodeStyleOptionGroups

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/VisualBasic/VisualBasicCodeStyleOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/VisualBasic/VisualBasicCodeStyleOptions.cs
@@ -51,5 +51,5 @@ internal sealed class VisualBasicCodeStyleOptions
         VisualBasicIdeCodeStyleOptions.Default.UnusedValueAssignment,
         CodeStyleHelpers.GetUnusedValuePreferenceSerializer);
 
-    public static ImmutableArray<IOption2> AllOptions => s_allOptionsBuilder.ToImmutable();
+    public static ImmutableArray<IOption2> EditorConfigOptions => s_allOptionsBuilder.ToImmutable();
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Editing/GenerationOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Editing/GenerationOptions.cs
@@ -24,5 +24,8 @@ internal class GenerationOptions
         group: CodeStyleOptionGroups.Usings,
         isEditorConfigOption: true);
 
-    public static readonly ImmutableArray<IOption2> AllOptions = [PlaceSystemNamespaceFirst, SeparateImportDirectiveGroups];
+    /// <summary>
+    /// Options that we expect the user to set in editorconfig.
+    /// </summary>
+    public static readonly ImmutableArray<IOption2> EditorConfigOptions = [PlaceSystemNamespaceFirst, SeparateImportDirectiveGroups];
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -65,8 +65,41 @@ internal sealed partial class FormattingOptions2
         group: FormattingOptionGroups.IndentationAndSpacing)
         .WithPublicOption(PublicFeatureName, "SmartIndent", static value => (PublicIndentStyle)value, static value => (IndentStyle)value);
 
+    /// <summary>
+    /// Default value of 120 was picked based on the amount of code in a github.com diff at 1080p.
+    /// That resolution is the most common value as per the last DevDiv survey as well as the latest
+    /// Steam hardware survey.  This also seems to a reasonable length default in that shorter
+    /// lengths can often feel too cramped for .NET languages, which are often starting with a
+    /// default indentation of at least 16 (for namespace, class, member, plus the final construct
+    /// indentation).
+    /// 
+    /// TODO: Currently the option has no storage and always has its default value. See https://github.com/dotnet/roslyn/pull/30422#issuecomment-436118696.
+    /// 
+    /// Internal option -- not exposed to tooling via <see cref="EditorConfigOptions"/>.
+    /// </summary>
+    public static readonly PerLanguageOption2<int> WrappingColumn = new(
+        $"dotnet_internal_wrapping_column",
+        defaultValue: 120,
+        isEditorConfigOption: true);
+
+    /// <summary>
+    /// Internal option -- not exposed to editorconfig tooling via <see cref="EditorConfigOptions"/>.
+    /// </summary>
+    public static readonly Option2<int> ConditionalExpressionWrappingLength = new(
+        $"dotnet_internal_conditional_expression_wrapping_length",
+        defaultValue: 120,
+        isEditorConfigOption: true);
+
 #if !CODE_STYLE
-    internal static readonly ImmutableArray<IOption2> Options = [UseTabs, TabSize, IndentationSize, NewLine, InsertFinalNewLine];
+    /// <summary>
+    /// Options that we expect the user to set in editorconfig.
+    /// </summary>
+    internal static readonly ImmutableArray<IOption2> EditorConfigOptions = [UseTabs, TabSize, IndentationSize, NewLine, InsertFinalNewLine];
+
+    /// <summary>
+    /// Options that can be set via editorconfig but we do not provide tooling support.
+    /// </summary>
+    internal static readonly ImmutableArray<IOption2> UndocumentedOptions = [WrappingColumn, ConditionalExpressionWrappingLength];
 #endif
 }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -75,19 +75,19 @@ internal sealed partial class FormattingOptions2
     /// 
     /// TODO: Currently the option has no storage and always has its default value. See https://github.com/dotnet/roslyn/pull/30422#issuecomment-436118696.
     /// 
-    /// Internal option -- not exposed to tooling via <see cref="EditorConfigOptions"/>.
+    /// Internal option -- not exposed to tooling.
     /// </summary>
     public static readonly PerLanguageOption2<int> WrappingColumn = new(
-        $"dotnet_internal_wrapping_column",
-        defaultValue: 120,
+        $"dotnet_unsupported_wrapping_column",
+        defaultValue: SyntaxFormattingOptions.CommonDefaults.WrappingColumn,
         isEditorConfigOption: true);
 
     /// <summary>
-    /// Internal option -- not exposed to editorconfig tooling via <see cref="EditorConfigOptions"/>.
+    /// Internal option -- not exposed to editorconfig tooling.
     /// </summary>
     public static readonly Option2<int> ConditionalExpressionWrappingLength = new(
-        $"dotnet_internal_conditional_expression_wrapping_length",
-        defaultValue: 120,
+        $"dotnet_unsupported_conditional_expression_wrapping_length",
+        defaultValue: SyntaxFormattingOptions.CommonDefaults.ConditionalExpressionWrappingLength,
         isEditorConfigOption: true);
 
 #if !CODE_STYLE

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -85,7 +85,7 @@ internal sealed partial class FormattingOptions2
     /// <summary>
     /// Internal option -- not exposed to editorconfig tooling.
     /// </summary>
-    public static readonly Option2<int> ConditionalExpressionWrappingLength = new(
+    public static readonly PerLanguageOption2<int> ConditionalExpressionWrappingLength = new(
         $"dotnet_unsupported_conditional_expression_wrapping_length",
         defaultValue: SyntaxFormattingOptions.CommonDefaults.ConditionalExpressionWrappingLength,
         isEditorConfigOption: true);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/SyntaxFormattingOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/SyntaxFormattingOptions.cs
@@ -39,7 +39,7 @@ internal record class SyntaxFormattingOptions
         SeparateImportDirectiveGroups = options.GetOption(GenerationOptions.SeparateImportDirectiveGroups, language, fallbackOptions.SeparateImportDirectiveGroups);
         AccessibilityModifiersRequired = options.GetOptionValue(CodeStyleOptions2.AccessibilityModifiersRequired, language, fallbackOptions.AccessibilityModifiersRequired);
         WrappingColumn = options.GetOption(FormattingOptions2.WrappingColumn, language, fallbackOptions.WrappingColumn);
-        ConditionalExpressionWrappingLength = options.GetOption(FormattingOptions2.ConditionalExpressionWrappingLength, fallbackOptions.ConditionalExpressionWrappingLength);
+        ConditionalExpressionWrappingLength = options.GetOption(FormattingOptions2.ConditionalExpressionWrappingLength, language, fallbackOptions.ConditionalExpressionWrappingLength);
     }
 
     public bool UseTabs => LineFormatting.UseTabs;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/SyntaxFormattingOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/SyntaxFormattingOptions.cs
@@ -26,6 +26,8 @@ internal record class SyntaxFormattingOptions
     [DataMember] public LineFormattingOptions LineFormatting { get; init; } = LineFormattingOptions.Default;
     [DataMember] public bool SeparateImportDirectiveGroups { get; init; } = false;
     [DataMember] public AccessibilityModifiersRequired AccessibilityModifiersRequired { get; init; } = AccessibilityModifiersRequired.ForNonInterfaceMembers;
+    [DataMember] public int WrappingColumn { get; init; } = 120;
+    [DataMember] public int ConditionalExpressionWrappingLength { get; init; } = 120;
 
     private protected SyntaxFormattingOptions()
     {
@@ -36,6 +38,8 @@ internal record class SyntaxFormattingOptions
         LineFormatting = options.GetLineFormattingOptions(language, fallbackOptions.LineFormatting);
         SeparateImportDirectiveGroups = options.GetOption(GenerationOptions.SeparateImportDirectiveGroups, language, fallbackOptions.SeparateImportDirectiveGroups);
         AccessibilityModifiersRequired = options.GetOptionValue(CodeStyleOptions2.AccessibilityModifiersRequired, language, fallbackOptions.AccessibilityModifiersRequired);
+        WrappingColumn = options.GetOption(FormattingOptions2.WrappingColumn, language, fallbackOptions.WrappingColumn);
+        ConditionalExpressionWrappingLength = options.GetOption(FormattingOptions2.ConditionalExpressionWrappingLength, fallbackOptions.ConditionalExpressionWrappingLength);
     }
 
     public bool UseTabs => LineFormatting.UseTabs;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/Option2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/Option2.cs
@@ -67,7 +67,7 @@ internal partial class Option2<T> : ISingleValuedOption<T>
             return;
         }
 
-        Debug.Assert(LanguageName is null == (Definition.ConfigName.StartsWith("dotnet_", StringComparison.Ordinal) ||
+        Debug.Assert(LanguageName is null == (Definition.ConfigName.StartsWith(OptionDefinition.LanguageAgnosticConfigNamePrefix, StringComparison.Ordinal) ||
             Definition.ConfigName is "file_header_template" or "insert_final_newline"));
         Debug.Assert(LanguageName is LanguageNames.CSharp == Definition.ConfigName.StartsWith(OptionDefinition.CSharpConfigNamePrefix, StringComparison.Ordinal));
         Debug.Assert(LanguageName is LanguageNames.VisualBasic == Definition.ConfigName.StartsWith(OptionDefinition.VisualBasicConfigNamePrefix, StringComparison.Ordinal));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/OptionDefinition.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/OptionDefinition.cs
@@ -12,9 +12,16 @@ namespace Microsoft.CodeAnalysis.Options;
 
 internal abstract class OptionDefinition : IEquatable<OptionDefinition?>
 {
-    // Editorconfig name prefixes used for C#/VB specific options:
+    // editorconfig name prefixes used for C#/VB specific options:
     public const string CSharpConfigNamePrefix = "csharp_";
     public const string VisualBasicConfigNamePrefix = "visual_basic_";
+
+    // editorconfig name prefix use for options that apply to both languages:
+    public const string LanguageAgnosticConfigNamePrefix = "dotnet_";
+
+    // editorconfig name prefix for feature options that are read from editorconfig 
+    // file but are currently not intended for users to be set in the editorconfig file.
+    public const string InternalConfigNamePrefix = "internal_";
 
     /// <summary>
     /// Optional group/sub-feature for this option.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CodeActionOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CodeActionOptions.cs
@@ -36,22 +36,6 @@ internal sealed record class CodeActionOptions
     public static readonly CodeActionOptionsProvider DefaultProvider = new DelegatingCodeActionOptionsProvider(static ls => GetDefault(ls));
 #endif
 
-    /// <summary>
-    /// Default value of 120 was picked based on the amount of code in a github.com diff at 1080p.
-    /// That resolution is the most common value as per the last DevDiv survey as well as the latest
-    /// Steam hardware survey.  This also seems to a reasonable length default in that shorter
-    /// lengths can often feel too cramped for .NET languages, which are often starting with a
-    /// default indentation of at least 16 (for namespace, class, member, plus the final construct
-    /// indentation).
-    /// 
-    /// TODO: Currently the option has no storage and always has its default value. See https://github.com/dotnet/roslyn/pull/30422#issuecomment-436118696.
-    /// </summary>
-    public const int DefaultWrappingColumn = 120;
-
-    public const int DefaultConditionalExpressionWrappingLength = 120;
-
-    public const int DefaultCollectionExpressionWrappingLength = 120;
-
 #if !CODE_STYLE
     [DataMember] public required CodeCleanupOptions CleanupOptions { get; init; }
     [DataMember] public required CodeGenerationOptions CodeGenerationOptions { get; init; }
@@ -60,9 +44,6 @@ internal sealed record class CodeActionOptions
     [DataMember] public ImplementTypeOptions ImplementTypeOptions { get; init; } = ImplementTypeOptions.Default;
     [DataMember] public ExtractMethodOptions ExtractMethodOptions { get; init; } = ExtractMethodOptions.Default;
     [DataMember] public bool HideAdvancedMembers { get; init; } = false;
-    [DataMember] public int WrappingColumn { get; init; } = DefaultWrappingColumn;
-    [DataMember] public int ConditionalExpressionWrappingLength { get; init; } = DefaultConditionalExpressionWrappingLength;
-    [DataMember] public int CollectionExpressionWrappingLength { get; init; } = DefaultCollectionExpressionWrappingLength;
 
     public static CodeActionOptions GetDefault(LanguageServices languageServices)
         => new()

--- a/src/Workspaces/VisualBasic/Portable/Options/VisualBasicEditorConfigOptionsEnumerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/Options/VisualBasicEditorConfigOptionsEnumerator.vb
@@ -18,12 +18,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Options
         Public Sub New()
         End Sub
 
-        Public Iterator Function GetOptions() As IEnumerable(Of (String, ImmutableArray(Of IOption2))) Implements IEditorConfigOptionsEnumerator.GetOptions
-            For Each entry In EditorConfigOptionsEnumerator.GetLanguageAgnosticEditorConfigOptions()
+        Public Iterator Function GetOptions(includeUndocumented As Boolean) As IEnumerable(Of (String, ImmutableArray(Of IOption2))) Implements IEditorConfigOptionsEnumerator.GetOptions
+            For Each entry In EditorConfigOptionsEnumerator.GetLanguageAgnosticEditorConfigOptions(includeUndocumented)
                 Yield entry
             Next
 
-            Yield (VBWorkspaceResources.VB_Coding_Conventions, VisualBasicCodeStyleOptions.AllOptions.As(Of IOption2))
+            Yield (VBWorkspaceResources.VB_Coding_Conventions, VisualBasicCodeStyleOptions.EditorConfigOptions.As(Of IOption2))
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Options/VisualBasicEditorConfigOptionsEnumerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/Options/VisualBasicEditorConfigOptionsEnumerator.vb
@@ -18,8 +18,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Options
         Public Sub New()
         End Sub
 
-        Public Iterator Function GetOptions(includeUndocumented As Boolean) As IEnumerable(Of (String, ImmutableArray(Of IOption2))) Implements IEditorConfigOptionsEnumerator.GetOptions
-            For Each entry In EditorConfigOptionsEnumerator.GetLanguageAgnosticEditorConfigOptions(includeUndocumented)
+        Public Iterator Function GetOptions(includeUnsupported As Boolean) As IEnumerable(Of (String, ImmutableArray(Of IOption2))) Implements IEditorConfigOptionsEnumerator.GetOptions
+            For Each entry In EditorConfigOptionsEnumerator.GetLanguageAgnosticEditorConfigOptions(includeUnsupported)
                 Yield entry
             Next
 


### PR DESCRIPTION
Wrapping options

- `dotnet_internal_wrapping_column`
- `dotnet_internal_conditional_expression_wrapping_length`
- `csharp_internal_collection_expression_wrapping_length`

are currently only available from global options. They are only set by tests at this moment. We do not allow the user to change the values via Tools > Options or editorconfig. See https://github.com/dotnet/roslyn/pull/30422#issuecomment-436118696.

These options are read from analyzers and the code doing so is different between features and code style.

This change unifies the code by making these options _undocumented_ editorconfig options. This means that tooling such as editorconfig generator, Tools > Options UI, etc. won't generate/display these options but the options will be available via `AnalyzerConfigOptions` to analyzers. Setting these in a proper editorconfig file will work, but is not officially supported. In future, once https://github.com/dotnet/roslyn/pull/30422#issuecomment-436118696 is resolved, we may decide to make these options official.

Ultimately, the goal is for all options used by analyzers that are currently only available from global options to be converted to (ndocumented) editorconfig options.

Possible follow-up:
- [ ] Fold `SyntaxWrappingOptions` into `SyntaxFormattingOptions` -- it doesn't seem worth having separate types for wrapping operations as they also reference formatting options.