### PR TITLE
Add a cancellation on typing for SmartRename if user begins to type 

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Specialized;
-using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -110,8 +109,6 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
             _smartRenameViewModel.IsSuggestionsPanelCollapsed = !_smartRenameViewModel.IsSuggestionsPanelCollapsed;
             if (_smartRenameViewModel.IsSuggestionsPanelExpanded)
             {
-                _smartRenameViewModel._cancellationTokenSource.Cancel();
-                _smartRenameViewModel._cancellationTokenSource = new CancellationTokenSource();
                 _smartRenameViewModel.GetSuggestionsCommand.Execute(null);
             }
         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameUserInputComboBox.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Specialized;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -109,6 +110,8 @@ internal sealed partial class SmartRenameUserInputComboBox : ComboBox, IRenameUs
             _smartRenameViewModel.IsSuggestionsPanelCollapsed = !_smartRenameViewModel.IsSuggestionsPanelCollapsed;
             if (_smartRenameViewModel.IsSuggestionsPanelExpanded)
             {
+                _smartRenameViewModel._cancellationTokenSource.Cancel();
+                _smartRenameViewModel._cancellationTokenSource = new CancellationTokenSource();
                 _smartRenameViewModel.GetSuggestionsCommand.Execute(null);
             }
         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -151,9 +151,9 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
                 _suggestionsDropdownTelemetry.DropdownButtonClickTimes += 1;
             }
 
-            var delayTask = Task.Delay(1000, _cancellationTokenSource.Token);
+            var delayTask = listener.Delay(DelayTimeSpan.Idle, _cancellationTokenSource.Token);
             var coreTask = _smartRenameSession.GetSuggestionsAsync(_cancellationTokenSource.Token);
-            _getSuggestionsTask = delayTask
+            _getSuggestionsTask = listener.Delay(DelayTimeSpan.Idle, _cancellationTokenSource.Token)
                 .ContinueWith(_ => coreTask)
                 .CompletesAsyncOperation(listenerToken);
         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -29,7 +29,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
     private readonly IGlobalOptionService _globalOptionService;
     private readonly IThreadingContext _threadingContext;
     private readonly IAsynchronousOperationListenerProvider _listenerProvider;
-    public CancellationTokenSource _cancellationTokenSource = new();
+    private CancellationTokenSource _cancellationTokenSource = new();
 
     private Task _getSuggestionsTask = Task.CompletedTask;
 
@@ -150,7 +150,8 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
             {
                 _suggestionsDropdownTelemetry.DropdownButtonClickTimes += 1;
             }
-
+            _cancellationTokenSource.Dispose();
+            _cancellationTokenSource = new CancellationTokenSource();
             _getSuggestionsTask = _smartRenameSession.GetSuggestionsAsync(_cancellationTokenSource.Token).CompletesAsyncOperation(listenerToken);
         }
     }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -29,7 +29,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
     private readonly IGlobalOptionService _globalOptionService;
     private readonly IThreadingContext _threadingContext;
     private readonly IAsynchronousOperationListenerProvider _listenerProvider;
-    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    public CancellationTokenSource _cancellationTokenSource = new();
 
     private Task _getSuggestionsTask = Task.CompletedTask;
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -29,7 +29,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
     private readonly IGlobalOptionService _globalOptionService;
     private readonly IThreadingContext _threadingContext;
     private readonly IAsynchronousOperationListenerProvider _listenerProvider;
-    private CancellationTokenSource _cancellationTokenSource = new();
+    private CancellationTokenSource? _cancellationTokenSource;
 
     private Task _getSuggestionsTask = Task.CompletedTask;
 
@@ -150,7 +150,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
             {
                 _suggestionsDropdownTelemetry.DropdownButtonClickTimes += 1;
             }
-            _cancellationTokenSource.Dispose();
+            _cancellationTokenSource?.Dispose();
             _cancellationTokenSource = new CancellationTokenSource();
             _getSuggestionsTask = _smartRenameSession.GetSuggestionsAsync(_cancellationTokenSource.Token).CompletesAsyncOperation(listenerToken);
         }
@@ -205,7 +205,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
 
     public void Cancel()
     {
-        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource?.Cancel();
         // It's needed by editor-side telemetry.
         _smartRenameSession.OnCancel();
         PostTelemetry(isCommit: false);
@@ -223,7 +223,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
         _smartRenameSession.PropertyChanged -= SessionPropertyChanged;
         BaseViewModel.PropertyChanged -= IdentifierTextPropertyChanged;
         _smartRenameSession.Dispose();
-        _cancellationTokenSource.Dispose();
+        _cancellationTokenSource?.Dispose();
     }
 
     private void NotifyPropertyChanged([CallerMemberName] string? name = null)
@@ -233,7 +233,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
     {
         if (e.PropertyName == nameof(BaseViewModel.IdentifierText))
         {
-            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource?.Cancel();
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/SmartRename/SmartRenameViewModel.cs
@@ -151,11 +151,7 @@ internal sealed partial class SmartRenameViewModel : INotifyPropertyChanged, IDi
                 _suggestionsDropdownTelemetry.DropdownButtonClickTimes += 1;
             }
 
-            var delayTask = listener.Delay(DelayTimeSpan.Idle, _cancellationTokenSource.Token);
-            var coreTask = _smartRenameSession.GetSuggestionsAsync(_cancellationTokenSource.Token);
-            _getSuggestionsTask = listener.Delay(DelayTimeSpan.Idle, _cancellationTokenSource.Token)
-                .ContinueWith(_ => coreTask)
-                .CompletesAsyncOperation(listenerToken);
+            _getSuggestionsTask = _smartRenameSession.GetSuggestionsAsync(_cancellationTokenSource.Token).CompletesAsyncOperation(listenerToken);
         }
     }
 


### PR DESCRIPTION
 We will target users who already know what they want to rename to, and they don't need the automatic suggestion.
**The PR is to add a cancellation on typing. If user begins to type an identifier name, we cancel requesting suggestions.**
Behavior before:
![delaybefore](https://github.com/dotnet/roslyn/assets/110192400/c92de720-34d0-4530-a7ed-840ee9b86073)

Current Behavior:
![cancellation2](https://github.com/dotnet/roslyn/assets/110192400/7e134a8d-f450-4530-8aea-162d1f52288f)

