### PR TITLE
Update required VS to 17.8.

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,9 +7,9 @@
   "tools": {
     "dotnet": "8.0.101",
     "vs": {
-      "version": "17.6.0"
+      "version": "17.8.0"
     },
-    "xcopy-msbuild": "17.6.0-2"
+    "xcopy-msbuild": "17.8.1-2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24266.3",


### PR DESCRIPTION
Building 17.8 is failing with the following error "SDK 8.0.101 requires VS 17.7 or higher". See https://dev.azure.com/dnceng/internal/_build/results?buildId=2470784&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=fb192a8b-e433-5fc8-e2b0-276ab015e7d5 (microsoft)

Fixes SigningValidation in the official build pipeline.