### PR TITLE
Remove A/B option to disable recoverable texts

### DIFF
--- a/src/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
@@ -15,7 +15,6 @@ internal static class WorkspaceConfigurationOptionsStorage
             EnableOpeningSourceGeneratedFiles:
                 globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspace) ??
                 globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspaceFeatureFlag),
-            DisableRecoverableText: globalOptions.GetOption(DisableRecoverableText),
             SourceGeneratorExecution:
                 globalOptions.GetOption(SourceGeneratorExecution) ??
                 (globalOptions.GetOption(SourceGeneratorExecutionBalancedFeatureFlag) ? SourceGeneratorExecutionPreference.Balanced : SourceGeneratorExecutionPreference.Automatic),
@@ -24,9 +23,6 @@ internal static class WorkspaceConfigurationOptionsStorage
 
     public static readonly Option2<StorageDatabase> Database = new(
         "dotnet_storage_database", WorkspaceConfigurationOptions.Default.CacheStorage, serializer: EditorConfigValueSerializer.CreateSerializerForEnum<StorageDatabase>());
-
-    public static readonly Option2<bool> DisableRecoverableText = new(
-        "dotnet_disable_recoverable_text", WorkspaceConfigurationOptions.Default.DisableRecoverableText);
 
     public static readonly Option2<bool> ValidateCompilationTrackerStates = new(
         "dotnet_validate_compilation_tracker_states", WorkspaceConfigurationOptions.Default.ValidateCompilationTrackerStates);

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -421,7 +421,6 @@ internal abstract class VisualStudioOptionStorage
         {"visual_basic_style_unused_value_assignment_preference", new RoamingProfileStorage("TextEditor.VisualBasic.Specific.UnusedValueAssignmentPreference")},
         {"visual_basic_style_unused_value_expression_statement_preference", new RoamingProfileStorage("TextEditor.VisualBasic.Specific.UnusedValueExpressionStatementPreference")},
         {"visual_studio_navigate_to_object_browser", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.NavigateToObjectBrowser")},
-        {"dotnet_disable_recoverable_text", new FeatureFlagStorage(@"Roslyn.DisableRecoverableText")},
         {"dotnet_validate_compilation_tracker_states", new FeatureFlagStorage(@"Roslyn.ValidateCompilationTrackerStates")},
         {"dotnet_enable_diagnostics_in_source_generated_files", new RoamingProfileStorage("TextEditor.Roslyn.Specific.EnableDiagnosticsInSourceGeneratedFilesExperiment")},
         {"dotnet_enable_diagnostics_in_source_generated_files_feature_flag", new FeatureFlagStorage(@"Roslyn.EnableDiagnosticsInSourceGeneratedFiles")},

--- a/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
@@ -36,9 +36,8 @@ internal sealed class DefaultWorkspaceConfigurationService() : IWorkspaceConfigu
 internal readonly record struct WorkspaceConfigurationOptions(
     [property: DataMember(Order = 0)] StorageDatabase CacheStorage = StorageDatabase.SQLite,
     [property: DataMember(Order = 1)] bool EnableOpeningSourceGeneratedFiles = false,
-    [property: DataMember(Order = 2)] bool DisableRecoverableText = false,
-    [property: DataMember(Order = 3)] SourceGeneratorExecutionPreference SourceGeneratorExecution = SourceGeneratorExecutionPreference.Automatic,
-    [property: DataMember(Order = 4)] bool ValidateCompilationTrackerStates =
+    [property: DataMember(Order = 2)] SourceGeneratorExecutionPreference SourceGeneratorExecution = SourceGeneratorExecutionPreference.Automatic,
+    [property: DataMember(Order = 3)] bool ValidateCompilationTrackerStates =
 #if DEBUG // We will default this on in DEBUG builds
         true
 #else
@@ -59,6 +58,5 @@ internal readonly record struct WorkspaceConfigurationOptions(
     /// </summary>
     public static readonly WorkspaceConfigurationOptions RemoteDefault = new(
         CacheStorage: StorageDatabase.None,
-        EnableOpeningSourceGeneratedFiles: false,
-        DisableRecoverableText: false);
+        EnableOpeningSourceGeneratedFiles: false);
 }


### PR DESCRIPTION
Speedometer def showed regressions here, as did manual validation.  We def benefit from being able to dump to mmfs and to have our different processes reference those same mmfs instead of pushing the data over as raw bits over our communication channel.  For context, this allows us to scale by the *number* of files we have (Around 25k) instead of the *size* of the files we have.  