### PR TITLE
Fix error in compile loop

### DIFF
--- a/src/Tools/Replay/Replay.cs
+++ b/src/Tools/Replay/Replay.cs
@@ -158,7 +158,7 @@ static async IAsyncEnumerable<BuildData> BuildAllAsync(
 
         var buildData = await completedTask.ConfigureAwait(false);
         yield return buildData;
-    } while (tasks.Count > 0);
+    } while (index < compilerCalls.Count);
 
     string GetOutputName(CompilerCall compilerCall)
     {


### PR DESCRIPTION
This is a silly error where I was tracknig the wrong value in the loop condition. Hadn't noticed because the bad code works as long as `maxParallel` is greater than 1.