### PR TITLE
Add Microsoft.IdentityModel.JsonWebTokens to InternalTools.props in 17.6

### DIFF
--- a/eng/InternalTools.props
+++ b/eng/InternalTools.props
@@ -6,7 +6,7 @@
           https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json;
           https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
         </RestoreSources>
-         <RestoreSources>
+        <RestoreSources>
           $(RestoreSources);
           https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
         </RestoreSources>
@@ -14,9 +14,11 @@
     
     <ItemGroup Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'">
         <!-- Add explicit top-level dependencies to override the implicit versions brought in by Microsoft.DevDiv.Optimization.Data.PowerShell -->
-        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)"/>
+        <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)"/>
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)"/>
         <PackageReference Include="Microsoft.DevDiv.Optimization.Data.PowerShell" Version="$(MicrosoftDevDivOptimizationDataPowerShellVersion)" ExcludeAssets="all"/>
+        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)"/>
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtVersion)"/>
     </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -300,9 +300,11 @@
       If you bump their versions, you must push your changes to a dev branch in dotnet/roslyn and
       create a test insertion in Visual Studio to validate.
     -->
-    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
+    <MicrosoftIdentityClientVersion>4.61.3</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityModelJsonWebTokensVersion>6.34.0</MicrosoftIdentityModelJsonWebTokensVersion>
+    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <StreamJsonRpcVersion>2.15.26</StreamJsonRpcVersion>
+    <SystemIdentityModelTokensJwtVersion>6.34.0</SystemIdentityModelTokensJwtVersion>
     <!--
       When updating the S.C.I or S.R.M version please let the MSBuild team know in advance so they
       can update to the same version. Version changes require a VS test insertion for validation.


### PR DESCRIPTION
Same as https://github.com/dotnet/roslyn/pull/73948 but not a cherry-pick since Versions.props has changed too much since then