### PR TITLE
Fix project configuration telemetry for legacy csproj projects

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
@@ -150,6 +150,9 @@ internal class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory, Server
 
     private static ImmutableArray<string> GetTargetFrameworks(IEnumerable<ProjectFileInfo> projectFileInfos)
     {
-        return projectFileInfos.Select(p => p.TargetFramework?.ToLower()).WhereNotNull().ToImmutableArray();
+        return projectFileInfos.Select(p => GetTargetFramework(p)?.ToLower()).WhereNotNull().ToImmutableArray();
+
+        string? GetTargetFramework(ProjectFileInfo projectFileInfo)
+            => projectFileInfo.TargetFramework ?? projectFileInfo.TargetFrameworkVersion;
     }
 }

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/PropertyNames.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Constants/PropertyNames.cs
@@ -62,6 +62,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string TargetFramework = nameof(TargetFramework);
         public const string TargetFrameworks = nameof(TargetFrameworks);
         public const string TargetFrameworkIdentifier = nameof(TargetFrameworkIdentifier);
+        public const string TargetFrameworkVersion = nameof(TargetFrameworkVersion);
         public const string TargetPath = nameof(TargetPath);
         public const string TargetRefPath = nameof(TargetRefPath);
         public const string TreatWarningsAsErrors = nameof(TreatWarningsAsErrors);

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -151,6 +151,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
             var targetFrameworkIdentifier = project.ReadPropertyString(PropertyNames.TargetFrameworkIdentifier);
 
+            var targetFrameworkVersion = project.ReadPropertyString(PropertyNames.TargetFrameworkVersion);
+
             var docs = project.GetDocuments()
                 .Where(IsNotTemporaryGeneratedFile)
                 .Select(MakeDocumentFileInfo)
@@ -178,6 +180,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 defaultNamespace,
                 targetFramework,
                 targetFrameworkIdentifier,
+                targetFrameworkVersion,
                 projectAssetsFilePath,
                 commandLineArgs,
                 docs,

--- a/src/Workspaces/Core/MSBuild.BuildHost/Rpc/Contracts/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Rpc/Contracts/ProjectFileInfo.cs
@@ -131,6 +131,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         [DataMember(Order = 17)]
         public ImmutableArray<PackageReference> PackageReferences { get; }
 
+        /// <summary>
+        /// Target framework version (for .net framework projects)
+        /// </summary>
+        [DataMember(Order = 18)]
+        public string? TargetFrameworkVersion { get; }
+
         public override string ToString()
             => RoslynString.IsNullOrWhiteSpace(TargetFramework)
                 ? FilePath ?? string.Empty
@@ -146,6 +152,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             string? defaultNamespace,
             string? targetFramework,
             string? targetFrameworkIdentifier,
+            string? targetFrameworkVersion,
             string? projectAssetsFilePath,
             ImmutableArray<string> commandLineArgs,
             ImmutableArray<DocumentFileInfo> documents,
@@ -167,6 +174,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             this.DefaultNamespace = defaultNamespace;
             this.TargetFramework = targetFramework;
             this.TargetFrameworkIdentifier = targetFrameworkIdentifier;
+            this.TargetFrameworkVersion = targetFrameworkVersion;
             this.ProjectAssetsFilePath = projectAssetsFilePath;
             this.CommandLineArgs = commandLineArgs;
             this.Documents = documents;
@@ -187,6 +195,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             string? defaultNamespace,
             string? targetFramework,
             string? targetFrameworkIdentifier,
+            string? targetFrameworkVersion,
             string? projectAssetsFilePath,
             ImmutableArray<string> commandLineArgs,
             ImmutableArray<DocumentFileInfo> documents,
@@ -206,6 +215,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 defaultNamespace,
                 targetFramework,
                 targetFrameworkIdentifier,
+                targetFrameworkVersion,
                 projectAssetsFilePath,
                 commandLineArgs,
                 documents,
@@ -227,6 +237,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 defaultNamespace: null,
                 targetFramework: null,
                 targetFrameworkIdentifier: null,
+                targetFrameworkVersion: null,
                 projectAssetsFilePath: null,
                 commandLineArgs: [],
                 documents: [],


### PR DESCRIPTION
Fixes telemetry issue with missing target framework information when using legacy .net framework csproj projects.  The telemetry event now contains
```
TargetFrameworks": [
    "v4.7.2"
],
```

This matches o# behavior to use the targetframeworkversion if targetframework is not present

See https://github.com/OmniSharp/omnisharp-roslyn/blob/ac7b9b8509356e39583de2b9fdf363005e6c8595/src/OmniSharp.MSBuild/ProjectLoadListener.cs#L139C69-L139C91