### PR TITLE
Fix flaky test: LanguageServerCleansUpOnUnexpectedJsonRpcDisconnectAsync 

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -710,8 +710,8 @@ namespace Roslyn.Test.Utilities
             {
                 var queueAccessor = GetQueueAccessor()!.Value;
                 await queueAccessor.WaitForProcessingToStopAsync().ConfigureAwait(false);
-                Assert.True(GetServerAccessor().HasShutdownStarted());
-                Assert.True(queueAccessor.IsComplete());
+                Assert.True(GetServerAccessor().HasShutdownStarted(), "Unexpected shutdown not started");
+                Assert.True(queueAccessor.IsComplete(), "Unexpected queue not complete");
             }
 
             internal async Task WaitForDiagnosticsAsync()

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -710,7 +710,12 @@ namespace Roslyn.Test.Utilities
             {
                 var queueAccessor = GetQueueAccessor()!.Value;
                 await queueAccessor.WaitForProcessingToStopAsync().ConfigureAwait(false);
-                Assert.True(GetServerAccessor().HasShutdownStarted(), "Unexpected shutdown not started");
+
+                var shutdownTask = GetServerAccessor().GetShutdownTaskAsync();
+                AssertEx.NotNull(shutdownTask, "Unexpected shutdown not started");
+
+                // Shutdown task will close the queue, so we need to wait for it to complete.
+                await shutdownTask.ConfigureAwait(false);
                 Assert.True(queueAccessor.IsComplete(), "Unexpected queue not complete");
             }
 

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
@@ -403,9 +403,14 @@ internal abstract class AbstractLanguageServer<TRequestContext>
 
         internal bool HasShutdownStarted()
         {
+            return GetShutdownTaskAsync() != null;
+        }
+
+        internal Task? GetShutdownTaskAsync()
+        {
             lock (_server._lifeCycleLock)
             {
-                return _server._shutdownRequestTask != null;
+                return _server._shutdownRequestTask;
             }
         }
     }

--- a/src/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -52,14 +52,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         [Theory, CombinatorialData]
-        public async Task LanguageServerCleansUpOnUnexpectedJsonRpcDisconnectAsync(bool mutatingLspWorkspace, [CombinatorialRange(0, 400)] int iteration)
+        public async Task LanguageServerCleansUpOnUnexpectedJsonRpcDisconnectAsync(bool mutatingLspWorkspace)
         {
-            _ = iteration;
             await using var server = await CreateTestLspServerAsync("", mutatingLspWorkspace);
             AssertServerAlive(server);
 
             server.GetServerAccessor().GetServerRpc().Dispose();
-
             await server.AssertServerShuttingDownAsync().ConfigureAwait(false);
             Assert.True(server.GetServerAccessor().GetServerRpc().IsDisposed);
         }

--- a/src/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -52,13 +52,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         [Theory, CombinatorialData]
-        public async Task LanguageServerCleansUpOnUnexpectedJsonRpcDisconnectAsync(bool mutatingLspWorkspace, [CombinatorialRange(0, 200)] int iteration)
+        public async Task LanguageServerCleansUpOnUnexpectedJsonRpcDisconnectAsync(bool mutatingLspWorkspace, [CombinatorialRange(0, 400)] int iteration)
         {
             _ = iteration;
             await using var server = await CreateTestLspServerAsync("", mutatingLspWorkspace);
             AssertServerAlive(server);
 
             server.GetServerAccessor().GetServerRpc().Dispose();
+
             await server.AssertServerShuttingDownAsync().ConfigureAwait(false);
             Assert.True(server.GetServerAccessor().GetServerRpc().IsDisposed);
         }

--- a/src/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -52,8 +52,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         [Theory, CombinatorialData]
-        public async Task LanguageServerCleansUpOnUnexpectedJsonRpcDisconnectAsync(bool mutatingLspWorkspace)
+        public async Task LanguageServerCleansUpOnUnexpectedJsonRpcDisconnectAsync(bool mutatingLspWorkspace, [CombinatorialRange(0, 200)] int iteration)
         {
+            _ = iteration;
             await using var server = await CreateTestLspServerAsync("", mutatingLspWorkspace);
             AssertServerAlive(server);
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/73977

Passed 400 iterations in CI (previously failed consistently ~20-30 times on that number)
![image](https://github.com/dotnet/roslyn/assets/5749229/637ae106-e454-4395-b537-df3bfa54aed1)
