### PR TITLE
Enable end-to-end binding and emit for basic scenarios involving instance extension members.

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -82,6 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         public CodeGenerator(
             MethodSymbol method,
+            SyntaxNode methodBodySyntaxOpt,
             BoundStatement boundBody,
             ILBuilder builder,
             PEModuleBuilder moduleBuilder,
@@ -146,9 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 _boundBody = boundBody;
             }
 
-            var sourceMethod = method as SourceMemberMethodSymbol;
-            (BlockSyntax blockBody, ArrowExpressionClauseSyntax expressionBody) = sourceMethod?.Bodies ?? default;
-            _methodBodySyntaxOpt = (SyntaxNode)blockBody ?? expressionBody ?? sourceMethod?.SyntaxNode;
+            _methodBodySyntaxOpt = methodBodySyntaxOpt;
         }
 
         private bool IsDebugPlus()

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1433,6 +1433,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     loweredBody = (BoundStatement)extensionRewriter.Visit(loweredBody);
                     method = metadataMethod;
                 }
+                else
+                {
+                    loweredBody = InstanceExtensionMethodReferenceRewriter.Rewrite(method, loweredBody);
+                }
 
                 if (sawAwaitInExceptionHandler)
                 {

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -777,13 +777,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (_emitMethodBodies && !diagnosticsThisMethod.HasAnyErrors() && !_globalHasErrors)
                         {
-                            var sourceMethod = method as SourceMemberMethodSymbol;
-                            (BlockSyntax blockBody, ArrowExpressionClauseSyntax expressionBody) = sourceMethod?.Bodies ?? default;
-
                             emittedBody = GenerateMethodBody(
                                 _moduleBeingBuiltOpt,
                                 method,
-                                blockBody ?? expressionBody ?? sourceMethod?.SyntaxNode,
+                                TryGetMethodBodySyntax(method as SourceMemberMethodSymbol),
                                 methodOrdinal,
                                 loweredBody,
                                 ImmutableArray<EncLambdaInfo>.Empty,
@@ -832,6 +829,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 stateMachineStateDebugInfoBuilder.Free();
             }
         }
+
+#nullable enable
+
+        private static SyntaxNode? TryGetMethodBodySyntax(SourceMemberMethodSymbol? sourceMethod)
+        {
+            (BlockSyntax blockBody, ArrowExpressionClauseSyntax expressionBody) = sourceMethod?.Bodies ?? default;
+            return blockBody ?? expressionBody ?? sourceMethod?.SyntaxNode;
+        }
+
+#nullable disable
 
         /// <summary>
         /// In some circumstances (e.g. implicit implementation of an interface method by a non-virtual method in a
@@ -1335,12 +1342,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             MethodSymbol metadataSymbol = (MethodSymbol)methodSymbol.ContainingType.TryGetCorrespondingStaticMetadataExtensionMember(methodSymbol) ?? methodSymbol;
 
-                            (BlockSyntax blockBody, ArrowExpressionClauseSyntax expressionBody) = sourceMethod?.Bodies ?? default;
-
                             var emittedBody = GenerateMethodBody(
                                 _moduleBeingBuiltOpt,
                                 metadataSymbol,
-                                (SyntaxNode)blockBody ?? expressionBody ?? sourceMethod?.SyntaxNode,
+                                TryGetMethodBodySyntax(sourceMethod),
                                 methodOrdinal,
                                 boundBody,
                                 lambdaDebugInfoBuilder.ToImmutable(),

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -940,7 +940,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (m.Kind == SymbolKind.Event)
                 {
-                    yield return (EventSymbol)m;
+                    yield return (EventSymbol)(TryGetCorrespondingStaticMetadataExtensionMember(m) ?? m);
                 }
             }
         }
@@ -1019,7 +1019,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (m.Kind == SymbolKind.Method)
                 {
-                    var method = (MethodSymbol)m;
+                    var method = (MethodSymbol)(TryGetCorrespondingStaticMetadataExtensionMember(m) ?? m);
+
                     if (method.ShouldEmit())
                     {
                         yield return method;
@@ -1036,7 +1037,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (m.Kind == SymbolKind.Property)
                 {
-                    yield return (PropertySymbol)m;
+                    yield return (PropertySymbol)(TryGetCorrespondingStaticMetadataExtensionMember(m) ?? m);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -1019,6 +1019,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (m.Kind == SymbolKind.Method)
                 {
+                    // PROTOTYPE(roles): Make sure this transformation is not going to break handling of partial
+                    //                   methods. For example, it looks like ShouldEmit filters out partial methods without
+                    //                   an implementation. In general we should make sure we have adequate testing
+                    //                   for partial instance methods.
                     var method = (MethodSymbol)(TryGetCorrespondingStaticMetadataExtensionMember(m) ?? m);
 
                     if (method.ShouldEmit())

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8057,7 +8057,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
-            Debug.Assert(false); // If this assert fails, add an appropriate test.
+
+            // PROTOTYPE(roles): The assert below fails for an instance call on a generic extension.
+            //Debug.Assert(false); // If this assert fails, add an appropriate test.
             return symbol;
 
             bool tryAsMemberOfSingleType(NamedTypeSymbol singleType, [NotNullWhen(true)] out Symbol? result)

--- a/src/Compilers/CSharp/Portable/Lowering/InstanceExtensionMethodBodyRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/InstanceExtensionMethodBodyRewriter.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -135,12 +136,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         [return: NotNullIfNotNull("symbol")]
         protected override MethodSymbol? VisitMethodSymbol(MethodSymbol? symbol)
         {
-            if (symbol?.MethodKind is MethodKind.LambdaMethod or MethodKind.LocalFunction)
+            switch (symbol?.MethodKind)
             {
-                return (MethodSymbol)_symbolMap[symbol];
-            }
+                case MethodKind.LambdaMethod:
+                    throw ExceptionUtilities.Unreachable();
 
-            return base.VisitMethodSymbol(symbol);
+                case MethodKind.LocalFunction:
+                    return (MethodSymbol)_symbolMap[symbol];
+
+                default:
+                    return base.VisitMethodSymbol(symbol);
+            }
         }
 
         // PROTOTYPE(roles): Here we are pretty much duplicating what InstanceExtensionMethodReferenceRewriter would do.

--- a/src/Compilers/CSharp/Portable/Lowering/InstanceExtensionMethodBodyRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/InstanceExtensionMethodBodyRewriter.cs
@@ -1,0 +1,142 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// Rewrites method body lowered in context of an instance extension method to a body
+    /// that corresponds to its static/metadata form.
+    /// </summary>
+    internal sealed class InstanceExtensionMethodBodyRewriter : BoundTreeToDifferentEnclosingContextRewriter
+    {
+        private readonly SourceExtensionMetadataMethodSymbol _metadataMethod;
+        private ImmutableDictionary<Symbol, Symbol> _symbolMap;
+        private RewrittenMethodSymbol _rewrittenContainingMethod;
+
+        public InstanceExtensionMethodBodyRewriter(MethodSymbol sourceMethod, SourceExtensionMetadataMethodSymbol metadataMethod)
+        {
+            _metadataMethod = metadataMethod;
+            _symbolMap = ImmutableDictionary<Symbol, Symbol>.Empty.WithComparers(ReferenceEqualityComparer.Instance, ReferenceEqualityComparer.Instance);
+            EnterMethod(sourceMethod, metadataMethod, metadataMethod.Parameters.AsSpan()[1..]);
+            Debug.Assert(_rewrittenContainingMethod is not null);
+        }
+
+        private (RewrittenMethodSymbol, ImmutableDictionary<Symbol, Symbol>) EnterMethod(MethodSymbol symbol, RewrittenMethodSymbol rewritten, ReadOnlySpan<ParameterSymbol> rewrittenParameters)
+        {
+            ImmutableDictionary<Symbol, Symbol> saveSymbolMap = _symbolMap;
+            RewrittenMethodSymbol savedContainer = _rewrittenContainingMethod;
+
+            Debug.Assert(symbol.Parameters.Length == rewrittenParameters.Length);
+
+            if (!rewrittenParameters.IsEmpty)
+            {
+                var builder = _symbolMap.ToBuilder();
+                foreach (var parameter in symbol.Parameters)
+                {
+                    builder.Add(parameter, rewrittenParameters[parameter.Ordinal]);
+                }
+                _symbolMap = builder.ToImmutable();
+            }
+
+            _rewrittenContainingMethod = rewritten;
+
+            return (savedContainer, saveSymbolMap);
+        }
+
+        private (RewrittenMethodSymbol, ImmutableDictionary<Symbol, Symbol>) EnterMethod(MethodSymbol symbol, RewrittenMethodSymbol rewritten)
+        {
+            return EnterMethod(symbol, rewritten, rewritten.Parameters.AsSpan());
+        }
+
+        protected override MethodSymbol CurrentMethod => _rewrittenContainingMethod;
+
+        protected override TypeMap TypeMap => _rewrittenContainingMethod.TypeMap;
+
+        // PROTOTYPE(roles): Should we adjust type of the node in the LocalRewriter, from extension type to extended type?
+        //                   When we are leaving the type as is in the LocalRewriter, we are producing somewhat inconsistent
+        //                   BoundCall nodes. The type of the first argument for the static/metadata call doesn't match corresponding
+        //                   parameter's type until we perform a fix up here. 
+        //                   If we were to adjust the type in the LocalRewriter, we would be be creating inconsistent BoundThisReference nodes.
+        //                   The type of the node wouldn't match the containing type.
+        public override BoundNode? VisitThisReference(BoundThisReference node)
+        {
+            return new BoundParameter(node.Syntax, _metadataMethod.Parameters[0]);
+        }
+
+        protected override ParameterSymbol VisitParameterSymbol(ParameterSymbol symbol)
+        {
+            return (ParameterSymbol)_symbolMap[symbol];
+        }
+
+        public override BoundNode? VisitLambda(BoundLambda node)
+        {
+            var rewritten = new RewrittenLambdaOrLocalFunctionSymbol(node.Symbol, _rewrittenContainingMethod);
+
+            var savedState = EnterMethod(node.Symbol, rewritten);
+            BoundBlock body = (BoundBlock)this.Visit(node.Body);
+            (_rewrittenContainingMethod, _symbolMap) = savedState;
+
+            TypeSymbol? type = this.VisitType(node.Type);
+            return node.Update(node.UnboundLambda, rewritten, body, node.Diagnostics, node.Binder, type);
+        }
+
+        public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
+        {
+            MethodSymbol symbol = this.VisitMethodSymbol(node.Symbol);
+            var savedState = EnterMethod(node.Symbol, (RewrittenMethodSymbol)symbol);
+
+            BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
+            BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
+
+            (_rewrittenContainingMethod, _symbolMap) = savedState;
+
+            return node.Update(symbol, blockBody, expressionBody);
+        }
+
+        public override BoundNode VisitBlock(BoundBlock node)
+        {
+            ImmutableDictionary<Symbol, Symbol> saveSymbolMap = _symbolMap;
+
+            if (!node.LocalFunctions.IsEmpty)
+            {
+                var builder = _symbolMap.ToBuilder();
+
+                foreach (var localFunction in node.LocalFunctions)
+                {
+                    builder.Add(localFunction, new RewrittenLambdaOrLocalFunctionSymbol(localFunction, _rewrittenContainingMethod));
+                }
+
+                _symbolMap = builder.ToImmutable();
+            }
+
+            var result = base.VisitBlock(node);
+
+            _symbolMap = saveSymbolMap;
+            return result;
+        }
+
+        protected override ImmutableArray<MethodSymbol> VisitDeclaredLocalFunctions(ImmutableArray<MethodSymbol> localFunctions)
+        {
+            return localFunctions.SelectAsArray(static (l, map) => (MethodSymbol)map[l], _symbolMap);
+        }
+
+        [return: NotNullIfNotNull("symbol")]
+        protected override MethodSymbol? VisitMethodSymbol(MethodSymbol? symbol)
+        {
+            if (symbol?.MethodKind is MethodKind.LambdaMethod or MethodKind.LocalFunction)
+            {
+                return (MethodSymbol)_symbolMap[symbol];
+            }
+
+            return base.VisitMethodSymbol(symbol);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/InstanceExtensionMethodReferenceRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/InstanceExtensionMethodReferenceRewriter.cs
@@ -1,0 +1,219 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// Replaces references to instance extension methods with references to their static/metadata form, passing what used to be
+    /// a receiver as the first argument.
+    /// </summary>
+    internal class InstanceExtensionMethodReferenceRewriter : BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+    {
+        private MethodSymbol _containingMethod;
+
+        private InstanceExtensionMethodReferenceRewriter(MethodSymbol containingMethod)
+        {
+            _containingMethod = containingMethod;
+        }
+
+        public static BoundStatement Rewrite(MethodSymbol method, BoundStatement statement)
+        {
+            var rewriter = new InstanceExtensionMethodReferenceRewriter(method);
+            return (BoundStatement)rewriter.Visit(statement);
+        }
+
+        public override BoundNode? VisitLambda(BoundLambda node)
+        {
+            var oldContainingMethod = _containingMethod;
+            _containingMethod = node.Symbol;
+
+            var result = base.VisitLambda(node);
+
+            _containingMethod = oldContainingMethod;
+            return result;
+        }
+
+        public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
+        {
+            var oldContainingMethod = _containingMethod;
+            _containingMethod = node.Symbol;
+
+            var result = base.VisitLocalFunctionStatement(node);
+
+            _containingMethod = oldContainingMethod;
+            return result;
+        }
+
+        public override BoundNode VisitCall(BoundCall node)
+        {
+            Debug.Assert(node != null);
+
+            BoundExpression rewrittenCall;
+
+            if (LocalRewriter.TryGetReceiver(node, out BoundCall? receiver1))
+            {
+                // Handle long call chain of both instance and extension method invocations.
+                var calls = ArrayBuilder<BoundCall>.GetInstance();
+
+                calls.Push(node);
+                node = receiver1;
+
+                while (LocalRewriter.TryGetReceiver(node, out BoundCall? receiver2))
+                {
+                    calls.Push(node);
+                    node = receiver2;
+                }
+
+                // Rewrite the receiver
+                BoundExpression? rewrittenReceiver = (BoundExpression?)this.Visit(node.ReceiverOpt);
+
+                do
+                {
+                    rewrittenCall = visitArgumentsAndFinishRewrite(node, rewrittenReceiver);
+                    rewrittenReceiver = rewrittenCall;
+                }
+                while (calls.TryPop(out node!));
+
+                calls.Free();
+            }
+            else
+            {
+                // Rewrite the receiver
+                BoundExpression? rewrittenReceiver = (BoundExpression?)this.Visit(node.ReceiverOpt);
+                rewrittenCall = visitArgumentsAndFinishRewrite(node, rewrittenReceiver);
+            }
+
+            return rewrittenCall;
+
+            BoundExpression visitArgumentsAndFinishRewrite(BoundCall node, BoundExpression? rewrittenReceiver)
+            {
+                return UpdateCall(
+                    _containingMethod,
+                    node,
+                    this.VisitMethodSymbol(node.Method),
+                    this.VisitSymbols<MethodSymbol>(node.OriginalMethodsOpt),
+                    rewrittenReceiver,
+                    this.VisitList(node.Arguments),
+                    node.ArgumentRefKindsOpt,
+                    node.InvokedAsExtensionMethod,
+                    this.VisitType(node.Type));
+            }
+        }
+
+        internal static BoundExpression UpdateCall(
+            MethodSymbol containingMethod,
+            BoundCall boundCall,
+            MethodSymbol method,
+            ImmutableArray<MethodSymbol> originalMethodsOpt,
+            BoundExpression? receiverOpt,
+            ImmutableArray<BoundExpression> arguments,
+            ImmutableArray<RefKind> argumentRefKinds,
+            bool invokedAsExtensionMethod,
+            TypeSymbol type)
+        {
+            var temps = ImmutableArray<LocalSymbol>.Empty;
+
+            if (receiverOpt is not null && method.OriginalDefinition.ContainingSymbol is NamedTypeSymbol declaringTypeDefinition &&
+                declaringTypeDefinition.TryGetCorrespondingStaticMetadataExtensionMember(method.OriginalDefinition) is MethodSymbol metadataMethod)
+            {
+                method = metadataMethod.AsMember(method.ContainingType).ConstructIfGeneric(method.TypeArgumentsWithAnnotations);
+
+                var thisRefKind = method.Parameters[0].RefKind;
+
+                if (argumentRefKinds.IsDefault)
+                {
+                    if (thisRefKind != RefKind.None)
+                    {
+                        argumentRefKinds = SyntheticBoundNodeFactory.ArgumentRefKindsFromParameterRefKinds(method, useStrictArgumentRefKinds: true);
+                    }
+                }
+                else
+                {
+                    argumentRefKinds = argumentRefKinds.Insert(0, SyntheticBoundNodeFactory.ArgumentRefKindFromParameterRefKind(thisRefKind, useStrictArgumentRefKinds: true));
+                }
+
+                invokedAsExtensionMethod = true;
+
+                // PROTOTYPE(roles): We probably need to convert the receiver to the parameter's type here
+
+                if (thisRefKind != RefKind.None)
+                {
+                    Debug.Assert(thisRefKind == RefKind.Ref);
+
+                    if (!Binder.HasHome(receiverOpt,
+                                        Binder.AddressKind.Writeable,
+                                        containingMethod,
+                                        peVerifyCompatEnabled: true,
+                                        stackLocalsOpt: null))
+                    {
+                        // PROTOTYPE(roles): If the following assert fails (for example this could happen if we start supporting 'readonly' extension members),
+                        //                   we will create a local of a wrong type below. 
+                        Debug.Assert(receiverOpt is not BoundThisReference || containingMethod.ContainingType.GetExtendedTypeNoUseSiteDiagnostics(null) is null);
+
+                        // We have an rValue, but the parameter is a 'ref'. Capture it in a local to keep CodeGenerator happy.
+                        receiverOpt = SyntheticBoundNodeFactory.StoreToTemp(containingMethod, receiverOpt, containingMethod.DeclaringCompilation.IsPeVerifyCompatEnabled, out BoundAssignmentOperator assignmentToTemp);
+                        temps = temps.Add(((BoundLocal)receiverOpt).LocalSymbol);
+                        receiverOpt = new BoundSequence(receiverOpt.Syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray.Create<BoundExpression>(assignmentToTemp), receiverOpt, receiverOpt.Type!);
+                    }
+                }
+
+                arguments = arguments.Insert(0, receiverOpt);
+                receiverOpt = null;
+            }
+
+            var result = boundCall.Update(
+                receiverOpt,
+                boundCall.InitialBindingReceiverIsSubjectToCloning,
+                method,
+                arguments,
+                default,
+                argumentRefKinds,
+                boundCall.IsDelegateCall,
+                boundCall.Expanded,
+                invokedAsExtensionMethod,
+                default,
+                default,
+                boundCall.ResultKind,
+                originalMethodsOpt,
+                type);
+
+            if (!temps.IsDefaultOrEmpty)
+            {
+                return new BoundSequence(
+                    boundCall.Syntax,
+                    locals: temps,
+                    sideEffects: ImmutableArray<BoundExpression>.Empty,
+                    value: result,
+                    type: result.Type);
+            }
+
+            return result;
+        }
+
+        public override BoundNode? VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
+        {
+            return UpdateDelegateCreation(node, this.VisitMethodSymbol(node.MethodOpt), (BoundExpression)this.Visit(node.Argument), node.IsExtensionMethod, this.VisitType(node.Type));
+        }
+
+        internal static BoundNode UpdateDelegateCreation(BoundDelegateCreationExpression node, MethodSymbol? methodOpt, BoundExpression argument, bool isExtensionMethod, TypeSymbol type)
+        {
+            if (methodOpt?.OriginalDefinition.ContainingSymbol is NamedTypeSymbol declaringTypeDefinition &&
+                declaringTypeDefinition.TryGetCorrespondingStaticMetadataExtensionMember(methodOpt.OriginalDefinition) is MethodSymbol metadataMethod)
+            {
+                methodOpt = metadataMethod.AsMember(methodOpt.ContainingType).ConstructIfGeneric(methodOpt.TypeArgumentsWithAnnotations);
+
+                // PROTOTYPE(roles): We probably also need to convert the receiver to the parameter's type here
+
+                isExtensionMethod = true;
+            }
+
+            return node.Update(argument, methodOpt, isExtensionMethod, node.WasTargetTyped, type);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -331,12 +331,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     rewrittenRight,
                     exprType);
 
-                BoundExpression setterCall = BoundCall.Synthesized(
+                BoundExpression setterCall = MakeCall(
+                    node: null,
                     syntax,
                     rewrittenReceiver,
-                    initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
                     setMethod,
-                    AppendToPossibleNull(arguments, rhsAssignment));
+                    AppendToPossibleNull(arguments, rhsAssignment),
+                    argumentRefKinds: default,
+                    LookupResultKind.Viable,
+                    ImmutableArray<LocalSymbol>.Empty).MakeCompilerGenerated();
 
                 return new BoundSequence(
                     syntax,
@@ -347,12 +350,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                BoundCall setterCall = BoundCall.Synthesized(
+                BoundExpression setterCall = MakeCall(
+                    node: null,
                     syntax,
                     rewrittenReceiver,
-                    initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
                     setMethod,
-                    AppendToPossibleNull(arguments, rewrittenRight));
+                    AppendToPossibleNull(arguments, rewrittenRight),
+                    argumentRefKinds: default,
+                    LookupResultKind.Viable,
+                    ImmutableArray<LocalSymbol>.Empty).MakeCompilerGenerated();
 
                 if (argTemps.IsDefaultOrEmpty)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -331,15 +331,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     rewrittenRight,
                     exprType);
 
-                BoundExpression setterCall = MakeCall(
-                    node: null,
+                BoundExpression setterCall = BoundCall.Synthesized(
                     syntax,
                     rewrittenReceiver,
+                    initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
                     setMethod,
-                    AppendToPossibleNull(arguments, rhsAssignment),
-                    argumentRefKinds: default,
-                    LookupResultKind.Viable,
-                    ImmutableArray<LocalSymbol>.Empty).MakeCompilerGenerated();
+                    AppendToPossibleNull(arguments, rhsAssignment));
 
                 return new BoundSequence(
                     syntax,
@@ -350,15 +347,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                BoundExpression setterCall = MakeCall(
-                    node: null,
+                BoundCall setterCall = BoundCall.Synthesized(
                     syntax,
                     rewrittenReceiver,
+                    initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
                     setMethod,
-                    AppendToPossibleNull(arguments, rewrittenRight),
-                    argumentRefKinds: default,
-                    LookupResultKind.Viable,
-                    ImmutableArray<LocalSymbol>.Empty).MakeCompilerGenerated();
+                    AppendToPossibleNull(arguments, rewrittenRight));
 
                 if (argTemps.IsDefaultOrEmpty)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -308,7 +308,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression rewrittenCall;
 
-            if (tryGetReceiver(node, out BoundCall? receiver1))
+            if (TryGetReceiver(node, out BoundCall? receiver1))
             {
                 // Handle long call chain of both instance and extension method invocations.
                 var calls = ArrayBuilder<BoundCall>.GetInstance();
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 calls.Push(node);
                 node = receiver1;
 
-                while (tryGetReceiver(node, out BoundCall? receiver2))
+                while (TryGetReceiver(node, out BoundCall? receiver2))
                 {
                     calls.Push(node);
                     node = receiver2;
@@ -342,26 +342,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return rewrittenCall;
-
-            // Gets the instance or extension invocation receiver if any.
-            static bool tryGetReceiver(BoundCall node, [MaybeNullWhen(returnValue: false)] out BoundCall receiver)
-            {
-                if (node.ReceiverOpt is BoundCall instanceReceiver)
-                {
-                    receiver = instanceReceiver;
-                    return true;
-                }
-
-                if (node.InvokedAsExtensionMethod && node.Arguments is [BoundCall extensionReceiver, ..])
-                {
-                    Debug.Assert(node.ReceiverOpt is null);
-                    receiver = extensionReceiver;
-                    return true;
-                }
-
-                receiver = null;
-                return false;
-            }
 
             BoundExpression visitArgumentsAndFinishRewrite(BoundCall node, BoundExpression? rewrittenReceiver)
             {
@@ -421,6 +401,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        /// <summary>
+        /// Gets the instance or extension invocation receiver if any.
+        /// </summary>
+        internal static bool TryGetReceiver(BoundCall node, [MaybeNullWhen(returnValue: false)] out BoundCall receiver)
+        {
+            if (node.ReceiverOpt is BoundCall instanceReceiver)
+            {
+                receiver = instanceReceiver;
+                return true;
+            }
+
+            if (node.InvokedAsExtensionMethod && node.Arguments is [BoundCall extensionReceiver, ..])
+            {
+                Debug.Assert(node.ReceiverOpt is null);
+                receiver = extensionReceiver;
+                return true;
+            }
+
+            receiver = null;
+            return false;
+        }
+
         private BoundExpression MakeCall(
             BoundCall? node,
             SyntaxNode syntax,
@@ -455,97 +457,40 @@ namespace Microsoft.CodeAnalysis.CSharp
                     rewrittenArguments[1],
                     method.ReturnType);
             }
+            else if (node == null)
+            {
+                rewrittenBoundCall = new BoundCall(
+                    syntax,
+                    rewrittenReceiver,
+                    initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
+                    method,
+                    rewrittenArguments,
+                    argumentNamesOpt: default(ImmutableArray<string?>),
+                    argumentRefKinds,
+                    isDelegateCall: false,
+                    expanded: false,
+                    invokedAsExtensionMethod: false,
+                    argsToParamsOpt: default(ImmutableArray<int>),
+                    defaultArguments: default(BitVector),
+                    resultKind: resultKind,
+                    type: method.ReturnType);
+            }
             else
             {
-                if (argumentRefKinds.IsDefault)
-                {
-                    argumentRefKinds = SyntheticBoundNodeFactory.ArgumentRefKindsFromParameterRefKinds(method, useStrictArgumentRefKinds: false);
-                }
-
-                // PROTOTYPE(roles): We could do this transformation in a separate pass after LocalRewriter and for instance extension methods
-                //                   that work could be bundled with InstanceExtensionMethodBodyRewriter, addressing all the concerns about
-                //                   BoundThisReference result type inconsistencies (see a comment for InstanceExtensionMethodBodyRewriter.VisitThisReference).
-                if (rewrittenReceiver is not null && method.OriginalDefinition.ContainingSymbol is NamedTypeSymbol declaringTypeDefinition &&
-                    declaringTypeDefinition.TryGetCorrespondingStaticMetadataExtensionMember(method.OriginalDefinition) is MethodSymbol metadataMethod)
-                {
-                    method = metadataMethod.AsMember(method.ContainingType).ConstructIfGeneric(method.TypeArgumentsWithAnnotations);
-
-                    var thisRefKind = method.Parameters[0].RefKind;
-
-                    if (argumentRefKinds.IsDefault)
-                    {
-                        if (thisRefKind != RefKind.None)
-                        {
-                            argumentRefKinds = SyntheticBoundNodeFactory.ArgumentRefKindsFromParameterRefKinds(method, useStrictArgumentRefKinds: true);
-                        }
-                    }
-                    else
-                    {
-                        argumentRefKinds = argumentRefKinds.Insert(0, SyntheticBoundNodeFactory.ArgumentRefKindFromParameterRefKind(thisRefKind, useStrictArgumentRefKinds: true));
-                    }
-
-                    // PROTOTYPE(roles): We probably need to convert the receiver to the parameter's type here
-
-                    if (thisRefKind != RefKind.None)
-                    {
-                        Debug.Assert(thisRefKind == RefKind.Ref);
-
-                        if (!Binder.HasHome(rewrittenReceiver,
-                                            Binder.AddressKind.Writeable,
-                                            _factory.CurrentFunction,
-                                            peVerifyCompatEnabled: true,
-                                            stackLocalsOpt: null))
-                        {
-                            // PROTOTYPE(roles): If the following assert fails (for example this could happen if we start supporting 'readonly' extension members),
-                            //                   we will create a local of a wrong type below. 
-                            Debug.Assert(rewrittenReceiver is not BoundThisReference || _factory.CurrentType?.GetExtendedTypeNoUseSiteDiagnostics(null) is null);
-
-                            // We have an rValue, but the parameter is a 'ref'. Capture it in a local to keep CodeGenerator happy.
-                            rewrittenReceiver = _factory.StoreToTemp(rewrittenReceiver, out BoundAssignmentOperator assignmentToTemp);
-                            temps = temps.Add(((BoundLocal)rewrittenReceiver).LocalSymbol);
-                            rewrittenReceiver = new BoundSequence(rewrittenReceiver.Syntax, ImmutableArray<LocalSymbol>.Empty, ImmutableArray.Create<BoundExpression>(assignmentToTemp), rewrittenReceiver, rewrittenReceiver.Type!);
-                        }
-                    }
-
-                    rewrittenArguments = rewrittenArguments.Insert(0, rewrittenReceiver);
-                    rewrittenReceiver = null;
-                }
-
-                if (node == null)
-                {
-                    rewrittenBoundCall = new BoundCall(
-                        syntax,
-                        rewrittenReceiver,
-                        initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
-                        method,
-                        rewrittenArguments,
-                        argumentNamesOpt: default(ImmutableArray<string?>),
-                        argumentRefKinds,
-                        isDelegateCall: false,
-                        expanded: false,
-                        invokedAsExtensionMethod: false,
-                        argsToParamsOpt: default(ImmutableArray<int>),
-                        defaultArguments: default(BitVector),
-                        resultKind: resultKind,
-                        type: method.ReturnType);
-                }
-                else
-                {
-                    rewrittenBoundCall = node.Update(
-                        rewrittenReceiver,
-                        initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
-                        method,
-                        rewrittenArguments,
-                        argumentNamesOpt: default(ImmutableArray<string?>),
-                        argumentRefKinds,
-                        node.IsDelegateCall,
-                        expanded: false,
-                        invokedAsExtensionMethod: false,
-                        argsToParamsOpt: default(ImmutableArray<int>),
-                        defaultArguments: default(BitVector),
-                        node.ResultKind,
-                        method.ReturnType);
-                }
+                rewrittenBoundCall = node.Update(
+                    rewrittenReceiver,
+                    initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
+                    method,
+                    rewrittenArguments,
+                    argumentNamesOpt: default(ImmutableArray<string?>),
+                    argumentRefKinds,
+                    node.IsDelegateCall,
+                    expanded: false,
+                    invokedAsExtensionMethod: false,
+                    argsToParamsOpt: default(ImmutableArray<int>),
+                    defaultArguments: default(BitVector),
+                    node.ResultKind,
+                    method.ReturnType);
             }
 
             Debug.Assert(rewrittenBoundCall.Type is not null);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -567,12 +567,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(method is { });
                         var oldSyntax = _factory.Syntax;
                         _factory.Syntax = (mg.ReceiverOpt ?? mg).Syntax;
-                        var receiver = (!method.RequiresInstanceReceiver && !oldNodeOpt.IsExtensionMethod && !method.IsAbstract && !method.IsVirtual) ? _factory.Type(method.ContainingType) : mg.ReceiverOpt;
+                        bool isExtensionMethod = oldNodeOpt.IsExtensionMethod;
+                        var receiver = (!method.RequiresInstanceReceiver && !isExtensionMethod && !method.IsAbstract && !method.IsVirtual) ? _factory.Type(method.ContainingType) : mg.ReceiverOpt;
                         Debug.Assert(receiver is { });
                         _factory.Syntax = oldSyntax;
 
+                        AdjustDelegateTargetMethodIfNecessary(ref method, ref isExtensionMethod);
+
                         var boundDelegateCreation = new BoundDelegateCreationExpression(syntax, argument: receiver, methodOpt: method,
-                                                                                        isExtensionMethod: oldNodeOpt.IsExtensionMethod, wasTargetTyped: false, type: rewrittenType);
+                                                                                        isExtensionMethod: isExtensionMethod, wasTargetTyped: false, type: rewrittenType);
 
                         EnsureParamCollectionAttributeExists(rewrittenOperand.Syntax, rewrittenType);
                         Debug.Assert(_factory.TopLevelMethod is { });

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -567,15 +567,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(method is { });
                         var oldSyntax = _factory.Syntax;
                         _factory.Syntax = (mg.ReceiverOpt ?? mg).Syntax;
-                        bool isExtensionMethod = oldNodeOpt.IsExtensionMethod;
-                        var receiver = (!method.RequiresInstanceReceiver && !isExtensionMethod && !method.IsAbstract && !method.IsVirtual) ? _factory.Type(method.ContainingType) : mg.ReceiverOpt;
+                        var receiver = (!method.RequiresInstanceReceiver && !oldNodeOpt.IsExtensionMethod && !method.IsAbstract && !method.IsVirtual) ? _factory.Type(method.ContainingType) : mg.ReceiverOpt;
                         Debug.Assert(receiver is { });
                         _factory.Syntax = oldSyntax;
 
-                        AdjustDelegateTargetMethodIfNecessary(ref method, ref isExtensionMethod);
-
                         var boundDelegateCreation = new BoundDelegateCreationExpression(syntax, argument: receiver, methodOpt: method,
-                                                                                        isExtensionMethod: isExtensionMethod, wasTargetTyped: false, type: rewrittenType);
+                                                                                        isExtensionMethod: oldNodeOpt.IsExtensionMethod, wasTargetTyped: false, type: rewrittenType);
 
                         EnsureParamCollectionAttributeExists(rewrittenOperand.Syntax, rewrittenType);
                         Debug.Assert(_factory.TopLevelMethod is { });

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DelegateCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DelegateCreationExpression.cs
@@ -32,33 +32,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(method is { });
                 var oldSyntax = _factory.Syntax;
                 _factory.Syntax = (mg.ReceiverOpt ?? mg).Syntax;
-                bool isExtensionMethod = node.IsExtensionMethod;
-                var receiver = (!method.RequiresInstanceReceiver && !isExtensionMethod && !method.IsAbstract && !method.IsVirtual) ? _factory.Type(method.ContainingType) : VisitExpression(mg.ReceiverOpt);
+                var receiver = (!method.RequiresInstanceReceiver && !node.IsExtensionMethod && !method.IsAbstract && !method.IsVirtual) ? _factory.Type(method.ContainingType) : VisitExpression(mg.ReceiverOpt)!;
                 _factory.Syntax = oldSyntax;
-
-                AdjustDelegateTargetMethodIfNecessary(ref method, ref isExtensionMethod);
-
-                Debug.Assert(receiver is not null);
-                return node.Update(receiver, method, isExtensionMethod, node.WasTargetTyped, node.Type);
+                return node.Update(receiver, method, node.IsExtensionMethod, node.WasTargetTyped, node.Type);
             }
 
             return base.VisitDelegateCreationExpression(node)!;
-        }
-
-        private static void AdjustDelegateTargetMethodIfNecessary(ref MethodSymbol method, ref bool isExtensionMethod)
-        {
-            // PROTOTYPE(roles): We could do this transformation in a separate pass after LocalRewriter and for instance extension methods
-            //                   that work could be bundled with InstanceExtensionMethodBodyRewriter, addressing all the concerns about
-            //                   BoundThisReference result type inconsistencies (see a comment for InstanceExtensionMethodBodyRewriter.VisitThisReference).
-            if (method.OriginalDefinition.ContainingSymbol is NamedTypeSymbol declaringTypeDefinition &&
-                declaringTypeDefinition.TryGetCorrespondingStaticMetadataExtensionMember(method.OriginalDefinition) is MethodSymbol metadataMethod)
-            {
-                method = metadataMethod.AsMember(method.ContainingType).ConstructIfGeneric(method.TypeArgumentsWithAnnotations);
-
-                // PROTOTYPE(roles): We probably also need to convert the receiver to the parameter's type here
-
-                isExtensionMethod = true;
-            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DelegateCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DelegateCreationExpression.cs
@@ -32,12 +32,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(method is { });
                 var oldSyntax = _factory.Syntax;
                 _factory.Syntax = (mg.ReceiverOpt ?? mg).Syntax;
-                var receiver = (!method.RequiresInstanceReceiver && !node.IsExtensionMethod && !method.IsAbstract && !method.IsVirtual) ? _factory.Type(method.ContainingType) : VisitExpression(mg.ReceiverOpt)!;
+                bool isExtensionMethod = node.IsExtensionMethod;
+                var receiver = (!method.RequiresInstanceReceiver && !isExtensionMethod && !method.IsAbstract && !method.IsVirtual) ? _factory.Type(method.ContainingType) : VisitExpression(mg.ReceiverOpt);
                 _factory.Syntax = oldSyntax;
-                return node.Update(receiver, method, node.IsExtensionMethod, node.WasTargetTyped, node.Type);
+
+                AdjustDelegateTargetMethodIfNecessary(ref method, ref isExtensionMethod);
+
+                Debug.Assert(receiver is not null);
+                return node.Update(receiver, method, isExtensionMethod, node.WasTargetTyped, node.Type);
             }
 
             return base.VisitDelegateCreationExpression(node)!;
+        }
+
+        private static void AdjustDelegateTargetMethodIfNecessary(ref MethodSymbol method, ref bool isExtensionMethod)
+        {
+            // PROTOTYPE(roles): We could do this transformation in a separate pass after LocalRewriter and for instance extension methods
+            //                   that work could be bundled with InstanceExtensionMethodBodyRewriter, addressing all the concerns about
+            //                   BoundThisReference result type inconsistencies (see a comment for InstanceExtensionMethodBodyRewriter.VisitThisReference).
+            if (method.OriginalDefinition.ContainingSymbol is NamedTypeSymbol declaringTypeDefinition &&
+                declaringTypeDefinition.TryGetCorrespondingStaticMetadataExtensionMember(method.OriginalDefinition) is MethodSymbol metadataMethod)
+            {
+                method = metadataMethod.AsMember(method.ContainingType).ConstructIfGeneric(method.TypeArgumentsWithAnnotations);
+
+                // PROTOTYPE(roles): We probably also need to convert the receiver to the parameter's type here
+
+                isExtensionMethod = true;
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -103,6 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression delegateCreationArgument = boundTemp ?? rewrittenReceiverOpt ?? _factory.Type(eventType);
 
+            // PROTOTYPE(roles): Ensure we are not getting here with instance extension events
             BoundDelegateCreationExpression removeDelegate = new BoundDelegateCreationExpression(
                 syntax: syntax,
                 argument: delegateCreationArgument,
@@ -140,6 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 NamedTypeSymbol func2Type = _factory.WellKnownType(WellKnownType.System_Func_T2).Construct(eventType, tokenType);
 
+                // PROTOTYPE(roles): Ensure we are not getting here with instance extension events
                 BoundDelegateCreationExpression addDelegate = new BoundDelegateCreationExpression(
                     syntax: syntax,
                     argument: delegateCreationArgument,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -663,9 +663,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-            Debug.Assert(_compilation.Conversions.ClassifyConversionFromType(rewrittenReceiver.Type, memberSymbol.ContainingType, isChecked: false, ref discardedUseSiteInfo).IsImplicit ||
-                         (memberSymbol.ContainingType.GetExtendedTypeNoUseSiteDiagnostics(null) is { } extended &&
-                          _compilation.Conversions.ClassifyConversionFromType(rewrittenReceiver.Type, extended, isChecked: false, ref discardedUseSiteInfo).IsImplicit));
+            Debug.Assert(_compilation.Conversions.ClassifyConversionFromType(rewrittenReceiver.Type, memberSymbol.ContainingType, isChecked: false, ref discardedUseSiteInfo).IsImplicit);
             // It is possible there are use site diagnostics from the above, but none that we need report as we aren't generating code for the conversion
 #endif
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -663,7 +663,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-            Debug.Assert(_compilation.Conversions.ClassifyConversionFromType(rewrittenReceiver.Type, memberSymbol.ContainingType, isChecked: false, ref discardedUseSiteInfo).IsImplicit);
+            Debug.Assert(_compilation.Conversions.ClassifyConversionFromType(rewrittenReceiver.Type, memberSymbol.ContainingType, isChecked: false, ref discardedUseSiteInfo).IsImplicit ||
+                         (memberSymbol.ContainingType.GetExtendedTypeNoUseSiteDiagnostics(null) is { } extended &&
+                          _compilation.Conversions.ClassifyConversionFromType(rewrittenReceiver.Type, extended, isChecked: false, ref discardedUseSiteInfo).IsImplicit));
             // It is possible there are use site diagnostics from the above, but none that we need report as we aren't generating code for the conversion
 #endif
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PropertyAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PropertyAccess.cs
@@ -94,16 +94,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(getMethod.ParameterCount == rewrittenArguments.Length);
                 Debug.Assert(getMethodOpt is null || ReferenceEquals(getMethod, getMethodOpt));
 
-                // PROTOTYPE(roles): Adjust remaining call sites of BoundCall.Synthesized in the LocalRewriter to use MakeCall.
-                return MakeCall(
-                    node: null,
+                return BoundCall.Synthesized(
                     syntax,
                     rewrittenReceiver,
+                    initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
                     getMethod,
                     rewrittenArguments,
-                    argumentRefKindsOpt,
-                    LookupResultKind.Viable,
-                    ImmutableArray<LocalSymbol>.Empty).MakeCompilerGenerated();
+                    argumentRefKindsOpt);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PropertyAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PropertyAccess.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol? getMethodOpt = null,
             BoundPropertyAccess? oldNodeOpt = null)
         {
-            if (_inExpressionLambda && rewrittenArguments.IsEmpty)
+            if (_inExpressionLambda && rewrittenArguments.IsEmpty) // PROTOTYPE(roles): This and other similar places should be revisited.
             {
                 Debug.Assert(argumentRefKindsOpt.IsDefaultOrEmpty);
                 return oldNodeOpt != null ?
@@ -94,13 +94,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(getMethod.ParameterCount == rewrittenArguments.Length);
                 Debug.Assert(getMethodOpt is null || ReferenceEquals(getMethod, getMethodOpt));
 
-                return BoundCall.Synthesized(
+                // PROTOTYPE(roles): Adjust remaining call sites of BoundCall.Synthesized in the LocalRewriter to use MakeCall.
+                return MakeCall(
+                    node: null,
                     syntax,
                     rewrittenReceiver,
-                    initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown,
                     getMethod,
                     rewrittenArguments,
-                    argumentRefKindsOpt);
+                    argumentRefKindsOpt,
+                    LookupResultKind.Viable,
+                    ImmutableArray<LocalSymbol>.Empty).MakeCompilerGenerated();
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1736,6 +1736,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             )
         {
             Debug.Assert(argument.Type is { });
+            Debug.Assert(containingMethod is { });
             Debug.Assert(kind != SynthesizedLocalKind.UserDefined);
 
             switch (refKind)

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
@@ -277,6 +277,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
                 => throw ExceptionUtilities.Unreachable();
 
+            internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
             internal abstract override bool Equals(TypeSymbol t2, TypeCompareKind comparison);
 
             public abstract override int GetHashCode();

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
@@ -328,6 +328,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
                 => throw ExceptionUtilities.Unreachable();
 
+            internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
             internal sealed override bool HasPossibleWellKnownCloneMethod() => false;
 
             internal sealed override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -565,6 +565,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
+        internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
         internal sealed override bool HasPossibleWellKnownCloneMethod() => false;
 
         internal sealed override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls()

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/PEExtensionInstanceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/PEExtensionInstanceEventSymbol.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class PEExtensionInstanceEventSymbol : RewrittenExtensionEventSymbol
+    {
+        private readonly PEExtensionInstanceMethodSymbol? _addMethod;
+        private readonly PEExtensionInstanceMethodSymbol? _removeMethod;
+
+        public PEExtensionInstanceEventSymbol(PEEventSymbol metadataEvent, PEExtensionInstanceMethodSymbol? addMethod, PEExtensionInstanceMethodSymbol? removeMethod) : base(metadataEvent)
+        {
+            Debug.Assert(metadataEvent.IsStatic);
+            _addMethod = addMethod;
+            _removeMethod = removeMethod;
+        }
+
+        public override bool IsStatic => false;
+        public override bool RequiresInstanceReceiver => true;
+
+        public override MethodSymbol? AddMethod => _addMethod;
+
+        public override MethodSymbol? RemoveMethod => _removeMethod;
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/PEExtensionInstanceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/PEExtensionInstanceMethodSymbol.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class PEExtensionInstanceMethodSymbol : RewrittenExtensionMethodSymbol
+    {
+        private ThisParameterSymbol? _lazyThisParameter;
+        private Symbol? _associatedPropertyOrEventOpt;
+
+        public PEExtensionInstanceMethodSymbol(PEMethodSymbol metadataMethod) : base(metadataMethod)
+        {
+            Debug.Assert(metadataMethod.IsStatic);
+        }
+
+        internal override int ParameterCount => UnderlyingMethod.ParameterCount - 1;
+        public override bool IsStatic => false;
+        public override bool RequiresInstanceReceiver => true;
+
+        internal override Microsoft.Cci.CallingConvention CallingConvention
+        {
+            get
+            {
+                return _originalMethod.CallingConvention | Cci.CallingConvention.HasThis;
+            }
+        }
+
+        public override Symbol? AssociatedSymbol => _associatedPropertyOrEventOpt;
+
+        internal void SetAssociatedProperty(PEExtensionInstancePropertySymbol propertySymbol)
+        {
+            this.SetAssociatedPropertyOrEvent(propertySymbol);
+        }
+
+        internal void SetAssociatedEvent(PEExtensionInstanceEventSymbol eventSymbol)
+        {
+            this.SetAssociatedPropertyOrEvent(eventSymbol);
+        }
+
+        private void SetAssociatedPropertyOrEvent(Symbol propertyOrEventSymbol)
+        {
+            if (_associatedPropertyOrEventOpt is null)
+            {
+                Debug.Assert((object)propertyOrEventSymbol.ContainingType == ContainingType);
+
+                // No locking required since SetAssociatedProperty/SetAssociatedEvent will only be called
+                // by the thread that created the method symbol (and will be called before the method
+                // symbol is added to the containing type members and available to other threads).
+                _associatedPropertyOrEventOpt = propertyOrEventSymbol;
+            }
+        }
+
+        protected override ImmutableArray<ParameterSymbol> MakeParameters()
+        {
+            var sourceParameters = _originalMethod.Parameters;
+            var parameters = ArrayBuilder<ParameterSymbol>.GetInstance(ParameterCount);
+
+            foreach (var parameter in sourceParameters[1..])
+            {
+                parameters.Add(new PEExtensionInstanceMethodParameterSymbol(this, parameter));
+            }
+
+            return parameters.ToImmutableAndFree();
+        }
+
+        internal override bool TryGetThisParameter(out ParameterSymbol? thisParameter)
+        {
+            thisParameter = _lazyThisParameter ?? InterlockedOperations.Initialize(ref _lazyThisParameter, new ThisParameterSymbol(this));
+            return true;
+        }
+
+        private sealed class PEExtensionInstanceMethodParameterSymbol : RewrittenMethodParameterSymbol
+        {
+            public PEExtensionInstanceMethodParameterSymbol(PEExtensionInstanceMethodSymbol containingMethod, ParameterSymbol sourceParameter) :
+                base(containingMethod, sourceParameter)
+            {
+            }
+
+            public override int Ordinal
+            {
+                get { return this._underlyingParameter.Ordinal - 1; }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/PEExtensionInstancePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/PEExtensionInstancePropertySymbol.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class PEExtensionInstancePropertySymbol : RewrittenExtensionPropertySymbol
+    {
+        private readonly PEExtensionInstanceMethodSymbol? _getMethod;
+        private readonly PEExtensionInstanceMethodSymbol? _setMethod;
+
+        public PEExtensionInstancePropertySymbol(PEPropertySymbol metadataProperty, PEExtensionInstanceMethodSymbol? getMethod, PEExtensionInstanceMethodSymbol? setMethod) : base(metadataProperty)
+        {
+            Debug.Assert(metadataProperty.IsStatic);
+            _getMethod = getMethod;
+            _setMethod = setMethod;
+        }
+
+        public override bool IsStatic => false;
+        public override bool RequiresInstanceReceiver => true;
+
+        internal override Microsoft.Cci.CallingConvention CallingConvention
+        {
+            get
+            {
+                return UnderlyingProperty.CallingConvention | Cci.CallingConvention.HasThis;
+            }
+        }
+
+        public override MethodSymbol? GetMethod => _getMethod;
+
+        public override MethodSymbol? SetMethod => _setMethod;
+
+        public override bool IsIndexedProperty => (this.ParameterCount > 0) && ContainingType.IsComImport;
+
+        protected override ImmutableArray<ParameterSymbol> MakeParameters()
+        {
+            var sourceParameters = UnderlyingProperty.Parameters;
+            var parameters = ArrayBuilder<ParameterSymbol>.GetInstance(sourceParameters.Length - 1);
+
+            foreach (var parameter in sourceParameters[1..])
+            {
+                parameters.Add(new PEExtensionInstancePropertyParameterSymbol(this, parameter));
+            }
+
+            return parameters.ToImmutableAndFree();
+        }
+
+        private sealed class PEExtensionInstancePropertyParameterSymbol : RewrittenParameterSymbol
+        {
+            private readonly PEExtensionInstancePropertySymbol _containingProperty;
+
+            public PEExtensionInstancePropertyParameterSymbol(PEExtensionInstancePropertySymbol containingProperty, ParameterSymbol sourceParameter) :
+                base(sourceParameter)
+            {
+                _containingProperty = containingProperty;
+            }
+
+            public sealed override Symbol ContainingSymbol
+            {
+                get { return _containingProperty; }
+            }
+
+            public override int Ordinal
+            {
+                get { return this._underlyingParameter.Ordinal - 1; }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenExtensionEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenExtensionEventSymbol.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal abstract class RewrittenExtensionEventSymbol : WrappedEventSymbol
+    {
+        protected RewrittenExtensionEventSymbol(EventSymbol originalEvent) : base(originalEvent)
+        {
+            Debug.Assert(originalEvent.IsDefinition);
+            Debug.Assert(originalEvent.ExplicitInterfaceImplementations.IsEmpty);
+        }
+
+        public sealed override bool IsVirtual => false;
+
+        public sealed override bool IsOverride => false;
+        public sealed override bool IsAbstract => false;
+        public sealed override bool IsSealed => false;
+
+        // PROTOTYPE(roles): Do we want to support extern/external instance events
+        public sealed override bool IsExtern => false;
+
+        // PROTOTYPE(roles): How doc comments are supposed to work? GetDocumentationCommentXml
+
+        internal sealed override bool MustCallMethodsDirectly => UnderlyingEvent.MustCallMethodsDirectly;
+
+        internal sealed override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            UnderlyingEvent.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+        }
+
+        internal sealed override UseSiteInfo<AssemblySymbol> GetUseSiteInfo()
+        {
+            return UnderlyingEvent.GetUseSiteInfo();
+        }
+
+        public sealed override Symbol ContainingSymbol => UnderlyingEvent.ContainingSymbol;
+
+        public override ImmutableArray<EventSymbol> ExplicitInterfaceImplementations => ImmutableArray<EventSymbol>.Empty;
+
+        public override TypeWithAnnotations TypeWithAnnotations => UnderlyingEvent.TypeWithAnnotations;
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenExtensionMethodSymbol.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal abstract class RewrittenExtensionMethodSymbol : RewrittenMethodSymbol
+    {
+        protected RewrittenExtensionMethodSymbol(MethodSymbol originalMethod) : base(originalMethod, TypeMap.Empty)
+        {
+            Debug.Assert(originalMethod.ContainingType.GetExtendedTypeNoUseSiteDiagnostics(null) is not null);
+        }
+
+        public sealed override bool IsExtensionMethod => false;
+        public sealed override bool IsVirtual => false;
+
+        public sealed override bool IsOverride => false;
+        public sealed override bool IsAbstract => false;
+        public sealed override bool IsSealed => false;
+
+        internal sealed override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false) => false;
+        internal sealed override bool IsMetadataFinal => false;
+        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
+
+        internal sealed override bool IsAccessCheckedOnOverride => false;
+
+        // PROTOTYPE(roles): Do we want to support extern/external instance methods
+        public sealed override bool IsExtern => false;
+        public sealed override DllImportData? GetDllImportData() => null;
+        internal sealed override bool IsExternal => false;
+
+        // PROTOTYPE(roles): How doc comments are supposed to work? GetDocumentationCommentXml
+
+        // PROTOTYPE(roles): Might need to adjust if we will support 'readonly' methods
+        internal sealed override bool IsDeclaredReadOnly => false;
+
+        // PROTOTYPE(roles): Are we going to support UnscopedRefAttribute? It should be moved to the 'this' parameter and back then. 
+        //internal sealed override bool HasUnscopedRefAttribute => false;
+
+        public sealed override Symbol ContainingSymbol => _originalMethod.ContainingSymbol;
+
+        internal sealed override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            _originalMethod.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenExtensionPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenExtensionPropertySymbol.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal abstract class RewrittenExtensionPropertySymbol : WrappedPropertySymbol
+    {
+        private ImmutableArray<ParameterSymbol> _lazyParameters;
+
+        protected RewrittenExtensionPropertySymbol(PropertySymbol originalProperty) : base(originalProperty)
+        {
+            Debug.Assert(originalProperty.IsDefinition);
+            Debug.Assert(originalProperty.ExplicitInterfaceImplementations.IsEmpty);
+        }
+
+        public sealed override bool IsVirtual => false;
+
+        public sealed override bool IsOverride => false;
+        public sealed override bool IsAbstract => false;
+        public sealed override bool IsSealed => false;
+
+        // PROTOTYPE(roles): Do we want to support extern/external instance properties
+        public sealed override bool IsExtern => false;
+
+        // PROTOTYPE(roles): How doc comments are supposed to work? GetDocumentationCommentXml
+
+        internal sealed override bool MustCallMethodsDirectly => UnderlyingProperty.MustCallMethodsDirectly;
+
+        internal sealed override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            UnderlyingProperty.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+        }
+
+        internal sealed override UseSiteInfo<AssemblySymbol> GetUseSiteInfo()
+        {
+            return UnderlyingProperty.GetUseSiteInfo();
+        }
+
+        public sealed override Symbol ContainingSymbol => UnderlyingProperty.ContainingSymbol;
+
+        public override ImmutableArray<PropertySymbol> ExplicitInterfaceImplementations => ImmutableArray<PropertySymbol>.Empty;
+
+        public sealed override ImmutableArray<ParameterSymbol> Parameters
+        {
+            get
+            {
+                if (_lazyParameters.IsDefault)
+                {
+                    ImmutableInterlocked.InterlockedInitialize(ref _lazyParameters, this.MakeParameters());
+                }
+                return _lazyParameters;
+            }
+        }
+
+        protected abstract ImmutableArray<ParameterSymbol> MakeParameters();
+
+        public override ImmutableArray<CustomModifier> RefCustomModifiers => UnderlyingProperty.RefCustomModifiers;
+
+        public override TypeWithAnnotations TypeWithAnnotations => UnderlyingProperty.TypeWithAnnotations;
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenLambdaOrLocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenLambdaOrLocalFunctionSymbol.cs
@@ -31,14 +31,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override ImmutableArray<ParameterSymbol> MakeParameters()
         {
-            var sourceParameters = _originalMethod.Parameters;
-            var parameters = ArrayBuilder<ParameterSymbol>.GetInstance(ParameterCount);
-
-            foreach (var parameter in sourceParameters)
-            {
-                parameters.Add(new RewrittenMethodParameterSymbol(this, parameter));
-            }
-
             return ImmutableArray<ParameterSymbol>.CastUp(_originalMethod.Parameters.SelectAsArray(static (p, @this) => new RewrittenMethodParameterSymbol(@this, p), this));
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenLambdaOrLocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenLambdaOrLocalFunctionSymbol.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class RewrittenLambdaOrLocalFunctionSymbol : RewrittenMethodSymbol
+    {
+        private readonly RewrittenMethodSymbol _containingMethod;
+
+        public RewrittenLambdaOrLocalFunctionSymbol(MethodSymbol lambdaOrLocalFunctionSymbol, RewrittenMethodSymbol containingMethod) : base(lambdaOrLocalFunctionSymbol, containingMethod.TypeMap)
+        {
+            Debug.Assert(lambdaOrLocalFunctionSymbol.AssociatedSymbol is null);
+            Debug.Assert(lambdaOrLocalFunctionSymbol.TryGetThisParameter(out var thisParameter) && thisParameter is null);
+            _containingMethod = containingMethod;
+        }
+
+        public override Symbol? AssociatedSymbol => null;
+
+        public override Symbol ContainingSymbol => _containingMethod;
+
+        internal override bool TryGetThisParameter(out ParameterSymbol? thisParameter)
+        {
+            thisParameter = null;
+            return true;
+        }
+
+        protected override ImmutableArray<ParameterSymbol> MakeParameters()
+        {
+            var sourceParameters = _originalMethod.Parameters;
+            var parameters = ArrayBuilder<ParameterSymbol>.GetInstance(ParameterCount);
+
+            foreach (var parameter in sourceParameters)
+            {
+                parameters.Add(new RewrittenMethodParameterSymbol(this, parameter));
+            }
+
+            return ImmutableArray<ParameterSymbol>.CastUp(_originalMethod.Parameters.SelectAsArray(static (p, @this) => new RewrittenMethodParameterSymbol(@this, p), this));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenMethodSymbol.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override UseSiteInfo<AssemblySymbol> GetUseSiteInfo()
         {
-            return UnderlyingMethod.GetUseSiteInfo();
+            return _originalMethod.GetUseSiteInfo();
         }
 
         public sealed override ImmutableArray<ParameterSymbol> Parameters

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenMethodSymbol.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal abstract class RewrittenMethodSymbol : WrappedMethodSymbol
+    {
+        protected readonly MethodSymbol _originalMethod;
+        protected readonly TypeMap _typeMap;
+        private readonly ImmutableArray<TypeParameterSymbol> _typeParameters;
+        private ImmutableArray<ParameterSymbol> _lazyParameters;
+
+        protected RewrittenMethodSymbol(MethodSymbol originalMethod, TypeMap typeMap)
+        {
+            Debug.Assert(originalMethod.IsDefinition);
+            Debug.Assert(originalMethod.ExplicitInterfaceImplementations.IsEmpty);
+
+            _originalMethod = originalMethod;
+
+            // PROTOTYPE(roles): Are we creating type parameters with the right emit behavior? Attributes, etc.
+            _typeMap = typeMap.WithAlphaRename(_originalMethod, this, out _typeParameters);
+        }
+
+        public TypeMap TypeMap => _typeMap;
+
+        public sealed override MethodSymbol UnderlyingMethod => _originalMethod;
+
+        public sealed override ImmutableArray<TypeParameterSymbol> TypeParameters
+        {
+            get { return _typeParameters; }
+        }
+
+        public sealed override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
+        {
+            get { return GetTypeParametersAsTypeArguments(); }
+        }
+
+        public sealed override TypeWithAnnotations ReturnTypeWithAnnotations
+        {
+            get { return _typeMap.SubstituteType(_originalMethod.ReturnTypeWithAnnotations); }
+        }
+
+        internal sealed override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
+        {
+            return _originalMethod.CalculateLocalSyntaxOffset(localPosition, localTree);
+        }
+
+        internal sealed override bool IsNullableAnalysisEnabled() => throw ExceptionUtilities.Unreachable();
+
+        public sealed override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<MethodSymbol>.Empty;
+
+        internal sealed override UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete)
+            => _originalMethod.GetUnmanagedCallersOnlyAttributeData(forceComplete);
+
+        public sealed override ImmutableArray<CustomModifier> RefCustomModifiers
+        {
+            get { return _typeMap.SubstituteCustomModifiers(_originalMethod.RefCustomModifiers); }
+        }
+
+        public sealed override ImmutableArray<CSharpAttributeData> GetAttributes()
+        {
+            return _originalMethod.GetAttributes();
+        }
+
+        internal sealed override UseSiteInfo<AssemblySymbol> GetUseSiteInfo()
+        {
+            return UnderlyingMethod.GetUseSiteInfo();
+        }
+
+        public sealed override ImmutableArray<ParameterSymbol> Parameters
+        {
+            get
+            {
+                if (_lazyParameters.IsDefault)
+                {
+                    ImmutableInterlocked.InterlockedInitialize(ref _lazyParameters, this.MakeParameters());
+                }
+                return _lazyParameters;
+            }
+        }
+
+        protected abstract ImmutableArray<ParameterSymbol> MakeParameters();
+
+        internal sealed override bool HasAsyncMethodBuilderAttribute(out TypeSymbol? builderArgument)
+        {
+            // PROTOTYPE(roles): Test this code path
+            return _originalMethod.HasAsyncMethodBuilderAttribute(out builderArgument);
+        }
+
+        protected class RewrittenMethodParameterSymbol : RewrittenParameterSymbol
+        {
+            protected readonly RewrittenMethodSymbol _containingMethod;
+
+            public RewrittenMethodParameterSymbol(RewrittenMethodSymbol containingMethod, ParameterSymbol originalParameter) :
+                base(originalParameter)
+            {
+                _containingMethod = containingMethod;
+            }
+
+            public sealed override Symbol ContainingSymbol
+            {
+                get { return _containingMethod; }
+            }
+
+            public override TypeWithAnnotations TypeWithAnnotations
+            {
+                get { return _containingMethod._typeMap.SubstituteType(this._underlyingParameter.TypeWithAnnotations); }
+            }
+
+            public override ImmutableArray<CustomModifier> RefCustomModifiers
+            {
+                get
+                {
+                    return _containingMethod._typeMap.SubstituteCustomModifiers(this._underlyingParameter.RefCustomModifiers);
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/RewrittenParameterSymbol.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal abstract class RewrittenParameterSymbol : WrappedParameterSymbol
+    {
+        public RewrittenParameterSymbol(ParameterSymbol originalParameter) :
+            base(originalParameter)
+        {
+        }
+
+        internal sealed override bool IsCallerLineNumber => _underlyingParameter.IsCallerLineNumber;
+
+        internal sealed override bool IsCallerFilePath => _underlyingParameter.IsCallerFilePath;
+
+        internal sealed override bool IsCallerMemberName => _underlyingParameter.IsCallerMemberName;
+
+        internal sealed override int CallerArgumentExpressionParameterIndex => _underlyingParameter.CallerArgumentExpressionParameterIndex;
+
+        internal sealed override ImmutableArray<int> InterpolatedStringHandlerArgumentIndexes => throw ExceptionUtilities.Unreachable(); // PROTOTYPE(roles): Follow up
+
+        internal sealed override bool HasInterpolatedStringHandlerArgumentError => throw ExceptionUtilities.Unreachable(); // PROTOTYPE(roles): Follow up
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionMetadataEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionMetadataEventSymbol.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SourceExtensionMetadataEventSymbol : RewrittenExtensionEventSymbol
+    {
+        public SourceExtensionMetadataEventSymbol(EventSymbol sourceEvent) : base(sourceEvent)
+        {
+            Debug.Assert(!sourceEvent.IsStatic);
+            Debug.Assert(!sourceEvent.MustCallMethodsDirectly);
+            Debug.Assert(sourceEvent.ContainingSymbol is SourceExtensionTypeSymbol);
+        }
+
+        public override bool IsStatic => true;
+        public override bool RequiresInstanceReceiver => false;
+
+        public override MethodSymbol? AddMethod
+        {
+            get
+            {
+                if (UnderlyingEvent.AddMethod is { } accessor)
+                {
+                    return (MethodSymbol?)ContainingType.TryGetCorrespondingStaticMetadataExtensionMember(accessor);
+                }
+
+                return null;
+            }
+        }
+
+        public override MethodSymbol? RemoveMethod
+        {
+            get
+            {
+                if (UnderlyingEvent.RemoveMethod is { } accessor)
+                {
+                    return (MethodSymbol?)ContainingType.TryGetCorrespondingStaticMetadataExtensionMember(accessor);
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionMetadataMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionMetadataMethodSymbol.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SourceExtensionMetadataMethodSymbol : RewrittenExtensionMethodSymbol
+    {
+        public SourceExtensionMetadataMethodSymbol(MethodSymbol sourceMethod) : base(sourceMethod)
+        {
+            Debug.Assert(!sourceMethod.IsStatic);
+            Debug.Assert(sourceMethod.ContainingSymbol is SourceExtensionTypeSymbol);
+        }
+
+        internal override int ParameterCount => UnderlyingMethod.ParameterCount + 1;
+        public override bool IsStatic => true;
+        public override bool RequiresInstanceReceiver => false;
+
+        internal override Microsoft.Cci.CallingConvention CallingConvention
+        {
+            get
+            {
+                return _originalMethod.CallingConvention & (~Cci.CallingConvention.HasThis);
+            }
+        }
+
+        public override Symbol? AssociatedSymbol
+        {
+            get
+            {
+                if (_originalMethod.AssociatedSymbol is Symbol associatedSymbol)
+                {
+                    return ((SourceExtensionTypeSymbol)_originalMethod.ContainingSymbol).TryGetCorrespondingStaticMetadataExtensionMember(associatedSymbol);
+                }
+
+                return null;
+            }
+        }
+
+        protected override ImmutableArray<ParameterSymbol> MakeParameters()
+        {
+            var sourceParameters = _originalMethod.Parameters;
+            var parameters = ArrayBuilder<ParameterSymbol>.GetInstance(ParameterCount);
+
+            // PROTOTYPE(roles): Need to confirm if this rewrite going to break LocalStateTracingInstrumenter
+            //                   Specifically BoundParameterId, etc.   
+            parameters.Add(new SynthesizedExtensionThisParameterMetadataSymbol(this));
+
+            foreach (var parameter in sourceParameters)
+            {
+                parameters.Add(new ExtensionMetadataMethodParameterSymbol(this, parameter));
+            }
+
+            return parameters.ToImmutableAndFree();
+        }
+
+        internal override bool TryGetThisParameter(out ParameterSymbol? thisParameter)
+        {
+            thisParameter = null;
+            return true;
+        }
+
+        private sealed class ExtensionMetadataMethodParameterSymbol : RewrittenMethodParameterSymbol
+        {
+            public ExtensionMetadataMethodParameterSymbol(SourceExtensionMetadataMethodSymbol containingMethod, ParameterSymbol sourceParameter) :
+                base(containingMethod, sourceParameter)
+            {
+            }
+
+            public override int Ordinal
+            {
+                get { return this._underlyingParameter.Ordinal + 1; }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionMetadataPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionMetadataPropertySymbol.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SourceExtensionMetadataPropertySymbol : RewrittenExtensionPropertySymbol
+    {
+        public SourceExtensionMetadataPropertySymbol(PropertySymbol sourceProperty) : base(sourceProperty)
+        {
+            Debug.Assert(!sourceProperty.IsStatic);
+            Debug.Assert(!sourceProperty.MustCallMethodsDirectly);
+            Debug.Assert(sourceProperty.ContainingSymbol is SourceExtensionTypeSymbol);
+        }
+
+        public override bool IsStatic => true;
+        public override bool RequiresInstanceReceiver => false;
+
+        internal override Microsoft.Cci.CallingConvention CallingConvention
+        {
+            get
+            {
+                return UnderlyingProperty.CallingConvention & (~Cci.CallingConvention.HasThis);
+            }
+        }
+
+        public override MethodSymbol? GetMethod
+        {
+            get
+            {
+                if (UnderlyingProperty.GetMethod is { } accessor)
+                {
+                    return (MethodSymbol?)ContainingType.TryGetCorrespondingStaticMetadataExtensionMember(accessor);
+                }
+
+                return null;
+            }
+        }
+
+        public override MethodSymbol? SetMethod
+        {
+            get
+            {
+                if (UnderlyingProperty.SetMethod is { } accessor)
+                {
+                    return (MethodSymbol?)ContainingType.TryGetCorrespondingStaticMetadataExtensionMember(accessor);
+                }
+
+                return null;
+            }
+        }
+
+        protected override ImmutableArray<ParameterSymbol> MakeParameters()
+        {
+            var sourceParameters = UnderlyingProperty.Parameters;
+            var parameters = ArrayBuilder<ParameterSymbol>.GetInstance(sourceParameters.Length + 1);
+
+            parameters.Add(new SynthesizedExtensionThisParameterMetadataSymbol(this));
+
+            foreach (var parameter in sourceParameters)
+            {
+                parameters.Add(new ExtensionMetadataPropertyParameterSymbol(this, parameter));
+            }
+
+            return parameters.ToImmutableAndFree();
+        }
+
+        private sealed class ExtensionMetadataPropertyParameterSymbol : RewrittenParameterSymbol
+        {
+            private readonly SourceExtensionMetadataPropertySymbol _containingProperty;
+
+            public ExtensionMetadataPropertyParameterSymbol(SourceExtensionMetadataPropertySymbol containingProperty, ParameterSymbol sourceParameter) :
+                base(sourceParameter)
+            {
+                _containingProperty = containingProperty;
+            }
+
+            public sealed override Symbol ContainingSymbol
+            {
+                get { return _containingProperty; }
+            }
+
+            public override int Ordinal
+            {
+                get { return this._underlyingParameter.Ordinal + 1; }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/SynthesizedExtensionThisParameterMetadataSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/SynthesizedExtensionThisParameterMetadataSymbol.cs
@@ -1,0 +1,175 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SynthesizedExtensionThisParameterMetadataSymbol : ParameterSymbol
+    {
+        private readonly Symbol _containingSymbol;
+
+        internal SynthesizedExtensionThisParameterMetadataSymbol(SourceExtensionMetadataMethodSymbol forMethod)
+        {
+            _containingSymbol = forMethod;
+        }
+
+        internal SynthesizedExtensionThisParameterMetadataSymbol(SourceExtensionMetadataPropertySymbol forProperty)
+        {
+            _containingSymbol = forProperty;
+        }
+
+        // PROTOTYPE(roles): Confirm what name should we use for this parameter
+        //                   Is this name going to hurt or help EE when this parameter is lifted into a closure?
+        public override string Name => GeneratedNames.ThisProxyFieldName();
+
+        public override bool IsDiscard => false;
+
+        public override TypeWithAnnotations TypeWithAnnotations
+            => TypeWithAnnotations.Create(
+                    ((SourceExtensionTypeSymbol)_containingSymbol.ContainingSymbol).GetExtendedTypeNoUseSiteDiagnostics(null),
+                    NullableAnnotation.NotAnnotated,
+                    ImmutableArray.Create<CustomModifier>(
+                        CSharpCustomModifier.CreateOptional(
+                            _containingSymbol.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ExtensionAttribute))));
+
+        public override RefKind RefKind
+        {
+            get
+            {
+                if (TypeWithAnnotations.Type.IsReferenceType)
+                {
+                    return RefKind.None;
+                }
+
+                // PROTOTYPE(roles): State machine operates on a copy of a struct type, therefore capturing that
+                //                   parameter by value for 'async'/iterator methods should probably work.
+                return RefKind.Ref;
+            }
+        }
+
+        public override ImmutableArray<Location> Locations
+        {
+            get { return _containingSymbol.Locations; }
+        }
+
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+        {
+            get { return ImmutableArray<SyntaxReference>.Empty; }
+        }
+
+        public override Symbol ContainingSymbol
+        {
+            get { return _containingSymbol; }
+        }
+
+        internal override ConstantValue? ExplicitDefaultConstantValue
+        {
+            get { return null; }
+        }
+
+        internal override bool IsMetadataOptional
+        {
+            get { return false; }
+        }
+
+        public override bool IsParamsArray
+        {
+            get { return false; }
+        }
+
+        public override bool IsParamsCollection
+        {
+            get { return false; }
+        }
+
+        internal override bool IsIDispatchConstant
+        {
+            get { return false; }
+        }
+
+        internal override bool IsIUnknownConstant
+        {
+            get { return false; }
+        }
+
+        internal override bool IsCallerFilePath
+        {
+            get { return false; }
+        }
+
+        internal override bool IsCallerLineNumber
+        {
+            get { return false; }
+        }
+
+        internal override bool IsCallerMemberName
+        {
+            get { return false; }
+        }
+
+        internal override int CallerArgumentExpressionParameterIndex
+        {
+            get { throw ExceptionUtilities.Unreachable(); }
+        }
+
+        internal override FlowAnalysisAnnotations FlowAnalysisAnnotations
+        {
+            get { throw ExceptionUtilities.Unreachable(); }
+        }
+
+        internal override ImmutableHashSet<string> NotNullIfParameterNotNull
+        {
+            get { throw ExceptionUtilities.Unreachable(); }
+        }
+
+        public override int Ordinal
+        {
+            get { return 0; }
+        }
+
+        public override ImmutableArray<CustomModifier> RefCustomModifiers
+        {
+            get { return ImmutableArray<CustomModifier>.Empty; }
+        }
+
+        public override bool IsImplicitlyDeclared
+        {
+            get { return true; }
+        }
+
+        internal override bool IsMetadataIn
+        {
+            get { return false; }
+        }
+
+        internal override bool IsMetadataOut
+        {
+            get { return false; }
+        }
+
+        internal override MarshalPseudoCustomAttributeData? MarshallingInformation
+        {
+            get { return null; }
+        }
+
+        internal override ImmutableArray<int> InterpolatedStringHandlerArgumentIndexes => throw ExceptionUtilities.Unreachable();
+
+        internal override bool HasInterpolatedStringHandlerArgumentError => throw ExceptionUtilities.Unreachable();
+
+        internal override ScopedKind EffectiveScope
+        {
+            get
+            {
+                // PROTOTYPE(roles): Confirm this is good enough.
+                return ScopedKind.None;
+            }
+        }
+
+        internal override bool HasUnscopedRefAttribute => false;
+
+        internal sealed override bool UseUpdatedEscapeRules => throw ExceptionUtilities.Unreachable();
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -773,6 +773,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 #nullable enable
         internal abstract TypeSymbol? GetDeclaredExtensionUnderlyingType();
+
+        /// <summary>
+        /// If this is an <see cref="OriginalDefinition"/> of an extension type and
+        /// <paramref name="member"/> is an instance extension member, return its corresponding
+        /// symbol from/for metadata. Return 'null' otherwise.  
+        /// </summary>
+        internal abstract Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member);
 #nullable disable
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -191,6 +191,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
+        internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
         internal sealed override bool HasPossibleWellKnownCloneMethod() => false;
 
         internal override bool Equals(TypeSymbol? other, TypeCompareKind comparison)

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbolExtensions.cs
@@ -61,9 +61,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return property.IsIndexedProperty && (!property.IsIndexer || property.HasRefOrOutParameter());
         }
 
-        public static bool HasRefOrOutParameter(this PropertySymbol property)
+        public static bool HasRefOrOutParameter(this PropertySymbol property, int skipParameters = 0)
         {
-            foreach (ParameterSymbol param in property.Parameters)
+            foreach (ParameterSymbol param in property.Parameters[skipParameters..])
             {
                 if (param.RefKind == RefKind.Ref || param.RefKind == RefKind.Out)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -443,6 +443,48 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return _lazyDeclaredExtendedType;
         }
 
+        internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member)
+        {
+            Debug.Assert(member.IsDefinition);
+            Debug.Assert(member.ContainingSymbol == (object)this);
+
+            if (member.ContainingSymbol != (object)this || member.IsStatic)
+            {
+                return null;
+            }
+
+            switch (member)
+            {
+                case RetargetingMethodSymbol method:
+
+                    if (UnderlyingNamedType.TryGetCorrespondingStaticMetadataExtensionMember(method.UnderlyingMethod) is MethodSymbol underlyingMetadataMethod)
+                    {
+                        return this.RetargetingTranslator.Retarget(underlyingMetadataMethod);
+                    }
+
+                    return null;
+
+                case RetargetingPropertySymbol property:
+                    if (UnderlyingNamedType.TryGetCorrespondingStaticMetadataExtensionMember(property.UnderlyingProperty) is PropertySymbol underlyingMetadataProperty)
+                    {
+                        return this.RetargetingTranslator.Retarget(underlyingMetadataProperty);
+                    }
+
+                    return null;
+
+                case RetargetingEventSymbol @event:
+                    if (UnderlyingNamedType.TryGetCorrespondingStaticMetadataExtensionMember(@event.UnderlyingEvent) is EventSymbol underlyingMetadataEvent)
+                    {
+                        return this.RetargetingTranslator.Retarget(underlyingMetadataEvent);
+                    }
+
+                    return null;
+
+                default:
+                    return null;
+            }
+        }
+
         private static NamedTypeSymbol MakeErrorType(TypeSymbol type)
         {
             // PROTOTYPE consider using a more specific diagnostic. Maybe ERR_MalformedExtensionInMetadata or "Extension type declaration is malformed"

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -186,6 +186,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
+        internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
         protected override void CheckUnderlyingType(BindingDiagnosticBag diagnostics)
             => throw ExceptionUtilities.Unreachable();
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -59,7 +59,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             static ConcurrentDictionary<Symbol, Symbol> ensureDictionary(ref ConcurrentDictionary<Symbol, Symbol>? storage)
             {
-                return storage ??= new ConcurrentDictionary<Symbol, Symbol>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+                if (storage is null)
+                {
+                    Interlocked.CompareExchange(ref storage, new ConcurrentDictionary<Symbol, Symbol>(Roslyn.Utilities.ReferenceEqualityComparer.Instance), null);
+                }
+
+                return storage;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -22,10 +23,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // For non-static extensions, we emit a field of the underlying type
         private FieldSymbol? _lazyUnderlyingInstanceField = null;
 
+        private ConcurrentDictionary<Symbol, Symbol>? _lazyInstanceMetadataMembers;
+
         internal SourceExtensionTypeSymbol(NamespaceOrTypeSymbol containingSymbol, MergedTypeDeclaration declaration, BindingDiagnosticBag diagnostics)
             : base(containingSymbol, declaration, diagnostics)
         {
             Debug.Assert(declaration.Kind == DeclarationKind.Extension);
+        }
+
+        internal override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member)
+        {
+            Debug.Assert(member.IsDefinition);
+            Debug.Assert(member.ContainingSymbol == (object)this);
+
+            if (member.ContainingSymbol != (object)this || member.IsStatic || GetExtendedTypeNoUseSiteDiagnostics(null) is null)
+            {
+                return null;
+            }
+
+            switch (member)
+            {
+                case SourceMemberMethodSymbol { MethodKind: not MethodKind.Constructor }:
+
+                    return ensureDictionary(ref _lazyInstanceMetadataMembers).GetOrAdd(member, static (member) => new SourceExtensionMetadataMethodSymbol((MethodSymbol)member));
+
+                case SourcePropertySymbol:
+                    return ensureDictionary(ref _lazyInstanceMetadataMembers).GetOrAdd(member, static (member) => new SourceExtensionMetadataPropertySymbol((PropertySymbol)member));
+
+                case SourceEventSymbol:
+                    return ensureDictionary(ref _lazyInstanceMetadataMembers).GetOrAdd(member, static (member) => new SourceExtensionMetadataEventSymbol((EventSymbol)member));
+
+                default:
+                    return null;
+            }
+
+            static ConcurrentDictionary<Symbol, Symbol> ensureDictionary(ref ConcurrentDictionary<Symbol, Symbol>? storage)
+            {
+                return storage ??= new ConcurrentDictionary<Symbol, Symbol>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+            }
         }
 
         // PROTOTYPE restore base extensions or remove this wrapper type

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
+        internal override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
         protected override void CheckUnderlyingType(BindingDiagnosticBag diagnostics)
             => throw ExceptionUtilities.Unreachable();
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -266,6 +266,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                 }
             }
+            else if (!IsStatic && ContainingType.IsExtension)
+            {
+                // PROTOTYPE(roles): Do we need to add similar check for properties and events or accessors come through here?
+                Binder.GetWellKnownType(DeclaringCompilation, WellKnownType.System_Runtime_CompilerServices_ExtensionAttribute, diagnostics, _location);
+            }
         }
 
         protected sealed override Location ReturnTypeLocation => GetSyntax().ReturnType.Location;

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -492,6 +492,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw new InvalidOperationException("PROTOTYPE"); // PROTOTYPE
 
+        internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
         internal sealed override bool HasInlineArrayAttribute(out int length)
         {
             return _underlyingType.HasInlineArrayAttribute(out length);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListEnumeratorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListEnumeratorTypeSymbol.cs
@@ -268,5 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
+
+        internal override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
@@ -949,5 +949,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
+
+        internal override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -65,6 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
+        internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
         internal sealed override bool HasPossibleWellKnownCloneMethod() => false;
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -179,6 +179,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
+
+        internal sealed override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
 #nullable disable
 
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
@@ -210,6 +210,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
 
+        internal override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
         private sealed class InlineArrayTypeParameterSymbol : TypeParameterSymbol
         {
             private readonly SynthesizedInlineArrayTypeSymbol _container;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedPrivateImplementationDetailsType.cs
@@ -194,5 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType()
             => throw ExceptionUtilities.Unreachable();
+
+        internal override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
     }
 }

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -39997,7 +39997,7 @@ class Program
 		IL_0001: callvirt instance void C::Increment()
 		IL_0006: ret
 	} // end of method E::EIncrement
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			class C ''
 		) cil managed 
@@ -40167,7 +40167,7 @@ class Program
 		IL_0001: call instance void C::Increment()
 		IL_0006: ret
 	} // end of method E::EIncrement
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			valuetype C ''
 		) cil managed 
@@ -40337,7 +40337,7 @@ class C<T>
 		IL_0002: callvirt instance void class C`1<!T>::Increment(!0)
 		IL_0007: ret
 	} // end of method E`1::EIncrement
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			class C`1<!T> ''
 		) cil managed 
@@ -40492,7 +40492,7 @@ class C
 		IL_0002: callvirt instance void C::Increment<!!S>(!!0)
 		IL_0007: ret
 	} // end of method E::EIncrement
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			class C ''
 		) cil managed 
@@ -40646,7 +40646,7 @@ class C : I1
 		IL_0006: callvirt instance void I1::Increment()
 		IL_000b: ret
 	} // end of method E`1::EIncrement
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			!T ''
 		) cil managed 
@@ -40864,7 +40864,7 @@ struct S : I1
 		IL_0007: callvirt instance void I1::Increment()
 		IL_000c: ret
 	} // end of method E`1::EIncrement
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			!T ''
 		) cil managed 
@@ -41024,7 +41024,7 @@ struct S : I1
 		IL_0007: callvirt instance void I1::Increment()
 		IL_000c: ret
 	} // end of method E`1::EIncrement
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			!T ''
 		) cil managed 
@@ -41830,7 +41830,7 @@ class Program
 		IL_0002: callvirt instance void C::set_P(int32)
 		IL_0007: ret
 	} // end of method E::set_P2
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			class C ''
 		) cil managed 
@@ -42000,7 +42000,7 @@ class Program
 		IL_0002: call instance void C::set_P(int32)
 		IL_0007: ret
 	} // end of method E::set_P2
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			valuetype C ''
 		) cil managed 
@@ -42143,7 +42143,7 @@ class Program
 		IL_0002: callvirt instance void C::set_P(int32)
 		IL_0007: ret
 	} // end of method E::set_Item
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			class C ''
 		) cil managed 
@@ -42283,7 +42283,7 @@ class Program
 		IL_0002: call instance void C::set_P(int32)
 		IL_0007: ret
 	} // end of method E::set_Item
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			valuetype C ''
 		) cil managed 
@@ -42463,7 +42463,7 @@ class Program
 		IL_0002: callvirt instance void C::remove_E(class [System.Runtime]System.Action)
 		IL_0007: ret
 	} // end of method E::remove_E2
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			class C ''
 		) cil managed 
@@ -42648,7 +42648,7 @@ class Program
 		IL_0002: call instance void C::remove_E(class [System.Runtime]System.Action)
 		IL_0007: ret
 	} // end of method E::remove_E2
-	.method private hidebysig static 
+	.method public hidebysig static 
 		void '<ImplicitExtension>$' (
 			valuetype C ''
 		) cil managed 

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -17745,18 +17745,16 @@ implicit extension E for C
 """;
         var comp = CreateCompilation(source);
 
-        var verifier = CompileAndVerify(comp, expectedOutput: "E.M",
-            verify: Verification.Fails with { ILVerifyMessage = "[<Main>$]: Unrecognized arguments for delegate .ctor. { Offset = 0xb }" });
+        var verifier = CompileAndVerify(comp, expectedOutput: "E.M");
 
         verifier.VerifyDiagnostics();
 
-        // PROTOTYPE Fix when adding support for emitting non-static members
         verifier.VerifyIL("<top-level-statements-entry-point>", """
 {
   // Code size       24 (0x18)
   .maxstack  2
   IL_0000:  newobj     "C..ctor()"
-  IL_0005:  ldftn      "void E.M(int)"
+  IL_0005:  ldftn      "void E.M(C, int)"
   IL_000b:  newobj     "D..ctor(object, System.IntPtr)"
   IL_0010:  ldc.i4.s   42
   IL_0012:  callvirt   "void D.Invoke(int)"
@@ -19335,12 +19333,10 @@ implicit extension E for C
 
         var comp = CreateCompilation(source, options: TestOptions.DebugExe);
 
-        var verifier = CompileAndVerify(comp, expectedOutput: "ran",
-            verify: Verification.Fails with { ILVerifyMessage = "[Main]: Unrecognized arguments for delegate .ctor. { Offset = 0x11 }" });
+        var verifier = CompileAndVerify(comp, expectedOutput: "ran");
 
         verifier.VerifyDiagnostics();
 
-        // PROTOTYPE Fix when adding support for emitting non-static members
         verifier.VerifyIL("D.Main", """
 {
   // Code size       29 (0x1d)
@@ -19349,7 +19345,7 @@ implicit extension E for C
   IL_0000:  nop
   IL_0001:  newobj     "D..ctor()"
   IL_0006:  newobj     "C..ctor()"
-  IL_000b:  ldftn      "int E.M()"
+  IL_000b:  ldftn      "int E.M(C)"
   IL_0011:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
   IL_0016:  call       "int D.Select<int>(System.Func<int>)"
   IL_001b:  stloc.0
@@ -19607,11 +19603,7 @@ public static class E2
         var comp = CreateCompilation(src);
         comp.VerifyEmitDiagnostics();
 
-        var verifier = CompileAndVerify(comp, expectedOutput: "not-invocation invocation",
-            verify: Verification.Fails with { ILVerifyMessage = """
-                [<Main>$]: Callvirt on a value type method. { Offset = 0x6 }
-                [<Main>$]: Unexpected type on the stack. { Offset = 0x6, Found = ref 'object', Expected = address of 'E1' }
-                """ });
+        var verifier = CompileAndVerify(comp, expectedOutput: "not-invocation invocation");
         verifier.VerifyDiagnostics();
         // PROTOTYPE Fix IL when adding support for emitting non-static members
         verifier.VerifyIL("<top-level-statements-entry-point>", """
@@ -19620,7 +19612,7 @@ public static class E2
   .maxstack  2
   IL_0000:  newobj     "object..ctor()"
   IL_0005:  dup
-  IL_0006:  callvirt   "string E1.Member.get"
+  IL_0006:  call       "string E1.Member[object].get"
   IL_000b:  call       "void System.Console.Write(string)"
   IL_0010:  call       "void E2.Member(object)"
   IL_0015:  ret
@@ -19696,20 +19688,16 @@ namespace N
 }
 """;
         var comp = CreateCompilation(src);
-        var verifier = CompileAndVerify(comp, expectedOutput: "not-invocation invocation",
-           verify: Verification.Fails with { ILVerifyMessage = """
-                [<Main>$]: Callvirt on a value type method. { Offset = 0x6 }
-                [<Main>$]: Unexpected type on the stack. { Offset = 0x6, Found = ref 'object', Expected = address of 'N.E1' }
-                """ });
+        var verifier = CompileAndVerify(comp, expectedOutput: "not-invocation invocation");
         verifier.VerifyDiagnostics();
         // PROTOTYPE Fix IL when adding support for emitting non-static members
         verifier.VerifyIL("<top-level-statements-entry-point>", """
-    {
+{
   // Code size       22 (0x16)
   .maxstack  2
   IL_0000:  newobj     "object..ctor()"
   IL_0005:  dup
-  IL_0006:  callvirt   "string N.E1.Member.get"
+  IL_0006:  call       "string N.E1.Member[object].get"
   IL_000b:  call       "void System.Console.Write(string)"
   IL_0010:  call       "void N.E2.Member(object)"
   IL_0015:  ret
@@ -19878,7 +19866,7 @@ namespace N
 }
 """;
         var comp = CreateCompilation(src, options: TestOptions.DebugExe);
-        CompileAndVerify(comp, expectedOutput: "42", verify: Verification.Fails).VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "42").VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -24797,7 +24785,11 @@ public {{(isExplicit ? "explicit" : "implicit")}} extension E for Underlying
 }
 """;
         var comp = CreateEmptyCompilation(source);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (34,17): error CS0518: Predefined type 'System.Runtime.CompilerServices.ExtensionAttribute' is not defined or imported
+            //     public void M(E e) { this.M2(); e.M2(); }
+            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(34, 17)
+            );
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -25473,7 +25465,11 @@ public {{(isExplicit ? "explicit" : "implicit")}} extension E<T> for T where T :
 }
 """;
         var comp = CreateEmptyCompilation(source);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (30,17): error CS0518: Predefined type 'System.Runtime.CompilerServices.ExtensionAttribute' is not defined or imported
+            //     public void M(E<T> e) { this.M2(); e.M2(); }
+            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(30, 17)
+            );
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -25553,7 +25549,14 @@ public {{(isExplicit ? "explicit" : "implicit")}} extension E<T> for T where T :
 }
 """;
         var comp = CreateEmptyCompilation(source);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (30,17): error CS0518: Predefined type 'System.Runtime.CompilerServices.ExtensionAttribute' is not defined or imported
+            //     public void M2() { }
+            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M2").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(30, 17),
+            // (31,17): error CS0518: Predefined type 'System.Runtime.CompilerServices.ExtensionAttribute' is not defined or imported
+            //     public void M(E<T> e) { this.M2(); e.M2(); }
+            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(31, 17)
+            );
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -25766,7 +25769,11 @@ public {{(isExplicit ? "explicit" : "implicit")}} extension E for Underlying
 }
 """;
         var comp = CreateEmptyCompilation(source);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (32,17): error CS0518: Predefined type 'System.Runtime.CompilerServices.ExtensionAttribute' is not defined or imported
+            //     public void M(E e) { this.M2(); e.M2(); }
+            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(32, 17)
+            );
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -25820,7 +25827,14 @@ public {{(isExplicit ? "explicit" : "implicit")}} extension E for Underlying
 }
 """;
         var comp = CreateEmptyCompilation(source);
-        comp.VerifyDiagnostics();
+        comp.VerifyDiagnostics(
+            // (32,17): error CS0518: Predefined type 'System.Runtime.CompilerServices.ExtensionAttribute' is not defined or imported
+            //     public void M2() { }
+            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M2").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(32, 17),
+            // (33,17): error CS0518: Predefined type 'System.Runtime.CompilerServices.ExtensionAttribute' is not defined or imported
+            //     public void M(E e) { this.M2(); e.M2(); }
+            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(33, 17)
+            );
 
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
@@ -29669,7 +29683,7 @@ static class E2
 }
 """;
         var comp = CreateCompilation(src);
-        CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.Fails).VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "ran").VerifyDiagnostics();
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
@@ -39830,4 +39844,2756 @@ object.M();
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
     }
+
+    [Fact]
+    public void InstanceMethod_Metadata_01()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public void Method()
+    {
+        this.Increment();
+        this.EIncrement();
+    }
+
+    public void EIncrement()
+    {
+        this.Increment();
+    }
+}
+
+public class C
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+        Test2();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.Method();
+        System.Console.WriteLine(c.F);
+    }
+
+    static void Test2()
+    {
+        GetC().Method();
+    }
+
+    static C GetC() => new C();
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       22 (0x16)
+  .maxstack  2
+  IL_0000:  newobj     "C..ctor()"
+  IL_0005:  dup
+  IL_0006:  call       "void E.Method(C)"
+  IL_000b:  ldfld      "int C.F"
+  IL_0010:  call       "void System.Console.WriteLine(int)"
+  IL_0015:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        var test2IL =
+"""
+{
+  // Code size       11 (0xb)
+  .maxstack  1
+  IL_0000:  call       "C Program.GetC()"
+  IL_0005:  call       "void E.Method(C)"
+  IL_000a:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test2", test2IL);
+
+        verifier.VerifyIL("E.Method(C)",
+"""
+{
+  // Code size       13 (0xd)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  callvirt   "void C.Increment()"
+  IL_0006:  ldarg.0
+  IL_0007:  call       "void E.EIncrement(C)"
+  IL_000c:  ret
+}
+""");
+
+        verifier.VerifyTypeIL("E",
+"""
+.class public sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private class C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig static 
+		void Method (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 13 (0xd)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: callvirt instance void C::Increment()
+		IL_0006: ldarg.0
+		IL_0007: call void E::EIncrement(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute))
+		IL_000c: ret
+	} // end of method E::Method
+	.method public hidebysig static 
+		void EIncrement (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x205e
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: callvirt instance void C::Increment()
+		IL_0006: ret
+	} // end of method E::EIncrement
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			class C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2066
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+} // end of class E
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test2IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test2IL);
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_02()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public void Method()
+    {
+        this.Increment();
+        this.EIncrement();
+    }
+
+    public void EIncrement()
+    {
+        this.Increment();
+    }
+}
+
+public struct C
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+        Test2();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.Method();
+        System.Console.WriteLine(c.F);
+    }
+
+    static void Test2()
+    {
+        GetC().Method();
+    }
+
+    static C GetC() => new C();
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+
+        var test1IL =
+"""
+{
+  // Code size       27 (0x1b)
+  .maxstack  1
+  .locals init (C V_0) //c
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "C"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       "void E.Method(ref C)"
+  IL_000f:  ldloc.0
+  IL_0010:  ldfld      "int C.F"
+  IL_0015:  call       "void System.Console.WriteLine(int)"
+  IL_001a:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        var test2IL =
+"""
+{
+  // Code size       14 (0xe)
+  .maxstack  1
+  .locals init (C V_0)
+  IL_0000:  call       "C Program.GetC()"
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       "void E.Method(ref C)"
+  IL_000d:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test2", test2IL);
+
+        verifier.VerifyIL("E.Method(ref C)",
+"""
+{
+  // Code size       13 (0xd)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  call       "void C.Increment()"
+  IL_0006:  ldarg.0
+  IL_0007:  call       "void E.EIncrement(ref C)"
+  IL_000c:  ret
+}
+""");
+
+        verifier.VerifyTypeIL("E",
+"""
+.class public sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private valuetype C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig static 
+		void Method (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 13 (0xd)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: call instance void C::Increment()
+		IL_0006: ldarg.0
+		IL_0007: call void E::EIncrement(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&)
+		IL_000c: ret
+	} // end of method E::Method
+	.method public hidebysig static 
+		void EIncrement (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x205e
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: call instance void C::Increment()
+		IL_0006: ret
+	} // end of method E::EIncrement
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			valuetype C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2066
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+} // end of class E
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test2IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test2IL);
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_03()
+    {
+        var src = """
+implicit extension E<T> for C<T>
+{
+    public void Method(T x)
+    {
+        this.Increment(x);
+        this.EIncrement(x);
+    }
+
+    public void EIncrement(T x)
+    {
+        this.Increment(x);
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+        Test2();
+    }
+
+    static void Test1()
+    {
+        var c = new C<int>();
+        c.Method(100);
+        System.Console.WriteLine(c.F);
+    }
+
+    static void Test2()
+    {
+        GetC().Method(200);
+    }
+
+    static C<uint> GetC() => new C<uint>();
+}
+
+class C<T>
+{
+    public int F;
+
+    public void Increment(T x)
+    {
+        F++;
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1",
+"""
+{
+  // Code size       24 (0x18)
+  .maxstack  3
+  IL_0000:  newobj     "C<int>..ctor()"
+  IL_0005:  dup
+  IL_0006:  ldc.i4.s   100
+  IL_0008:  call       "void E<int>.Method(C<int>, int)"
+  IL_000d:  ldfld      "int C<int>.F"
+  IL_0012:  call       "void System.Console.WriteLine(int)"
+  IL_0017:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2",
+"""
+{
+  // Code size       16 (0x10)
+  .maxstack  2
+  IL_0000:  call       "C<uint> Program.GetC()"
+  IL_0005:  ldc.i4     0xc8
+  IL_000a:  call       "void E<uint>.Method(C<uint>, uint)"
+  IL_000f:  ret
+}
+""");
+
+        verifier.VerifyIL("E<T>.Method(C<T>, T)",
+"""
+{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  callvirt   "void C<T>.Increment(T)"
+  IL_0007:  ldarg.0
+  IL_0008:  ldarg.1
+  IL_0009:  call       "void E<T>.EIncrement(C<T>, T)"
+  IL_000e:  ret
+}
+""");
+
+        verifier.VerifyTypeIL("E`1",
+"""
+.class private sequential ansi sealed beforefieldinit E`1<T>
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private class C`1<!T> '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig static 
+		void Method (
+			class C`1<!T> modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			!T x
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 15 (0xf)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: callvirt instance void class C`1<!T>::Increment(!0)
+		IL_0007: ldarg.0
+		IL_0008: ldarg.1
+		IL_0009: call void valuetype E`1<!T>::EIncrement(class C`1<!0> modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), !0)
+		IL_000e: ret
+	} // end of method E`1::Method
+	.method public hidebysig static 
+		void EIncrement (
+			class C`1<!T> modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			!T x
+		) cil managed 
+	{
+		// Method begins at RVA 0x2060
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: callvirt instance void class C`1<!T>::Increment(!0)
+		IL_0007: ret
+	} // end of method E`1::EIncrement
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			class C`1<!T> ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2069
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E`1::'<ImplicitExtension>$'
+} // end of class E`1
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_04()
+    {
+        var src = """
+implicit extension E for C
+{
+    public void Method<S>(S x)
+    {
+        this.Increment<S>(x);
+        this.EIncrement<S>(x);
+    }
+
+    public void EIncrement<S>(S x)
+    {
+        this.Increment<S>(x);
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+        Test2();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.Method<int>(100);
+        System.Console.WriteLine(c.F);
+    }
+
+    static void Test2()
+    {
+        GetC().Method<uint>(200);
+    }
+
+    static C GetC() => new C();
+}
+
+class C
+{
+    public int F;
+
+    public void Increment<S>(S x)
+    {
+        F++;
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1",
+"""
+{
+  // Code size       24 (0x18)
+  .maxstack  3
+  IL_0000:  newobj     "C..ctor()"
+  IL_0005:  dup
+  IL_0006:  ldc.i4.s   100
+  IL_0008:  call       "void E.Method<int>(C, int)"
+  IL_000d:  ldfld      "int C.F"
+  IL_0012:  call       "void System.Console.WriteLine(int)"
+  IL_0017:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2",
+"""
+{
+  // Code size       16 (0x10)
+  .maxstack  2
+  IL_0000:  call       "C Program.GetC()"
+  IL_0005:  ldc.i4     0xc8
+  IL_000a:  call       "void E.Method<uint>(C, uint)"
+  IL_000f:  ret
+}
+""");
+
+        verifier.VerifyIL("E.Method<S>(C, S)",
+"""
+{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  callvirt   "void C.Increment<S>(S)"
+  IL_0007:  ldarg.0
+  IL_0008:  ldarg.1
+  IL_0009:  call       "void E.EIncrement<S>(C, S)"
+  IL_000e:  ret
+}
+""");
+
+        verifier.VerifyTypeIL("E",
+"""
+.class private sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private class C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig static 
+		void Method<S> (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			!!S x
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 15 (0xf)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: callvirt instance void C::Increment<!!S>(!!0)
+		IL_0007: ldarg.0
+		IL_0008: ldarg.1
+		IL_0009: call void E::EIncrement<!!S>(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), !!0)
+		IL_000e: ret
+	} // end of method E::Method
+	.method public hidebysig static 
+		void EIncrement<S> (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			!!S x
+		) cil managed 
+	{
+		// Method begins at RVA 0x2060
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: callvirt instance void C::Increment<!!S>(!!0)
+		IL_0007: ret
+	} // end of method E::EIncrement
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			class C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2069
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+} // end of class E
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_05()
+    {
+        var src = """
+implicit extension E<T> for T where T : class, I1
+{
+    public void Method()
+    {
+        this.Increment();
+        this.EIncrement();
+    }
+
+    public void EIncrement()
+    {
+        this.Increment();
+    }
+}
+
+interface I1
+{
+    void Increment();
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+        Test2();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.Method();
+        System.Console.WriteLine(c.F);
+    }
+
+    static void Test2()
+    {
+        GetC().Method();
+    }
+
+    static C GetC() => new C();
+}
+
+class C : I1
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1",
+"""
+{
+  // Code size       22 (0x16)
+  .maxstack  2
+  IL_0000:  newobj     "C..ctor()"
+  IL_0005:  dup
+  IL_0006:  call       "void E<C>.Method(C)"
+  IL_000b:  ldfld      "int C.F"
+  IL_0010:  call       "void System.Console.WriteLine(int)"
+  IL_0015:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2",
+"""
+{
+  // Code size       11 (0xb)
+  .maxstack  1
+  IL_0000:  call       "C Program.GetC()"
+  IL_0005:  call       "void E<C>.Method(C)"
+  IL_000a:  ret
+}
+""");
+
+        verifier.VerifyIL("E<T>.Method(T)",
+"""
+{
+  // Code size       18 (0x12)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  box        "T"
+  IL_0006:  callvirt   "void I1.Increment()"
+  IL_000b:  ldarg.0
+  IL_000c:  call       "void E<T>.EIncrement(T)"
+  IL_0011:  ret
+}
+""");
+
+        verifier.VerifyTypeIL("E`1",
+"""
+.class private sequential ansi sealed beforefieldinit E`1<class (I1) T>
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private !T '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig static 
+		void Method (
+			!T modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 18 (0x12)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: box !T
+		IL_0006: callvirt instance void I1::Increment()
+		IL_000b: ldarg.0
+		IL_000c: call void valuetype E`1<!T>::EIncrement(!0 modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute))
+		IL_0011: ret
+	} // end of method E`1::Method
+	.method public hidebysig static 
+		void EIncrement (
+			!T modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2063
+		// Code size 12 (0xc)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: box !T
+		IL_0006: callvirt instance void I1::Increment()
+		IL_000b: ret
+	} // end of method E`1::EIncrement
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			!T ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2070
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E`1::'<ImplicitExtension>$'
+} // end of class E`1
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_06()
+    {
+        var src = """
+implicit extension E<T> for T where T : I1
+{
+    public void Method()
+    {
+        this.Increment();
+        this.EIncrement();
+    }
+
+    public void EIncrement()
+    {
+        this.Increment();
+    }
+}
+
+interface I1
+{
+    void Increment();
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+        Test2();
+        Test3();
+        Test4();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.Method();
+        System.Console.Write(c.F);
+    }
+
+    static void Test2()
+    {
+        GetC().Method();
+    }
+
+    static C GetC() => new C();
+
+    static void Test3()
+    {
+        var s = new S();
+        s.Method();
+        System.Console.Write(s.F);
+    }
+
+    static void Test4()
+    {
+        GetS().Method();
+    }
+
+    static S GetS() => new S();
+}
+
+class C : I1
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+
+struct S : I1
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("22"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1",
+"""
+{
+  // Code size       25 (0x19)
+  .maxstack  1
+  .locals init (C V_0) //c
+  IL_0000:  newobj     "C..ctor()"
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       "void E<C>.Method(ref C)"
+  IL_000d:  ldloc.0
+  IL_000e:  ldfld      "int C.F"
+  IL_0013:  call       "void System.Console.Write(int)"
+  IL_0018:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2",
+"""
+{
+  // Code size       14 (0xe)
+  .maxstack  1
+  .locals init (C V_0)
+  IL_0000:  call       "C Program.GetC()"
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       "void E<C>.Method(ref C)"
+  IL_000d:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test3",
+"""
+{
+  // Code size       27 (0x1b)
+  .maxstack  1
+  .locals init (S V_0) //s
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "S"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       "void E<S>.Method(ref S)"
+  IL_000f:  ldloc.0
+  IL_0010:  ldfld      "int S.F"
+  IL_0015:  call       "void System.Console.Write(int)"
+  IL_001a:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test4",
+"""
+{
+  // Code size       14 (0xe)
+  .maxstack  1
+  .locals init (S V_0)
+  IL_0000:  call       "S Program.GetS()"
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       "void E<S>.Method(ref S)"
+  IL_000d:  ret
+}
+""");
+
+        // PROTOTYPE(roles): The constraint call is probably a subject to a receiver overwrite during argument evaluation. 
+        verifier.VerifyIL("E<T>.Method(ref T)",
+"""
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  constrained. "T"
+  IL_0007:  callvirt   "void I1.Increment()"
+  IL_000c:  ldarg.0
+  IL_000d:  call       "void E<T>.EIncrement(ref T)"
+  IL_0012:  ret
+}
+""");
+
+        verifier.VerifyTypeIL("E`1",
+"""
+.class private sequential ansi sealed beforefieldinit E`1<(I1) T>
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private !T '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig static 
+		void Method (
+			!T modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 19 (0x13)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: constrained. !T
+		IL_0007: callvirt instance void I1::Increment()
+		IL_000c: ldarg.0
+		IL_000d: call void valuetype E`1<!T>::EIncrement(!0 modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&)
+		IL_0012: ret
+	} // end of method E`1::Method
+	.method public hidebysig static 
+		void EIncrement (
+			!T modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Code size 13 (0xd)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: constrained. !T
+		IL_0007: callvirt instance void I1::Increment()
+		IL_000c: ret
+	} // end of method E`1::EIncrement
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			!T ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2072
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E`1::'<ImplicitExtension>$'
+} // end of class E`1
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("22"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_07()
+    {
+        var src = """
+implicit extension E<T> for T where T : struct, I1
+{
+    public void Method()
+    {
+        this.Increment();
+        this.EIncrement();
+    }
+
+    public void EIncrement()
+    {
+        this.Increment();
+    }
+}
+
+interface I1
+{
+    void Increment();
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test3();
+        Test4();
+    }
+
+    static void Test3()
+    {
+        var s = new S();
+        s.Method();
+        System.Console.Write(s.F);
+    }
+
+    static void Test4()
+    {
+        GetS().Method();
+    }
+
+    static S GetS() => new S();
+}
+
+struct S : I1
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test3",
+"""
+{
+  // Code size       27 (0x1b)
+  .maxstack  1
+  .locals init (S V_0) //s
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "S"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       "void E<S>.Method(ref S)"
+  IL_000f:  ldloc.0
+  IL_0010:  ldfld      "int S.F"
+  IL_0015:  call       "void System.Console.Write(int)"
+  IL_001a:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test4",
+"""
+{
+  // Code size       14 (0xe)
+  .maxstack  1
+  .locals init (S V_0)
+  IL_0000:  call       "S Program.GetS()"
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       "void E<S>.Method(ref S)"
+  IL_000d:  ret
+}
+""");
+
+        verifier.VerifyIL("E<T>.Method(ref T)",
+"""
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  constrained. "T"
+  IL_0007:  callvirt   "void I1.Increment()"
+  IL_000c:  ldarg.0
+  IL_000d:  call       "void E<T>.EIncrement(ref T)"
+  IL_0012:  ret
+}
+""");
+
+        verifier.VerifyTypeIL("E`1",
+"""
+.class private sequential ansi sealed beforefieldinit E`1<valuetype .ctor (I1, [System.Runtime]System.ValueType) T>
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private !T '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig static 
+		void Method (
+			!T modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 19 (0x13)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: constrained. !T
+		IL_0007: callvirt instance void I1::Increment()
+		IL_000c: ldarg.0
+		IL_000d: call void valuetype E`1<!T>::EIncrement(!0 modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&)
+		IL_0012: ret
+	} // end of method E`1::Method
+	.method public hidebysig static 
+		void EIncrement (
+			!T modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2064
+		// Code size 13 (0xd)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: constrained. !T
+		IL_0007: callvirt instance void I1::Increment()
+		IL_000c: ret
+	} // end of method E`1::EIncrement
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			!T ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2072
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E`1::'<ImplicitExtension>$'
+} // end of class E`1
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_08()
+    {
+        var src = """
+implicit extension E for C
+{
+    public int Method(int x)
+    {
+        return x;
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Console.WriteLine(c.Method(123));
+    }
+}
+
+class C
+{
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("E.Method(C, int)",
+"""
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_09()
+    {
+        var src = """
+implicit extension E for C
+{
+    public T Method<T>(T x)
+    {
+        return x;
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Console.WriteLine(c.Method(123));
+    }
+}
+
+class C
+{
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("E.Method<T>(C, T)",
+"""
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_10()
+    {
+        var src = """
+implicit extension E for C
+{
+    public T Method<T>(T x)
+    {
+
+        T local(T y) => Method2(x);
+        return local(x);
+    }
+
+    public T Method2<T>(T x)
+    {
+        return x;
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Console.WriteLine(c.Method(123));
+    }
+}
+
+class C
+{
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("E.Method<T>(C, T)",
+"""
+{
+  // Code size       30 (0x1e)
+  .maxstack  2
+  .locals init (E.<>c__DisplayClass0_0<T> V_0) //CS$<>8__locals0
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldarg.0
+  IL_0003:  stfld      "C E.<>c__DisplayClass0_0<T>.<>4__this"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldarg.1
+  IL_000b:  stfld      "T E.<>c__DisplayClass0_0<T>.x"
+  IL_0010:  ldloc.0
+  IL_0011:  ldfld      "T E.<>c__DisplayClass0_0<T>.x"
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  call       "T E.<Method>b__0_0<T>(T, ref E.<>c__DisplayClass0_0<T>)"
+  IL_001d:  ret
+}
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_11()
+    {
+        var src = """
+implicit extension E for C
+{
+    public T Method<T>(T x)
+    {
+
+        var d = (T y) => Method2(x);
+        return d(x);
+    }
+
+    public T Method2<T>(T x)
+    {
+        return x;
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Console.WriteLine(c.Method(123));
+    }
+}
+
+class C
+{
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("E.Method<T>(C, T)",
+"""
+{
+  // Code size       44 (0x2c)
+  .maxstack  2
+  .locals init (E.<>c__DisplayClass0_0<T> V_0) //CS$<>8__locals0
+  IL_0000:  newobj     "E.<>c__DisplayClass0_0<T>..ctor()"
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  stfld      "C E.<>c__DisplayClass0_0<T>.<>4__this"
+  IL_000d:  ldloc.0
+  IL_000e:  ldarg.1
+  IL_000f:  stfld      "T E.<>c__DisplayClass0_0<T>.x"
+  IL_0014:  ldloc.0
+  IL_0015:  ldftn      "T E.<>c__DisplayClass0_0<T>.<Method>b__0(T)"
+  IL_001b:  newobj     "System.Func<T, T>..ctor(object, nint)"
+  IL_0020:  ldloc.0
+  IL_0021:  ldfld      "T E.<>c__DisplayClass0_0<T>.x"
+  IL_0026:  callvirt   "T System.Func<T, T>.Invoke(T)"
+  IL_002b:  ret
+}
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_12()
+    {
+        var src = """
+implicit extension E for C
+{
+    public T Method<T>(T x)
+    {
+
+        T local(T y) => Method2(y);
+        return local(x);
+    }
+
+    public T Method2<T>(T x)
+    {
+        return x;
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Console.WriteLine(c.Method(123));
+    }
+}
+
+class C
+{
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("E.Method<T>(C, T)",
+"""
+{
+  // Code size       17 (0x11)
+  .maxstack  2
+  .locals init (E.<>c__DisplayClass0_0<T> V_0) //CS$<>8__locals0
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldarg.0
+  IL_0003:  stfld      "C E.<>c__DisplayClass0_0<T>.<>4__this"
+  IL_0008:  ldarg.1
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  call       "T E.<Method>b__0_0<T>(T, ref E.<>c__DisplayClass0_0<T>)"
+  IL_0010:  ret
+}
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_13()
+    {
+        var src = """
+implicit extension E for C
+{
+    public T Method<T>(T x)
+    {
+
+        var d = (T y) => Method2(y);
+        return d(x);
+    }
+
+    public T Method2<T>(T x)
+    {
+        return x;
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Console.WriteLine(c.Method(123));
+    }
+}
+
+class C
+{
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("E.Method<T>(C, T)",
+"""
+{
+  // Code size       30 (0x1e)
+  .maxstack  3
+  IL_0000:  newobj     "E.<>c__DisplayClass0_0<T>..ctor()"
+  IL_0005:  dup
+  IL_0006:  ldarg.0
+  IL_0007:  stfld      "C E.<>c__DisplayClass0_0<T>.<>4__this"
+  IL_000c:  ldftn      "T E.<>c__DisplayClass0_0<T>.<Method>b__0(T)"
+  IL_0012:  newobj     "System.Func<T, T>..ctor(object, nint)"
+  IL_0017:  ldarg.1
+  IL_0018:  callvirt   "T System.Func<T, T>.Invoke(T)"
+  IL_001d:  ret
+}
+""");
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_14()
+    {
+        var src = """
+implicit extension E for C
+{
+    public T Method<T>(T x)
+    {
+
+        T local()
+        {
+            T y = x;
+            return Method2(y);
+        }
+
+        return local();
+    }
+
+    public T Method2<T>(T x)
+    {
+        return x;
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Console.WriteLine(c.Method(123));
+    }
+}
+
+class C
+{
+}
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        comp = CreateCompilation(src, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("123"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_15()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public void Method()
+    {
+        this.Increment();
+    }
+}
+
+public class C
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+        Test2();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Action d = c.Method;
+        d();
+        System.Console.Write(c.F);
+    }
+
+    static void Test2()
+    {
+        var c = new C();
+        var d = new System.Action(c.Method);
+        d();
+        System.Console.Write(c.F);
+    }
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("11"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       33 (0x21)
+  .maxstack  3
+  IL_0000:  newobj     "C..ctor()"
+  IL_0005:  dup
+  IL_0006:  ldftn      "void E.Method(C)"
+  IL_000c:  newobj     "System.Action..ctor(object, nint)"
+  IL_0011:  callvirt   "void System.Action.Invoke()"
+  IL_0016:  ldfld      "int C.F"
+  IL_001b:  call       "void System.Console.Write(int)"
+  IL_0020:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test1IL);
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("11"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("11"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test1IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("11"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test1IL);
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_16()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public void Method()
+    {
+        this.Increment();
+    }
+}
+
+public struct C
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+        Test2();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        System.Action d = c.Method;
+        d();
+        System.Console.Write(c.F);
+    }
+
+    static void Test2()
+    {
+        var c = new C();
+        var d = new System.Action(c.Method);
+        d();
+        System.Console.Write(c.F);
+    }
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+
+        // PROTOTYPE(roles): Probably should report ErrorCode.ERR_ValueTypeExtDelegate instead, like we do for a legacy extension method 
+        Verification verify = Verification.Fails.WithILVerifyMessage(
+"""
+[Test1]: Unrecognized arguments for delegate .ctor. { Offset = 0x15 }
+[Test2]: Unrecognized arguments for delegate .ctor. { Offset = 0x15 }
+""");
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("00"), verify: verify).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       42 (0x2a)
+  .maxstack  3
+  .locals init (C V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "C"
+  IL_0008:  ldloc.0
+  IL_0009:  dup
+  IL_000a:  box        "C"
+  IL_000f:  ldftn      "void E.Method(ref C)"
+  IL_0015:  newobj     "System.Action..ctor(object, nint)"
+  IL_001a:  callvirt   "void System.Action.Invoke()"
+  IL_001f:  ldfld      "int C.F"
+  IL_0024:  call       "void System.Console.Write(int)"
+  IL_0029:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test1IL);
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("00"), verify: verify).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("00"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test1IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("00"), verify: verify).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+        verifier.VerifyIL("Program.Test2", test1IL);
+    }
+
+    [Fact]
+    public void InstanceProperty_Metadata_01()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public int P1
+    {
+        get => this.P2;
+        set => this.P2 = value; 
+    }
+
+    public int P2
+    {
+        get => this.P;
+        set => this.P = value; 
+    }
+}
+
+public class C
+{
+    public int P { get; set; }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.P1 = 2;
+        System.Console.WriteLine(c.P1);
+    }
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       23 (0x17)
+  .maxstack  3
+  IL_0000:  newobj     "C..ctor()"
+  IL_0005:  dup
+  IL_0006:  ldc.i4.2
+  IL_0007:  call       "void E.P1[C].set"
+  IL_000c:  call       "int E.P1[C].get"
+  IL_0011:  call       "void System.Console.WriteLine(int)"
+  IL_0016:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        verifier.VerifyTypeIL("E",
+"""
+.class public sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private class C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig specialname static 
+		int32 get_P1 (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: call int32 E::get_P2(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute))
+		IL_0006: ret
+	} // end of method E::get_P1
+	.method public hidebysig specialname static 
+		void set_P1 (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			int32 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2058
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call void E::set_P2(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), int32)
+		IL_0007: ret
+	} // end of method E::set_P1
+	.method public hidebysig specialname static 
+		int32 get_P2 (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2061
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: callvirt instance int32 C::get_P()
+		IL_0006: ret
+	} // end of method E::get_P2
+	.method public hidebysig specialname static 
+		void set_P2 (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			int32 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2069
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: callvirt instance void C::set_P(int32)
+		IL_0007: ret
+	} // end of method E::set_P2
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			class C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2072
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+	// Properties
+	.property int32 P1(
+		class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this'
+	)
+	{
+		.get int32 E::get_P1(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute))
+		.set void E::set_P1(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), int32)
+	}
+	.property int32 P2(
+		class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this'
+	)
+	{
+		.get int32 E::get_P2(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute))
+		.set void E::set_P2(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), int32)
+	}
+} // end of class E
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+    }
+
+    [Fact]
+    public void InstanceProperty_Metadata_02()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public int P1
+    {
+        get => this.P2;
+        set => this.P2 = value; 
+    }
+
+    public int P2
+    {
+        get => this.P;
+        set => this.P = value; 
+    }
+}
+
+public struct C
+{
+    public int P { get; set; }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.P1 = 2;
+        System.Console.WriteLine(c.P1);
+    }
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       29 (0x1d)
+  .maxstack  2
+  .locals init (C V_0) //c
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "C"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldc.i4.2
+  IL_000b:  call       "void E.P1[ref C].set"
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  call       "int E.P1[ref C].get"
+  IL_0017:  call       "void System.Console.WriteLine(int)"
+  IL_001c:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        verifier.VerifyTypeIL("E",
+"""
+.class public sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private valuetype C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig specialname static 
+		int32 get_P1 (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: call int32 E::get_P2(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&)
+		IL_0006: ret
+	} // end of method E::get_P1
+	.method public hidebysig specialname static 
+		void set_P1 (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+			int32 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2058
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call void E::set_P2(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, int32)
+		IL_0007: ret
+	} // end of method E::set_P1
+	.method public hidebysig specialname static 
+		int32 get_P2 (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2061
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: call instance int32 C::get_P()
+		IL_0006: ret
+	} // end of method E::get_P2
+	.method public hidebysig specialname static 
+		void set_P2 (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+			int32 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2069
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call instance void C::set_P(int32)
+		IL_0007: ret
+	} // end of method E::set_P2
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			valuetype C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2072
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+	// Properties
+	.property int32 P1(
+		valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+	)
+	{
+		.get int32 E::get_P1(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&)
+		.set void E::set_P1(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, int32)
+	}
+	.property int32 P2(
+		valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this'
+	)
+	{
+		.get int32 E::get_P2(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&)
+		.set void E::set_P2(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, int32)
+	}
+} // end of class E
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+    }
+
+    [Fact]
+    public void InstanceIndexer_Metadata_01()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public int this[int x]
+    {
+        get => this.P;
+        set => this.P = value; 
+    }
+}
+
+public class C
+{
+    public int P { get; set; }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c[1] = 2;
+        System.Console.WriteLine(c[1]);
+    }
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       25 (0x19)
+  .maxstack  4
+  IL_0000:  newobj     "C..ctor()"
+  IL_0005:  dup
+  IL_0006:  ldc.i4.1
+  IL_0007:  ldc.i4.2
+  IL_0008:  call       "void E.this[C, int].set"
+  IL_000d:  ldc.i4.1
+  IL_000e:  call       "int E.this[C, int].get"
+  IL_0013:  call       "void System.Console.WriteLine(int)"
+  IL_0018:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        verifier.VerifyTypeIL("E",
+"""
+.class public sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	.custom instance void [System.Runtime]System.Reflection.DefaultMemberAttribute::.ctor(string) = (
+		01 00 04 49 74 65 6d 00 00
+	)
+	// Fields
+	.field private class C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig specialname static 
+		int32 get_Item (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			int32 x
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: callvirt instance int32 C::get_P()
+		IL_0006: ret
+	} // end of method E::get_Item
+	.method public hidebysig specialname static 
+		void set_Item (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			int32 x,
+			int32 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2058
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.2
+		IL_0002: callvirt instance void C::set_P(int32)
+		IL_0007: ret
+	} // end of method E::set_Item
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			class C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2061
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+	// Properties
+	.property int32 Item(
+		class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+		int32 x
+	)
+	{
+		.get int32 E::get_Item(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), int32)
+		.set void E::set_Item(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), int32, int32)
+	}
+} // end of class E
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+    }
+
+    [Fact]
+    public void InstanceIndexer_Metadata_02()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public int this[int x]
+    {
+        get => this.P;
+        set => this.P = value; 
+    }
+}
+
+public struct C
+{
+    public int P { get; set; }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c[1] = 2;
+        System.Console.WriteLine(c[1]);
+    }
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       31 (0x1f)
+  .maxstack  3
+  .locals init (C V_0) //c
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "C"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldc.i4.1
+  IL_000b:  ldc.i4.2
+  IL_000c:  call       "void E.this[ref C, int].set"
+  IL_0011:  ldloca.s   V_0
+  IL_0013:  ldc.i4.1
+  IL_0014:  call       "int E.this[ref C, int].get"
+  IL_0019:  call       "void System.Console.WriteLine(int)"
+  IL_001e:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        verifier.VerifyTypeIL("E",
+"""
+.class public sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	.custom instance void [System.Runtime]System.Reflection.DefaultMemberAttribute::.ctor(string) = (
+		01 00 04 49 74 65 6d 00 00
+	)
+	// Fields
+	.field private valuetype C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig specialname static 
+		int32 get_Item (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+			int32 x
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: call instance int32 C::get_P()
+		IL_0006: ret
+	} // end of method E::get_Item
+	.method public hidebysig specialname static 
+		void set_Item (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+			int32 x,
+			int32 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2058
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.2
+		IL_0002: call instance void C::set_P(int32)
+		IL_0007: ret
+	} // end of method E::set_Item
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			valuetype C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2061
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+	// Properties
+	.property int32 Item(
+		valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+		int32 x
+	)
+	{
+		.get int32 E::get_Item(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, int32)
+		.set void E::set_Item(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, int32, int32)
+	}
+} // end of class E
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+    }
+
+    [Fact]
+    public void InstanceEvent_Metadata_01()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public event System.Action E1
+    {
+        add => this.E2 += value ;
+        remove => this.E2 -= value; 
+    }
+
+    public event System.Action E2
+    {
+        add => this.E += value;
+        remove => this.E -= value; 
+    }
+}
+
+public class C
+{
+    public event System.Action E;
+
+    public void Fire() => E();
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.E1 += M2();
+        c.Fire();
+        c.E1 += M3();
+        c.E1 -= M2();
+        c.Fire();
+    }
+
+    static System.Action M2() => (() => System.Console.Write(2));
+    static System.Action M3() => (() => System.Console.Write(3));
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("23"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       50 (0x32)
+  .maxstack  3
+  IL_0000:  newobj     "C..ctor()"
+  IL_0005:  dup
+  IL_0006:  call       "System.Action Program.M2()"
+  IL_000b:  call       "void E.E1.add"
+  IL_0010:  dup
+  IL_0011:  callvirt   "void C.Fire()"
+  IL_0016:  dup
+  IL_0017:  call       "System.Action Program.M3()"
+  IL_001c:  call       "void E.E1.add"
+  IL_0021:  dup
+  IL_0022:  call       "System.Action Program.M2()"
+  IL_0027:  call       "void E.E1.remove"
+  IL_002c:  callvirt   "void C.Fire()"
+  IL_0031:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        verifier.VerifyTypeIL("E",
+"""
+.class public sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private class C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig specialname static 
+		void add_E1 (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			class [System.Runtime]System.Action 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call void E::add_E2(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), class [System.Runtime]System.Action)
+		IL_0007: ret
+	} // end of method E::add_E1
+	.method public hidebysig specialname static 
+		void remove_E1 (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			class [System.Runtime]System.Action 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2059
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call void E::remove_E2(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), class [System.Runtime]System.Action)
+		IL_0007: ret
+	} // end of method E::remove_E1
+	.method public hidebysig specialname static 
+		void add_E2 (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			class [System.Runtime]System.Action 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2062
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: callvirt instance void C::add_E(class [System.Runtime]System.Action)
+		IL_0007: ret
+	} // end of method E::add_E2
+	.method public hidebysig specialname static 
+		void remove_E2 (
+			class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute) '<>4__this',
+			class [System.Runtime]System.Action 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x206b
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: callvirt instance void C::remove_E(class [System.Runtime]System.Action)
+		IL_0007: ret
+	} // end of method E::remove_E2
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			class C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2074
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+	// Events
+	.event [System.Runtime]System.Action E1
+	{
+		.addon void E::add_E1(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), class [System.Runtime]System.Action)
+		.removeon void E::remove_E1(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), class [System.Runtime]System.Action)
+	}
+	.event [System.Runtime]System.Action E2
+	{
+		.addon void E::add_E2(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), class [System.Runtime]System.Action)
+		.removeon void E::remove_E2(class C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute), class [System.Runtime]System.Action)
+	}
+} // end of class E
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("23"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("23"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("23"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+    }
+
+    [Fact]
+    public void InstanceEvent_Metadata_02()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public event System.Action E1
+    {
+        add => this.E2 += value ;
+        remove => this.E2 -= value; 
+    }
+
+    public event System.Action E2
+    {
+        add => this.E += value;
+        remove => this.E -= value; 
+    }
+}
+
+public struct C
+{
+    public event System.Action E;
+
+    public void Fire() => E();
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.E1 += M2();
+        c.Fire();
+        c.E1 += M3();
+        c.E1 -= M2();
+        c.Fire();
+    }
+
+    static System.Action M2() => (() => System.Console.Write(2));
+    static System.Action M3() => (() => System.Console.Write(3));
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("23"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var test1IL =
+"""
+{
+  // Code size       59 (0x3b)
+  .maxstack  2
+  .locals init (C V_0) //c
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "C"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       "System.Action Program.M2()"
+  IL_000f:  call       "void E.E1.add"
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  call       "void C.Fire()"
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  call       "System.Action Program.M3()"
+  IL_0022:  call       "void E.E1.add"
+  IL_0027:  ldloca.s   V_0
+  IL_0029:  call       "System.Action Program.M2()"
+  IL_002e:  call       "void E.E1.remove"
+  IL_0033:  ldloca.s   V_0
+  IL_0035:  call       "void C.Fire()"
+  IL_003a:  ret
+}
+""";
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        verifier.VerifyTypeIL("E",
+"""
+.class public sequential ansi sealed beforefieldinit E
+	extends [System.Runtime]System.ValueType
+{
+	// Fields
+	.field private valuetype C '<UnderlyingInstance>$'
+	.custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Methods
+	.method public hidebysig specialname static 
+		void add_E1 (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+			class [System.Runtime]System.Action 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call void E::add_E2(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, class [System.Runtime]System.Action)
+		IL_0007: ret
+	} // end of method E::add_E1
+	.method public hidebysig specialname static 
+		void remove_E1 (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+			class [System.Runtime]System.Action 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2059
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call void E::remove_E2(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, class [System.Runtime]System.Action)
+		IL_0007: ret
+	} // end of method E::remove_E1
+	.method public hidebysig specialname static 
+		void add_E2 (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+			class [System.Runtime]System.Action 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x2062
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call instance void C::add_E(class [System.Runtime]System.Action)
+		IL_0007: ret
+	} // end of method E::add_E2
+	.method public hidebysig specialname static 
+		void remove_E2 (
+			valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)& '<>4__this',
+			class [System.Runtime]System.Action 'value'
+		) cil managed 
+	{
+		// Method begins at RVA 0x206b
+		// Code size 8 (0x8)
+		.maxstack 8
+		IL_0000: ldarg.0
+		IL_0001: ldarg.1
+		IL_0002: call instance void C::remove_E(class [System.Runtime]System.Action)
+		IL_0007: ret
+	} // end of method E::remove_E2
+	.method private hidebysig static 
+		void '<ImplicitExtension>$' (
+			valuetype C ''
+		) cil managed 
+	{
+		// Method begins at RVA 0x2074
+		// Code size 1 (0x1)
+		.maxstack 8
+		IL_0000: ret
+	} // end of method E::'<ImplicitExtension>$'
+	// Events
+	.event [System.Runtime]System.Action E1
+	{
+		.addon void E::add_E1(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, class [System.Runtime]System.Action)
+		.removeon void E::remove_E1(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, class [System.Runtime]System.Action)
+	}
+	.event [System.Runtime]System.Action E2
+	{
+		.addon void E::add_E2(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, class [System.Runtime]System.Action)
+		.removeon void E::remove_E2(valuetype C modopt([System.Runtime]System.Runtime.CompilerServices.ExtensionAttribute)&, class [System.Runtime]System.Action)
+	}
+} // end of class E
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("23"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        var comp1 = CreateCompilation(src1, targetFramework: TargetFramework.NetStandard20, options: TestOptions.ReleaseDll);
+
+        var comp2 = CreateCompilation(src2, references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net80,
+            options: TestOptions.ReleaseExe.WithSpecificDiagnosticOptions("CS1701", ReportDiagnostic.Suppress)); // warning CS1701: Assuming assembly reference 'System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by '512c7a1c-7c4e-4467-84af-5b75683f75fb' matches identity 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("23"), verify: Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+
+        comp2 = CreateCompilation(src2, references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(comp2, expectedOutput: IncludeExpectedOutput("23"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", test1IL);
+    }
+
+    // PROTOTYPE(roles): Add flavors of "_Metadata" types for an underlying type a type parameter known/unknown to be a reference type
+
+    // PROTOTYPE(roles): Test capturing of struct underlying type into a closure in an instance extension member.  
+    //                   Probably should be an error.
+
+    // PROTOTYPE(roles): Test expression trees with instance members.
+
+    // PROTOTYPE(roles): Ensure instance events are never treated as WINRT events.
+
+    // PROTOTYPE(roles): Test consumption of instance APIs from VB as static APIs. Also check behavior of legacy C# compilers.
 }

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -42689,7 +42689,7 @@ class Program
         verifier.VerifyIL("Program.Test1", test1IL);
     }
 
-    // PROTOTYPE(roles): Add flavors of "_Metadata" types for an underlying type a type parameter known/unknown to be a reference type
+    // PROTOTYPE(roles): Add flavors of "_Metadata" tests for an underlying type a type parameter known/unknown to be a reference type
 
     // PROTOTYPE(roles): Test capturing of struct underlying type into a closure in an instance extension member.  
     //                   Probably should be an error.

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -339,6 +339,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal override TypeSymbol? GetExtendedTypeNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved) => null;
 
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();
+
+        internal override Symbol? TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
 #nullable disable
         internal override bool IsInterpolatedStringHandlerType => false;
 

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -2366,10 +2366,10 @@ tryAgain:
         /// <param name="eventType">Type of the event containing the accessor.</param>
         /// <param name="methodParams">Signature of the accessor (return type and then parameters).</param>
         /// <returns>True if the accessor signature is appropriate for the containing event.</returns>
-        internal bool DoesSignatureMatchEvent(TypeSymbol eventType, ParamInfo<TypeSymbol>[] methodParams)
+        internal bool DoesSignatureMatchEvent(TypeSymbol eventType, ParamInfo<TypeSymbol>[] methodParams, bool isInstanceExtension)
         {
             // Check the number of parameters.
-            if (methodParams.Length != 2)
+            if (methodParams.Length != (isInstanceExtension ? 3 : 2))
             {
                 return false;
             }
@@ -2380,7 +2380,7 @@ tryAgain:
                 return false;
             }
 
-            var methodParam = methodParams[1];
+            var methodParam = methodParams[isInstanceExtension ? 2 : 1];
             return !methodParam.IsByRef && methodParam.Type.Equals(eventType);
         }
     }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -292,6 +292,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return TypeKind.Class; }
         }
 
+        internal override Symbol TryGetCorrespondingStaticMetadataExtensionMember(Symbol member) => null;
+
         public override NamedTypeSymbol ContainingType
         {
             get { return null; }


### PR DESCRIPTION
- Translate instance declarations in source to static declarations in metadata
  - A new parameter is added at the beginning.
  - The parameter's name is unspeakable
  - The type of the parameter is the extended type
  -  A modopt(System.Runtime.CompilerServices.ExtensionAttribute) is added to the type. On import the presence of the modopt is checked by verifying fully qualified name of the ExtensionAttribute type.
  - The parameter is a 'ref' parameter, unless it is known to be a reference type
- Rewrite usages of the instance APIs in bound tree to usages of the corresponding static APIs.
- Rewrite bound tree corresponding to a body of an instance extension method to a body corresponding to the static/metadata form of the method. This rewrite is done by `InstanceExtensionMethodBodyRewriter` right after the `LocalRewriter`. All the following rewrite phases and emit phase are performed with the static/metadata form as the owner of the body.
- Translate static declarations in metadata to language representation (i.e. an instance form). This allows binding to them as to instance API during semantic analysis.

Relates to test plan https://github.com/dotnet/roslyn/issues/66722