### PR TITLE
Fix find refs doing too much work lookign for types that had an alias to them in one file.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
@@ -94,9 +94,7 @@ internal partial class FindReferencesSearchEngine
 
             foreach (var symbol in symbols)
             {
-                var state = new FindReferencesDocumentState(
-                    cache, TryGet(symbolToGlobalAliases, symbol));
-
+                var state = new FindReferencesDocumentState(cache, TryGet(symbolToGlobalAliases, symbol));
                 await PerformSearchInDocumentWorkerAsync(symbol, state).ConfigureAwait(false);
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
@@ -94,7 +94,9 @@ internal partial class FindReferencesSearchEngine
 
             foreach (var symbol in symbols)
             {
-                var state = new FindReferencesDocumentState(cache, TryGet(symbolToGlobalAliases, symbol));
+                var state = new FindReferencesDocumentState(
+                    cache, TryGet(symbolToGlobalAliases, symbol));
+
                 await PerformSearchInDocumentWorkerAsync(symbol, state).ConfigureAwait(false);
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -147,16 +147,23 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
             namedType, namedType.Name, state, processResult, processResultData, cancellationToken);
 
         foreach (var globalAlias in state.GlobalAliases)
-        {
-            // ignore the cases where the global alias might match the type name (i.e.
-            // global alias Console = System.Console).  We'll already find those references
-            // above.
-            if (state.SyntaxFacts.StringComparer.Equals(namedType.Name, globalAlias))
-                continue;
+            FindReferenceToAlias(namedType, state, processResult, processResultData, globalAlias, cancellationToken);
 
-            AddNonAliasReferences(
-                namedType, globalAlias, state, processResult, processResultData, cancellationToken);
-        }
+        foreach (var localAlias in state.Cache.SyntaxTreeIndex.GetAliases(namedType.Name, namedType.Arity))
+            FindReferenceToAlias(namedType, state, processResult, processResultData, localAlias, cancellationToken);
+    }
+
+    private static void FindReferenceToAlias<TData>(
+        INamedTypeSymbol namedType, FindReferencesDocumentState state, Action<FinderLocation, TData> processResult, TData processResultData, string alias, CancellationToken cancellationToken)
+    {
+        // ignore the cases where the global alias might match the type name (i.e.
+        // global alias Console = System.Console).  We'll already find those references
+        // above.
+        if (state.SyntaxFacts.StringComparer.Equals(namedType.Name, alias))
+            return;
+
+        AddNonAliasReferences(
+            namedType, alias, state, processResult, processResultData, cancellationToken);
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -17,7 +17,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols;
 internal partial class AbstractSyntaxIndex<TIndex>
 {
     private static readonly string s_persistenceName = typeof(TIndex).Name;
-    private static readonly Checksum s_serializationFormatChecksum = CodeAnalysis.Checksum.Create("39");
+
+    /// <summary>
+    /// Increment this whenever the data format of the <see cref="AbstractSyntaxIndex{TIndex}"/> changes.  This ensures
+    /// that we will not try to read previously cached data from a prior version of roslyn with a different format and
+    /// will instead regenerate all the indices with the new format.
+    /// </summary>
+    private static readonly Checksum s_serializationFormatChecksum = CodeAnalysis.Checksum.Create("40");
 
     /// <summary>
     /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -14,6 +14,7 @@ internal sealed partial class SyntaxTreeIndex : AbstractSyntaxIndex<SyntaxTreeIn
     private readonly LiteralInfo _literalInfo;
     private readonly IdentifierInfo _identifierInfo;
     private readonly ContextInfo _contextInfo;
+    private readonly HashSet<(string alias, string name, int arity)>? _aliasInfo;
     private readonly HashSet<(string alias, string name, int arity)>? _globalAliasInfo;
 
     private SyntaxTreeIndex(
@@ -21,12 +22,14 @@ internal sealed partial class SyntaxTreeIndex : AbstractSyntaxIndex<SyntaxTreeIn
         LiteralInfo literalInfo,
         IdentifierInfo identifierInfo,
         ContextInfo contextInfo,
+        HashSet<(string alias, string name, int arity)>? aliasInfo,
         HashSet<(string alias, string name, int arity)>? globalAliasInfo)
         : base(checksum)
     {
         _literalInfo = literalInfo;
         _identifierInfo = identifierInfo;
         _contextInfo = contextInfo;
+        _aliasInfo = aliasInfo;
         _globalAliasInfo = globalAliasInfo;
     }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -14,23 +14,20 @@ internal sealed partial class SyntaxTreeIndex : AbstractSyntaxIndex<SyntaxTreeIn
     private readonly LiteralInfo _literalInfo;
     private readonly IdentifierInfo _identifierInfo;
     private readonly ContextInfo _contextInfo;
-    private readonly HashSet<(string alias, string name, int arity)>? _aliasInfo;
-    private readonly HashSet<(string alias, string name, int arity)>? _globalAliasInfo;
+    private readonly HashSet<(string alias, string name, int arity, bool isGlobal)>? _aliasInfo;
 
     private SyntaxTreeIndex(
         Checksum? checksum,
         LiteralInfo literalInfo,
         IdentifierInfo identifierInfo,
         ContextInfo contextInfo,
-        HashSet<(string alias, string name, int arity)>? aliasInfo,
-        HashSet<(string alias, string name, int arity)>? globalAliasInfo)
+        HashSet<(string alias, string name, int arity, bool isGlobal)>? aliasInfo)
         : base(checksum)
     {
         _literalInfo = literalInfo;
         _identifierInfo = identifierInfo;
         _contextInfo = contextInfo;
         _aliasInfo = aliasInfo;
-        _globalAliasInfo = globalAliasInfo;
     }
 
     public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -48,6 +48,7 @@ internal sealed partial class SyntaxTreeIndex
         var longLiterals = LongLiteralHashSetPool.Allocate();
 
         HashSet<(string alias, string name, int arity)>? globalAliasInfo = null;
+        var isCSharp = project.Language == LanguageNames.CSharp;
 
         try
         {
@@ -98,7 +99,8 @@ internal sealed partial class SyntaxTreeIndex
                         containsConversion = containsConversion || syntaxFacts.IsConversionExpression(node);
                         containsCollectionInitializer = containsCollectionInitializer || syntaxFacts.IsObjectCollectionInitializer(node);
 
-                        TryAddGlobalAliasInfo(syntaxFacts, ref globalAliasInfo, node);
+                        if (isCSharp)
+                            TryAddGlobalAliasInfo(syntaxFacts, ref globalAliasInfo, node);
                     }
                     else
                     {
@@ -228,7 +230,7 @@ internal sealed partial class SyntaxTreeIndex
             return;
 
         syntaxFacts.GetPartsOfUsingAliasDirective(node, out var globalToken, out var alias, out var usingTarget);
-        if (globalToken.IsMissing)
+        if (globalToken == default)
             return;
 
         // if we have `global using X = Y.Z` then walk down the rhs to pull out 'Z'.

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Collections;
@@ -43,22 +42,22 @@ internal sealed partial class SyntaxTreeIndex
     /// <c>name="C"</c> and arity=1 will return <c>X</c>.
     /// </summary>
     public ImmutableArray<string> GetGlobalAliases(string name, int arity)
-        => GetAliasesWorker(name, arity, _globalAliasInfo);
+        => GetAliasesWorker(name, arity, isGlobal: true);
 
     public ImmutableArray<string> GetAliases(string name, int arity)
-        => GetAliasesWorker(name, arity, _aliasInfo);
+        => GetAliasesWorker(name, arity, isGlobal: false);
 
-    private static ImmutableArray<string> GetAliasesWorker(
-        string name, int arity, HashSet<(string alias, string name, int arity)>? aliases)
+    private ImmutableArray<string> GetAliasesWorker(
+        string name, int arity, bool isGlobal)
     {
-        if (aliases == null)
+        if (_aliasInfo == null)
             return [];
 
         using var result = TemporaryArray<string>.Empty;
 
-        foreach (var (alias, aliasName, aliasArity) in aliases)
+        foreach (var (alias, aliasName, aliasArity, aliasIsGlobal) in _aliasInfo)
         {
-            if (aliasName == name && aliasArity == arity)
+            if (aliasIsGlobal == isGlobal && aliasArity == arity && aliasName == name)
                 result.Add(alias);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Collections;
@@ -42,13 +43,20 @@ internal sealed partial class SyntaxTreeIndex
     /// <c>name="C"</c> and arity=1 will return <c>X</c>.
     /// </summary>
     public ImmutableArray<string> GetGlobalAliases(string name, int arity)
+        => GetAliasesWorker(name, arity, _globalAliasInfo);
+
+    public ImmutableArray<string> GetAliases(string name, int arity)
+        => GetAliasesWorker(name, arity, _aliasInfo);
+
+    private static ImmutableArray<string> GetAliasesWorker(
+        string name, int arity, HashSet<(string alias, string name, int arity)>? aliases)
     {
-        if (_globalAliasInfo == null)
+        if (aliases == null)
             return [];
 
         using var result = TemporaryArray<string>.Empty;
 
-        foreach (var (alias, aliasName, aliasArity) in _globalAliasInfo)
+        foreach (var (alias, aliasName, aliasArity) in aliases)
         {
             if (aliasName == name && aliasArity == arity)
                 result.Add(alias);


### PR DESCRIPTION
A silly bug was making it so that if there was a regular (non-global) using alias to a symbol anywhere in a project, that we would think there wa sa global alias to it.  We'd then search for that global alias in all files to see if it was a hit for the original symbol, doing lots of unnecessary work.