### PR TITLE
Do not offer to add default switch case when it handles `null` and an underlying value

### DIFF
--- a/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchExpressionTests.cs
@@ -1757,6 +1757,27 @@ public partial class PopulateSwitchExpressionTests : AbstractCSharpDiagnosticPro
     }
 
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("int")]
+    [InlineData("int i")]
+    public async Task NullableValueTypeWithNullAndUnderlyingValueArms3(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                int M(int? x)
+                {
+                    return x [||]switch
+                    {
+                        null => -1,
+                        0 => 0,
+                        {{underlyingTypePattern}} => 1,
+                    };
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
     [InlineData("string")]
     [InlineData("string s")]
     public async Task NullableReferenceTypeWithNullAndUnderlyingValueArms1(string underlyingTypePattern)
@@ -1790,6 +1811,27 @@ public partial class PopulateSwitchExpressionTests : AbstractCSharpDiagnosticPro
                     {
                         {{underlyingTypePattern}} => 0,
                         null => -1,
+                    };
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("string")]
+    [InlineData("string s")]
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueArms3(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                int M(string? x)
+                {
+                    return x [||]switch
+                    {
+                        null => -1,
+                        "" => 0,
+                        {{underlyingTypePattern}} => 1,
                     };
                 }
             }

--- a/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchExpressionTests.cs
@@ -4,7 +4,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.PopulateSwitch;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -1711,6 +1710,86 @@ public partial class PopulateSwitchExpressionTests : AbstractCSharpDiagnosticPro
                         true => "true",
                         false => "false",
                         _ => throw new System.NotImplementedException(),
+                    };
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("int")]
+    [InlineData("int i")]
+    public async Task NullableValueTypeWithNullAndUnderlyingValueArms1(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                int M(int? x)
+                {
+                    return x [||]switch
+                    {
+                        null => -1,
+                        {{underlyingTypePattern}} => 0,
+                    };
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("int")]
+    [InlineData("int i")]
+    public async Task NullableValueTypeWithNullAndUnderlyingValueArms2(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                int M(int? x)
+                {
+                    return x [||]switch
+                    {
+                        {{underlyingTypePattern}} => 0,
+                        null => -1,
+                    };
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("string")]
+    [InlineData("string s")]
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueArms1(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                int M(string? x)
+                {
+                    return x [||]switch
+                    {
+                        null => -1,
+                        {{underlyingTypePattern}} => 0,
+                    };
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("string")]
+    [InlineData("string s")]
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueArms2(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                int M(string? x)
+                {
+                    return x [||]switch
+                    {
+                        {{underlyingTypePattern}} => 0,
+                        null => -1,
                     };
                 }
             }

--- a/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchStatementTests.cs
@@ -1803,8 +1803,32 @@ public partial class PopulateSwitchStatementTests(ITestOutputHelper logger)
             """);
     }
 
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("int")]
+    [InlineData("int i")]
+    public async Task NullableValueTypeWithNullAndUnderlyingValueCases3(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                void M(int? x)
+                {
+                    [||]switch (x)
+                    {
+                        case null:
+                            break;
+                        case 0:
+                            break;
+                        case {{underlyingTypePattern}}:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
-    public async Task NullableValueTypeWithNullAndUnderlyingValueCases3()
+    public async Task NullableValueTypeWithNullAndUnderlyingValueCases4()
     {
         await TestMissingInRegularAndScriptAsync("""
             class C
@@ -1823,7 +1847,7 @@ public partial class PopulateSwitchStatementTests(ITestOutputHelper logger)
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
-    public async Task NullableValueTypeWithNullAndUnderlyingValueCases4()
+    public async Task NullableValueTypeWithNullAndUnderlyingValueCases5()
     {
         await TestMissingInRegularAndScriptAsync("""
             class C
@@ -1885,8 +1909,32 @@ public partial class PopulateSwitchStatementTests(ITestOutputHelper logger)
             """);
     }
 
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("string")]
+    [InlineData("string s")]
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases3(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                void M(string? x)
+                {
+                    [||]switch (x)
+                    {
+                        case null:
+                            break;
+                        case "":
+                            break;
+                        case {{underlyingTypePattern}}:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
-    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases3()
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases4()
     {
         await TestMissingInRegularAndScriptAsync("""
             class C
@@ -1905,7 +1953,7 @@ public partial class PopulateSwitchStatementTests(ITestOutputHelper logger)
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
-    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases4()
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases5()
     {
         await TestMissingInRegularAndScriptAsync("""
             class C

--- a/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchStatementTests.cs
@@ -1758,4 +1758,168 @@ public partial class PopulateSwitchStatementTests(ITestOutputHelper logger)
             }
             """);
     }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("int")]
+    [InlineData("int i")]
+    public async Task NullableValueTypeWithNullAndUnderlyingValueCases1(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                void M(int? x)
+                {
+                    [||]switch (x)
+                    {
+                        case null:
+                            break;
+                        case {{underlyingTypePattern}}:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("int")]
+    [InlineData("int i")]
+    public async Task NullableValueTypeWithNullAndUnderlyingValueCases2(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                int M(int? x)
+                {
+                    [||]switch (x)
+                    {
+                        case {{underlyingTypePattern}}:
+                            break;
+                        case null:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    public async Task NullableValueTypeWithNullAndUnderlyingValueCases3()
+    {
+        await TestMissingInRegularAndScriptAsync("""
+            class C
+            {
+                int M(int? x)
+                {
+                    [||]switch (x)
+                    {
+                        case null:
+                        case int:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    public async Task NullableValueTypeWithNullAndUnderlyingValueCases4()
+    {
+        await TestMissingInRegularAndScriptAsync("""
+            class C
+            {
+                int M(int? x)
+                {
+                    [||]switch (x)
+                    {
+                        case int:
+                        case null:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("string")]
+    [InlineData("string s")]
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases1(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                void M(string? x)
+                {
+                    [||]switch (x)
+                    {
+                        case null:
+                            break;
+                        case {{underlyingTypePattern}}:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    [InlineData("string")]
+    [InlineData("string s")]
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases2(string underlyingTypePattern)
+    {
+        await TestMissingInRegularAndScriptAsync($$"""
+            class C
+            {
+                int M(string? x)
+                {
+                    [||]switch (x)
+                    {
+                        case {{underlyingTypePattern}}:
+                            break;
+                        case null:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases3()
+    {
+        await TestMissingInRegularAndScriptAsync("""
+            class C
+            {
+                int M(string? x)
+                {
+                    [||]switch (x)
+                    {
+                        case null:
+                        case string:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50983")]
+    public async Task NullableReferenceTypeWithNullAndUnderlyingValueCases4()
+    {
+        await TestMissingInRegularAndScriptAsync("""
+            class C
+            {
+                int M(string? x)
+                {
+                    [||]switch (x)
+                    {
+                        case string:
+                        case null:
+                            break;
+                    }
+                }
+            }
+            """);
+    }
 }

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchDiagnosticAnalyzer.cs
@@ -111,7 +111,7 @@ internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperatio
         if (HasDefaultCase(operation) || hasAllCases)
             return default;
 
-        return (missingCases: true, missingDefaultCase: true);
+        return (missingCases: false, missingDefaultCase: true);
     }
 
     private (bool missingCases, bool missingDefaultCase) AnalyzeEnumSwitch(TSwitchOperation operation, ITypeSymbol type)

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchDiagnosticAnalyzer.cs
@@ -76,8 +76,15 @@ internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperatio
 
     private bool SwitchIsIncomplete(
         TSwitchOperation operation,
-        out bool missingCases, out bool missingDefaultCase)
+        out bool missingCases,
+        out bool missingDefaultCase)
     {
+        missingCases = false;
+        missingDefaultCase = false;
+
+        if (HasExhaustiveNullAndTypeCheckCases(operation))
+            return false;
+
         if (!IsBooleanSwitch(operation, out missingCases, out missingDefaultCase))
         {
             var missingEnumMembers = GetMissingEnumMembers(operation);
@@ -86,13 +93,7 @@ internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperatio
             missingDefaultCase = !HasDefaultCase(operation);
         }
 
-        if (missingCases)
-            return true;
-
-        if (HasExhaustiveNullAndTypeCheckCases(operation))
-            return false;
-
-        return missingDefaultCase;
+        return missingCases || missingDefaultCase;
     }
 
     private bool IsBooleanSwitch(TSwitchOperation operation, out bool missingCases, out bool missingDefaultCase)

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchDiagnosticAnalyzer.cs
@@ -37,7 +37,7 @@ internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperatio
     protected abstract bool HasConstantCase(TSwitchOperation operation, object? value);
     protected abstract ICollection<ISymbol> GetMissingEnumMembers(TSwitchOperation operation);
     protected abstract bool HasDefaultCase(TSwitchOperation operation);
-    protected abstract bool HasBothNullAndUnderlyingValueCases(TSwitchOperation operation);
+    protected abstract bool HasExhaustiveNullAndTypeCheckCases(TSwitchOperation operation);
     protected abstract Location GetDiagnosticLocation(TSwitchSyntax switchBlock);
 
     public sealed override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
@@ -89,7 +89,7 @@ internal abstract class AbstractPopulateSwitchDiagnosticAnalyzer<TSwitchOperatio
         if (missingCases)
             return true;
 
-        if (HasBothNullAndUnderlyingValueCases(operation))
+        if (HasExhaustiveNullAndTypeCheckCases(operation))
             return false;
 
         return missingDefaultCase;

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchExpressionDiagnosticAnalyzer.cs
@@ -32,8 +32,8 @@ internal abstract class AbstractPopulateSwitchExpressionDiagnosticAnalyzer<TSwit
     protected sealed override bool HasDefaultCase(ISwitchExpressionOperation operation)
         => PopulateSwitchExpressionHelpers.HasDefaultCase(operation);
 
-    protected override bool HasBothNullAndUnderlyingValueCases(ISwitchExpressionOperation operation)
-        => PopulateSwitchExpressionHelpers.HasBothNullAndUnderlyingValueCases(operation);
+    protected override bool HasExhaustiveNullAndTypeCheckCases(ISwitchExpressionOperation operation)
+        => PopulateSwitchExpressionHelpers.HasExhaustiveNullAndTypeCheckCases(operation);
 
     protected override bool HasConstantCase(ISwitchExpressionOperation operation, object? value)
     {

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchExpressionDiagnosticAnalyzer.cs
@@ -32,6 +32,9 @@ internal abstract class AbstractPopulateSwitchExpressionDiagnosticAnalyzer<TSwit
     protected sealed override bool HasDefaultCase(ISwitchExpressionOperation operation)
         => PopulateSwitchExpressionHelpers.HasDefaultCase(operation);
 
+    protected override bool HasBothNullAndUnderlyingValueCases(ISwitchExpressionOperation operation)
+        => PopulateSwitchExpressionHelpers.HasBothNullAndUnderlyingValueCases(operation);
+
     protected override bool HasConstantCase(ISwitchExpressionOperation operation, object? value)
     {
         foreach (var arm in operation.Arms)

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchStatementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchStatementDiagnosticAnalyzer.cs
@@ -32,8 +32,8 @@ internal abstract class AbstractPopulateSwitchStatementDiagnosticAnalyzer<TSwitc
     protected sealed override bool HasDefaultCase(ISwitchOperation operation)
         => PopulateSwitchStatementHelpers.HasDefaultCase(operation);
 
-    protected override bool HasBothNullAndUnderlyingValueCases(ISwitchOperation operation)
-        => PopulateSwitchStatementHelpers.HasBothNullAndUnderlyingValueCases(operation);
+    protected override bool HasExhaustiveNullAndTypeCheckCases(ISwitchOperation operation)
+        => PopulateSwitchStatementHelpers.HasExhaustiveNullAndTypeCheckCases(operation);
 
     protected sealed override Location GetDiagnosticLocation(TSwitchSyntax switchBlock)
         => switchBlock.GetFirstToken().GetLocation();

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchStatementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/AbstractPopulateSwitchStatementDiagnosticAnalyzer.cs
@@ -32,6 +32,9 @@ internal abstract class AbstractPopulateSwitchStatementDiagnosticAnalyzer<TSwitc
     protected sealed override bool HasDefaultCase(ISwitchOperation operation)
         => PopulateSwitchStatementHelpers.HasDefaultCase(operation);
 
+    protected override bool HasBothNullAndUnderlyingValueCases(ISwitchOperation operation)
+        => PopulateSwitchStatementHelpers.HasBothNullAndUnderlyingValueCases(operation);
+
     protected sealed override Location GetDiagnosticLocation(TSwitchSyntax switchBlock)
         => switchBlock.GetFirstToken().GetLocation();
 

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -103,7 +103,7 @@ internal static class PopulateSwitchExpressionHelpers
             _ => false
         };
 
-    public static bool HasBothNullAndUnderlyingValueCases(ISwitchExpressionOperation operation)
+    public static bool HasExhaustiveNullAndTypeCheckCases(ISwitchExpressionOperation operation)
     {
         var type = operation.Value.Type;
         var underlyingType = type.RemoveNullableIfPresent();
@@ -114,6 +114,8 @@ internal static class PopulateSwitchExpressionHelpers
         foreach (var arm in operation.Arms)
         {
             var pattern = arm.Pattern;
+            if (arm.Guard != null)
+                continue;
 
             if (pattern is IConstantPatternOperation { Value: IConversionOperation { ConstantValue: { HasValue: true, Value: null } } })
             {

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -118,20 +118,23 @@ internal static class PopulateSwitchExpressionHelpers
             if (pattern is IConstantPatternOperation { Value: IConversionOperation { ConstantValue: { HasValue: true, Value: null } } })
             {
                 hasNullArm = true;
-                continue;
+            }
+            else
+            {
+                hasUnderlyingTypeArm |= SymbolEqualityComparer.Default.Equals(
+                    underlyingType,
+                    pattern switch
+                    {
+                        ITypePatternOperation typePattern => typePattern.MatchedType,
+                        IDeclarationPatternOperation declarationPattern => declarationPattern.MatchedType,
+                        _ => null
+                    });
             }
 
-            var matchedType = pattern switch
-            {
-                ITypePatternOperation typePattern => typePattern.MatchedType,
-                IDeclarationPatternOperation declarationPattern => declarationPattern.MatchedType,
-                _ => null
-            };
-
-            if (SymbolEqualityComparer.Default.Equals(matchedType, underlyingType))
-                hasUnderlyingTypeArm = true;
+            if (hasNullArm && hasUnderlyingTypeArm)
+                return true;
         }
 
-        return hasNullArm && hasUnderlyingTypeArm;
+        return false;
     }
 }

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -106,7 +106,7 @@ internal static class PopulateSwitchExpressionHelpers
     public static bool HasBothNullAndUnderlyingValueCases(ISwitchExpressionOperation operation)
     {
         var type = operation.Value.Type;
-        var underlyingType = type.IsNullable(out var underlying) ? underlying : type;
+        var underlyingType = type.RemoveNullableIfPresent();
 
         var hasNullArm = false;
         var hasUnderlyingTypeArm = false;

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -198,20 +198,22 @@ internal static class PopulateSwitchStatementHelpers
                         hasNullCase = true;
                         break;
                     case IPatternCaseClauseOperation { Pattern: var pattern }:
-                        var matchedType = pattern switch
-                        {
-                            ITypePatternOperation typePattern => typePattern.MatchedType,
-                            IDeclarationPatternOperation declarationPattern => declarationPattern.MatchedType,
-                            _ => null
-                        };
-
-                        if (SymbolEqualityComparer.Default.Equals(matchedType, underlyingType))
-                            hasUnderlyingTypeCase = true;
+                        hasUnderlyingTypeCase |= SymbolEqualityComparer.Default.Equals(
+                            underlyingType,
+                            pattern switch
+                            {
+                                ITypePatternOperation typePattern => typePattern.MatchedType,
+                                IDeclarationPatternOperation declarationPattern => declarationPattern.MatchedType,
+                                _ => null
+                            });
                         break;
                 }
+
+                if (hasNullCase && hasUnderlyingTypeCase)
+                    return true;
             }
         }
 
-        return hasNullCase && hasUnderlyingTypeCase;
+        return false;
     }
 }

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -183,7 +183,7 @@ internal static class PopulateSwitchStatementHelpers
     public static bool HasBothNullAndUnderlyingValueCases(ISwitchOperation operation)
     {
         var type = operation.Value.Type;
-        var underlyingType = type.IsNullable(out var underlying) ? underlying : type;
+        var underlyingType = type.RemoveNullableIfPresent();
 
         var hasNullCase = false;
         var hasUnderlyingTypeCase = false;

--- a/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -180,7 +180,7 @@ internal static class PopulateSwitchStatementHelpers
         return true;
     }
 
-    public static bool HasBothNullAndUnderlyingValueCases(ISwitchOperation operation)
+    public static bool HasExhaustiveNullAndTypeCheckCases(ISwitchOperation operation)
     {
         var type = operation.Value.Type;
         var underlyingType = type.RemoveNullableIfPresent();
@@ -197,7 +197,7 @@ internal static class PopulateSwitchStatementHelpers
                     case ISingleValueCaseClauseOperation { Value: IConversionOperation { ConstantValue: { HasValue: true, Value: null } } }:
                         hasNullCase = true;
                         break;
-                    case IPatternCaseClauseOperation { Pattern: var pattern }:
+                    case IPatternCaseClauseOperation { Pattern: var pattern, Guard: null }:
                         hasUnderlyingTypeCase |= SymbolEqualityComparer.Default.Equals(
                             underlyingType,
                             pattern switch

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -732,9 +732,9 @@ internal static partial class ITypeSymbolExtensions
     [return: NotNullIfNotNull(parameterName: nameof(symbol))]
     public static ITypeSymbol? RemoveNullableIfPresent(this ITypeSymbol? symbol)
     {
-        if (symbol.IsNullable())
+        if (symbol.IsNullable(out var underlyingType))
         {
-            return symbol.GetTypeArguments().Single();
+            return underlyingType;
         }
 
         return symbol;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/50983