### PR TITLE
Bump razor to include fix for project serialization

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -144,7 +144,7 @@
     <PackageVersion Include="NuGet.ProjectModel" Version="6.8.0-rc.112" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftTestPlatformVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="9.0.0-preview.24281.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="9.0.0-preview.24316.1" />
 
     <!--
       Analyzers


### PR DESCRIPTION
Two major changes being introduced: 

https://github.com/dotnet/razor/pull/10480 moves our project change listener to AsyncBatchingWorkQueue to improve stability
https://github.com/dotnet/razor/pull/10475 rearchitects our project syncing. Expected to have no impact on VS Code