### PR TITLE
Ensure an empty run result doesn't throw when generators are present.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -564,10 +564,10 @@ class C { }
             var result = Assert.Single(results.Results);
 
             Assert.Null(result.Exception);
-            Assert.Empty(result.Diagnostics);
-            Assert.Empty(result.GeneratedSources);
-            Assert.Empty(result.TrackedSteps);
-            Assert.Empty(result.TrackedOutputSteps);
+            Assert.True(result.Diagnostics.IsDefault);
+            Assert.True(result.GeneratedSources.IsDefault);
+            Assert.Null(result.TrackedSteps);
+            Assert.Null(result.TrackedOutputSteps);
             Assert.Equal(TimeSpan.Zero, result.ElapsedTime);
             Assert.Equal(generator, result.Generator);
         }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -550,6 +550,28 @@ class C { }
             Assert.Empty(results.Results);
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74033")]
+        public void RunResults_Are_Empty_Before_Generation_With_Generators()
+        {
+            var generator = new SingleFileTestGenerator("public class D {}", "source.cs");
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create([generator], parseOptions: TestOptions.Regular);
+            var results = driver.GetRunResult();
+
+            Assert.Empty(results.GeneratedTrees);
+            Assert.Empty(results.Diagnostics);
+
+            var result = Assert.Single(results.Results);
+
+            Assert.Null(result.Exception);
+            Assert.Empty(result.Diagnostics);
+            Assert.Empty(result.GeneratedSources);
+            Assert.Empty(result.TrackedSteps);
+            Assert.Empty(result.TrackedOutputSteps);
+            Assert.Equal(TimeSpan.Zero, result.ElapsedTime);
+            Assert.Equal(generator, result.Generator);
+        }
+
         [Fact]
         public void RunResults_Are_Available_After_Generation()
         {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis
         internal GeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts, GeneratorDriverOptions driverOptions)
         {
             var incrementalGenerators = GetIncrementalGenerators(generators, SourceExtension);
-            _state = new GeneratorDriverState(parseOptions, optionsProvider, generators, incrementalGenerators, additionalTexts, generators.SelectAsArray(g => GeneratorState.Empty), DriverStateTable.Empty, SyntaxStore.Empty, driverOptions, runtime: TimeSpan.Zero, parseOptionsChanged: true);
+            _state = new GeneratorDriverState(parseOptions, optionsProvider, generators, incrementalGenerators, additionalTexts, generators.SelectAsArray(g => GeneratorState.Uninitialized), DriverStateTable.Empty, SyntaxStore.Empty, driverOptions, runtime: TimeSpan.Zero, parseOptionsChanged: true);
         }
 
         public GeneratorDriver RunGenerators(Compilation compilation, CancellationToken cancellationToken = default)
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    states.Add(GeneratorState.Empty);
+                    states.Add(GeneratorState.Uninitialized);
                 }
             }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis
         internal GeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts, GeneratorDriverOptions driverOptions)
         {
             var incrementalGenerators = GetIncrementalGenerators(generators, SourceExtension);
-            _state = new GeneratorDriverState(parseOptions, optionsProvider, generators, incrementalGenerators, additionalTexts, generators.SelectAsArray(g => GeneratorState.Uninitialized), DriverStateTable.Empty, SyntaxStore.Empty, driverOptions, runtime: TimeSpan.Zero, parseOptionsChanged: true);
+            _state = new GeneratorDriverState(parseOptions, optionsProvider, generators, incrementalGenerators, additionalTexts, ImmutableArray.Create(new GeneratorState[generators.Length]), DriverStateTable.Empty, SyntaxStore.Empty, driverOptions, runtime: TimeSpan.Zero, parseOptionsChanged: true);
         }
 
         public GeneratorDriver RunGenerators(Compilation compilation, CancellationToken cancellationToken = default)
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    states.Add(GeneratorState.Uninitialized);
+                    states.Add(default);
                 }
             }
 
@@ -171,6 +171,11 @@ namespace Microsoft.CodeAnalysis
 
             static ImmutableArray<GeneratedSourceResult> getGeneratorSources(GeneratorState generatorState)
             {
+                if (!generatorState.Initialized)
+                {
+                    return default;
+                }
+
                 ArrayBuilder<GeneratedSourceResult> sources = ArrayBuilder<GeneratedSourceResult>.GetInstance(generatorState.PostInitTrees.Length + generatorState.GeneratedTrees.Length);
                 foreach (var tree in generatorState.PostInitTrees)
                 {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis
         internal GeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts, GeneratorDriverOptions driverOptions)
         {
             var incrementalGenerators = GetIncrementalGenerators(generators, SourceExtension);
-            _state = new GeneratorDriverState(parseOptions, optionsProvider, generators, incrementalGenerators, additionalTexts, ImmutableArray.Create(new GeneratorState[generators.Length]), DriverStateTable.Empty, SyntaxStore.Empty, driverOptions, runtime: TimeSpan.Zero, parseOptionsChanged: true);
+            _state = new GeneratorDriverState(parseOptions, optionsProvider, generators, incrementalGenerators, additionalTexts, generators.SelectAsArray(g => GeneratorState.Empty), DriverStateTable.Empty, SyntaxStore.Empty, driverOptions, runtime: TimeSpan.Zero, parseOptionsChanged: true);
         }
 
         public GeneratorDriver RunGenerators(Compilation compilation, CancellationToken cancellationToken = default)

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -14,6 +14,9 @@ namespace Microsoft.CodeAnalysis
     internal readonly struct GeneratorState
     {
 
+        /// <summary>
+        /// A generator state that has been initialized but produced no results
+        /// </summary>
         public static readonly GeneratorState Empty = new GeneratorState(ImmutableArray<GeneratedSyntaxTree>.Empty,
                                                                          ImmutableArray<SyntaxInputNode>.Empty,
                                                                          ImmutableArray<IIncrementalGeneratorOutputNode>.Empty,
@@ -24,6 +27,11 @@ namespace Microsoft.CodeAnalysis
                                                                          ImmutableArray<(string, string)>.Empty,
                                                                          exception: null,
                                                                          elapsedTime: TimeSpan.Zero);
+
+        /// <summary>
+        /// A generator state for a generator that has not yet been initialized
+        /// </summary>
+        public static readonly GeneratorState Uninitialized = Empty with { Initialized = false };
 
         /// <summary>
         /// Creates a new generator state that contains information, constant trees and an execution pipeline
@@ -100,7 +108,7 @@ namespace Microsoft.CodeAnalysis
                                       elapsedTime);
         }
 
-        internal bool Initialized { get; }
+        internal bool Initialized { get; private init; }
 
         internal ImmutableArray<GeneratedSyntaxTree> PostInitTrees { get; }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis
                                       elapsedTime);
         }
 
-        internal bool Initialized { get; private init; }
+        internal bool Initialized { get; }
 
         internal ImmutableArray<GeneratedSyntaxTree> PostInitTrees { get; }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -29,11 +29,6 @@ namespace Microsoft.CodeAnalysis
                                                                          elapsedTime: TimeSpan.Zero);
 
         /// <summary>
-        /// A generator state for a generator that has not yet been initialized
-        /// </summary>
-        public static readonly GeneratorState Uninitialized = Empty with { Initialized = false };
-
-        /// <summary>
         /// Creates a new generator state that contains information, constant trees and an execution pipeline
         /// </summary>
         public GeneratorState(ImmutableArray<GeneratedSyntaxTree> postInitTrees, ImmutableArray<SyntaxInputNode> inputNodes, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes)

--- a/src/Compilers/Core/Portable/SourceGeneration/RunResults.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/RunResults.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (_lazyDiagnostics.IsDefault)
                 {
-                    ImmutableInterlocked.InterlockedInitialize(ref _lazyDiagnostics, Results.SelectMany(r => r.Diagnostics).ToImmutableArray());
+                    ImmutableInterlocked.InterlockedInitialize(ref _lazyDiagnostics, Results.Where(r => !r.Diagnostics.IsDefaultOrEmpty).SelectMany(r => r.Diagnostics).ToImmutableArray());
                 }
                 return _lazyDiagnostics;
             }
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (_lazyGeneratedTrees.IsDefault)
                 {
-                    ImmutableInterlocked.InterlockedInitialize(ref _lazyGeneratedTrees, Results.SelectMany(r => r.GeneratedSources.Select(g => g.SyntaxTree)).ToImmutableArray());
+                    ImmutableInterlocked.InterlockedInitialize(ref _lazyGeneratedTrees, Results.Where(r => !r.GeneratedSources.IsDefaultOrEmpty).SelectMany(r => r.GeneratedSources.Select(g => g.SyntaxTree)).ToImmutableArray());
                 }
                 return _lazyGeneratedTrees;
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74033