### PR TITLE
Preserve trivia for 'Use Collection Expression' fixer in more cases

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -733,18 +733,12 @@ internal static class UseCollectionExpressionHelpers
                 .WithPrependedLeadingTrivia(ElasticMarker);
     }
 
-    private static bool HasStructuredTriviaBetweenCloseTokenAndInitializer(InitializerExpressionSyntax initializer)
-    {
-        static bool IsComment(SyntaxTrivia trivia) => trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia);
-        return initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(IsComment);
-    }
-
     private static bool ShouldReplaceExistingExpressionEntirely(
         SourceText sourceText,
         InitializerExpressionSyntax initializer,
         bool newCollectionIsSingleLine)
     {
-        if (HasStructuredTriviaBetweenCloseTokenAndInitializer(initializer))
+        if (initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(x => x.IsSingleOrMultiLineComment()))
             return false;
 
         // Any time we have `{ x, y, z }` in any form, then always just replace the whole original expression

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -733,11 +733,20 @@ internal static class UseCollectionExpressionHelpers
                 .WithPrependedLeadingTrivia(ElasticMarker);
     }
 
+    private static bool HasStructuredTriviaBetweenCloseTokenAndInitializer(InitializerExpressionSyntax initializer)
+    {
+        static bool IsComment(SyntaxTrivia trivia) => trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia);
+        return initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(IsComment);
+    }
+
     private static bool ShouldReplaceExistingExpressionEntirely(
         SourceText sourceText,
         InitializerExpressionSyntax initializer,
         bool newCollectionIsSingleLine)
     {
+        if (HasStructuredTriviaBetweenCloseTokenAndInitializer(initializer))
+            return false;
+
         // Any time we have `{ x, y, z }` in any form, then always just replace the whole original expression
         // with `[x, y, z]`.
         if (newCollectionIsSingleLine && sourceText.AreOnSameLine(initializer.OpenBraceToken, initializer.CloseBraceToken))

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -738,7 +738,7 @@ internal static class UseCollectionExpressionHelpers
         InitializerExpressionSyntax initializer,
         bool newCollectionIsSingleLine)
     {
-        if (initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(x => x.IsSingleOrMultiLineComment()))
+        if (initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(static x => x.IsSingleOrMultiLineComment()))
             return false;
 
         // Any time we have `{ x, y, z }` in any form, then always just replace the whole original expression

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -190,17 +190,19 @@ internal static class CSharpCollectionExpressionRewriter
                 //    [1, 2, 3]
                 // ]
                 var shouldIncludeAdditionalLeadingTrivia = initializer is not null &&
-                   initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(static x => x.IsSingleOrMultiLineComment() || x.IsEndOfLine());
+                    initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(static x => x.IsSingleOrMultiLineComment() || x.IsEndOfLine());
 
                 if (shouldIncludeAdditionalLeadingTrivia)
                 {
                     var additionalLeadingTrivia = initializer!.OpenBraceToken.GetPreviousToken().TrailingTrivia
                         .SkipInitialWhitespace()
-                        .Concat(initializer.OpenBraceToken.LeadingTrivia)
-                        .Concat(expressionToReplace
-                            .GetLeadingTrivia()
-                            .SkipInitialWhitespace());
+                        .Concat(initializer.OpenBraceToken.LeadingTrivia);
                     collectionExpression = collectionExpression.WithLeadingTrivia(additionalLeadingTrivia);
+                }
+                else
+                {
+                    // otherwise, we want to unconditionally preserve any and all trivia in the original expression
+                    collectionExpression = collectionExpression.WithTriviaFrom(expressionToReplace);
                 }
 
                 return collectionExpression;

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -180,7 +180,6 @@ internal static class CSharpCollectionExpressionRewriter
                     OpenBracketToken.WithoutTrivia(),
                     SeparatedList<CollectionElementSyntax>(nodesAndTokens),
                     CloseBracketToken.WithoutTrivia());
-                //return collectionExpression.WithTriviaFrom(expressionToReplace).WithPrependedLeadingTrivia(trivia);
                 return collectionExpression.WithLeadingTrivia(trivia);
             }
         }

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -190,22 +190,20 @@ internal static class CSharpCollectionExpressionRewriter
                 //    [1, 2, 3]
                 // ]
                 var shouldIncludeAdditionalLeadingTrivia = initializer is not null &&
-                    initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(static x => x.IsSingleOrMultiLineComment() || x.IsEndOfLine());
+                    initializer.OpenBraceToken.GetPreviousToken().TrailingTrivia.Any(static x => x.IsSingleOrMultiLineComment());
 
                 if (shouldIncludeAdditionalLeadingTrivia)
                 {
                     var additionalLeadingTrivia = initializer!.OpenBraceToken.GetPreviousToken().TrailingTrivia
                         .SkipInitialWhitespace()
                         .Concat(initializer.OpenBraceToken.LeadingTrivia);
-                    collectionExpression = collectionExpression.WithLeadingTrivia(additionalLeadingTrivia);
+                    return collectionExpression.WithLeadingTrivia(additionalLeadingTrivia);
                 }
                 else
                 {
                     // otherwise, we want to unconditionally preserve any and all trivia in the original expression
-                    collectionExpression = collectionExpression.WithTriviaFrom(expressionToReplace);
+                    return collectionExpression.WithTriviaFrom(expressionToReplace);
                 }
-
-                return collectionExpression;
             }
         }
 

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -5521,8 +5521,7 @@ public class UseCollectionExpressionForArrayTests
             FixedCode = """
                 class C
                 {
-                    int[] i = 
-                    [];
+                    int[] i = [];
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -5349,7 +5349,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer1()
     {
         await new VerifyCS.Test
@@ -5373,7 +5373,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer2()
     {
         await new VerifyCS.Test
@@ -5396,7 +5396,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer3()
     {
         await new VerifyCS.Test
@@ -5437,7 +5437,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer4()
     {
         await new VerifyCS.Test
@@ -5460,7 +5460,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer5()
     {
         await new VerifyCS.Test
@@ -5483,7 +5483,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer6()
     {
         await new VerifyCS.Test
@@ -5506,7 +5506,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer7()
     {
         await new VerifyCS.Test
@@ -5529,7 +5529,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer8()
     {
         await new VerifyCS.Test
@@ -5553,7 +5553,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer9()
     {
         await new VerifyCS.Test
@@ -5576,7 +5576,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer10()
     {
         await new VerifyCS.Test
@@ -5617,7 +5617,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer11()
     {
         await new VerifyCS.Test
@@ -5640,7 +5640,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer12()
     {
         await new VerifyCS.Test
@@ -5663,7 +5663,7 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73740")]
     public async Task PreservesTrailingTriviaAfterInitializer14()
     {
         await new VerifyCS.Test

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -5348,4 +5348,355 @@ public class UseCollectionExpressionForArrayTests
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|] //Test
+                    { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    //Test
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = //Test
+                    [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = //Test
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[][][] a = //Other comment
+                    [|{|]
+                        [|[|new|] int[][]|] //my comment
+                        {
+                            [|[|new|] int[]|] { 123, 456 }
+                        },
+                        [|[|new|] int[][]|] //my comment 2
+                        {
+                            [|[|new|] int[]|] { 789, 101 }
+                        }
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[][][] a = //Other comment
+                    [
+                        //my comment
+                        [
+                            [123, 456]
+                        ],
+                        //my comment 2
+                        [
+                            [789, 101]
+                        ]
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|] //Test
+                    { };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = //Test
+                    [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = //Test
+                    [|{|] };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = //Test
+                    [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer6()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|{|] };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer7()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|]
+                    { };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = 
+                    [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer8()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|] /* Test */
+                    { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    /* Test */
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer9()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = /* Test */
+                    [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = /* Test */
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer10()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[][][] a = /* Other comment */
+                    [|{|]
+                        [|[|new|] int[][]|] /* my comment */
+                        {
+                            [|[|new|] int[]|] { 123, 456 }
+                        },
+                        [|[|new|] int[][]|] /* my comment 2 */
+                        {
+                            [|[|new|] int[]|] { 789, 101 }
+                        }
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[][][] a = /* Other comment */
+                    [
+                        /* my comment */
+                        [
+                            [123, 456]
+                        ],
+                        /* my comment 2 */
+                        [
+                            [789, 101]
+                        ]
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer11()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|] /* Test */
+                    { };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = /* Test */
+                    [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer12()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = /* Test */
+                    [|{|] };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = /* Test */
+                    [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task PreservesTrailingTriviaAfterInitializer14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[][][] a = /* Other 
+                    comment */
+                    //other comment
+                    [|{|]
+                        [|[|new|] int[][]|] /* mixed comments */ // here
+                        {
+                            [|[|new|] int[]|] { 123, 456 } //with some trailing comments!
+                        },
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[][][] a = /* Other 
+                    comment */
+                    //other comment
+                    [
+                        /* mixed comments */ // here
+                        [
+                            [123, 456] //with some trailing comments!
+                        ],
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForFluentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForFluentTests.cs
@@ -2887,4 +2887,47 @@ public class UseCollectionExpressionForFluentTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestObjectCreation_PreservesTrivia()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                using System.Collections.Immutable;
+                
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        int[] array = new List<int>() //Some comment
+                        {
+                            1, 2, 3
+                        }.Concat(x).[|ToArray|]();
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Linq;
+                using System.Collections.Generic;
+                using System.Collections.Immutable;
+                
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        int[] array =
+                        //Some comment
+                        [
+                            1, 2, 3, .. x
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
@@ -22,7 +23,7 @@ using VerifyCS = CSharpCodeFixVerifier<
 [Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
 public partial class UseCollectionInitializerTests_CollectionExpression
 {
-    private static async Task TestInRegularAndScriptAsync(string testCode, string fixedCode, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
+    private static async Task TestInRegularAndScriptAsync([StringSyntax("C#-test")] string testCode, [StringSyntax("C#-test")] string fixedCode, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
     {
         await new VerifyCS.Test
         {
@@ -34,7 +35,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
         }.RunAsync();
     }
 
-    private static Task TestMissingInRegularAndScriptAsync(string testCode)
+    private static Task TestMissingInRegularAndScriptAsync([StringSyntax("C#-test")] string testCode)
         => TestInRegularAndScriptAsync(testCode, testCode);
 
     [Fact]
@@ -2937,7 +2938,8 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M()
                 {
-                    List<int> c = [];
+                    List<int> c = 
+                    [];
                 }
             }
             """);
@@ -3027,6 +3029,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 void M()
                 {
                     List<int> c =
+
                         [];
                 }
             }
@@ -3059,6 +3062,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 void M()
                 {
                     List<int> c =
+
                         [];
                 }
             }
@@ -3089,7 +3093,8 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M()
                 {
-                    List<int> c = [];
+                    List<int> c = 
+                        [];
                 }
             }
             """);

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -2938,8 +2938,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M()
                 {
-                    List<int> c = 
-                    [];
+                    List<int> c = [];
                 }
             }
             """);
@@ -3029,7 +3028,6 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 void M()
                 {
                     List<int> c =
-
                         [];
                 }
             }
@@ -3062,7 +3060,6 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 void M()
                 {
                     List<int> c =
-
                         [];
                 }
             }
@@ -3093,8 +3090,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M()
                 {
-                    List<int> c = 
-                        [];
+                    List<int> c = [];
                 }
             }
             """);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTriviaListExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTriviaListExtensions.cs
@@ -42,6 +42,9 @@ internal static class SyntaxTriviaListExtensions
     public static IEnumerable<SyntaxTrivia> SkipInitialWhitespace(this SyntaxTriviaList triviaList)
         => triviaList.SkipWhile(t => t.Kind() == SyntaxKind.WhitespaceTrivia);
 
+    public static IEnumerable<SyntaxTrivia> SkipInitialWhitespace(this IEnumerable<SyntaxTrivia> triviaList)
+        => triviaList.SkipWhile(t => t.Kind() == SyntaxKind.WhitespaceTrivia);
+
     private static ImmutableArray<ImmutableArray<SyntaxTrivia>> GetLeadingBlankLines(SyntaxTriviaList triviaList)
     {
         using var result = TemporaryArray<ImmutableArray<SyntaxTrivia>>.Empty;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTriviaListExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTriviaListExtensions.cs
@@ -39,9 +39,6 @@ internal static class SyntaxTriviaListExtensions
             .LastOrNull();
     }
 
-    public static IEnumerable<SyntaxTrivia> SkipInitialWhitespace(this SyntaxTriviaList triviaList)
-        => triviaList.SkipWhile(t => t.Kind() == SyntaxKind.WhitespaceTrivia);
-
     public static IEnumerable<SyntaxTrivia> SkipInitialWhitespace(this IEnumerable<SyntaxTrivia> triviaList)
         => triviaList.SkipWhile(t => t.Kind() == SyntaxKind.WhitespaceTrivia);
 


### PR DESCRIPTION
Fixes #73740.

See tests for some of the corner cases that are now better than before, but not perfect. I opted not to fix all of them due to the fact that fixing would involve complicating what is already a very complicated fixer. See comments for specific examples and what additional improvements are left on the table.

It does fix the original problem raised in the issue, which in my (definitely biased) opinion, should be a more common case.

