### PR TITLE
Create new AsyncServiceProvider instead of using AsyncServiceProvider.GlobalProvider

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorInProcess.cs
@@ -50,6 +50,7 @@ using Roslyn.VisualStudio.IntegrationTests.InProcess;
 using Roslyn.VisualStudio.NewIntegrationTests.InProcess;
 using WindowsInput.Native;
 using Xunit;
+using COMAsyncServiceProvider = Microsoft.VisualStudio.Shell.Interop.COMAsyncServiceProvider;
 using IComponentModel = Microsoft.VisualStudio.ComponentModelHost.IComponentModel;
 using IObjectWithSite = Microsoft.VisualStudio.OLE.Interop.IObjectWithSite;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
@@ -455,7 +456,7 @@ internal partial class EditorInProcess : ITextViewWindowInProcess
         ErrorHandler.ThrowOnFailure(vsView.GetBuffer(out var textLines));
         ErrorHandler.ThrowOnFailure(textLines.GetLanguageServiceID(out var languageServiceGuid));
 
-        var languageService = await ((AsyncServiceProvider)AsyncServiceProvider.GlobalProvider).QueryServiceAsync(languageServiceGuid).WithCancellation(cancellationToken);
+        var languageService = await new AsyncServiceProvider((COMAsyncServiceProvider.IAsyncServiceProvider)AsyncServiceProvider.GlobalProvider).QueryServiceAsync(languageServiceGuid).WithCancellation(cancellationToken);
         Assumes.Present(languageService);
 
         var languageContextProvider = (IVsLanguageContextProvider)languageService;


### PR DESCRIPTION
`AsyncServiceProvider.GlobalProvider` is no longer an instance of `AsyncServiceProvider`, so the original code is failing.