### PR TITLE
Fix error recovery for various nested conversion scenarios

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -683,6 +683,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var elementConversions = conversion.UnderlyingConversions;
+                conversion.MarkUnderlyingConversionsChecked();
 
                 Debug.Assert(elementType is { });
                 Debug.Assert(elements.Length == elementConversions.Length);
@@ -1645,6 +1646,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool targetTyped = conversionIfTargetTyped is { };
             Debug.Assert(targetTyped || destination.IsErrorType() || destination.Equals(source.Type, TypeCompareKind.ConsiderEverything));
             ImmutableArray<Conversion> underlyingConversions = conversionIfTargetTyped.GetValueOrDefault().UnderlyingConversions;
+            conversionIfTargetTyped.GetValueOrDefault().MarkUnderlyingConversionsChecked();
             var condition = source.Condition;
             hasErrors |= source.HasErrors || destination.IsErrorType();
 
@@ -1682,6 +1684,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Conversion conversion = conversionIfTargetTyped ?? Conversion.Identity;
             Debug.Assert(targetTyped || destination.IsErrorType() || destination.Equals(source.Type, TypeCompareKind.ConsiderEverything));
             ImmutableArray<Conversion> underlyingConversions = conversion.UnderlyingConversions;
+            conversion.MarkUnderlyingConversionsChecked();
             var builder = ArrayBuilder<BoundSwitchExpressionArm>.GetInstance(source.SwitchArms.Length);
             for (int i = 0, n = source.SwitchArms.Length; i < n; i++)
             {
@@ -1723,7 +1726,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return new BoundConversion(
                     syntax,
-                    source,
+                    BindToNaturalType(source, diagnostics),
                     conversion,
                     CheckOverflowAtRuntime,
                     explicitCastInCode: isCast,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7184,7 +7184,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case RefKind.In:
                     {
                         // Note: for lambda arguments, they will be converted in the context/state we saved for that argument
-                        if (conversion is { Kind: ConversionKind.ImplicitUserDefined })
+                        if (conversion is { IsValid: true, Kind: ConversionKind.ImplicitUserDefined })
                         {
                             var argumentResultType = resultType.Type;
                             conversion = GenerateConversion(_conversions, argumentNoConversion, argumentResultType, parameterType.Type, fromExplicitCast: false, extensionMethodThisArgument: false, isChecked: conversionOpt?.Checked ?? false);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -917,10 +917,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (inferType && inferredType is null)
             {
-                // This can happen when we're inferring the return type of a lambda, or when there are no arms (an error case).
-                // For this case, we don't need to do any work, as the unconverted switch expression can't contribute info, and
-                // there is nothing that is being publicly exposed to the semantic model.
-                Debug.Assert((node is BoundUnconvertedSwitchExpression && _returnTypesOpt is not null)
+                // This can happen when we're inferring the return type of a lambda or visiting a node without diagnostics like
+                // BoundConvertedTupleLiteral.SourceTuple. For these cases, we don't need to do any work,
+                // the unconverted switch expression can't contribute info. The conversion that should be on top of this
+                // can add or remove nullability, and nested nodes aren't being publicly exposed by the semantic model.
+                // See also NullableWalker.VisitConditionalOperatorCore for a similar check for conditional operators.
+                Debug.Assert((node is BoundUnconvertedSwitchExpression && (_returnTypesOpt is not null || _disableDiagnostics))
                                 || node is BoundSwitchExpression { SwitchArms: { Length: 0 } });
                 inferredState = default;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
@@ -2016,8 +2016,8 @@ public struct S
                 }
                 """;
 
-            var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics();
+            var verifier = CompileAndVerify(source, expectedOutput: "string");
+            verifier.VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2088611")]


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2088611

- We had various places where we visited the underlying conversions of a conversion, but did not call MarkUnderlyingConversionsChecked. This caused assert failures in various nested conversion scenarios (exercised in new tests). It seems like this method is just a sanity check to ensure we actually traversed the whole conversion "tree" and should be called whenever we are applying the nested conversions to the corresponding subexpressions. See pre-existing call sites of the method for comparison.
- We were not calling BindToNaturalType for the operand of a user-defined conversion which was not valid e.g. due to ambiguity. This results in unexpected unconverted target-typed expressions in the bound tree in later phases.
- Increased uniformity of NullableWalker assertions for switch expressions versus conditional operators. This fixed assertion failures in some of the new tests.
- NullableWalker would report nullability warnings for user-defined conversion arguments, when the conversion was not valid in initial binding anyway. Note that a user-defined conversion may *exist* but still not be *valid*, when it is ambiguous which user-defined conversion method should be used. Entering this code path in such cases was causing an assertion to fail and is not needed.