### PR TITLE
Reduce time spent in ConflictResolver.Session.GetNodesOrTokensToCheckForConflicts

### DIFF
--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -159,15 +159,12 @@ internal class CSharpRenameConflictLanguageService : AbstractRenameRewriterLangu
 
             var isInConflictLambdaBody = false;
             var lambdas = node.GetAncestorsOrThis(n => n is SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax);
-            if (lambdas.Count() != 0)
+            foreach (var lambda in lambdas)
             {
-                foreach (var lambda in lambdas)
+                if (_conflictLocations.Any(cf => cf.Contains(lambda.Span)))
                 {
-                    if (_conflictLocations.Any(cf => cf.Contains(lambda.Span)))
-                    {
-                        isInConflictLambdaBody = true;
-                        break;
-                    }
+                    isInConflictLambdaBody = true;
+                    break;
                 }
             }
 
@@ -298,7 +295,7 @@ internal class CSharpRenameConflictLanguageService : AbstractRenameRewriterLangu
             RoslynDebug.Assert(_speculativeModel != null, "expanding a syntax node which cannot be speculated?");
 
             var oldSpan = originalNode.Span;
-            var expandParameter = originalNode.GetAncestorsOrThis(n => n is SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax).Count() == 0;
+            var expandParameter = !originalNode.GetAncestorsOrThis(n => n is SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax).Any();
 
             newNode = _simplificationService.Expand(newNode,
                                                                 _speculativeModel,

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -505,9 +505,13 @@ internal static partial class ConflictResolver
         private IEnumerable<(SyntaxNodeOrToken syntax, RenameActionAnnotation annotation)> GetNodesOrTokensToCheckForConflicts(
             SyntaxNode syntaxRoot)
         {
-            return syntaxRoot.DescendantNodesAndTokens(descendIntoTrivia: true)
-                .Where(_renameAnnotations.HasAnnotations<RenameActionAnnotation>)
-                .Select(s => (s, _renameAnnotations.GetAnnotations<RenameActionAnnotation>(s).Single()));
+            foreach (var nodeOrToken in syntaxRoot.GetAnnotatedNodesAndTokens(RenameAnnotation.Kind))
+            {
+                var annotation = _renameAnnotations.GetAnnotations<RenameActionAnnotation>(nodeOrToken).FirstOrDefault();
+
+                if (annotation != null)
+                    yield return (nodeOrToken, annotation);
+            }
         }
 
         private async Task<bool> CheckForConflictAsync(


### PR DESCRIPTION
This method previoulsy realized/walked the whole tree to try to find annotations to search for in it's AnnotationTable. Instead, use the GetAnnotatedNodesAndTokens to limit the search to only those areas of the tree that contain annotations.

This showed up in a profile I took of a lightbulb session which showed the preview window.