### PR TITLE
Sign `VSSetup/Installer/Roslyn_Preview.zip`

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -17,6 +17,7 @@
   -->
   <ItemGroup>
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.tgz" />
+    <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.zip" />
 
     <!-- Expression Compiler dependencies that run in remote debugger must be signed with Microsoft101240624 certificate in order to work on Windows 10S -->
 


### PR DESCRIPTION
Fixes CodeSign Validation warnings in official builds.

Official build of this PR: https://dev.azure.com/dnceng/internal/_build/results?buildId=2479205&view=results