### PR TITLE
Reduce allocations in AbstractProjectExtensionProvider.FilterExtensions

### DIFF
--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -81,15 +81,7 @@ internal sealed class CodeRefactoringService(
 
         static ProjectCodeRefactoringProvider.ExtensionInfo GetExtensionInfo(ExportCodeRefactoringProviderAttribute attribute)
         {
-            var kinds = new TextDocumentKind[attribute.DocumentKinds.Length];
-            for (var i = 0; i < kinds.Length; i++)
-            {
-                var kindString = attribute.DocumentKinds[i];
-                if (!Enum.TryParse(kindString, out TextDocumentKind kind))
-                    kind = 0;
-
-                kinds[i] = kind;
-            }
+            var kinds = EnumArrayConverter.FromStringArray<TextDocumentKind>(attribute.DocumentKinds);
 
             return new(kinds, attribute.DocumentExtensions);
         }

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -80,7 +80,19 @@ internal sealed class CodeRefactoringService(
         }
 
         static ProjectCodeRefactoringProvider.ExtensionInfo GetExtensionInfo(ExportCodeRefactoringProviderAttribute attribute)
-            => new(attribute.DocumentKinds, attribute.DocumentExtensions);
+        {
+            var kinds = new TextDocumentKind[attribute.DocumentKinds.Length];
+            for (var i = 0; i < kinds.Length; i++)
+            {
+                var kindString = attribute.DocumentKinds[i];
+                if (!Enum.TryParse(kindString, out TextDocumentKind kind))
+                    kind = 0;
+
+                kinds[i] = kind;
+            }
+
+            return new(kinds, attribute.DocumentExtensions);
+        }
     }
 
     public async Task<bool> HasRefactoringsAsync(

--- a/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
+++ b/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
@@ -112,7 +112,7 @@ internal abstract class AbstractProjectExtensionProvider<TProvider, TExtension, 
             return true;
         }
 
-        static ExtensionInfo? GetOrCreateExtensionInfo(TExtension extension, Func< TExportAttribute, ExtensionInfo> getExtensionInfoForFiltering)
+        static ExtensionInfo? GetOrCreateExtensionInfo(TExtension extension, Func<TExportAttribute, ExtensionInfo> getExtensionInfoForFiltering)
         {
             return s_extensionInfoMap.GetValue(extension,
                 new ConditionalWeakTable<TExtension, ExtensionInfo?>.CreateValueCallback(ComputeExtensionInfo));

--- a/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
+++ b/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
@@ -19,7 +18,7 @@ internal abstract class AbstractProjectExtensionProvider<TProvider, TExtension, 
     where TExportAttribute : Attribute
     where TExtension : class
 {
-    public record class ExtensionInfo(TextDocumentKind[] DocumentKinds, string[]? DocumentExtensions);
+    public record class ExtensionInfo(ImmutableArray<TextDocumentKind> DocumentKinds, string[]? DocumentExtensions);
 
     // Following CWTs are used to cache completion providers from projects' references,
     // so we can avoid the slow path unless there's any change to the references.
@@ -99,7 +98,7 @@ internal abstract class AbstractProjectExtensionProvider<TProvider, TExtension, 
             if (extensionInfo == null)
                 return true;
 
-            if (Array.IndexOf(extensionInfo.DocumentKinds, document.Kind) < 0)
+            if (extensionInfo.DocumentKinds.IndexOf(document.Kind) < 0)
                 return false;
 
             if (document.FilePath != null &&

--- a/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
+++ b/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
@@ -104,7 +104,7 @@ internal abstract class AbstractProjectExtensionProvider<TProvider, TExtension, 
 
             if (document.FilePath != null &&
                 extensionInfo.DocumentExtensions != null &&
-                -1 == Array.IndexOf(extensionInfo.DocumentExtensions, PathUtilities.GetExtension(document.FilePath)))
+                Array.IndexOf(extensionInfo.DocumentExtensions, PathUtilities.GetExtension(document.FilePath)) < 0)
             {
                 return false;
             }

--- a/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
+++ b/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
@@ -99,7 +99,7 @@ internal abstract class AbstractProjectExtensionProvider<TProvider, TExtension, 
             if (extensionInfo == null)
                 return true;
 
-            if (-1 == Array.IndexOf(extensionInfo.DocumentKinds, document.Kind))
+            if (Array.IndexOf(extensionInfo.DocumentKinds, document.Kind) < 0)
                 return false;
 
             if (document.FilePath != null &&

--- a/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -989,7 +989,19 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
 
         private static ProjectCodeFixProvider.ExtensionInfo GetExtensionInfo(ExportCodeFixProviderAttribute attribute)
-                => new(attribute.DocumentKinds, attribute.DocumentExtensions);
+        {
+            var kinds = new TextDocumentKind[attribute.DocumentKinds.Length];
+            for (var i = 0; i < kinds.Length; i++)
+            {
+                var kindString = attribute.DocumentKinds[i];
+                if (!Enum.TryParse(kindString, out TextDocumentKind kind))
+                    kind = 0;
+
+                kinds[i] = kind;
+            }
+
+            return new(kinds, attribute.DocumentExtensions);
+        }
 
         private sealed class FixerComparer : IComparer<CodeFixProvider>
         {

--- a/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -990,15 +990,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
         private static ProjectCodeFixProvider.ExtensionInfo GetExtensionInfo(ExportCodeFixProviderAttribute attribute)
         {
-            var kinds = new TextDocumentKind[attribute.DocumentKinds.Length];
-            for (var i = 0; i < kinds.Length; i++)
-            {
-                var kindString = attribute.DocumentKinds[i];
-                if (!Enum.TryParse(kindString, out TextDocumentKind kind))
-                    kind = 0;
-
-                kinds[i] = kind;
-            }
+            var kinds = EnumArrayConverter.FromStringArray<TextDocumentKind>(attribute.DocumentKinds);
 
             return new(kinds, attribute.DocumentExtensions);
         }

--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/EnumArrayConverter.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/EnumArrayConverter.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.CodeFixesAndRefactorings;
+
+internal class EnumArrayConverter
+{
+    public static TEnum[] FromStringArray<TEnum>(string[] strings) where TEnum : struct
+    {
+        if (!typeof(TEnum).IsEnum)
+            throw new ArgumentException("T must be an enumerated type");
+
+        var enums = new TEnum[strings.Length];
+        for (var i = 0; i < enums.Length; i++)
+        {
+            var s = strings[i];
+            if (!Enum.TryParse(s, out TEnum enumValue))
+                enumValue = default;
+
+            enums[i] = enumValue;
+        }
+
+        return enums;
+    }
+}

--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/EnumArrayConverter.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/EnumArrayConverter.cs
@@ -3,23 +3,24 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CodeFixesAndRefactorings;
 
 internal static class EnumArrayConverter
 {
-    public static TEnum[] FromStringArray<TEnum>(string[] strings) where TEnum : struct, Enum
+    public static ImmutableArray<TEnum> FromStringArray<TEnum>(string[] strings) where TEnum : struct, Enum
     {
-        var enums = new TEnum[strings.Length];
-        for (var i = 0; i < enums.Length; i++)
+        var enums = new FixedSizeArrayBuilder<TEnum>(strings.Length);
+        for (var i = 0; i < strings.Length; i++)
         {
             var s = strings[i];
             if (!Enum.TryParse(s, out TEnum enumValue))
                 enumValue = default;
 
-            enums[i] = enumValue;
+            enums.Add(enumValue);
         }
 
-        return enums;
+        return enums.MoveToImmutable();
     }
 }

--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/EnumArrayConverter.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/EnumArrayConverter.cs
@@ -6,13 +6,10 @@ using System;
 
 namespace Microsoft.CodeAnalysis.CodeFixesAndRefactorings;
 
-internal class EnumArrayConverter
+internal static class EnumArrayConverter
 {
-    public static TEnum[] FromStringArray<TEnum>(string[] strings) where TEnum : struct
+    public static TEnum[] FromStringArray<TEnum>(string[] strings) where TEnum : struct, Enum
     {
-        if (!typeof(TEnum).IsEnum)
-            throw new ArgumentException("T must be an enumerated type");
-
         var enums = new TEnum[strings.Length];
         for (var i = 0; i < enums.Length; i++)
         {


### PR DESCRIPTION
This ends up reducing allocations in the profile where I repeatedly brough up a lightbulb by about 0.7%.

1) Got rid of an Enum.ToString that happened on each filtering. Instead changed the code that reads the mef attributes to convert from string -> enum. 
2) Got rid of a a couple Contains calls which were allocating an enumerator 
3) Got rid of some closures by using the args version of WhereAsArray and by creating a separate method to handle the CWT insertion.

*** Prior allocations that no longer show up ***
![image](https://github.com/dotnet/roslyn/assets/6785178/5e4de2f4-9a23-4ebc-be88-c8761e3b7398)
