### PR TITLE
Escaping also considers record structs

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -107,6 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SymbolDisplayPartKind.ClassName:
                 case SymbolDisplayPartKind.RecordClassName:
                 case SymbolDisplayPartKind.StructName:
+                case SymbolDisplayPartKind.RecordStructName:
                 case SymbolDisplayPartKind.InterfaceName:
                 case SymbolDisplayPartKind.EnumName:
                 case SymbolDisplayPartKind.DelegateName:

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -1093,8 +1093,7 @@ class @true {
                 SymbolDisplayPartKind.Punctuation);
         }
 
-        [WorkItem(74117, "https://github.com/dotnet/roslyn/issues/74117")]
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74117")]
         public void TestBug74117()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -1094,7 +1094,7 @@ class @true {
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74117")]
-        public void TestBug74117()
+        public void TestRecordStructName()
         {
             var text = @"
 public record struct @decimal {

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -1093,6 +1093,39 @@ class @true {
                 SymbolDisplayPartKind.Punctuation);
         }
 
+        [WorkItem(74117, "https://github.com/dotnet/roslyn/issues/74117")]
+        [Fact]
+        public void TestBug74117()
+        {
+            var text = @"
+public record struct @decimal {
+    void M(@decimal p1) { return; } }
+";
+
+            Func<NamespaceSymbol, Symbol> findSymbol = global =>
+                global.GetTypeMembers("decimal", 0).Single().
+                GetMembers("M").Single();
+
+            var format = new SymbolDisplayFormat(
+                memberOptions: SymbolDisplayMemberOptions.IncludeType | SymbolDisplayMemberOptions.IncludeParameters,
+                parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeDefaultValue,
+                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+            TestSymbolDescription(
+                text,
+                findSymbol,
+                format,
+                "void M(@decimal p1)",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.MethodName, //M
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.RecordStructName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName, //p1
+                SymbolDisplayPartKind.Punctuation);
+        }
+
         [Fact]
         public void TestNoEscapeKeywordIdentifiers()
         {


### PR DESCRIPTION
fix: https://github.com/dotnet/roslyn/issues/74117

Previously, `record struct` was not considered as needing to be escaped, so types like `record struct @decimal` would be represented as `record struct decimal`