### PR TITLE
Better detect equivalence in our strong name provider

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
@@ -45,8 +45,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void EqualityUsingKeyFileSearchPaths()
         {
             var tempDir = Temp.CreateDirectory();
-            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test"]);
-            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test"]);
+            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [tempDir.Path]);
+            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [tempDir.Path]);
 
             Assert.Equal(provider1, provider2);
         }
@@ -65,8 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void InequalityUsingKeyFileSearchPaths()
         {
             var tempDir = Temp.CreateDirectory();
-            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test"]);
-            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test2"]);
+            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [tempDir.Path]);
+            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [tempDir.Path + "2"]);
 
             Assert.NotEqual(provider1, provider2);
         }
@@ -75,8 +75,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void InequalityUsingKeyFileSearchPathsDueToCaseSensitivity()
         {
             var tempDir = Temp.CreateDirectory();
-            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test"]);
-            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\Test"]);
+            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [tempDir.Path]);
+            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [tempDir.Path.ToUpper()]);
 
             Assert.NotEqual(provider1, provider2);
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
@@ -32,6 +32,46 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void EqualityUsingPath()
+        {
+            var tempDir = Temp.CreateDirectory();
+            var provider1 = new DesktopStrongNameProvider(tempPath: tempDir.Path);
+            var provider2 = new DesktopStrongNameProvider(tempPath: tempDir.Path);
+
+            Assert.Equal(provider1, provider2);
+        }
+
+        [Fact]
+        public void EqualityUsingKeyFileSearchPaths()
+        {
+            var tempDir = Temp.CreateDirectory();
+            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test"]);
+            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test"]);
+
+            Assert.Equal(provider1, provider2);
+        }
+
+        [Fact]
+        public void InequalityUsingPath()
+        {
+            var tempDir = Temp.CreateDirectory();
+            var provider1 = new DesktopStrongNameProvider(tempPath: tempDir.Path);
+            var provider2 = new DesktopStrongNameProvider(tempPath: tempDir.Path + "2");
+
+            Assert.NotEqual(provider1, provider2);
+        }
+
+        [Fact]
+        public void InequalityUsingKeyFileSearchPaths()
+        {
+            var tempDir = Temp.CreateDirectory();
+            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test"]);
+            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test2"]);
+
+            Assert.NotEqual(provider1, provider2);
+        }
+
+        [Fact]
         public void EmitWithCustomTempPath()
         {
             string src = @"

--- a/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
@@ -72,6 +72,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void InequalityUsingKeyFileSearchPathsDueToCaseSensitivity()
+        {
+            var tempDir = Temp.CreateDirectory();
+            var provider1 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\test"]);
+            var provider2 = new DesktopStrongNameProvider(keyFileSearchPaths: [@"c:\Test"]);
+
+            Assert.NotEqual(provider1, provider2);
+        }
+
+        [Fact]
         public void EmitWithCustomTempPath()
         {
             string src = @"

--- a/src/Compilers/Core/Portable/StrongName/DesktopStrongNameProvider.cs
+++ b/src/Compilers/Core/Portable/StrongName/DesktopStrongNameProvider.cs
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             var other = (DesktopStrongNameProvider)obj;
-            if (FileSystem != other.FileSystem)
+            if (!FileSystem.Equals(other.FileSystem))
             {
                 return false;
             }

--- a/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
+++ b/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
@@ -41,5 +41,26 @@ namespace Microsoft.CodeAnalysis
         }
 
         internal string? GetSigningTempPath() => _signingTempPath;
+
+        public override int GetHashCode()
+        {
+            return _signingTempPath?.GetHashCode() ?? 0;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (Object.ReferenceEquals(obj, this))
+            {
+                return true;
+            }
+
+            if (GetType() != obj!.GetType())
+            {
+                return false;
+            }
+
+            var other = (StrongNameFileSystem)obj;
+            return string.Equals(_signingTempPath, other._signingTempPath, StringComparison.Ordinal);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
+++ b/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
@@ -43,9 +43,7 @@ namespace Microsoft.CodeAnalysis
         internal string? GetSigningTempPath() => _signingTempPath;
 
         public override int GetHashCode()
-        {
-            return _signingTempPath?.GetHashCode() ?? 0;
-        }
+        => StringComparer.Ordinal.GetHashCode(_signingTempPath);
 
         public override bool Equals(object? obj)
         {

--- a/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
+++ b/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
@@ -46,19 +46,15 @@ namespace Microsoft.CodeAnalysis
         => StringComparer.Ordinal.GetHashCode(_signingTempPath);
 
         public override bool Equals(object? obj)
+            => Equals(obj as StrongNameFileSystem);
+
+        private bool Equals(StringNameFileSystem? other)
         {
-            if (Object.ReferenceEquals(obj, this))
-            {
+            if (this == other)
                 return true;
-            }
-
-            if (GetType() != obj!.GetType())
-            {
-                return false;
-            }
-
-            var other = (StrongNameFileSystem)obj;
-            return string.Equals(_signingTempPath, other._signingTempPath, StringComparison.Ordinal);
+                
+            return this.GetType() == other?.GetType() && StringComparer.Ordinal.Equals(_signingTempPath, other?._signingTempPath);
+        }
         }
     }
 }

--- a/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
+++ b/src/Compilers/Core/Portable/StrongName/StrongNameFileSystem.cs
@@ -43,18 +43,17 @@ namespace Microsoft.CodeAnalysis
         internal string? GetSigningTempPath() => _signingTempPath;
 
         public override int GetHashCode()
-        => StringComparer.Ordinal.GetHashCode(_signingTempPath);
+            => _signingTempPath != null ? StringComparer.Ordinal.GetHashCode(_signingTempPath) : 0;
 
         public override bool Equals(object? obj)
             => Equals(obj as StrongNameFileSystem);
 
-        private bool Equals(StringNameFileSystem? other)
+        private bool Equals(StrongNameFileSystem? other)
         {
             if (this == other)
                 return true;
-                
+
             return this.GetType() == other?.GetType() && StringComparer.Ordinal.Equals(_signingTempPath, other?._signingTempPath);
-        }
         }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/dotnet/roslyn/issues/74058

LiveUnitTest team reported a fairly recent regression where Roslyn started reporting Project changed workspace events during file addition / removal. This causes the LUT window to unnecessarilly rerun tests.

This regressed as part of a change I made back in March around passing in a temp path to the compiler's strong name provider, as otherwise an EmitStream call fails, breaking intellisense in projects using assembly signing. (Change here: https://github.com/dotnet/roslyn/pull/72587)

The regression is due to me changing several callers to creating a strong name provider based on the path, instead of them all using the default instance. With the previous behavior, equality checks on these newly created StrongNameFileSystem and DesktopStrongNameProvider instances would return false, even though the temp path in the file systems were the same.

It's a bit of a windy path to how this relates to the LUT window. The Roslyn ProjectSystemProject.ChangeProjectProperty call is the crux of where the issue was being exposed. UpdateProjectOptions_NoLock was calling it with a new DesktopStrongNameProvider created with the temp path as outlined above. ChangeProjectProperty checks the old value of the strong name provider against the newValue, and if they are the same, it doesn't add anything to the batched events it will later send out. However, in this case, the equality check failed, so we started sending out a project changed notification, breaking the LUT behavior.

The fix here is to simply implement Equals in StrongNameFileSystem, and have DesktopStrongNameProvider use that instead of just checking for reference equality.