### PR TITLE
Remove GetTempPath copy

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -520,8 +520,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 var requestId = getRequestId();
                 logger.Log($"Compilation request {requestId}, PathToTool={pathToTool}");
 
-                string workingDirectory = CurrentDirectoryToUse();
-                string? tempDirectory = BuildServerConnection.GetTempPath(workingDirectory);
+                string? tempDirectory = Path.GetTempPath();
 
                 if (!UseSharedCompilation ||
                     !IsManagedTool ||
@@ -549,7 +548,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     requestId,
                     Language,
                     GenerateCommandLineArgsList(responseFileCommands),
-                    workingDirectory: workingDirectory,
+                    workingDirectory: CurrentDirectoryToUse(),
                     tempDirectory: tempDirectory,
                     keepAlive: null,
                     libDirectory: LibDirectoryToUse());

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -200,7 +200,7 @@ End Module")
                 clientDir: Path.GetDirectoryName(typeof(CommonCompiler).Assembly.Location),
                 workingDir: currentDirectory.Path,
                 sdkDir: sdkDir,
-                tempDir: BuildServerConnection.GetTempPath(currentDirectory.Path));
+                tempDir: Path.GetTempPath());
 
             var (result, output) = UseTextWriter(redirectEncoding, writer => ApplyEnvironmentVariables(additionalEnvironmentVars, () => client.RunCompilation(arguments, buildPaths, writer)));
             Assert.Equal(shouldRunOnServer, result.RanOnServer);

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var client = new BuildClient(logger, language, compileFunc, compileOnServerFunc);
             var clientDir = GetClientDirectory();
             var workingDir = Directory.GetCurrentDirectory();
-            var tempDir = BuildServerConnection.GetTempPath(workingDir);
+            var tempDir = Path.GetTempPath();
             var buildPaths = new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: sdkDir, tempDir: tempDir);
             var originalArguments = GetCommandLineArgs(arguments);
             return client.RunCompilation(originalArguments, buildPaths).ExitCode;


### PR DESCRIPTION
This function was addedin 2016 when the compiler was still coming to terms with its server process model. At that time we discovered that the return for `Path.GetTempPath()` was different for different invocation of our build task. This happened when more complex builds changed environment variables that influenced temp directories.

Part of our reaction was adding this function that gave us more control over how temporary paths could vary between builds. It let us have explicit control over the working directory.

In the years since this change was made we've gotten a lot more mature in our model here:

1. `Path.GetTemPath` is banned in the compiler via analyzers
2. The server process model is established and we are much more rigorous with how environment variables, temp paths, etc ... are handled.

As such this method serves very little purpose. It just makes our code different and harder to understand. As such we're removing it.