### PR TITLE
Rename the record parameter when its property get renamed

### DIFF
--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2383,5 +2383,26 @@ class [|C|]
             End Using
         End Function
 
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameRecordProperty(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+                                public record MyRecord(string [|$$MyProperty|]);
+                                public class ReferenceClass
+                                {
+                                    public static void Test()
+                                    {
+                                        var record = new MyRecord("HelloWorld");
+                                        var c = r.[|MyProperty|];
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="MyNewProperty")
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2396,7 +2396,7 @@ class [|C|]
                                     public static void Test()
                                     {
                                         var record = new MyRecord("HelloWorld");
-                                        var c = r.[|MyProperty|];
+                                        var c = record.[|MyProperty|];
                                     }
                                 }
                             </Document>
@@ -2418,7 +2418,7 @@ class [|C|]
                                     public static void Test()
                                     {
                                         var record = new MyRecord("HelloWorld");
-                                        var c = r.[|$$MyProperty|];
+                                        var c = record.[|$$MyProperty|];
                                     }
                                 }
                             </Document>

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2385,7 +2385,7 @@ class [|C|]
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Sub RenameRecordProperty(host As RenameTestHost)
+        Public Sub RenameRecordParameter(host As RenameTestHost)
             Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
@@ -2397,6 +2397,28 @@ class [|C|]
                                     {
                                         var record = new MyRecord("HelloWorld");
                                         var c = r.[|MyProperty|];
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="MyNewProperty")
+            End Using
+        End Sub
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameRecordProperty(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+                                public record MyRecord(string [|MyProperty|]);
+                                public class ReferenceClass
+                                {
+                                    public static void Test()
+                                    {
+                                        var record = new MyRecord("HelloWorld");
+                                        var c = r.[|$$MyProperty|];
                                     }
                                 }
                             </Document>

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2426,5 +2426,53 @@ class [|C|]
                     </Workspace>, host:=host, renameTo:="MyNewProperty")
             End Using
         End Sub
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameRecordParameterWithGenerics(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+                                <![CDATA[
+                                public record MyRecord<T>(T [|$$MyProperty|]);
+                                public class ReferenceClass
+                                {
+                                    public static void Test()
+                                    {
+                                        var record = new MyRecord<string>("HelloWorld");
+                                        var c = record.[|MyProperty|];
+                                    }
+                                }
+                            ']]>
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="MyNewProperty")
+            End Using
+        End Sub
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameRecordPropertyWithGenerics(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+                                <![CDATA[
+                                public record MyRecord<T>(T [|MyProperty|]);
+                                public class ReferenceClass
+                                {
+                                    public static void Test()
+                                    {
+                                        var record = new MyRecord<string>("HelloWorld");
+                                        var c = record.[|$$MyProperty|];
+                                    }
+                                }
+                            ']]>
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="MyNewProperty")
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -130,15 +130,7 @@ internal sealed partial class SymbolicRenameLocations
 
         private static bool IsPropertyGeneratedFromPrimaryConstructorParameter(
             ISymbol propertySymbol, ISymbol parameterSymbol, CancellationToken cancellationToken)
-        {
-            if (parameterSymbol is IParameterSymbol parameter)
-            {
-                var generatedPropertySymbol = parameter.GetAssociatedSynthesizedRecordProperty(cancellationToken);
-                return propertySymbol.Equals(generatedPropertySymbol);
-            }
-
-            return false;
-        }
+            => parameterSymbol is IParameterSymbol parameter && propertySymbol.Equals(parameter.GetAssociatedSynthesizedRecordProperty(cancellationToken));
 
         private static async Task<bool> IsPropertyAccessorOrAnOverrideAsync(
             ISymbol symbol, Solution solution, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -110,6 +110,13 @@ internal sealed partial class SymbolicRenameLocations
                 return true;
             }
 
+            // When a parameter in primary constructor get renamed, we also want to rename its generated property. And vice versa.
+            if (IsPropertyGeneratedFromPrimaryConstructorParameter(originalSymbol, referencedSymbol, cancellationToken)
+                || IsPropertyGeneratedFromPrimaryConstructorParameter(referencedSymbol, originalSymbol, cancellationToken))
+            {
+                return true;
+            }
+
             return false;
 
             // Local functions
@@ -119,6 +126,18 @@ internal sealed partial class SymbolicRenameLocations
                     && possibleType is INamedTypeSymbol namedType
                     && Equals(possibleConstructor.ContainingType.ConstructedFrom, namedType.ConstructedFrom);
             }
+        }
+
+        private static bool IsPropertyGeneratedFromPrimaryConstructorParameter(
+            ISymbol propertySymbol, ISymbol parameterSymbol, CancellationToken cancellationToken)
+        {
+            if (parameterSymbol is IParameterSymbol parameter)
+            {
+                var generatedPropertySymbol = parameter.GetAssociatedSynthesizedRecordProperty(cancellationToken);
+                return propertySymbol.Equals(generatedPropertySymbol);
+            }
+
+            return false;
         }
 
         private static async Task<bool> IsPropertyAccessorOrAnOverrideAsync(


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/72581

Reason:
Using code snnipet
```
    public record MyRecord(string MyProperty);
    public class ReferenceClass
    {
        public static void Test()
        {
            var record = new MyRecord("HelloWorld");
            var c = record.MyProperty;
        }
    }
```
When we rename the `MyProperty` in constructor, we are renaming the parameter, `var c = record.MyProperty` is not renamed, because it's referencing the generated property.

This PR fix by adding an additional check.