### PR TITLE
Add WorkspaceKinds flags enum

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveSupportsFeatureService.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveSupportsFeatureService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 {
     internal sealed class InteractiveSupportsFeatureService
     {
-        [ExportWorkspaceService(typeof(ITextBufferSupportsFeatureService), [WorkspaceKind.Interactive]), Shared]
+        [ExportWorkspaceService(typeof(ITextBufferSupportsFeatureService), WorkspaceKinds.Interactive), Shared]
         internal class InteractiveTextBufferSupportsFeatureService : ITextBufferSupportsFeatureService
         {
             [ImportingConstructor]
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 => true;
         }
 
-        [ExportWorkspaceService(typeof(IDocumentSupportsFeatureService), [WorkspaceKind.Interactive]), Shared]
+        [ExportWorkspaceService(typeof(IDocumentSupportsFeatureService), WorkspaceKinds.Interactive), Shared]
         internal class InteractiveDocumentSupportsFeatureService : IDocumentSupportsFeatureService
         {
             [ImportingConstructor]

--- a/src/EditorFeatures/Core/Workspaces/VSAnalyzerAssemblyLoaderProvider.cs
+++ b/src/EditorFeatures/Core/Workspaces/VSAnalyzerAssemblyLoaderProvider.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Workspaces;
 
-[ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), [WorkspaceKind.Host]), Shared]
+[ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), WorkspaceKinds.Host), Shared]
 internal class VSAnalyzerAssemblyLoaderProvider : AbstractAnalyzerAssemblyLoaderProvider
 {
     [ImportingConstructor]

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VSCodeAnalyzerLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VSCodeAnalyzerLoader.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 
-[ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), [WorkspaceKind.Host]), Shared]
+[ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), WorkspaceKinds.Host), Shared]
 internal class VSCodeAnalyzerLoaderProvider : AbstractAnalyzerAssemblyLoaderProvider
 {
     private readonly ExtensionAssemblyManager _extensionAssemblyManager;

--- a/src/VisualStudio/LiveShare/Impl/Client/CloudEnvironmentSupportsFeatureService.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/CloudEnvironmentSupportsFeatureService.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
 {
-    [ExportWorkspaceService(typeof(ITextBufferSupportsFeatureService), [WorkspaceKind.CloudEnvironmentClientWorkspace]), Shared]
+    [ExportWorkspaceService(typeof(ITextBufferSupportsFeatureService), WorkspaceKinds.CloudEnvironmentClientWorkspace), Shared]
     internal class CloudEnvironmentSupportsFeatureService : ITextBufferSupportsFeatureService
     {
         [ImportingConstructor]

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportWorkspaceServiceAttribute.cs
@@ -31,16 +31,21 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         public string Layer { get; } = layer ?? throw new ArgumentNullException(nameof(layer));
 
         /// <summary>
-        /// <see cref="WorkspaceKind"/>s that the service is specified for.
+        /// <see cref="WorkspaceKinds"/> that the service is specified for.
         /// If non-empty the service is only exported for the listed workspace kinds and <see cref="Layer"/> is not applied,
         /// unless <see cref="Layer"/> is <see cref="ServiceLayer.Test"/> in which case the export overrides all other exports.
         /// </summary>
-        internal IReadOnlyList<string> WorkspaceKinds { get; } = [];
+        internal WorkspaceKinds WorkspaceKinds { get; } = WorkspaceKinds.Unknown;
 
-        internal ExportWorkspaceServiceAttribute(Type serviceType, string[] workspaceKinds)
+        internal ExportWorkspaceServiceAttribute(Type serviceType, WorkspaceKinds workspaceKinds)
             : this(serviceType)
         {
             WorkspaceKinds = workspaceKinds;
         }
+
+        //internal ExportWorkspaceServiceAttribute(Type serviceType, WorkspaceKinds workspaceKinds)
+        //    : this(serviceType, workspaceKinds.ToArray())
+        //{
+        //}
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceTests/WorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/WorkspaceTests.cs
@@ -11,12 +11,25 @@ using Xunit;
 using System;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.Test.Utilities;
+using System.Reflection;
+using System.Linq;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
     [UseExportProvider, Trait(Traits.Feature, Traits.Features.Workspace)]
     public class WorkspaceTests
     {
+        [Fact]
+        public void WorkspaceKindsFields()
+        {
+            // Field of WorkspaceKind should match values of WorkspaceKinds that have a single bit set.
+
+            AssertEx.SetEqual(
+                ((WorkspaceKinds[])Enum.GetValues(typeof(WorkspaceKinds))).Where(k => BitArithmeticUtilities.CountBits((int)k) == 1).Select(k => k.ToString()),
+                typeof(WorkspaceKind).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).Select(f => f.Name));
+        }
+
         [Fact]
         public void TestChangeDocumentContent_TryApplyChanges_Throws()
         {

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoaderService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
     /// <summary>
     /// Customizes the path where to store shadow-copies of analyzer assemblies.
     /// </summary>
-    [ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), [WorkspaceKind.RemoteWorkspace]), Shared]
+    [ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), WorkspaceKinds.RemoteWorkspace), Shared]
     internal sealed class RemoteAnalyzerAssemblyLoaderService : IAnalyzerAssemblyLoaderProvider
     {
         private readonly RemoteAnalyzerAssemblyLoader _loader;

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/PerformanceTrackerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/PerformanceTrackerService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
     /// <summary>
     /// Track diagnostic performance 
     /// </summary>
-    [ExportWorkspaceService(typeof(IPerformanceTrackerService), [WorkspaceKind.RemoteWorkspace]), Shared]
+    [ExportWorkspaceService(typeof(IPerformanceTrackerService), WorkspaceKinds.RemoteWorkspace), Shared]
     internal class PerformanceTrackerService : IPerformanceTrackerService
     {
         // We require at least 100 samples for background document analysis result to be stable.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/ILayeredServiceMetadata.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/ILayeredServiceMetadata.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef;
 
 internal interface ILayeredServiceMetadata
 {
-    public IReadOnlyList<string> WorkspaceKinds { get; }
+    public WorkspaceKinds WorkspaceKinds { get; }
     public string Layer { get; }
     public string ServiceType { get; }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/LanguageServiceMetadata.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/LanguageServiceMetadata.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         //
         public string Layer { get; } = (string?)data.GetValueOrDefault(nameof(ExportLanguageServiceAttribute.Layer)) ?? ServiceLayer.Default;
 
-        public IReadOnlyList<string> WorkspaceKinds { get; } = (IReadOnlyList<string>)data[
+        public WorkspaceKinds WorkspaceKinds { get; } = (WorkspaceKinds)data[
 #if CODE_STYLE
             "WorkspaceKinds"
 #else

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/LayeredServiceUtilities.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/LayeredServiceUtilities.cs
@@ -51,10 +51,14 @@ internal static class LayeredServiceUtilities
         // If a service is exported for specific workspace kinds and the current workspace kind is among them, use it.
         if (workspaceKind != null)
         {
-            service = servicesOfMatchingType.SingleOrDefault(static (lz, workspaceKind) => lz.Metadata.WorkspaceKinds.Contains(workspaceKind), workspaceKind);
-            if (service != null)
+            var kind = WorkspaceKindsFactory.FromKind(workspaceKind);
+            if (kind != WorkspaceKinds.Unknown)
             {
-                return service;
+                service = servicesOfMatchingType.SingleOrDefault(static (lz, workspaceKind) => lz.Metadata.WorkspaceKinds.HasFlag(workspaceKind), kind);
+                if (service != null)
+                {
+                    return service;
+                }
             }
 
             // For backward compat check workspace kind specific service.
@@ -79,6 +83,6 @@ internal static class LayeredServiceUtilities
         return null;
 
         Lazy<TServiceInterface, TMetadata>? TryGetServiceByLayer(string layer)
-            => servicesOfMatchingType.SingleOrDefault(static (lz, layer) => lz.Metadata.WorkspaceKinds is [] && lz.Metadata.Layer == layer, layer);
+            => servicesOfMatchingType.SingleOrDefault(static (lz, layer) => lz.Metadata.WorkspaceKinds == WorkspaceKinds.Unknown && lz.Metadata.Layer == layer, layer);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/WorkspaceKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/WorkspaceKinds.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis;
+
+[Flags]
+internal enum WorkspaceKinds
+{
+    Unknown = 0,
+
+    Host = 1,
+    Debugger = 1 << 1,
+    Interactive = 1 << 2,
+    MetadataAsSource = 1 << 3,
+    MiscellaneousFiles = 1 << 4,
+    Preview = 1 << 5,
+    SemanticSearch = 1 << 6,
+
+    Custom = 1 << 7,
+    MSBuild = 1 << 8,
+    CloudEnvironmentClientWorkspace = 1 << 9,
+    RemoteWorkspace = 1 << 10,
+}
+
+internal static class WorkspaceKindsFactory
+{
+    internal static WorkspaceKinds FromKind(string kind)
+        => kind switch
+        {
+            nameof(WorkspaceKind.Host) => WorkspaceKinds.Host,
+            nameof(WorkspaceKind.Debugger) => WorkspaceKinds.Debugger,
+            nameof(WorkspaceKind.Interactive) => WorkspaceKinds.Interactive,
+            nameof(WorkspaceKind.MetadataAsSource) => WorkspaceKinds.MetadataAsSource,
+            nameof(WorkspaceKind.MiscellaneousFiles) => WorkspaceKinds.MiscellaneousFiles,
+            nameof(WorkspaceKind.Preview) => WorkspaceKinds.Preview,
+            nameof(WorkspaceKind.MSBuild) => WorkspaceKinds.MSBuild,
+#if !CODE_STYLE
+            nameof(WorkspaceKind.Custom) => WorkspaceKinds.Custom,
+            nameof(WorkspaceKind.SemanticSearch) => WorkspaceKinds.SemanticSearch,
+            nameof(WorkspaceKind.CloudEnvironmentClientWorkspace) => WorkspaceKinds.CloudEnvironmentClientWorkspace,
+            nameof(WorkspaceKind.RemoteWorkspace) => WorkspaceKinds.RemoteWorkspace,
+#endif
+            _ => WorkspaceKinds.Unknown
+        };
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/WorkspaceServiceMetadata.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/WorkspaceServiceMetadata.cs
@@ -14,7 +14,7 @@ internal sealed class WorkspaceServiceMetadata(IDictionary<string, object> data)
     public string ServiceType { get; } = (string)data[nameof(ExportWorkspaceServiceAttribute.ServiceType)];
     public string Layer { get; } = (string)data[nameof(ExportWorkspaceServiceAttribute.Layer)];
 
-    public IReadOnlyList<string> WorkspaceKinds { get; } = (IReadOnlyList<string>)data[
+    public WorkspaceKinds WorkspaceKinds { get; } = (WorkspaceKinds)data[
 #if CODE_STYLE
             "WorkspaceKinds"
 #else

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
@@ -140,6 +140,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\LanguageMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\LanguageServiceMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\LayeredServiceUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\WorkspaceKinds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\MefConstruction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\MefLanguageServices.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\Mef\MefWorkspaceServices.cs" />


### PR DESCRIPTION
Use WorkspaceKinds flags enum in ExportWorkspaceServiceAttribute. Unlike string arrays combined enum values (e.g. `WorkspaceKinds.SemanticSearch | WorkspaceKinds.Interactive`) can be shared among multiple exports.

