### PR TITLE
Display lifted primary constructor parameters in watch window …

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameParser.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameParser.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (closeBracketOffset >= 0 && closeBracketOffset + 1 < name.Length)
                 {
                     int c = name[closeBracketOffset + 1];
-                    if (c is >= '1' and <= '9' or >= 'a' and <= 'z') // Note '0' is not special.
+                    if (c is >= '1' and <= '9' or >= 'a' and <= 'z' or >= 'A' and <= 'Z') // Note '0' is not special.
                     {
                         kind = (GeneratedNameKind)c;
                         return true;

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
@@ -37,6 +38,30 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override bool IsPrimitiveType(Type type)
         {
             return type.IsPredefinedType();
+        }
+
+#nullable enable
+        internal override bool TryGetMemberDisplay(string metadataName, out bool isGenerated, out string? displayName)
+        {
+            isGenerated = GeneratedNameParser.TryParseGeneratedName(metadataName, out var kind, out var openBracketOffset, out var closeBracketOffset);
+            if (!isGenerated)
+            {
+                displayName = metadataName;
+                return true;
+            }
+
+            switch (kind)
+            {
+                case GeneratedNameKind.PrimaryConstructorParameter:
+                    // display the member using the unmangled name:
+                    displayName = metadataName.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
+                    return true;
+
+                default:
+                    // do not display other generated members:
+                    displayName = null;
+                    return false;
+            }
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
@@ -41,13 +42,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         }
 
 #nullable enable
-        internal override bool TryGetMemberDisplay(string metadataName, out bool isGenerated, out string? displayName)
+        internal override bool TryGetGeneratedMemberDisplay(string metadataName, [NotNullWhen(true)] out string? displayName)
         {
-            isGenerated = GeneratedNameParser.TryParseGeneratedName(metadataName, out var kind, out var openBracketOffset, out var closeBracketOffset);
-            if (!isGenerated)
+            if (!GeneratedNameParser.TryParseGeneratedName(metadataName, out var kind, out var openBracketOffset, out var closeBracketOffset))
             {
-                displayName = metadataName;
-                return true;
+                displayName = null;
+                return false;
             }
 
             switch (kind)
@@ -58,7 +58,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     return true;
 
                 default:
-                    // do not display other generated members:
+                    // Do not display other generated members.
+                    // Set the display name to metadata name for raw view.
                     displayName = null;
                     return false;
             }

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
@@ -1001,7 +1001,7 @@ namespace @namespace
 
             IDkmClrFullNameProvider2 fullNameProvider = new CSharpFormatter();
             var inspectionContext = CreateDkmInspectionContext();
-            Assert.Equal("<StringParameter>P", fullNameProvider.GetClrNameForField(inspectionContext, new DkmClrRuntimeInstance(assembly).Modules[0], fieldToken));
+            Assert.Equal("StringParameter", fullNameProvider.GetClrNameForField(inspectionContext, new DkmClrRuntimeInstance(assembly).Modules[0], fieldToken));
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -475,12 +475,19 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var fullNameProvider = resultProvider.FullNameProvider;
             var declaredType = member.Type;
             var declaredTypeInfo = customTypeInfoMap.SubstituteCustomTypeInfo(member.OriginalDefinitionType, member.TypeInfo);
+            string? memberNameForFullName;
 
             // Considering, we're not handling the case of a member inherited from a generic base type.
-            if (!member.TryGetExplicitlyImplementedInterface(out var declaringType, out var memberDisplayName))
+            if (member.TryGetExplicitlyImplementedInterface(out var declaringType, out var memberDisplayName))
+            {
+                // full name will include cast to the interface, e.g. "((I)obj).MemberName":
+                memberNameForFullName = memberDisplayName;
+            }
+            else
             {
                 declaringType = member.DeclaringType;
                 memberDisplayName = member.DisplayName;
+                memberNameForFullName = member.MetadataName;
             }
 
             var declaringTypeInfo = declaringType.IsInterface
@@ -490,7 +497,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var appDomain = memberValue.Type.AppDomain;
             string? fullName;
 
-            var memberNameForFullName = member.IsGenerated ? null : fullNameProvider.GetClrValidIdentifier(inspectionContext, member.MetadataName);
+            memberNameForFullName = fullNameProvider.GetClrValidIdentifier(inspectionContext, memberNameForFullName);
             if (memberNameForFullName == null)
             {
                 fullName = null;

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Microsoft.VisualStudio.Debugger.Metadata;
+using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
@@ -75,9 +76,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var allMembers = ArrayBuilder<MemberAndDeclarationInfo>.GetInstance();
             var includeInherited = (flags & ExpansionFlags.IncludeBaseMembers) == ExpansionFlags.IncludeBaseMembers;
             var hideNonPublic = (inspectionContext.EvaluationFlags & DkmEvaluationFlags.HideNonPublicMembers) == DkmEvaluationFlags.HideNonPublicMembers;
-            var includeCompilerGenerated = (inspectionContext.EvaluationFlags & DkmEvaluationFlags.ShowValueRaw) == DkmEvaluationFlags.ShowValueRaw;
+            var raw = (inspectionContext.EvaluationFlags & DkmEvaluationFlags.ShowValueRaw) == DkmEvaluationFlags.ShowValueRaw;
             var favoritesInfo = supportsFavorites ? type.GetFavorites() : null;
-            runtimeType.AppendTypeMembers(allMembers, predicate, declaredTypeAndInfo.Type, appDomain, includeInherited, hideNonPublic, isProxyType, includeCompilerGenerated, supportsFavorites, favoritesInfo);
+            runtimeType.AppendTypeMembers(allMembers, predicate, resultProvider, declaredTypeAndInfo.Type, appDomain, includeInherited, hideNonPublic, isProxyType, raw, supportsFavorites, favoritesInfo);
 
             var favoritesMembersByName = new Dictionary<string, MemberAndDeclarationInfo>();
 
@@ -86,7 +87,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 // Favorites are currently never static
                 if (member.IsFavorite && !value.IsNull)
                 {
-                    favoritesMembersByName.Add(member.Name, member);
+                    favoritesMembersByName.Add(member.DisplayName, member);
                 }
                 else if (member.IsStatic)
                 {
@@ -460,7 +461,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     inspectionContext: inspectionContext);
             }
         }
-
+#nullable enable
         internal static EvalResult CreateMemberDataItem(
             ResultProvider resultProvider,
             DkmInspectionContext inspectionContext,
@@ -474,35 +475,43 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var fullNameProvider = resultProvider.FullNameProvider;
             var declaredType = member.Type;
             var declaredTypeInfo = customTypeInfoMap.SubstituteCustomTypeInfo(member.OriginalDefinitionType, member.TypeInfo);
-            string memberName;
+
             // Considering, we're not handling the case of a member inherited from a generic base type.
-            var typeDeclaringMember = member.GetExplicitlyImplementedInterface(out memberName) ?? member.DeclaringType;
-            var typeDeclaringMemberInfo = typeDeclaringMember.IsInterface
-                ? customTypeInfoMap.SubstituteCustomTypeInfo(typeDeclaringMember.GetInterfaceListEntry(member.DeclaringType), customInfo: null)
+            if (!member.TryGetExplicitlyImplementedInterface(out var declaringType, out var memberDisplayName))
+            {
+                declaringType = member.DeclaringType;
+                memberDisplayName = member.DisplayName;
+            }
+
+            var declaringTypeInfo = declaringType.IsInterface
+                ? customTypeInfoMap.SubstituteCustomTypeInfo(declaringType.GetInterfaceListEntry(member.DeclaringType), customInfo: null)
                 : null;
-            var memberNameForFullName = fullNameProvider.GetClrValidIdentifier(inspectionContext, memberName);
+
             var appDomain = memberValue.Type.AppDomain;
-            string fullName;
+            string? fullName;
+
+            var memberNameForFullName = member.IsGenerated ? null : fullNameProvider.GetClrValidIdentifier(inspectionContext, member.MetadataName);
             if (memberNameForFullName == null)
             {
                 fullName = null;
             }
             else
             {
-                memberName = memberNameForFullName;
+                memberDisplayName = memberNameForFullName;
                 fullName = MakeFullName(
                        fullNameProvider,
                        inspectionContext,
                        memberNameForFullName,
-                       new TypeAndCustomInfo(DkmClrType.Create(appDomain, typeDeclaringMember), typeDeclaringMemberInfo), // Note: Won't include DynamicAttribute.
+                       new TypeAndCustomInfo(DkmClrType.Create(appDomain, declaringType), declaringTypeInfo), // Note: Won't include DynamicAttribute.
                        member.RequiresExplicitCast,
                        member.IsStatic,
                        parent);
             }
+
             return resultProvider.CreateDataItem(
                 inspectionContext,
-                memberName,
-                typeDeclaringMemberAndInfo: (member.IncludeTypeInMemberName || typeDeclaringMember.IsInterface) ? new TypeAndCustomInfo(DkmClrType.Create(appDomain, typeDeclaringMember), typeDeclaringMemberInfo) : default(TypeAndCustomInfo), // Note: Won't include DynamicAttribute.
+                memberDisplayName,
+                typeDeclaringMemberAndInfo: (member.IncludeTypeInMemberName || declaringType.IsInterface) ? new TypeAndCustomInfo(DkmClrType.Create(appDomain, declaringType), declaringTypeInfo) : default(TypeAndCustomInfo), // Note: Won't include DynamicAttribute.
                 declaredTypeAndInfo: new TypeAndCustomInfo(DkmClrType.Create(appDomain, declaredType), declaredTypeInfo),
                 value: memberValue,
                 useDebuggerDisplay: parent != null,
@@ -517,7 +526,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 isFavorite: member.IsFavorite,
                 supportsFavorites: supportsFavorites);
         }
-
+#nullable disable
         private static string MakeFullName(
             IDkmClrFullNameProvider fullNameProvider,
             DkmInspectionContext inspectionContext,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/MemberAndDeclarationInfo.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/MemberAndDeclarationInfo.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Microsoft.VisualStudio.Debugger.Metadata;
 using Roslyn.Utilities;
@@ -45,10 +44,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         /// The full name for this member access expression will require a cast to the declaring type.
         /// </summary>
         RequiresExplicitCast = 1 << 4,
-        /// <summary>
-        /// The member is compiler generated. It has no full name.
-        /// </summary>
-        IsCompilerGenerated = 1 << 5,
     }
 
     internal static class DeclarationInfoExtensions

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -100,9 +100,21 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 foreach (var member in type.GetMembers(MemberBindingFlags))
                 {
-                    if (!resultProvider.TryGetMemberDisplay(member.Name, out var isGenerated, out var memberName) && !raw)
+                    var memberName = member.Name;
+                    var isGenerated = memberName.IsCompilerGenerated();
+
+                    if (isGenerated)
                     {
-                        continue;
+                        // Some generated names are displayed under their original (unmangled) name,
+                        // others are only shown when displaying raw object.
+                        if (resultProvider.TryGetGeneratedMemberDisplay(memberName, out var unmangledMemberName))
+                        {
+                            memberName = unmangledMemberName;
+                        }
+                        else if (!raw)
+                        {
+                            continue;
+                        }
                     }
 
                     // The native EE shows proxy members regardless of accessibility if they have a

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ValueHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/ValueHelpers.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal static DkmClrValue GetMemberValue(this DkmClrValue value, MemberAndDeclarationInfo member, DkmInspectionContext inspectionContext)
         {
             // Note: GetMemberValue() may return special value when func-eval of properties is disabled.
-            return value.GetMemberValue(member.Name, (int)member.MemberType, member.DeclaringType.FullName, inspectionContext);
+            return value.GetMemberValue(member.MetadataName, (int)member.MemberType, member.DeclaringType.FullName, inspectionContext);
         }
 
         internal static string Parenthesize(this string expr)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.CallStack;
@@ -62,7 +63,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal abstract bool IsPrimitiveType(Type type);
 
 #nullable enable
-        internal abstract bool TryGetMemberDisplay(string metadataName, out bool isGenerated, out string? displayName);
+        /// <summary>
+        /// Returns true if a generated member of <paramref name="metadataName"/> should be displayed.
+        /// <paramref name="displayName"/> is set to the unmangled name to be displayed.
+        /// </summary>
+        internal abstract bool TryGetGeneratedMemberDisplay(string metadataName, [NotNullWhen(true)] out string? displayName);
 #nullable disable
 
         void IDkmClrResultProvider.GetResult(DkmClrValue value, DkmWorkList workList, DkmClrType declaredType, DkmClrCustomTypeInfo declaredTypeInfo, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers, string resultName, string resultFullName, DkmCompletionRoutine<DkmEvaluationAsyncResult> completionRoutine)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -61,6 +61,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal abstract bool IsPrimitiveType(Type type);
 
+#nullable enable
+        internal abstract bool TryGetMemberDisplay(string metadataName, out bool isGenerated, out string? displayName);
+#nullable disable
+
         void IDkmClrResultProvider.GetResult(DkmClrValue value, DkmWorkList workList, DkmClrType declaredType, DkmClrCustomTypeInfo declaredTypeInfo, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers, string resultName, string resultFullName, DkmCompletionRoutine<DkmEvaluationAsyncResult> completionRoutine)
         {
             formatSpecifiers ??= Formatter.NoFormatSpecifiers;

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicResultProvider.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicResultProvider.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.VisualStudio.Debugger.ComponentInterfaces
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicResultProvider.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicResultProvider.vb
@@ -2,6 +2,8 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Reflection.Adds
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.VisualStudio.Debugger.ComponentInterfaces
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
@@ -41,6 +43,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return type.IsPredefinedType()
         End Function
 
+        Friend Overrides Function TryGetMemberDisplay(metadataName As String, <Out> ByRef isGenerated As Boolean, <Out> ByRef displayName As String) As Boolean
+            isGenerated = metadataName.IndexOf("$"c) >= 0
+            displayName = If(isGenerated, Nothing, metadataName)
+            Return Not isGenerated
+        End Function
     End Class
-
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicResultProvider.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicResultProvider.vb
@@ -2,8 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Reflection.Adds
-Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.VisualStudio.Debugger.ComponentInterfaces
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicResultProvider.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicResultProvider.vb
@@ -43,10 +43,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return type.IsPredefinedType()
         End Function
 
-        Friend Overrides Function TryGetMemberDisplay(metadataName As String, <Out> ByRef isGenerated As Boolean, <Out> ByRef displayName As String) As Boolean
-            isGenerated = metadataName.IndexOf("$"c) >= 0
-            displayName = If(isGenerated, Nothing, metadataName)
-            Return Not isGenerated
+        Friend Overrides Function TryGetGeneratedMemberDisplay(metadataName As String, <Out> ByRef displayName As String) As Boolean
+            displayName = Nothing
+            Return False
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
…as children of the object

Fixes https://github.com/dotnet/roslyn/issues/74082