### PR TITLE
Make project system workspace transformation functions resilient to being attempted twice

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataServiceFactory.cs
@@ -20,9 +20,9 @@ internal sealed class MetadataServiceFactory : IWorkspaceServiceFactory
     }
 
     public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        => new Service(workspaceServices.GetService<IDocumentationProviderService>());
+        => new DefaultMetadataService(workspaceServices.GetService<IDocumentationProviderService>());
 
-    private sealed class Service(IDocumentationProviderService documentationService) : IMetadataService
+    private sealed class DefaultMetadataService(IDocumentationProviderService documentationService) : IMetadataService
     {
         private readonly MetadataReferenceCache _metadataCache = new MetadataReferenceCache((path, properties) =>
                 MetadataReference.CreateFromFile(path, properties, documentationService.GetDocumentationProvider(path)));

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
@@ -19,8 +19,6 @@ internal sealed class FileWatchedPortableExecutableReferenceFactory
 {
     private readonly object _gate = new();
 
-    private readonly SolutionServices _solutionServices;
-
     /// <summary>
     /// A file change context used to watch metadata references. This is lazy to avoid creating this immediately during our LSP process startup, when we
     /// don't yet know the LSP client's capabilities.
@@ -31,7 +29,7 @@ internal sealed class FileWatchedPortableExecutableReferenceFactory
     /// File watching tokens from <see cref="_fileReferenceChangeContext"/> that are watching metadata references. These are only created once we are actually applying a batch because
     /// we don't determine until the batch is applied if the file reference will actually be a file reference or it'll be a converted project reference.
     /// </summary>
-    private readonly Dictionary<PortableExecutableReference, IWatchedFile> _metadataReferenceFileWatchingTokens = [];
+    private readonly Dictionary<PortableExecutableReference, (IWatchedFile Token, int Count)> _metadataReferenceFileWatchingTokens = [];
 
     /// <summary>
     /// Stores the caller for a previous disposal of a reference produced by this class, to track down a double-dispose issue.
@@ -49,11 +47,8 @@ internal sealed class FileWatchedPortableExecutableReferenceFactory
     private readonly Dictionary<string, CancellationTokenSource> _metadataReferenceRefreshCancellationTokenSources = [];
 
     public FileWatchedPortableExecutableReferenceFactory(
-        SolutionServices solutionServices,
         IFileChangeWatcher fileChangeWatcher)
     {
-        _solutionServices = solutionServices;
-
         _fileReferenceChangeContext = new Lazy<IFileChangeContext>(() =>
         {
             var referenceDirectories = new HashSet<string>();
@@ -101,34 +96,56 @@ internal sealed class FileWatchedPortableExecutableReferenceFactory
 
     public event EventHandler<string>? ReferenceChanged;
 
-    public PortableExecutableReference CreateReferenceAndStartWatchingFile(string fullFilePath, MetadataReferenceProperties properties)
+    /// <summary>
+    /// Starts watching a particular PortableExecutableReference for changes to the file.
+    /// If this is already being watched , the reference count will be incremented.
+    /// This is *not* safe to attempt to call multiple times for the same project and reference (e.g. in applying workspace updates)
+    /// </summary>
+    public void StartWatchingReference(PortableExecutableReference reference, string fullFilePath)
     {
         lock (_gate)
         {
-            var reference = _solutionServices.GetRequiredService<IMetadataService>().GetReference(fullFilePath, properties);
-            var fileWatchingToken = _fileReferenceChangeContext.Value.EnqueueWatchingFile(fullFilePath);
-
-            _metadataReferenceFileWatchingTokens.Add(reference, fileWatchingToken);
-
-            return reference;
+            var (token, count) = _metadataReferenceFileWatchingTokens.GetOrAdd(reference, (_) =>
+            {
+                var fileToken = _fileReferenceChangeContext.Value.EnqueueWatchingFile(fullFilePath);
+                return (fileToken, 0);
+            });
+            _metadataReferenceFileWatchingTokens[reference] = (token, count + 1);
         }
     }
 
+    /// <summary>
+    /// Decrements the reference count for the given PortableExecutableReference.
+    /// When the reference count reaches 0, the file watcher will be stopped.
+    /// This is *not* safe to attempt to call multiple times for the same project and reference (e.g. in applying workspace updates)
+    /// </summary>
     public void StopWatchingReference(PortableExecutableReference reference, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
     {
         lock (_gate)
         {
             var disposalLocation = callerFilePath + ", line " + callerLineNumber;
-
-            if (!_metadataReferenceFileWatchingTokens.TryGetValue(reference, out var watchedFile))
+            if (!_metadataReferenceFileWatchingTokens.TryGetValue(reference, out var watchedFileReference))
             {
+                // We're attempting to stop watching a file that we never started watching. This is a bug.
                 var existingDisposalStackTrace = _previousDisposalLocations.TryGetValue(reference, out var previousDisposalLocation);
                 throw new ArgumentException("The reference was already disposed at " + previousDisposalLocation);
             }
 
-            watchedFile.Dispose();
-            _metadataReferenceFileWatchingTokens.Remove(reference);
-            _previousDisposalLocations.Add(reference, disposalLocation);
+            var newRefCount = watchedFileReference.Count - 1;
+            Contract.ThrowIfFalse(newRefCount >= 0, "Ref count cannot be negative");
+            if (newRefCount == 0)
+            {
+                // No one else is watching this file, so stop watching it and remove from our map.
+                watchedFileReference.Token.Dispose();
+                _metadataReferenceFileWatchingTokens.Remove(reference);
+
+                _previousDisposalLocations.Remove(reference);
+                _previousDisposalLocations.Add(reference, disposalLocation);
+            }
+            else
+            {
+                _metadataReferenceFileWatchingTokens[reference] = (watchedFileReference.Token, newRefCount);
+            }
 
             // Note we still potentially have an outstanding change that we haven't raised a notification
             // for due to the delay we use. We could cancel the notification for that file path,

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.BatchingDocumentCollection.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.BatchingDocumentCollection.cs
@@ -429,7 +429,7 @@ internal sealed partial class ProjectSystemProject
                         }
                     }
                     return projectUpdateState;
-                }, onAfterUpdate: null).ConfigureAwait(false);
+                }, onAfterUpdateAlways: null).ConfigureAwait(false);
 
                 documentsToChange.Free();
             }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -230,7 +230,7 @@ internal sealed partial class ProjectSystemProject
         ChangeProjectProperty(
             ref field,
             newValue,
-            (solutionChanges, projectUpdateState, oldValue) =>
+            (solutionChanges, projectUpdateState, _) =>
             {
                 solutionChanges.UpdateSolutionForProjectAction(Id, updateSolution(solutionChanges.Solution));
                 return projectUpdateState;
@@ -242,8 +242,7 @@ internal sealed partial class ProjectSystemProject
         ref T field,
         T newValue,
         Func<SolutionChangeAccumulator, ProjectUpdateState, T, ProjectUpdateState> updateSolution,
-        bool logThrowAwayTelemetry = false,
-        Action<ProjectUpdateState>? onAfterUpdate = null)
+        bool logThrowAwayTelemetry = false)
     {
         using (_gate.DisposableWait())
         {
@@ -291,7 +290,7 @@ internal sealed partial class ProjectSystemProject
             {
                 _projectSystemProjectFactory.ApplyBatchChangeToWorkspace(
                     (solutionChanges, projectUpdateState) => updateSolution(solutionChanges, projectUpdateState, oldValue),
-                    onAfterUpdateAlways: onAfterUpdate);
+                    onAfterUpdateAlways: null);
             }
         }
     }
@@ -679,7 +678,7 @@ internal sealed partial class ProjectSystemProject
 
                 return projectUpdateState;
             },
-            onAfterUpdateAlways: (projectUpdateState) =>
+            onAfterUpdateAlways: projectUpdateState =>
             {
                 // It is very important that these are cleared in the onAfterUpdateAlways action passed to ApplyBatchChangeToWorkspaceMaybeAsync
                 // This is because the transformation may be run multiple times (if the workspace current solution is changed underneath us),

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -291,7 +291,7 @@ internal sealed partial class ProjectSystemProject
             {
                 _projectSystemProjectFactory.ApplyBatchChangeToWorkspace(
                     (solutionChanges, projectUpdateState) => updateSolution(solutionChanges, projectUpdateState, oldValue),
-                    onAfterUpdate: onAfterUpdate);
+                    onAfterUpdateAlways: onAfterUpdate);
             }
         }
     }
@@ -675,7 +675,7 @@ internal sealed partial class ProjectSystemProject
 
                 return projectUpdateState;
             },
-            onAfterUpdate: (projectUpdateState) =>
+            onAfterUpdateAlways: (projectUpdateState) =>
             {
                 // It is very important that these are cleared in the onAfterUpdate action passed to ApplyBatchChangeToWorkspaceMaybeAsync
                 // This is because the transformation may be run multiple times (if the workspace current solution is changed underneath us),

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.ProjectUpdateState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.ProjectUpdateState.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
+
+internal sealed partial class ProjectSystemProjectFactory
+{
+    /// <summary>
+    /// Immutable data type that holds the current state of the project system factory as well as
+    /// storing any incremental state changes in the current workspace update.
+    /// 
+    /// This state is updated by various project system update operations under the <see cref="_gate"/>.
+    /// Importantly, this immutable type allows us to discard updates to the state that fail to apply
+    /// due to interceding workspace operations.
+    /// 
+    /// There are two kinds of state that this type holds that need to support discarding:
+    ///   1.  Global state for the <see cref="ProjectSystemProjectFactory"/> (various maps of project information).
+    ///       This state must be saved between different changes.
+    ///   2.  Incremental state for the current change being processed.  This state has information that is
+    ///       cannot be resilient to being applied multiple times during the workspace update, so is saved
+    ///       to be applied only once the workspace update is successful.
+    ///
+    /// </summary>
+    /// <param name="ProjectsByOutputPath">
+    /// Global state representing a multimap from an output path to the project outputting to it. Ideally, this shouldn't ever
+    /// actually be a true multimap, since we shouldn't have two projects outputting to the same path, but
+    /// any bug by a project adding the wrong output path means we could end up with some duplication.
+    /// In that case, we'll temporarily have two until (hopefully) somebody removes it.
+    /// </param>
+    /// <param name="ProjectReferenceInfos">
+    /// Global state containing output paths and converted project reference information for each project.
+    /// </param>
+    /// <param name="RemovedReferences">
+    /// Incremental state containing references removed in the current update.
+    /// </param>
+    /// <param name="AddedReferences">
+    /// Incremental state containing references added in the current update.
+    /// </param>
+    public record class ProjectUpdateState(
+        ImmutableDictionary<string, ImmutableArray<ProjectId>> ProjectsByOutputPath,
+        ImmutableDictionary<ProjectId, ProjectReferenceInformation> ProjectReferenceInfos,
+        ImmutableArray<PortableExecutableReference> RemovedReferences,
+        ImmutableArray<PortableExecutableReference> AddedReferences)
+    {
+        public ProjectUpdateState WithProjectReferenceInfo(ProjectId projectId, ProjectReferenceInformation projectReferenceInformation)
+        {
+            return this with
+            {
+                ProjectReferenceInfos = ProjectReferenceInfos.SetItem(projectId, projectReferenceInformation)
+            };
+        }
+
+        public ProjectUpdateState WithProjectOutputPath(string projectOutputPath, ProjectId projectId)
+        {
+            return this with
+            {
+                ProjectsByOutputPath = AddProject(projectOutputPath, projectId, ProjectsByOutputPath)
+            };
+
+            static ImmutableDictionary<string, ImmutableArray<ProjectId>> AddProject(string path, ProjectId projectId, ImmutableDictionary<string, ImmutableArray<ProjectId>> map)
+            {
+                if (!map.TryGetValue(path, out var projects))
+                {
+                    return map.Add(path, [projectId]);
+                }
+                else
+                {
+                    return map.SetItem(path, projects.Add(projectId));
+                }
+            }
+        }
+
+        public ProjectUpdateState RemoveProjectOutputPath(string projectOutputPath, ProjectId projectId)
+        {
+            return this with
+            {
+                ProjectsByOutputPath = RemoveProject(projectOutputPath, projectId, ProjectsByOutputPath)
+            };
+
+            static ImmutableDictionary<string, ImmutableArray<ProjectId>> RemoveProject(string path, ProjectId projectId, ImmutableDictionary<string, ImmutableArray<ProjectId>> map)
+            {
+                if (map.TryGetValue(path, out var projects))
+                {
+                    projects = projects.Remove(projectId);
+                    if (projects.IsEmpty)
+                    {
+                        return map.Remove(path);
+                    }
+                    else
+                    {
+                        return map.SetItem(path, projects);
+                    }
+                }
+
+                return map;
+            }
+        }
+
+        public ProjectUpdateState WithIncrementalReferenceRemoved(PortableExecutableReference reference)
+        {
+            return this with
+            {
+                RemovedReferences = RemovedReferences.Add(reference)
+            };
+        }
+
+        public ProjectUpdateState WithIncrementalReferenceAdded(PortableExecutableReference reference)
+        {
+            return this with
+            {
+                AddedReferences = AddedReferences.Add(reference)
+            };
+        }
+
+        /// <summary>
+        /// Returns a new instance with any incremental state that should not be saved between updates cleared.
+        /// </summary>
+        public ProjectUpdateState ClearIncrementalState()
+        {
+            return this with
+            {
+                RemovedReferences = [],
+                AddedReferences = []
+            };
+        }
+    }
+
+    public record struct ProjectReferenceInformation(ImmutableArray<string> OutputPaths, ImmutableArray<(string path, ProjectReference ProjectReference)> ConvertedProjectReferences)
+    {
+        internal ProjectReferenceInformation WithConvertedProjectReference(string path, ProjectReference projectReference)
+        {
+            return this with
+            {
+                ConvertedProjectReferences = ConvertedProjectReferences.Add((path, projectReference))
+            };
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.ProjectUpdateState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.ProjectUpdateState.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
@@ -39,12 +40,16 @@ internal sealed partial class ProjectSystemProjectFactory
     /// <param name="AddedReferences">
     /// Incremental state containing references added in the current update.
     /// </param>
-    public record class ProjectUpdateState(
+    public sealed record class ProjectUpdateState(
         ImmutableDictionary<string, ImmutableArray<ProjectId>> ProjectsByOutputPath,
         ImmutableDictionary<ProjectId, ProjectReferenceInformation> ProjectReferenceInfos,
         ImmutableArray<PortableExecutableReference> RemovedReferences,
         ImmutableArray<PortableExecutableReference> AddedReferences)
     {
+        public static ProjectUpdateState Empty = new(
+            ImmutableDictionary<string, ImmutableArray<ProjectId>>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
+            ImmutableDictionary<ProjectId, ProjectReferenceInformation>.Empty, [], []);
+
         public ProjectUpdateState WithProjectReferenceInfo(ProjectId projectId, ProjectReferenceInformation projectReferenceInformation)
         {
             return this with

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -30,7 +30,9 @@ internal sealed partial class ProjectSystemProjectFactory
     // serialization lock and then allow us to update our own state under that lock.
     private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
 
-    private ProjectUpdateState _projectUpdateState = new(ImmutableDictionary<string, ImmutableArray<ProjectId>>.Empty, ImmutableDictionary<ProjectId, ProjectReferenceInformation>.Empty, [], []);
+    private ProjectUpdateState _projectUpdateState = new(
+        ImmutableDictionary<string, ImmutableArray<ProjectId>>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
+        ImmutableDictionary<ProjectId, ProjectReferenceInformation>.Empty, [], []);
 
     public Workspace Workspace { get; }
     public IAsynchronousOperationListener WorkspaceListener { get; }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -262,6 +262,7 @@ internal sealed partial class ProjectSystemProjectFactory
         return ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: true, mutation, onAfterUpdateAlways);
     }
 
+    /// <inheritdoc cref="ApplyBatchChangeToWorkspaceAsync(Func{SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState}, Action{ProjectUpdateState}?)"/>
     public async Task ApplyBatchChangeToWorkspaceMaybeAsync(bool useAsync, Func<SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState> mutation, Action<ProjectUpdateState>? onAfterUpdateAlways)
     {
         using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -19,7 +18,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
-internal sealed class ProjectSystemProjectFactory
+internal sealed partial class ProjectSystemProjectFactory
 {
     /// <summary>
     /// The main gate to synchronize updates to this solution.
@@ -31,10 +30,13 @@ internal sealed class ProjectSystemProjectFactory
     // serialization lock and then allow us to update our own state under that lock.
     private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
 
+    private ProjectUpdateState _projectUpdateState = new(ImmutableDictionary<string, ImmutableArray<ProjectId>>.Empty, ImmutableDictionary<ProjectId, ProjectReferenceInformation>.Empty, [], []);
+
     public Workspace Workspace { get; }
     public IAsynchronousOperationListener WorkspaceListener { get; }
     public IFileChangeWatcher FileChangeWatcher { get; }
     public FileWatchedPortableExecutableReferenceFactory FileWatchedReferenceFactory { get; }
+    public SolutionServices SolutionServices { get; }
 
     private readonly Func<bool, ImmutableArray<string>, Task> _onDocumentsAddedMaybeAsync;
     private readonly Action<Project> _onProjectRemoved;
@@ -68,8 +70,10 @@ internal sealed class ProjectSystemProjectFactory
         Workspace = workspace;
         WorkspaceListener = workspace.Services.GetRequiredService<IWorkspaceAsynchronousOperationListenerProvider>().GetListener();
 
+        SolutionServices = workspace.Services.SolutionServices;
+
         FileChangeWatcher = fileChangeWatcher;
-        FileWatchedReferenceFactory = new FileWatchedPortableExecutableReferenceFactory(workspace.Services.SolutionServices, fileChangeWatcher);
+        FileWatchedReferenceFactory = new FileWatchedPortableExecutableReferenceFactory(fileChangeWatcher);
         FileWatchedReferenceFactory.ReferenceChanged += this.StartRefreshingMetadataReferencesForFile;
 
         _onDocumentsAddedMaybeAsync = onDocumentsAddedMaybeAsync;
@@ -218,8 +222,24 @@ internal sealed class ProjectSystemProjectFactory
     }
 
     /// <summary>
+    /// Applies a single operation to the workspace that also needs to update the <see cref="_projectUpdateState"/>.
+    /// <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
+    /// </summary>
+    public void ApplyChangeToWorkspaceWithProjectUpdateState(Func<Workspace, ProjectUpdateState, ProjectUpdateState> action)
+    {
+        using (_gate.DisposableWait())
+        {
+            var projectUpdateState = _projectUpdateState;
+            projectUpdateState = action(Workspace, projectUpdateState);
+            ApplyProjectUpdateState(projectUpdateState);
+        }
+    }
+
+    /// <summary>
     /// Applies a solution transformation to the workspace and triggers workspace changed event for specified <paramref name="projectId"/>.
     /// The transformation shall only update the project of the solution with the specified <paramref name="projectId"/>.
+    /// 
+    /// The <paramref name="solutionTransformation"/> function must be safe to be attempted multiple times (and not update local state).
     /// </summary>
     public void ApplyChangeToWorkspace(ProjectId projectId, Func<CodeAnalysis.Solution, CodeAnalysis.Solution> solutionTransformation)
     {
@@ -229,86 +249,101 @@ internal sealed class ProjectSystemProjectFactory
         }
     }
 
-    /// <inheritdoc cref="ApplyBatchChangeToWorkspaceMaybeAsync(bool, Action{SolutionChangeAccumulator})"/>
-    public void ApplyBatchChangeToWorkspace(Action<SolutionChangeAccumulator> mutation)
+    /// <inheritdoc cref="ApplyBatchChangeToWorkspaceAsync(Func{SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState}, Action{ProjectUpdateState}?)"/>
+    public void ApplyBatchChangeToWorkspace(Func<SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState> mutation, Action<ProjectUpdateState>? onAfterUpdate)
     {
-        ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: false, mutation).VerifyCompleted();
+        ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: false, mutation, onAfterUpdate).VerifyCompleted();
     }
 
-    /// <inheritdoc cref="ApplyBatchChangeToWorkspaceMaybeAsync(bool, Action{SolutionChangeAccumulator})"/>
-    public Task ApplyBatchChangeToWorkspaceAsync(Action<SolutionChangeAccumulator> mutation)
+    /// <inheritdoc cref="ApplyBatchChangeToWorkspaceAsync(Func{SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState}, Action{ProjectUpdateState}?)"/>
+    public Task ApplyBatchChangeToWorkspaceAsync(Func<SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState> mutation, Action<ProjectUpdateState>? onAfterUpdate)
     {
-        return ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: true, mutation);
+        return ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: true, mutation, onAfterUpdate);
+    }
+
+    public async Task ApplyBatchChangeToWorkspaceMaybeAsync(bool useAsync, Func<SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState> mutation, Action<ProjectUpdateState>? onAfterUpdate)
+    {
+        using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())
+        {
+            await ApplyBatchChangeToWorkspaceMaybe_NoLockAsync(useAsync, mutation, onAfterUpdate).ConfigureAwait(false);
+        }
     }
 
     /// <summary>
     /// Applies a change to the workspace that can do any number of project changes.
+    /// The mutation action must be safe to attempt multiple times, in case there are interceding solution changes.
+    /// If outside changes need to run under the global lock and run only once, they should use the <paramref name="onAfterUpdate"/> action.
     /// </summary>
     /// <remarks>This is needed to synchronize with <see cref="ApplyChangeToWorkspace(Action{Workspace})" /> to avoid any races. This
     /// method could be moved down to the core Workspace layer and then could use the synchronization lock there.</remarks>
-    public async Task ApplyBatchChangeToWorkspaceMaybeAsync(bool useAsync, Action<SolutionChangeAccumulator> mutation)
+    public async Task ApplyBatchChangeToWorkspaceMaybe_NoLockAsync(bool useAsync, Func<SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState> mutation, Action<ProjectUpdateState>? onAfterUpdate)
     {
-        using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())
-        {
-            // We need the data from the accumulator across the lambda callbacks to SetCurrentSolutionAsync, so declare
-            // it here. It will be assigned in `transformation:` below (which may happen multiple times if the
-            // transformation needs to rerun).  Once the transformation succeeds and is applied, the
-            // 'onBeforeUpdate/onAfterUpdate' callbacks will be called, and can use the last assigned value in
-            // `transformation`.
-            SolutionChangeAccumulator solutionChanges = null!;
+        // We need the data from the accumulator across the lambda callbacks to SetCurrentSolutionAsync, so declare
+        // it here. It will be assigned in `transformation:` below (which may happen multiple times if the
+        // transformation needs to rerun).  Once the transformation succeeds and is applied, the
+        // 'onBeforeUpdate/onAfterUpdate' callbacks will be called, and can use the last assigned value in
+        // `transformation`.
+        SolutionChangeAccumulator solutionChanges = null!;
+        ProjectUpdateState projectUpdateState = null!;
 
-            await Workspace.SetCurrentSolutionAsync(
-                useAsync,
-                transformation: oldSolution =>
-                {
-                    solutionChanges = new SolutionChangeAccumulator(oldSolution);
-                    mutation(solutionChanges);
+        var (didUpdate, newSolution) = await Workspace.SetCurrentSolutionAsync(
+            useAsync,
+            transformation: oldSolution =>
+            {
+                solutionChanges = new SolutionChangeAccumulator(oldSolution);
 
-                    // Note: If the accumulator showed no changes it will return oldSolution.  This ensures that
-                    // SetCurrentSolutionAsync bails out immediately and no further work is done.
-                    return solutionChanges.Solution;
-                },
-                changeKind: (_, _) => (solutionChanges.WorkspaceChangeKind, solutionChanges.WorkspaceChangeProjectId, solutionChanges.WorkspaceChangeDocumentId),
-                onBeforeUpdate: (_, _) =>
-                {
-                    // Clear out mutable state not associated with the solution snapshot (for example, which documents are
-                    // currently open).
-                    foreach (var documentId in solutionChanges.DocumentIdsRemoved)
-                        Workspace.ClearDocumentData(documentId);
-                },
-                onAfterUpdate: null,
-                CancellationToken.None).ConfigureAwait(false);
-        }
-    }
+                // Reset the project update state in case this is a retry (we don't want to save the results of the last attempt).
+                projectUpdateState = _projectUpdateState;
+                projectUpdateState = mutation(solutionChanges, projectUpdateState);
 
-    private void ApplyBatchChangeToWorkspace_NoLock(SolutionChangeAccumulator solutionChanges)
-    {
-        Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-        if (!solutionChanges.HasChange)
-            return;
-
-        Workspace.SetCurrentSolution(
-            _ => solutionChanges.Solution,
-            solutionChanges.WorkspaceChangeKind,
-            solutionChanges.WorkspaceChangeProjectId,
-            solutionChanges.WorkspaceChangeDocumentId,
+                // Note: If the accumulator showed no changes it will return oldSolution.  This ensures that
+                // SetCurrentSolutionAsync bails out immediately and no further work is done.
+                return solutionChanges.Solution;
+            },
+            changeKind: (_, _) => (solutionChanges.WorkspaceChangeKind, solutionChanges.WorkspaceChangeProjectId, solutionChanges.WorkspaceChangeDocumentId),
             onBeforeUpdate: (_, _) =>
             {
                 // Clear out mutable state not associated with the solution snapshot (for example, which documents are
                 // currently open).
                 foreach (var documentId in solutionChanges.DocumentIdsRemoved)
                     Workspace.ClearDocumentData(documentId);
-            });
+            },
+            onAfterUpdate: (_, _) =>
+            {
+                // Now that the project update has actually applied, we can apply the results of it.
+                // For example saving the state and updating file watchers for added/removed references.
+                ApplyProjectUpdateState(projectUpdateState);
+                if (onAfterUpdate != null)
+                {
+                    onAfterUpdate(projectUpdateState);
+                }
+            },
+            CancellationToken.None).ConfigureAwait(false);
     }
 
-    private readonly Dictionary<ProjectId, ProjectReferenceInformation> _projectReferenceInfoMap = [];
-
-    private ProjectReferenceInformation GetReferenceInfo_NoLock(ProjectId projectId)
+    private void ApplyBatchChangeToWorkspace_NoLock(
+        Func<SolutionChangeAccumulator, ProjectUpdateState, ProjectUpdateState> mutation, Action<ProjectUpdateState>? onAfterUpdate)
     {
         Contract.ThrowIfFalse(_gate.CurrentCount == 0);
 
-        return _projectReferenceInfoMap.GetOrAdd(projectId, _ => new ProjectReferenceInformation());
+        ApplyBatchChangeToWorkspaceMaybe_NoLockAsync(useAsync: false, mutation, onAfterUpdate).VerifyCompleted();
+    }
+
+    private static ProjectUpdateState GetReferenceInformation(ProjectId projectId, ProjectUpdateState projectUpdateState, out ProjectReferenceInformation projectReference)
+    {
+        if (projectUpdateState.ProjectReferenceInfos.TryGetValue(projectId, out var referenceInfo))
+        {
+            projectReference = referenceInfo;
+            return projectUpdateState;
+        }
+        else
+        {
+            projectReference = new ProjectReferenceInformation([], []);
+            return projectUpdateState with
+            {
+                ProjectReferenceInfos = projectUpdateState.ProjectReferenceInfos.Add(projectId, projectReference)
+            };
+        }
     }
 
     /// <summary>
@@ -321,26 +356,69 @@ internal sealed class ProjectSystemProjectFactory
 
         var project = Workspace.CurrentSolution.GetRequiredProject(projectId);
 
-        if (_projectReferenceInfoMap.TryGetValue(projectId, out var projectReferenceInfo))
+        ApplyBatchChangeToWorkspace_NoLock((solutionChanges, projectUpdateState) =>
         {
-            // If we still had any output paths, we'll want to remove them to cause conversion back to metadata references.
-            // The call below implicitly is modifying the collection we've fetched, so we'll make a copy.
-            var solutionChanges = new SolutionChangeAccumulator(Workspace.CurrentSolution);
+            var project = Workspace.CurrentSolution.GetRequiredProject(projectId);
 
-            foreach (var outputPath in projectReferenceInfo.OutputPaths.ToList())
+            if (projectUpdateState.ProjectReferenceInfos.TryGetValue(projectId, out var projectReferenceInfo))
             {
-                RemoveProjectOutputPath_NoLock(solutionChanges, projectId, outputPath);
+                // If we still had any output paths, we'll want to remove them to cause conversion back to metadata references.
+                // The call below implicitly is modifying the collection we've fetched, so we'll make a copy.
+                foreach (var outputPath in projectReferenceInfo.OutputPaths.ToList())
+                {
+                    projectUpdateState = RemoveProjectOutputPath_NoLock(solutionChanges, projectId, outputPath, projectUpdateState, SolutionClosing, SolutionServices);
+                }
+
+                projectUpdateState = projectUpdateState with
+                {
+                    ProjectReferenceInfos = projectUpdateState.ProjectReferenceInfos.Remove(projectId)
+                };
             }
 
-            ApplyBatchChangeToWorkspace_NoLock(solutionChanges);
+            return projectUpdateState;
+        }, onAfterUpdate: (projectUpdateState) =>
+        {
+            ImmutableInterlocked.TryRemove<ProjectId, string?>(ref _projectToMaxSupportedLangVersionMap, projectId, out _);
+            ImmutableInterlocked.TryRemove(ref _projectToDependencyNodeTargetIdentifier, projectId, out _);
 
-            _projectReferenceInfoMap.Remove(projectId);
+            _onProjectRemoved?.Invoke(project);
+        });
+    }
+
+    internal void ApplyProjectUpdateState(ProjectUpdateState projectUpdateState)
+    {
+        Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+        UpdateReferenceFileWatchers(projectUpdateState.RemovedReferences, projectUpdateState.AddedReferences);
+
+        // Clear the state from the this update in preparation for the next.
+        projectUpdateState = projectUpdateState.ClearIncrementalState();
+        _projectUpdateState = projectUpdateState;
+
+        void UpdateReferenceFileWatchers(
+            ImmutableArray<PortableExecutableReference> removedReferences,
+            ImmutableArray<PortableExecutableReference> addedReferences)
+        {
+            // Remove file watchers for any references we're no longer watching.
+            if (removedReferences.Count() > 0)
+            {
+                // Now that we've removed the references from the sln, we can stop watching them.
+                foreach (var reference in removedReferences)
+                {
+                    FileWatchedReferenceFactory.StopWatchingReference(reference);
+                }
+            }
+
+            // Add file watchers for any references we are now watching.
+            if (addedReferences.Count() > 0)
+            {
+                // Now that we've added the references to the sln, we can start watching them.
+                foreach (var reference in addedReferences)
+                {
+                    FileWatchedReferenceFactory.StartWatchingReference(reference, reference.FilePath!);
+                }
+            }
         }
-
-        ImmutableInterlocked.TryRemove<ProjectId, string?>(ref _projectToMaxSupportedLangVersionMap, projectId, out _);
-        ImmutableInterlocked.TryRemove(ref _projectToDependencyNodeTargetIdentifier, projectId, out _);
-
-        _onProjectRemoved?.Invoke(project);
     }
 
     internal void RemoveSolution_NoLock()
@@ -349,7 +427,7 @@ internal sealed class ProjectSystemProjectFactory
 
         // At this point, we should have had RemoveProjectFromTrackingMaps_NoLock called for everything else, so it's just the solution itself
         // to clean up
-        Contract.ThrowIfFalse(_projectReferenceInfoMap.Count == 0);
+        Contract.ThrowIfFalse(_projectUpdateState.ProjectReferenceInfos.Count == 0);
         Contract.ThrowIfFalse(_projectToMaxSupportedLangVersionMap.Count == 0);
         Contract.ThrowIfFalse(_projectToDependencyNodeTargetIdentifier.Count == 0);
 
@@ -388,36 +466,28 @@ internal sealed class ProjectSystemProjectFactory
             (projectId, targetIdentifier));
     }
 
-    private sealed class ProjectReferenceInformation
+    public static ProjectUpdateState AddProjectOutputPath_NoLock(
+        SolutionChangeAccumulator solutionChanges,
+        ProjectId projectId,
+        string outputPath,
+        ProjectUpdateState projectUpdateState,
+        SolutionServices solutionServices)
     {
-        public readonly List<string> OutputPaths = [];
-        public readonly List<(string path, ProjectReference projectReference)> ConvertedProjectReferences = [];
-    }
+        projectUpdateState = GetReferenceInformation(projectId, projectUpdateState, out var projectReferenceInformation);
+        projectUpdateState = projectUpdateState.WithProjectReferenceInfo(projectId, projectReferenceInformation with
+        {
+            OutputPaths = projectReferenceInformation.OutputPaths.Add(outputPath)
+        });
 
-    /// <summary>
-    /// A multimap from an output path to the project outputting to it. Ideally, this shouldn't ever
-    /// actually be a true multimap, since we shouldn't have two projects outputting to the same path, but
-    /// any bug by a project adding the wrong output path means we could end up with some duplication.
-    /// In that case, we'll temporarily have two until (hopefully) somebody removes it.
-    /// </summary>
-    private readonly Dictionary<string, List<ProjectId>> _projectsByOutputPath = new(StringComparer.OrdinalIgnoreCase);
+        projectUpdateState = projectUpdateState.WithProjectOutputPath(outputPath, projectId);
 
-    public void AddProjectOutputPath_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
-    {
-        Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-        var projectReferenceInformation = GetReferenceInfo_NoLock(projectId);
-
-        projectReferenceInformation.OutputPaths.Add(outputPath);
-        _projectsByOutputPath.MultiAdd(outputPath, projectId);
-
-        var projectsForOutputPath = _projectsByOutputPath[outputPath];
+        var projectsForOutputPath = projectUpdateState.ProjectsByOutputPath[outputPath];
         var distinctProjectsForOutputPath = projectsForOutputPath.Distinct().ToList();
 
         // If we have exactly one, then we're definitely good to convert
-        if (projectsForOutputPath.Count == 1)
+        if (projectsForOutputPath.Count() == 1)
         {
-            ConvertMetadataReferencesToProjectReferences_NoLock(solutionChanges, projectId, outputPath);
+            projectUpdateState = ConvertMetadataReferencesToProjectReferences_NoLock(solutionChanges, projectId, outputPath, projectUpdateState);
         }
         else if (distinctProjectsForOutputPath.Count == 1)
         {
@@ -435,10 +505,12 @@ internal sealed class ProjectSystemProjectFactory
                 // we're colliding with
                 if (otherProjectId != projectId)
                 {
-                    ConvertProjectReferencesToMetadataReferences_NoLock(solutionChanges, otherProjectId, outputPath);
+                    projectUpdateState = ConvertProjectReferencesToMetadataReferences_NoLock(solutionChanges, otherProjectId, outputPath, projectUpdateState, solutionServices);
                 }
             }
         }
+
+        return projectUpdateState;
     }
 
     /// <summary>
@@ -448,10 +520,12 @@ internal sealed class ProjectSystemProjectFactory
     /// <param name="outputPath">The output path to replace.</param>
     [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/31306",
         Constraint = "Avoid calling " + nameof(CodeAnalysis.Solution.GetProject) + " to avoid realizing all projects.")]
-    private void ConvertMetadataReferencesToProjectReferences_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectIdToReference, string outputPath)
+    private static ProjectUpdateState ConvertMetadataReferencesToProjectReferences_NoLock(
+        SolutionChangeAccumulator solutionChanges,
+        ProjectId projectIdToReference,
+        string outputPath,
+        ProjectUpdateState projectUpdateState)
     {
-        Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
         foreach (var projectIdToRetarget in solutionChanges.Solution.ProjectIds)
         {
             if (CanConvertMetadataReferenceToProjectReference(solutionChanges.Solution, projectIdToRetarget, referencedProjectId: projectIdToReference))
@@ -462,7 +536,7 @@ internal sealed class ProjectSystemProjectFactory
                 {
                     if (string.Equals(reference.FilePath, outputPath, StringComparison.OrdinalIgnoreCase))
                     {
-                        FileWatchedReferenceFactory.StopWatchingReference(reference);
+                        projectUpdateState = projectUpdateState.WithIncrementalReferenceRemoved(reference);
 
                         var projectReference = new ProjectReference(projectIdToReference, reference.Properties.Aliases, reference.Properties.EmbedInteropTypes);
                         var newSolution = solutionChanges.Solution.RemoveMetadataReference(projectIdToRetarget, reference)
@@ -470,8 +544,9 @@ internal sealed class ProjectSystemProjectFactory
 
                         solutionChanges.UpdateSolutionForProjectAction(projectIdToRetarget, newSolution);
 
-                        GetReferenceInfo_NoLock(projectIdToRetarget).ConvertedProjectReferences.Add(
-                            (reference.FilePath!, projectReference));
+                        projectUpdateState = GetReferenceInformation(projectIdToRetarget, projectUpdateState, out var projectInfo);
+                        projectUpdateState = projectUpdateState.WithProjectReferenceInfo(projectIdToRetarget,
+                            projectInfo.WithConvertedProjectReference(reference.FilePath!, projectReference));
 
                         // We have converted one, but you could have more than one reference with different aliases
                         // that we need to convert, so we'll keep going
@@ -479,6 +554,8 @@ internal sealed class ProjectSystemProjectFactory
                 }
             }
         }
+
+        return projectUpdateState;
     }
 
     [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/31306",
@@ -532,35 +609,44 @@ internal sealed class ProjectSystemProjectFactory
     [PerformanceSensitive(
         "https://github.com/dotnet/roslyn/issues/37616",
         Constraint = "Update ConvertedProjectReferences in place to avoid duplicate list allocations.")]
-    private void ConvertProjectReferencesToMetadataReferences_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
+    private static ProjectUpdateState ConvertProjectReferencesToMetadataReferences_NoLock(
+        SolutionChangeAccumulator solutionChanges,
+        ProjectId projectId,
+        string outputPath,
+        ProjectUpdateState projectUpdateState,
+        SolutionServices solutionServices)
     {
-        Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
         foreach (var projectIdToRetarget in solutionChanges.Solution.ProjectIds)
         {
-            var referenceInfo = GetReferenceInfo_NoLock(projectIdToRetarget);
+            projectUpdateState = GetReferenceInformation(projectId, projectUpdateState, out var referenceInfo);
 
             // Update ConvertedProjectReferences in place to avoid duplicate list allocations
-            for (var i = 0; i < referenceInfo.ConvertedProjectReferences.Count; i++)
+            for (var i = 0; i < referenceInfo.ConvertedProjectReferences.Count(); i++)
             {
                 var convertedReference = referenceInfo.ConvertedProjectReferences[i];
 
                 if (string.Equals(convertedReference.path, outputPath, StringComparison.OrdinalIgnoreCase) &&
-                    convertedReference.projectReference.ProjectId == projectId)
+                    convertedReference.ProjectReference.ProjectId == projectId)
                 {
                     var metadataReference =
-                        FileWatchedReferenceFactory.CreateReferenceAndStartWatchingFile(
+                        CreateReference_NoLock(
                             convertedReference.path,
                             new MetadataReferenceProperties(
-                                aliases: convertedReference.projectReference.Aliases,
-                                embedInteropTypes: convertedReference.projectReference.EmbedInteropTypes));
+                                aliases: convertedReference.ProjectReference.Aliases,
+                                embedInteropTypes: convertedReference.ProjectReference.EmbedInteropTypes),
+                            solutionServices);
+                    projectUpdateState = projectUpdateState.WithIncrementalReferenceAdded(metadataReference);
 
-                    var newSolution = solutionChanges.Solution.RemoveProjectReference(projectIdToRetarget, convertedReference.projectReference)
+                    var newSolution = solutionChanges.Solution.RemoveProjectReference(projectIdToRetarget, convertedReference.ProjectReference)
                                                               .AddMetadataReference(projectIdToRetarget, metadataReference);
 
                     solutionChanges.UpdateSolutionForProjectAction(projectIdToRetarget, newSolution);
 
-                    referenceInfo.ConvertedProjectReferences.RemoveAt(i);
+                    referenceInfo = referenceInfo with
+                    {
+                        ConvertedProjectReferences = referenceInfo.ConvertedProjectReferences.RemoveAt(i)
+                    };
+                    projectUpdateState = projectUpdateState.WithProjectReferenceInfo(projectId, referenceInfo);
 
                     // We have converted one, but you could have more than one reference with different aliases
                     // that we need to convert, so we'll keep going. Make sure to decrement the index so we don't
@@ -569,73 +655,101 @@ internal sealed class ProjectSystemProjectFactory
                 }
             }
         }
+
+        return projectUpdateState;
     }
 
-    public ProjectReference? TryCreateConvertedProjectReference_NoLock(ProjectId referencingProject, string path, MetadataReferenceProperties properties)
+    /// <summary>
+    /// Converts a metadata reference to a project reference if possible.
+    /// This must be safe to run multiple times for the same reference as it is called
+    /// during a workspace update (which will attempt to apply the update multiple times).
+    /// </summary>
+    public static ProjectUpdateState TryCreateConvertedProjectReference_NoLock(
+        ProjectId referencingProject,
+        string path,
+        MetadataReferenceProperties properties,
+        ProjectUpdateState projectUpdateState,
+        Solution currentSolution,
+        out ProjectReference? projectReference)
     {
-        // Any conversion to or from project references must be done under the global workspace lock,
-        // since that needs to be coordinated with updating all projects simultaneously.
-        Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-        if (_projectsByOutputPath.TryGetValue(path, out var ids) && ids.Distinct().Count() == 1)
+        if (projectUpdateState.ProjectsByOutputPath.TryGetValue(path, out var ids) && ids.Distinct().Count() == 1)
         {
             var projectIdToReference = ids.First();
 
-            if (CanConvertMetadataReferenceToProjectReference(Workspace.CurrentSolution, referencingProject, projectIdToReference))
+            if (CanConvertMetadataReferenceToProjectReference(currentSolution, referencingProject, projectIdToReference))
             {
-                var projectReference = new ProjectReference(
+                projectReference = new ProjectReference(
                     projectIdToReference,
                     aliases: properties.Aliases,
                     embedInteropTypes: properties.EmbedInteropTypes);
 
-                GetReferenceInfo_NoLock(referencingProject).ConvertedProjectReferences.Add((path, projectReference));
-
-                return projectReference;
+                projectUpdateState = GetReferenceInformation(referencingProject, projectUpdateState, out var projectReferenceInfo);
+                projectUpdateState = projectUpdateState.WithProjectReferenceInfo(referencingProject, projectReferenceInfo.WithConvertedProjectReference(path, projectReference));
+                return projectUpdateState;
             }
             else
             {
-                return null;
+                projectReference = null;
+                return projectUpdateState;
             }
         }
         else
         {
-            return null;
+            projectReference = null;
+            return projectUpdateState;
         }
     }
 
-    public ProjectReference? TryRemoveConvertedProjectReference_NoLock(ProjectId referencingProject, string path, MetadataReferenceProperties properties)
+    /// <summary>
+    /// Tries to convert a metadata reference to remove to a project reference.
+    /// </summary>
+    public static ProjectUpdateState TryRemoveConvertedProjectReference_NoLock(
+        ProjectId referencingProject,
+        string path,
+        MetadataReferenceProperties properties,
+        ProjectUpdateState projectUpdateState,
+        out ProjectReference? projectReference)
     {
-        // Any conversion to or from project references must be done under the global workspace lock,
-        // since that needs to be coordinated with updating all projects simultaneously.
-        Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-        var projectReferenceInformation = GetReferenceInfo_NoLock(referencingProject);
+        projectUpdateState = GetReferenceInformation(referencingProject, projectUpdateState, out var projectReferenceInformation);
         foreach (var convertedProject in projectReferenceInformation.ConvertedProjectReferences)
         {
             if (convertedProject.path == path &&
-                convertedProject.projectReference.EmbedInteropTypes == properties.EmbedInteropTypes &&
-                convertedProject.projectReference.Aliases.SequenceEqual(properties.Aliases))
+                convertedProject.ProjectReference.EmbedInteropTypes == properties.EmbedInteropTypes &&
+                convertedProject.ProjectReference.Aliases.SequenceEqual(properties.Aliases))
             {
-                projectReferenceInformation.ConvertedProjectReferences.Remove(convertedProject);
-                return convertedProject.projectReference;
+                projectUpdateState = projectUpdateState.WithProjectReferenceInfo(referencingProject, projectReferenceInformation with
+                {
+                    ConvertedProjectReferences = projectReferenceInformation.ConvertedProjectReferences.Remove(convertedProject)
+                });
+                projectReference = convertedProject.ProjectReference;
+                return projectUpdateState;
             }
         }
 
-        return null;
+        projectReference = null;
+        return projectUpdateState;
     }
 
-    public void RemoveProjectOutputPath_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
+    public static ProjectUpdateState RemoveProjectOutputPath_NoLock(
+        SolutionChangeAccumulator solutionChanges,
+        ProjectId projectId,
+        string outputPath,
+        ProjectUpdateState projectUpdateState,
+        bool solutionClosing,
+        SolutionServices solutionServices)
     {
-        Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-        var projectReferenceInformation = GetReferenceInfo_NoLock(projectId);
+        projectUpdateState = GetReferenceInformation(projectId, projectUpdateState, out var projectReferenceInformation);
         if (!projectReferenceInformation.OutputPaths.Contains(outputPath))
         {
             throw new ArgumentException($"Project does not contain output path '{outputPath}'", nameof(outputPath));
         }
 
-        projectReferenceInformation.OutputPaths.Remove(outputPath);
-        _projectsByOutputPath.MultiRemove(outputPath, projectId);
+        projectUpdateState = projectUpdateState.WithProjectReferenceInfo(projectId, projectReferenceInformation with
+        {
+            OutputPaths = projectReferenceInformation.OutputPaths.Remove(outputPath)
+        });
+
+        projectUpdateState = projectUpdateState.RemoveProjectOutputPath(outputPath, projectId);
 
         // When a project is closed, we may need to convert project references to metadata references (or vice
         // versa). Failure to convert the references could leave a project in the workspace with a project
@@ -645,24 +759,36 @@ internal sealed class ProjectSystemProjectFactory
         // remaining projects as each project closes, because we know those projects will be closed without
         // further use. Avoiding reference conversion when the solution is closing improves performance for both
         // IDE close scenarios and solution reload scenarios that occur after complex branch switches.
-        if (!SolutionClosing)
+        if (!solutionClosing)
         {
-            if (_projectsByOutputPath.TryGetValue(outputPath, out var remainingProjectsForOutputPath))
+            if (projectUpdateState.ProjectsByOutputPath.TryGetValue(outputPath, out var remainingProjectsForOutputPath))
             {
                 var distinctRemainingProjects = remainingProjectsForOutputPath.Distinct();
                 if (distinctRemainingProjects.Count() == 1)
                 {
                     // We had more than one project outputting to the same path. Now we're back down to one
                     // so we can reference that one again
-                    ConvertMetadataReferencesToProjectReferences_NoLock(solutionChanges, distinctRemainingProjects.Single(), outputPath);
+                    projectUpdateState = ConvertMetadataReferencesToProjectReferences_NoLock(solutionChanges, distinctRemainingProjects.Single(), outputPath, projectUpdateState);
                 }
             }
             else
             {
                 // No projects left, we need to convert back to metadata references
-                ConvertProjectReferencesToMetadataReferences_NoLock(solutionChanges, projectId, outputPath);
+                projectUpdateState = ConvertProjectReferencesToMetadataReferences_NoLock(solutionChanges, projectId, outputPath, projectUpdateState, solutionServices);
             }
         }
+
+        return projectUpdateState;
+    }
+
+    /// <summary>
+    /// Gets or creates a PortableExecutableReference instance for the given file path and properties.
+    /// Calls to this are expected to be serialized by the caller.
+    /// </summary>
+    public static PortableExecutableReference CreateReference_NoLock(string fullFilePath, MetadataReferenceProperties properties, SolutionServices solutionServices)
+    {
+        var reference = solutionServices.GetRequiredService<IMetadataService>().GetReference(fullFilePath, properties);
+        return reference;
     }
 
 #pragma warning disable VSTHRD100 // Avoid async void methods
@@ -671,8 +797,9 @@ internal sealed class ProjectSystemProjectFactory
     {
         using var asyncToken = WorkspaceListener.BeginAsyncOperation(nameof(StartRefreshingMetadataReferencesForFile));
 
-        await ApplyBatchChangeToWorkspaceAsync(solutionChanges =>
+        await ApplyBatchChangeToWorkspaceAsync((solutionChanges, projectUpdateState) =>
         {
+            // Access the current update state under the workspace sync.
             foreach (var project in Workspace.CurrentSolution.Projects)
             {
                 // Loop to find each reference with the given path. It's possible that there might be multiple references of the same path;
@@ -683,22 +810,25 @@ internal sealed class ProjectSystemProjectFactory
                 {
                     if (portableExecutableReference.FilePath == fullFilePath)
                     {
-                        FileWatchedReferenceFactory.StopWatchingReference(portableExecutableReference);
+                        projectUpdateState = projectUpdateState.WithIncrementalReferenceRemoved(portableExecutableReference);
 
                         var newPortableExecutableReference =
-                            FileWatchedReferenceFactory.CreateReferenceAndStartWatchingFile(
+                            CreateReference_NoLock(
                                 portableExecutableReference.FilePath,
-                                portableExecutableReference.Properties);
+                                portableExecutableReference.Properties,
+                                SolutionServices);
+
+                        projectUpdateState = projectUpdateState.WithIncrementalReferenceAdded(newPortableExecutableReference);
 
                         var newSolution = solutionChanges.Solution.RemoveMetadataReference(project.Id, portableExecutableReference)
                                                                     .AddMetadataReference(project.Id, newPortableExecutableReference);
 
                         solutionChanges.UpdateSolutionForProjectAction(project.Id, newSolution);
-
                     }
                 }
             }
-        }).ConfigureAwait(false);
+            return projectUpdateState;
+        }, onAfterUpdate: null).ConfigureAwait(false);
     }
 
     internal Task RaiseOnDocumentsAddedMaybeAsync(bool useAsync, ImmutableArray<string> filePaths)


### PR DESCRIPTION
This fixes an issue where project system updates would fail to apply (or apply arbitrary state) when there are interceding workspace updates underneath the project system changes.

There are two important things to understand that lead to the issue here.

Firstly, when a transformation function is passed to `Workspace.SetCurrentSolution`, it is possible for that transformation to run multiple times if the `Workspace.CurrentSolution` changes underneath it.

Secondly, the original design of how the project system updates the workspace was that *any and all* changes to the workspace would happen under an additional project system factory global lock here (as well as the normal workspace update lock) - https://github.com/dotnet/roslyn/blob/064a7464024c543df8e12c9b2c7a887f4651be64/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs#L32

However, the recent changes to source generators broke the assumption that all changes to the workspace would be applied under the factory lock - source generators can now update and change the solution instance outside of the project system factory lock - https://github.com/dotnet/roslyn/blob/064a7464024c543df8e12c9b2c7a887f4651be64/src/Workspaces/Core/Portable/Workspace/Workspace.cs#L94

This lead to cases where the initial call to the transformation function made by project system updates would fail due to the solution source generator information changing underneath.  Normally this is fine, `SetCurrentSolution` will retry the transformation.  However we were updating and clearing tons of local state inside the transformation function, for example https://github.com/dotnet/roslyn/blob/5d8b9b8f2ab2b0ef5d262daf482e0605a8ba76ce/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs#L631

This meant that subsequent attempts no longer had the correct state (or had incorrect state) in the second attempt, leading to things like dropping all metadata references.

In resolving this a couple options were considered
1.  Make the source generator updates take the factory lock to ensure they cannot run concurrently with project system updates.
2.  Make the project system transformations resilient to being applied twice.
3.  Remove the project system factory lock and make everything resilient to being run twice, and only under the workspace lock.

I took the second approach in this PR.  1) is temporary at best - it is very easy to write new code that does not take the lock.  
3)  is the desired long term goal here.  However the scope of the changes are much larger as there are a lot of places we would need to audit to make sure any state changes are happening under the workspace lock.

2) is relatively focused in scope - it ensures that the transformations are resilient to running multiple times (a requirement for 3 anyway), but keeps the lock to avoid having to change everything else right now to fix this issue.

Resolves https://github.com/microsoft/vscode-dotnettools/issues/1198
Potentially fixes https://github.com/dotnet/vscode-csharp/issues/7231
