### PR TITLE
Don't reference netstandard1.x packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,6 +15,7 @@
       Keep the setting conditional. The toolset sets the assembly version to 42.42.42.42 if not set explicitly.
     -->
     <AssemblyVersion Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <FlagNetStandard1XDependencies Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</FlagNetStandard1XDependencies>
   </PropertyGroup>
   <!--
     Versions managed by Arcade (see Versions.Details.xml)

--- a/src/Scripting/Core/Microsoft.CodeAnalysis.Scripting.csproj
+++ b/src/Scripting/Core/Microsoft.CodeAnalysis.Scripting.csproj
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Runtime.Loader" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime.Loader" PrivateAssets="all" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Compilers\Shared\CoreClrShim.cs" />


### PR DESCRIPTION
... when building from source.

This was the only remaining project in roslyn that brought them in.

Contributes to https://github.com/dotnet/source-build/issues/4482