### PR TITLE
Dispose various locations using PEReader

### DIFF
--- a/src/Features/Core/Portable/Emit/CompilationOutputs.cs
+++ b/src/Features/Core/Portable/Emit/CompilationOutputs.cs
@@ -165,7 +165,7 @@ internal abstract class CompilationOutputs
 
     internal async ValueTask<bool> TryCopyPdbToAsync(Stream stream, CancellationToken cancellationToken)
     {
-        var pdb = OpenPdb();
+        using var pdb = OpenPdb();
         if (pdb == null)
         {
             return false;

--- a/src/LanguageServer/Protocol/Features/DecompiledSource/CSharpCodeDecompilerDecompilationService.cs
+++ b/src/LanguageServer/Protocol/Features/DecompiledSource/CSharpCodeDecompilerDecompilationService.cs
@@ -50,29 +50,32 @@ namespace Microsoft.CodeAnalysis.CSharp.DecompiledSource
             if (file is null)
                 return null;
 
-            // Initialize a decompiler with default settings.
-            var decompiler = new CSharpDecompiler(file, resolver, new DecompilerSettings());
-            // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
-            // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
-            decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers());
+            using (file)
+            {
+                // Initialize a decompiler with default settings.
+                var decompiler = new CSharpDecompiler(file, resolver, new DecompilerSettings());
+                // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
+                // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
+                decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers());
 
-            var fullTypeName = new FullTypeName(fullName);
+                var fullTypeName = new FullTypeName(fullName);
 
-            // ILSpy only allows decompiling a type that comes from the 'Main Module'.  They will throw on anything
-            // else.  Prevent this by doing this quick check corresponding to:
-            // https://github.com/icsharpcode/ILSpy/blob/4ebe075e5859939463ae420446f024f10c3bf077/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs#L978
-            var type = decompiler.TypeSystem.MainModule.GetTypeDefinition(fullTypeName);
-            if (type is null)
-                return null;
+                // ILSpy only allows decompiling a type that comes from the 'Main Module'.  They will throw on anything
+                // else.  Prevent this by doing this quick check corresponding to:
+                // https://github.com/icsharpcode/ILSpy/blob/4ebe075e5859939463ae420446f024f10c3bf077/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs#L978
+                var type = decompiler.TypeSystem.MainModule.GetTypeDefinition(fullTypeName);
+                if (type is null)
+                    return null;
 
-            // Try to decompile; if an exception is thrown the caller will handle it
-            var text = decompiler.DecompileTypeAsString(fullTypeName);
+                // Try to decompile; if an exception is thrown the caller will handle it
+                var text = decompiler.DecompileTypeAsString(fullTypeName);
 
-            text += "#if false // " + FeaturesResources.Decompilation_log + Environment.NewLine;
-            text += logger.ToString();
-            text += "#endif" + Environment.NewLine;
+                text += "#if false // " + FeaturesResources.Decompilation_log + Environment.NewLine;
+                text += logger.ToString();
+                text += "#endif" + Environment.NewLine;
 
-            return document.WithText(SourceText.From(text, encoding: null, checksumAlgorithm: SourceHashAlgorithms.Default));
+                return document.WithText(SourceText.From(text, encoding: null, checksumAlgorithm: SourceHashAlgorithms.Default));
+            }
         }
     }
 }


### PR DESCRIPTION
Attempt to address https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2104770

Multiple hdmps gathered for this bug indicate a leak of native memory in NativeHeapMemoryBlock+DisposableData. Tracking this backwards through code leads to a PEReader leak, but I wasn't able to keep tracking back from the data in the dmps. Looking at the PEReader objects in the dmp, I was able to infer that the PEStreamOptions.PrefetchEntireImage option was set when creating the PEReader.

This led to the most likely culprit, CSharpDecompilationService.PerformDecompilation not disposing the PEFile it owns.

Additionally, I noticed CompilationOutputs.TryCopyPdbToAsync wasn't disposing a PEReader it owned through the DebugInformationReaderProvider it owns from the call to OpenPdb.