### PR TITLE
Escape `record` keywords

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -103,10 +103,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new SymbolDisplayPart(kind, symbol, text);
             }
 
-            bool escapeRecord = StringComparer.Ordinal.Equals(text, "record") && symbol?.Kind is SymbolKind.NamedType or SymbolKind.Alias;
+            bool isNamedTypeOrAliasName = symbol?.Kind is SymbolKind.NamedType or SymbolKind.Alias;
+            
             bool isEscapable = IsEscapable(kind);
 
-            text = isEscapable ? EscapeIdentifier(text, escapeRecord) : text;
+            text = isEscapable ? EscapeIdentifier(text, isNamedTypeOrAliasName) : text;
 
             return new SymbolDisplayPart(kind, symbol, text);
         }
@@ -136,12 +137,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static string EscapeIdentifier(string identifier, bool escapeRecord)
+        private static string EscapeIdentifier(string identifier, bool isNamedTypeOrAliasName)
         {
             SyntaxKind kind = SyntaxFacts.GetKeywordKind(identifier);
-            if (kind == SyntaxKind.None && escapeRecord)
+            
+            if (kind is SyntaxKind.None && isNamedTypeOrAliasName && StringComparer.Ordinal.Equals(identifier, "record"))
             {
-                return $"@{identifier}";
+                kind = SyntaxKind.RecordKeyword;
             }
 
             return kind == SyntaxKind.None ? identifier : $"@{identifier}";

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -103,11 +103,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new SymbolDisplayPart(kind, symbol, text);
             }
 
-            bool isNamedTypeOrAliasName = symbol?.Kind is SymbolKind.NamedType or SymbolKind.Alias;
-
-            bool isEscapable = IsEscapable(kind);
-
-            text = isEscapable ? EscapeIdentifier(text, isNamedTypeOrAliasName) : text;
+            if (IsEscapable(kind))
+            {
+                text = EscapeIdentifier(text, symbol?.Kind is SymbolKind.NamedType or SymbolKind.Alias);
+            }
 
             return new SymbolDisplayPart(kind, symbol, text);
         }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             bool isNamedTypeOrAliasName = symbol?.Kind is SymbolKind.NamedType or SymbolKind.Alias;
-            
+
             bool isEscapable = IsEscapable(kind);
 
             text = isEscapable ? EscapeIdentifier(text, isNamedTypeOrAliasName) : text;
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static string EscapeIdentifier(string identifier, bool isNamedTypeOrAliasName)
         {
             SyntaxKind kind = SyntaxFacts.GetKeywordKind(identifier);
-            
+
             if (kind is SyntaxKind.None && isNamedTypeOrAliasName && StringComparer.Ordinal.Equals(identifier, "record"))
             {
                 kind = SyntaxKind.RecordKeyword;

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static string EscapeIdentifier(string identifier)
         {
             var kind = SyntaxFacts.GetKeywordKind(identifier);
-            return kind == SyntaxKind.None
+            return kind == SyntaxKind.None && !StringComparer.Ordinal.Equals(identifier, "record")
                 ? identifier
                 : $"@{identifier}";
         }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -95,7 +95,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (text == null)
             {
-
                 return new SymbolDisplayPart(kind, symbol, "?");
             }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -991,8 +991,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return SyntaxKind.UsingKeyword;
                 case "class":
                     return SyntaxKind.ClassKeyword;
-                case "record":
-                    return SyntaxKind.RecordKeyword;
                 case "struct":
                     return SyntaxKind.StructKeyword;
                 case "interface":

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -991,6 +991,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return SyntaxKind.UsingKeyword;
                 case "class":
                     return SyntaxKind.ClassKeyword;
+                case "record":
+                    return SyntaxKind.RecordKeyword;
                 case "struct":
                     return SyntaxKind.StructKeyword;
                 case "interface":

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -1093,6 +1093,47 @@ class @true {
                 SymbolDisplayPartKind.Punctuation);
         }
 
+        [Fact]
+        public void TestEscapeRecordKeywordIdentifiers()
+        {
+            var text = @"
+class @record {
+    @record @struct(@record @true, bool @bool = true) { return @record; } }
+";
+
+            Func<NamespaceSymbol, Symbol> findSymbol = global =>
+                global.GetTypeMembers("record", 0).Single().
+                GetMembers("struct").Single();
+
+            var format = new SymbolDisplayFormat(
+                memberOptions: SymbolDisplayMemberOptions.IncludeType | SymbolDisplayMemberOptions.IncludeParameters,
+                parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeDefaultValue,
+                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+            TestSymbolDescription(
+                text,
+                findSymbol,
+                format,
+                "@record @struct(@record @true, bool @bool = true)",
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.MethodName, //@struct
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName, //@record
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName, //@bool
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation);
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74117")]
         public void TestRecordStructName()
         {

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -1143,12 +1143,12 @@ class @record {
         public void TestEscapeRecordKeywordIdentifiers_DoesNotEscapesMethodNames()
         {
             var text = @"
-class Foo {
-    Foo record() { return default; } }
+class C {
+    C record() { return default; } }
 ";
 
             Func<NamespaceSymbol, Symbol> findSymbol = global =>
-                global.GetTypeMembers("Foo", 0).Single().
+                global.GetTypeMembers("C", 0).Single().
                 GetMembers("record").Single();
 
             var format = new SymbolDisplayFormat(
@@ -1160,7 +1160,7 @@ class Foo {
                 text,
                 findSymbol,
                 format,
-                "Foo record()",
+                "C record()",
                 SymbolDisplayPartKind.ClassName,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.MethodName, //record

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2664,7 +2664,7 @@ namespace N1 {
                 GetTypeMembers("C2").Single();
 
             var format = new SymbolDisplayFormat(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces, miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
 
             TestSymbolDescription(
                 text,
@@ -2676,6 +2676,35 @@ namespace N1 {
                 SymbolDisplayPartKind.AliasName,
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.ClassName);
+        }
+
+        [Fact]
+        public void TestAliases_AliasesNamedRecordAreEscaped()
+        {
+            var text = @"
+using @record = N1;
+
+namespace N1 {
+    class C1 {} }
+";
+
+            Func<NamespaceSymbol, Symbol> findSymbol = global =>
+                global.GetNestedNamespace("N1").
+                GetTypeMembers("C1").Single();
+
+            var format = new SymbolDisplayFormat(
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces, miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
+
+            TestSymbolDescription(
+                text,
+                findSymbol,
+                format,
+                "@record.C1",
+                text.IndexOf("namespace", StringComparison.Ordinal),
+                true,
+                SymbolDisplayPartKind.AliasName,
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.ClassName);
         }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -1094,11 +1094,11 @@ class @true {
         }
 
         [Fact]
-        public void TestEscapeRecordKeywordIdentifiers()
+        public void TestEscapeRecordKeywordIdentifiers_EscapesTypeNames()
         {
             var text = @"
 class @record {
-    @record @struct(@record @true, bool @bool = true) { return @record; } }
+    @record @struct(@record @true, string name, bool @bool = true) { return @record; } }
 ";
 
             Func<NamespaceSymbol, Symbol> findSymbol = global =>
@@ -1114,7 +1114,7 @@ class @record {
                 text,
                 findSymbol,
                 format,
-                "@record @struct(@record @true, bool @bool = true)",
+                "@record @struct(@record @true, string name, bool @bool = true)",
                 SymbolDisplayPartKind.ClassName,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.MethodName, //@struct
@@ -1126,11 +1126,45 @@ class @record {
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName, //string
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ParameterName, //@bool
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation);
+        }
+
+        [Fact]
+        public void TestEscapeRecordKeywordIdentifiers_DoesNotEscapesMethodNames()
+        {
+            var text = @"
+class Foo {
+    Foo record() { return default; } }
+";
+
+            Func<NamespaceSymbol, Symbol> findSymbol = global =>
+                global.GetTypeMembers("Foo", 0).Single().
+                GetMembers("record").Single();
+
+            var format = new SymbolDisplayFormat(
+                memberOptions: SymbolDisplayMemberOptions.IncludeType | SymbolDisplayMemberOptions.IncludeParameters,
+                parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeDefaultValue,
+                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+            TestSymbolDescription(
+                text,
+                findSymbol,
+                format,
+                "Foo record()",
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.MethodName, //record
+                SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.Punctuation);
         }
 


### PR DESCRIPTION
See issue #74117 where [it was decided ](https://github.com/dotnet/roslyn/issues/74117#issuecomment-2192770534)that records should be escaped, even though they're not keywords, as it is the safer thing to do.

See other PR #74125
