### PR TITLE
Editor color scheme is visible but disabled when unsupported theme is selected

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
                 (await _colorSchemeApplier.IsSupportedThemeAsync(cancellationToken).ConfigureAwait(false),
                  await _colorSchemeApplier.IsThemeCustomizedAsync(cancellationToken).ConfigureAwait(false)));
 
-            Editor_color_scheme.Visibility = isSupportedTheme ? Visibility.Visible : Visibility.Collapsed;
+            Editor_color_scheme.IsEnabled = isSupportedTheme;
             Customized_Theme_Warning.Visibility = isSupportedTheme && isThemeCustomized ? Visibility.Visible : Visibility.Collapsed;
             Custom_VS_Theme_Warning.Visibility = isSupportedTheme ? Visibility.Collapsed : Visibility.Visible;
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -211,7 +211,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
             Dim isSupportedTheme = values.isSupportedTheme
             Dim isCustomized = values.isCustomized
-            Editor_color_scheme.Visibility = If(isSupportedTheme, Visibility.Visible, Visibility.Collapsed)
+            Editor_color_scheme.IsEnabled = isSupportedTheme
             Customized_Theme_Warning.Visibility = If(isSupportedTheme AndAlso isCustomized, Visibility.Visible, Visibility.Collapsed)
             Custom_VS_Theme_Warning.Visibility = If(isSupportedTheme, Visibility.Collapsed, Visibility.Visible)
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2100189

🔗 [Public link](https://developercommunity.visualstudio.com/t/regression-%E2%80%9CUse-Enhanced-colors-for-C/10689345)

![image](https://github.com/dotnet/roslyn/assets/1408396/3767b827-e2f6-4f0d-b865-26c812b8ca97)
