### PR TITLE
Avoid recreating stateset objects continually.

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -237,7 +237,7 @@ dotnet_diagnostic.{DisabledByDefaultAnalyzer.s_compilationRule.Id}.severity = wa
     }
 
     [Fact]
-    public void TestHostAnalyzerOrdering()
+    public async Task TestHostAnalyzerOrderingAsync()
     {
         using var workspace = CreateWorkspace();
         var exportProvider = workspace.Services.SolutionServices.ExportProvider;
@@ -265,7 +265,8 @@ dotnet_diagnostic.{DisabledByDefaultAnalyzer.s_compilationRule.Id}.severity = wa
         var service = Assert.IsType<DiagnosticAnalyzerService>(exportProvider.GetExportedValue<IDiagnosticAnalyzerService>());
 
         var incrementalAnalyzer = service.CreateIncrementalAnalyzer(workspace);
-        var analyzers = incrementalAnalyzer.GetAnalyzersTestOnly(project).ToArray();
+        var analyzers = await incrementalAnalyzer.GetAnalyzersTestOnlyAsync(project, CancellationToken.None).ConfigureAwait(false);
+        var analyzersArray = analyzers.ToArray();
 
         AssertEx.Equal(new[]
         {
@@ -278,7 +279,7 @@ dotnet_diagnostic.{DisabledByDefaultAnalyzer.s_compilationRule.Id}.severity = wa
             typeof(Priority10Analyzer),
             typeof(Priority15Analyzer),
             typeof(Priority20Analyzer)
-        }, analyzers.Select(a => a.GetType()));
+        }, analyzersArray.Select(a => a.GetType()));
     }
 
     [Fact]

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -79,8 +79,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             return DiagnosticAnalysisResult.CreateEmpty(projectId, version);
         }
 
-        internal IEnumerable<DiagnosticAnalyzer> GetAnalyzersTestOnly(Project project)
-            => _stateManager.GetOrCreateStateSets(project).Select(s => s.Analyzer);
+        internal async Task<IEnumerable<DiagnosticAnalyzer>> GetAnalyzersTestOnlyAsync(Project project, CancellationToken cancellationToken)
+        {
+            var analyzers = await _stateManager.GetOrCreateStateSetsAsync(project, cancellationToken).ConfigureAwait(false);
+
+            return analyzers.Select(s => s.Analyzer);
+        }
 
         private static string GetProjectLogMessage(Project project, ImmutableArray<StateSet> stateSets)
             => $"project: ({project.Id}), ({string.Join(Environment.NewLine, stateSets.Select(s => s.Analyzer.ToString()))})";

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return [];
                 }
 
-                var stateSet = StateManager.GetOrCreateStateSet(project, analyzer);
+                var stateSet = await StateManager.GetOrCreateStateSetAsync(project, analyzer, cancellationToken).ConfigureAwait(false);
                 if (stateSet == null)
                 {
                     return [];
@@ -238,7 +238,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 Action<DiagnosticData> callback, CancellationToken cancellationToken)
             {
                 // get analyzers that are not suppressed.
-                var stateSets = StateManager.GetOrCreateStateSets(project).Where(s => ShouldIncludeStateSet(project, s)).ToImmutableArrayOrEmpty();
+                var stateSetsForProject = await StateManager.GetOrCreateStateSetsAsync(project, cancellationToken).ConfigureAwait(false);
+                var stateSets = stateSetsForProject.Where(s => ShouldIncludeStateSet(project, s)).ToImmutableArrayOrEmpty();
 
                 var ideOptions = Owner.AnalyzerService.GlobalOptions.GetIdeAnalyzerOptions(project);
 

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -86,8 +85,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                  CancellationToken cancellationToken)
             {
                 var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-                var stateSets = owner._stateManager
-                    .GetOrCreateStateSets(document.Project)
+                var unfilteredStateSets = await owner._stateManager
+                    .GetOrCreateStateSetsAsync(document.Project, cancellationToken)
+                    .ConfigureAwait(false);
+                var stateSets = unfilteredStateSets
                     .Where(s => DocumentAnalysisExecutor.IsAnalyzerEnabledForProject(s.Analyzer, document.Project, owner.GlobalOptions))
                     .ToImmutableArray();
 

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             try
             {
-                var stateSets = GetStateSetsForFullSolutionAnalysis(_stateManager.GetOrUpdateStateSets(project), project);
+                var stateSets = GetStateSetsForFullSolutionAnalysis(_stateManager.GetOrCreateStateSets(project), project);
 
                 // get driver only with active analyzers.
                 var ideOptions = AnalyzerService.GlobalOptions.GetIdeAnalyzerOptions(project);

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -22,7 +22,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             try
             {
-                var stateSets = GetStateSetsForFullSolutionAnalysis(_stateManager.GetOrCreateStateSets(project), project);
+                var stateSetsForProject = await _stateManager.GetOrCreateStateSetsAsync(project, cancellationToken).ConfigureAwait(false);
+                var stateSets = GetStateSetsForFullSolutionAnalysis(stateSetsForProject, project);
 
                 // get driver only with active analyzers.
                 var ideOptions = AnalyzerService.GlobalOptions.GetIdeAnalyzerOptions(project);


### PR DESCRIPTION
Lightbulbs had both functionality and performance regressions after the 17.10 change where solution crawler no longer initialzed or updated StateSets on idle. I merged a functional fix last week, attacking the problem in a fairly safe way which was a generally good thing anyways (removing a Try* codepath that allowed lightbulbs to not generate results when semantic results were not available).

However, the underlying issue still existed, in that StateSet objects are being recreated many times, and their creation is actually fairly costly. This PR changes codepaths that were previously just creating statesets and not updating the underlying data structure to now do both. As these updates may now occur during arbitrary calls into the StateManager, I changed the _projectAnalyzerStateMap to an ImmutableDictionary to allow users of it to reason a bit more sanely about it's contents.