### PR TITLE
Improve performance of expensive operation

### DIFF
--- a/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregator.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregator.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings;
 
@@ -76,30 +78,25 @@ internal partial class SettingsAggregator : ISettingsAggregator
 
     private static ISettingsProviderFactory<T> GetOptionsProviderFactory<T>(Workspace workspace)
     {
-        var providers = new List<ISettingsProviderFactory<T>>();
+        using var providers = TemporaryArray<ISettingsProviderFactory<T>>.Empty;
+
         var commonProvider = workspace.Services.GetRequiredService<IWorkspaceSettingsProviderFactory<T>>();
         providers.Add(commonProvider);
-        var solution = workspace.CurrentSolution;
-        var supportsCSharp = solution.Projects.Any(p => p.Language.Equals(LanguageNames.CSharp, StringComparison.OrdinalIgnoreCase));
-        var supportsVisualBasic = solution.Projects.Any(p => p.Language.Equals(LanguageNames.VisualBasic, StringComparison.OrdinalIgnoreCase));
-        if (supportsCSharp)
-        {
-            TryAddProviderForLanguage(LanguageNames.CSharp, workspace, providers);
-        }
 
-        if (supportsVisualBasic)
-        {
-            TryAddProviderForLanguage(LanguageNames.VisualBasic, workspace, providers);
-        }
+        var projectCountByLanguage = workspace.CurrentSolution.SolutionState.ProjectCountByLanguage;
 
-        return new CombinedOptionsProviderFactory<T>([.. providers]);
+        TryAddProviderForLanguage(LanguageNames.CSharp);
+        TryAddProviderForLanguage(LanguageNames.VisualBasic);
 
-        static void TryAddProviderForLanguage(string language, Workspace workspace, List<ISettingsProviderFactory<T>> providers)
+        return new CombinedOptionsProviderFactory<T>(providers.ToImmutableAndClear());
+
+        void TryAddProviderForLanguage(string language)
         {
-            var provider = workspace.Services.GetLanguageServices(language).GetService<ILanguageSettingsProviderFactory<T>>();
-            if (provider is not null)
+            if (projectCountByLanguage.TryGetValue(language, out var languageCount) && languageCount > 0)
             {
-                providers.Add(provider);
+                var provider = workspace.Services.GetLanguageServices(language).GetService<ILanguageSettingsProviderFactory<T>>();
+                if (provider != null)
+                    providers.Add(provider);
             }
         }
     }

--- a/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregator.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregator.cs
@@ -92,7 +92,7 @@ internal partial class SettingsAggregator : ISettingsAggregator
 
         void TryAddProviderForLanguage(string language)
         {
-            if (projectCountByLanguage.TryGetValue(language, out var languageCount) && languageCount > 0)
+            if (projectCountByLanguage.ContainsKey(language))
             {
                 var provider = workspace.Services.GetLanguageServices(language).GetService<ILanguageSettingsProviderFactory<T>>();
                 if (provider != null)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -49,7 +49,7 @@ internal sealed partial class SolutionState
 
     /// <summary>
     /// Number of projects in the solution of the given language.  The value is guaranteed to always be greater than zero.
-    /// If the project count does ever hit then there simply is no key/value pair for that language in this map.
+    /// If the project count does ever hit zero then there simply is no key/value pair for that language in this map.
     /// </summary>
     internal ImmutableDictionary<string, int> ProjectCountByLanguage { get; } = ImmutableDictionary<string, int>.Empty;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -48,7 +48,8 @@ internal sealed partial class SolutionState
     public ImmutableDictionary<string, StructuredAnalyzerConfigOptions> FallbackAnalyzerOptions { get; } = ImmutableDictionary<string, StructuredAnalyzerConfigOptions>.Empty;
 
     /// <summary>
-    /// Number of projects in the solution of the given language.
+    /// Number of projects in the solution of the given language.  The value is guaranteed to always be greater than zero.
+    /// If the project count does ever hit then there simply is no key/value pair for that language in this map.
     /// </summary>
     internal ImmutableDictionary<string, int> ProjectCountByLanguage { get; } = ImmutableDictionary<string, int>.Empty;
 


### PR DESCRIPTION
Reported by dave kean as being super expensive.  We walk the entire soluiotn, creating all the red project nodes, just to determine if we have a single C#/VB project.  But we already have that info, so just use it directly.