### PR TITLE
Do not include collection expression conversion to nullable value type in ClassifyStandardImplicitConversion()

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -669,7 +669,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Conversion conversion = ClassifyImplicitBuiltInConversionFromExpression(sourceExpression, source, destination, ref useSiteInfo);
             if (conversion.Exists &&
                 !conversion.IsInterpolatedStringHandler &&
-                !conversion.IsCollectionExpression)
+                !isImplicitCollectionExpressionConversion(conversion))
             {
                 Debug.Assert(IsStandardImplicitConversionFromExpression(conversion.Kind));
                 return conversion;
@@ -681,6 +681,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return Conversion.NoConversion;
+
+            static bool isImplicitCollectionExpressionConversion(Conversion conversion)
+            {
+                return conversion switch
+                {
+                    { Kind: ConversionKind.CollectionExpression } => true,
+                    { Kind: ConversionKind.ImplicitNullable, UnderlyingConversions: [{ Kind: ConversionKind.CollectionExpression }] } => true,
+                    _ => false,
+                };
+            }
         }
 
         private Conversion ClassifyStandardImplicitConversion(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)


### PR DESCRIPTION
Do not include collection expression conversions to nullable value types in `ClassifyStandardImplicitConversion()`.

User-defined conversions should not be considered in collection expression conversions. And it looks like the scenarios were not supported previously, even though `ClassifyStandardImplicitConversion()` allowed user-defined conversions *from nullable value types*, because `Binder.ConvertCollectionExpression()` created a `BoundCollectionExpression` with `HasErrors=true` when the conversion was a user-defined conversion rather than a collection expression conversion.

In some cases, such as the repro from #74185 with 17.8, a specific error was reported for the target type: `CS1061: 'Container<object>' does not contain a definition for 'Add'`

In other cases, no diagnostic was reported from binding, but the invalid `BoundCollectionExpression` would cause emit to fail with a general error: `CS7038: Failed to emit module: Unable to determine specific cause of the failure.`

Now, the user-defined conversion is ignored in `ClassifyStandardImplicitConversion()`, and an error should be reported for the target type in all cases.

Fixes #74185
