### PR TITLE
Fix style binding failure in Document Outline

### DIFF
--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
@@ -60,7 +60,7 @@
                 </Style.Triggers>
             </Style>
 
-            <Style TargetType="TreeView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogTreeViewStyleKey}}" >
+            <Style TargetType="self:VirtualizingTreeView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogTreeViewStyleKey}}" >
                 <Setter Property="BorderThickness" Value="0" />
                 <Setter Property="Padding" Value="0, 5, 0, 0" />
             </Style>


### PR DESCRIPTION
This issue was introduced by #73564.

Fixes #73810