### PR TITLE
Reduce closures allocated during invocation of CapturedSymbolReplacement.Replacement

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
@@ -624,12 +624,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // frame pointers are organized in a linked list.
                 return proxyField.Replacement(
                     syntax,
-                    static (frameType, arg) =>
-                    {
-                        var (syntax, @this) = arg;
-                        return @this.FramePointer(syntax, frameType);
-                    },
-                    (syntax, this));
+                    static (frameType, arg) => arg.self.FramePointer(arg.syntax, frameType),
+                    (syntax, self: this));
             }
 
             var localFrame = (LocalSymbol)framePointer;
@@ -786,11 +782,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var left = proxy.Replacement(
                     syntax,
-                    static (frameType1, arg) =>
-                    {
-                        var (syntax, framePointer) = arg;
-                        return new BoundLocal(syntax, framePointer, null, framePointer.Type);
-                    },
+                    static (frameType1, arg) => new BoundLocal(arg.syntax, arg.framePointer, null, arg.framePointer.Type),
                     (syntax, framePointer));
 
                 var assignToProxy = new BoundAssignmentOperator(syntax, left, value, value.Type);

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -369,7 +369,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (proxies.TryGetValue(parameterOrLocal, out CapturedSymbolReplacement? proxy))
             {
-                replacement = proxy.Replacement(syntax, frameType => FramePointer(syntax, frameType));
+                replacement = proxy.Replacement(
+                    syntax,
+                    static (frameType, arg) =>
+                    {
+                        var (syntax, @this) = arg;
+                        return @this.FramePointer(syntax, frameType);
+                    },
+                    (syntax, this));
+
                 return true;
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -371,12 +371,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 replacement = proxy.Replacement(
                     syntax,
-                    static (frameType, arg) =>
-                    {
-                        var (syntax, @this) = arg;
-                        return @this.FramePointer(syntax, frameType);
-                    },
-                    (syntax, this));
+                    static (frameType, arg) => arg.self.FramePointer(arg.syntax, frameType),
+                    (syntax, self: this));
 
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/CapturedSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/CapturedSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Rewrite the replacement expression for the hoisted local so all synthesized field are accessed as members
         /// of the appropriate frame.
         /// </summary>
-        public abstract BoundExpression Replacement(SyntaxNode node, Func<NamedTypeSymbol, BoundExpression> makeFrame);
+        public abstract BoundExpression Replacement<TArg>(SyntaxNode node, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame, TArg arg);
     }
 
     internal sealed class CapturedToFrameSymbolReplacement : CapturedSymbolReplacement
@@ -36,9 +36,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.HoistedField = hoistedField;
         }
 
-        public override BoundExpression Replacement(SyntaxNode node, Func<NamedTypeSymbol, BoundExpression> makeFrame)
+        public override BoundExpression Replacement<TArg>(SyntaxNode node, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame, TArg arg)
         {
-            var frame = makeFrame(this.HoistedField.ContainingType);
+            var frame = makeFrame(this.HoistedField.ContainingType, arg);
             var field = this.HoistedField.AsMember((NamedTypeSymbol)frame.Type);
             return new BoundFieldAccess(node, frame, field, constantValueOpt: null);
         }
@@ -54,9 +54,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.HoistedField = hoistedField;
         }
 
-        public override BoundExpression Replacement(SyntaxNode node, Func<NamedTypeSymbol, BoundExpression> makeFrame)
+        public override BoundExpression Replacement<TArg>(SyntaxNode node, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame, TArg arg)
         {
-            var frame = makeFrame(this.HoistedField.ContainingType);
+            var frame = makeFrame(this.HoistedField.ContainingType, arg);
             var field = this.HoistedField.AsMember((NamedTypeSymbol)frame.Type);
             return new BoundFieldAccess(node, frame, field, constantValueOpt: null);
         }
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.HoistedFields = hoistedFields;
         }
 
-        public override BoundExpression Replacement(SyntaxNode node, Func<NamedTypeSymbol, BoundExpression> makeFrame)
+        public override BoundExpression Replacement<TArg>(SyntaxNode node, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame, TArg arg)
         {
             // By returning the same replacement each time, it is possible we
             // are constructing a DAG instead of a tree for the translation.

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 proxies.TryGetValue(thisParameter, out thisProxy) &&
                 F.Compilation.Options.OptimizationLevel == OptimizationLevel.Release)
             {
-                BoundExpression thisProxyReplacement = thisProxy.Replacement(F.Syntax, frameType => F.This());
+                BoundExpression thisProxyReplacement = thisProxy.Replacement(F.Syntax, static (frameType, F) => F.This(), F);
                 Debug.Assert(thisProxyReplacement.Type is not null);
                 this.cachedThis = F.SynthesizedLocal(thisProxyReplacement.Type, syntax: F.Syntax, kind: SynthesizedLocalKind.FrameCache);
             }
@@ -925,7 +925,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)this.cachedThis != null)
             {
                 CapturedSymbolReplacement proxy = proxies[this.OriginalMethod.ThisParameter];
-                var fetchThis = proxy.Replacement(F.Syntax, frameType => F.This());
+                var fetchThis = proxy.Replacement(F.Syntax, static (frameType, F) => F.This(), F);
                 return F.Assignment(F.Local(this.cachedThis), fetchThis);
             }
 
@@ -961,7 +961,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 Debug.Assert(proxy != null);
-                return proxy.Replacement(F.Syntax, frameType => F.This());
+                return proxy.Replacement(F.Syntax, static (frameType, F) => F.This(), F);
             }
         }
 
@@ -977,7 +977,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             CapturedSymbolReplacement proxy = proxies[this.OriginalMethod.ThisParameter];
             Debug.Assert(proxy != null);
-            return proxy.Replacement(F.Syntax, frameType => F.This());
+            return proxy.Replacement(F.Syntax, static (frameType, F) => F.This(), F);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -311,7 +311,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CapturedSymbolReplacement proxy;
                 if (proxies.TryGetValue(method.ThisParameter, out proxy))
                 {
-                    bodyBuilder.Add(F.Assignment(proxy.Replacement(F.Syntax, frameType1 => F.Local(stateMachineVariable)), F.This()));
+                    var leftExpression = proxy.Replacement(
+                        F.Syntax,
+                        static (frameType1, arg) =>
+                        {
+                            var (F, stateMachineVariable) = arg;
+                            return F.Local(stateMachineVariable);
+                        },
+                        (F, stateMachineVariable));
+
+                    bodyBuilder.Add(F.Assignment(leftExpression, F.This()));
                 }
             }
 
@@ -320,8 +329,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CapturedSymbolReplacement proxy;
                 if (proxies.TryGetValue(parameter, out proxy))
                 {
-                    bodyBuilder.Add(F.Assignment(proxy.Replacement(F.Syntax, frameType1 => F.Local(stateMachineVariable)),
-                                                 F.Parameter(parameter)));
+                    var leftExpression = proxy.Replacement(
+                        F.Syntax,
+                        static (frameType1, arg) =>
+                        {
+                            var (F, stateMachineVariable) = arg;
+                            return F.Local(stateMachineVariable);
+                        },
+                        (F, stateMachineVariable));
+
+                    bodyBuilder.Add(F.Assignment(leftExpression, F.Parameter(parameter)));
                 }
             }
 
@@ -456,10 +473,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CapturedSymbolReplacement proxy;
                 if (copyDest.TryGetValue(method.ThisParameter, out proxy))
                 {
-                    bodyBuilder.Add(
-                        F.Assignment(
-                            proxy.Replacement(F.Syntax, stateMachineType => F.Local(resultVariable)),
-                            copySrc[method.ThisParameter].Replacement(F.Syntax, stateMachineType => F.This())));
+                    var leftExpression = proxy.Replacement(
+                        F.Syntax,
+                        static (stateMachineType, arg) =>
+                        {
+                            var (F, resultVariable) = arg;
+                            return F.Local(resultVariable);
+                        },
+                        (F, resultVariable));
+
+                    var rightExpression = copySrc[method.ThisParameter].Replacement(F.Syntax, static (stateMachineType, F) => F.This(), F);
+
+                    bodyBuilder.Add(F.Assignment(leftExpression, rightExpression));
                 }
             }
 
@@ -471,9 +496,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (copyDest.TryGetValue(parameter, out proxy))
                 {
                     // result.parameter
-                    BoundExpression resultParameter = proxy.Replacement(F.Syntax, stateMachineType => F.Local(resultVariable));
+                    BoundExpression resultParameter = proxy.Replacement(
+                        F.Syntax,
+                        static (stateMachineType, arg) =>
+                        {
+                            var (F, resultVariable) = arg;
+                            return F.Local(resultVariable);
+                        },
+                        (F, resultVariable));
+
                     // this.parameterProxy
-                    BoundExpression parameterProxy = copySrc[parameter].Replacement(F.Syntax, stateMachineType => F.This());
+                    BoundExpression parameterProxy = copySrc[parameter].Replacement(F.Syntax, static (stateMachineType, F) => F.This(), F);
                     BoundStatement copy = InitializeParameterField(getEnumeratorMethod, parameter, resultParameter, parameterProxy);
 
                     bodyBuilder.Add(copy);

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -313,11 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var leftExpression = proxy.Replacement(
                         F.Syntax,
-                        static (frameType1, arg) =>
-                        {
-                            var (F, stateMachineVariable) = arg;
-                            return F.Local(stateMachineVariable);
-                        },
+                        static (frameType1, arg) => arg.F.Local(arg.stateMachineVariable),
                         (F, stateMachineVariable));
 
                     bodyBuilder.Add(F.Assignment(leftExpression, F.This()));
@@ -331,11 +327,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var leftExpression = proxy.Replacement(
                         F.Syntax,
-                        static (frameType1, arg) =>
-                        {
-                            var (F, stateMachineVariable) = arg;
-                            return F.Local(stateMachineVariable);
-                        },
+                        static (frameType1, arg) => arg.F.Local(arg.stateMachineVariable),
                         (F, stateMachineVariable));
 
                     bodyBuilder.Add(F.Assignment(leftExpression, F.Parameter(parameter)));
@@ -475,11 +467,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var leftExpression = proxy.Replacement(
                         F.Syntax,
-                        static (stateMachineType, arg) =>
-                        {
-                            var (F, resultVariable) = arg;
-                            return F.Local(resultVariable);
-                        },
+                        static (stateMachineType, arg) => arg.F.Local(arg.resultVariable),
                         (F, resultVariable));
 
                     var rightExpression = copySrc[method.ThisParameter].Replacement(F.Syntax, static (stateMachineType, F) => F.This(), F);
@@ -498,11 +486,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // result.parameter
                     BoundExpression resultParameter = proxy.Replacement(
                         F.Syntax,
-                        static (stateMachineType, arg) =>
-                        {
-                            var (F, resultVariable) = arg;
-                            return F.Local(resultVariable);
-                        },
+                        static (stateMachineType, arg) => arg.F.Local(arg.resultVariable),
                         (F, resultVariable));
 
                     // this.parameterProxy


### PR DESCRIPTION
This method previously took in a Func<NamedTypeSymbol, BoundExpression> and most callers allocated a closure to implement the callback. This PR uses the args pattern and adds a parameter to the Replacement method that is passed back into that callback to better allow static lambdas to be used.

This was the top allocating closure allocation in vbcscompiler in a customer profile I'm looking at (0.2% -- 42 MB)

![image](https://github.com/dotnet/roslyn/assets/6785178/13765de0-d766-4a3a-aaf0-551c157a5095)