### PR TITLE
Improve performance of SourceText.LineInfo indexer.

### DIFF
--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -966,12 +966,12 @@ namespace Microsoft.CodeAnalysis.Text
                     int start = _lineStarts[index];
                     if (index == _lineStarts.Count - 1)
                     {
-                        return TextLine.FromKnownSpan(_text, TextSpan.FromBounds(start, _text.Length));
+                        return TextLine.FromSpanUnsafe(_text, TextSpan.FromBounds(start, _text.Length));
                     }
                     else
                     {
                         int end = _lineStarts[index + 1];
-                        return TextLine.FromKnownSpan(_text, TextSpan.FromBounds(start, end));
+                        return TextLine.FromSpanUnsafe(_text, TextSpan.FromBounds(start, end));
                     }
                 }
             }

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -966,12 +966,12 @@ namespace Microsoft.CodeAnalysis.Text
                     int start = _lineStarts[index];
                     if (index == _lineStarts.Count - 1)
                     {
-                        return TextLine.FromSpan(_text, TextSpan.FromBounds(start, _text.Length));
+                        return TextLine.FromKnownSpan(_text, TextSpan.FromBounds(start, _text.Length));
                     }
                     else
                     {
                         int end = _lineStarts[index + 1];
-                        return TextLine.FromSpan(_text, TextSpan.FromBounds(start, end));
+                        return TextLine.FromKnownSpan(_text, TextSpan.FromBounds(start, end));
                     }
                 }
             }

--- a/src/Compilers/Core/Portable/Text/TextLine.cs
+++ b/src/Compilers/Core/Portable/Text/TextLine.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text
@@ -82,10 +83,13 @@ namespace Microsoft.CodeAnalysis.Text
         }
 
         // Do not use unless you are certain the span you are passing in is valid!
-        // This was added to allow SourceText's indexer to directly create TextLines
+        // This was added to allow SourceText.LineInfo's indexer to directly create TextLines
         // without the performance implications of calling FromSpan.
         internal static TextLine FromKnownSpan(SourceText text, TextSpan span)
         {
+            Debug.Assert(span.Start == 0 || TextUtilities.IsAnyLineBreakCharacter(text[span.Start - 1]));
+            Debug.Assert(span.End == text.Length || TextUtilities.IsAnyLineBreakCharacter(text[span.End - 1]));
+
             return new TextLine(text, span.Start, span.End);
         }
 

--- a/src/Compilers/Core/Portable/Text/TextLine.cs
+++ b/src/Compilers/Core/Portable/Text/TextLine.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Text
         // Do not use unless you are certain the span you are passing in is valid!
         // This was added to allow SourceText.LineInfo's indexer to directly create TextLines
         // without the performance implications of calling FromSpan.
-        internal static TextLine FromKnownSpan(SourceText text, TextSpan span)
+        internal static TextLine FromSpanUnsafe(SourceText text, TextSpan span)
         {
             Debug.Assert(span.Start == 0 || TextUtilities.IsAnyLineBreakCharacter(text[span.Start - 1]));
             Debug.Assert(span.End == text.Length || TextUtilities.IsAnyLineBreakCharacter(text[span.End - 1]));

--- a/src/Compilers/Core/Portable/Text/TextLine.cs
+++ b/src/Compilers/Core/Portable/Text/TextLine.cs
@@ -81,6 +81,14 @@ namespace Microsoft.CodeAnalysis.Text
             }
         }
 
+        // Do not use unless you are certain the span you are passing in is valid!
+        // This was added to allow SourceText's indexer to directly create TextLines
+        // without the performance implications of calling FromSpan.
+        internal static TextLine FromKnownSpan(SourceText text, TextSpan span)
+        {
+            return new TextLine(text, span.Start, span.End);
+        }
+
         /// <summary>
         /// Gets the source text.
         /// </summary>


### PR DESCRIPTION
Saw something new in a customer performance profile, a *ton* of time spent in the LSP DidChangeHandler. It's uncertain, but my guess is the customer did a Find/Replace that ended up doing a huge number of edits within the current file. The way the Roslyn didChange handler currently works, it takes each of those edits and creates a new SourceText. (This is something I'm going to pursue in a separate PR).

Each of those new source texts ends up calling into ChangedText.GetLinesCore, and subsequently the LineInfo indexer, during the didChangeHandler. This is the method that ends up showing in the profile (23.5 seconds of CPU time in the trace, which was 40% of CPU time in the VS process)

The change here is to allow SourceText a way to create TextLine's with a known extent, avoiding the overhead involved with calling the LineInfo indexer.

![image](https://github.com/dotnet/roslyn/assets/6785178/60fed4ea-753d-44ab-8c01-016c89a0b4c7)