### PR TITLE
Fix leading comments not being preserved on variable case

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForBuilderDiagnosticAnalyzer.cs
@@ -165,11 +165,11 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderDiagnosticA
         using var enumerator = state.GetSubsequentStatements().GetEnumerator();
         while (enumerator.MoveNext())
         {
-            var subseqeuntStatement = enumerator.Current;
+            var subsequentStatement = enumerator.Current;
 
             // See if it's one of the statement forms that can become a collection expression element.
             var match = state.TryAnalyzeStatementForCollectionExpression(
-                CSharpUpdateExpressionSyntaxHelper.Instance, subseqeuntStatement, cancellationToken);
+                CSharpUpdateExpressionSyntaxHelper.Instance, subsequentStatement, cancellationToken);
             if (match != null)
             {
                 matches.Add(match.Value);
@@ -182,7 +182,7 @@ internal sealed partial class CSharpUseCollectionExpressionForBuilderDiagnosticA
 
             // Now, look for something in the current statement (like `builder.ToImmutable()`) indicating we're
             // converting the builder to the final form.
-            var creationExpression = TryFindCreationExpression(identifier, subseqeuntStatement);
+            var creationExpression = TryFindCreationExpression(identifier, subsequentStatement);
             if (creationExpression is null)
                 return null;
 

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForBuilderTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForBuilderTests.cs
@@ -1589,4 +1589,119 @@ public partial class UseCollectionExpressionForBuilderTests
                 """
         }.RunAsync();
     }
+
+    [Theory, MemberData(nameof(SuccessCreationPatterns))]
+    public async Task TestLeadingComment(string pattern)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System.Collections.Immutable;
+
+                class C
+                {
+                    void M()
+                    {
+                        //Leading
+                        {{pattern}}
+                        [|builder.Add(|]0);
+                        ImmutableArray<int> array = builder.ToImmutable();
+                    }
+                }
+                """ + s_arrayBuilderApi,
+            FixedCode = """
+                using System.Collections.Immutable;
+
+                class C
+                {
+                    void M()
+                    {
+                        //Leading
+                        ImmutableArray<int> array = [0];
+                    }
+                }
+                """ + s_arrayBuilderApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Theory, MemberData(nameof(SuccessCreationPatterns))]
+    public async Task TestLeadingCommentWithAdditionalTrivia1(string pattern)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System.Collections.Immutable;
+
+                class C
+                {
+                    void M()
+                    {
+                        //Leading
+                        {{pattern}}
+                        [|builder.Add(|]0);
+                        //comment
+                        ImmutableArray<int> array = builder.ToImmutable();
+                    }
+                }
+                """ + s_arrayBuilderApi,
+            FixedCode = """
+                using System.Collections.Immutable;
+
+                class C
+                {
+                    void M()
+                    {
+                        //Leading
+                        //comment
+                        ImmutableArray<int> array = [0];
+                    }
+                }
+                """ + s_arrayBuilderApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Theory, MemberData(nameof(SuccessCreationPatterns))]
+    public async Task TestLeadingCommentWithAdditionalTrivia2(string pattern)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System.Collections.Immutable;
+
+                class C
+                {
+                    void M()
+                    {
+                        //Leading
+                        {{pattern}}
+                        //Leading
+                        [|builder.Add(|]0); //Trailing
+                        ImmutableArray<int> array = builder.ToImmutable();
+                    }
+                }
+                """ + s_arrayBuilderApi,
+            FixedCode = """
+                using System.Collections.Immutable;
+
+                class C
+                {
+                    void M()
+                    {
+                        //Leading
+                        ImmutableArray<int> array =
+                        [
+                            //Leading
+                            0, //Trailing
+                        ];
+                    }
+                }
+                """ + s_arrayBuilderApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForBuilderTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForBuilderTests.cs
@@ -1591,6 +1591,7 @@ public partial class UseCollectionExpressionForBuilderTests
     }
 
     [Theory, MemberData(nameof(SuccessCreationPatterns))]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/74208")]
     public async Task TestLeadingComment(string pattern)
     {
         await new VerifyCS.Test
@@ -1627,6 +1628,7 @@ public partial class UseCollectionExpressionForBuilderTests
     }
 
     [Theory, MemberData(nameof(SuccessCreationPatterns))]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/74208")]
     public async Task TestLeadingCommentWithAdditionalTrivia1(string pattern)
     {
         await new VerifyCS.Test
@@ -1665,6 +1667,7 @@ public partial class UseCollectionExpressionForBuilderTests
     }
 
     [Theory, MemberData(nameof(SuccessCreationPatterns))]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/74208")]
     public async Task TestLeadingCommentWithAdditionalTrivia2(string pattern)
     {
         await new VerifyCS.Test


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/74208
FYI: 
This does not fix the return case: `return builder.ToImmutable()`
 and the method case: `Goo(builder.ToImmutable())`
and potential other cases i'm not aware of.