### PR TITLE
Enable running in ARM64-native mode on .NET Framework.

### DIFF
--- a/eng/config/app.manifest
+++ b/eng/config/app.manifest
@@ -14,6 +14,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+      <supportedArchitectures xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">amd64 arm64</supportedArchitectures>
     </windowsSettings>
   </application>
 </assembly>


### PR DESCRIPTION
Fixes dotnet/runtime#104548.

This PR updates `app.manifest` to add the newly introduced [`supportedArchitectures`](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#supportedarchitectures) element. This enables Roslyn to run in native ARM64 architecture when running on .NET Framework (for example in builds inside Visual Studio), and on Windows 11 24H2+.