### PR TITLE
Add Solution.WithProjectInfo API

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -206,6 +206,10 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
         _sessionId = default;
     }
 
+    // access to internal API:
+    public static Solution WithProjectInfo(Solution solution, ProjectInfo info)
+        => solution.WithProjectInfo(info);
+
     internal TestAccessor GetTestAccessor()
         => new(this);
 

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -991,7 +991,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 return null;
             }
 
-            var spanMappingService = document.Services.GetService<ISpanMappingService>();
+            var spanMappingService = document.DocumentServiceProvider.GetService<ISpanMappingService>();
             if (spanMappingService == null)
             {
                 return null;

--- a/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Def/CodeLens/RemoteCodeLensReferencesService.cs
@@ -150,7 +150,7 @@ internal sealed class RemoteCodeLensReferencesService : ICodeLensReferencesServi
                 continue;
             }
 
-            var spanMapper = document.Services.GetService<ISpanMappingService>();
+            var spanMapper = document.DocumentServiceProvider.GetService<ISpanMappingService>();
             if (spanMapper == null)
             {
                 // for normal document, just add one as they are
@@ -173,7 +173,7 @@ internal sealed class RemoteCodeLensReferencesService : ICodeLensReferencesServi
                 continue;
             }
 
-            var excerpter = document.Services.GetService<IDocumentExcerptService>();
+            var excerpter = document.DocumentServiceProvider.GetService<IDocumentExcerptService>();
             if (excerpter == null)
             {
                 continue;

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -462,7 +462,7 @@ internal partial class StreamingFindUsagesPresenter
             var document = documentSpan.Document;
             var sourceSpan = documentSpan.SourceSpan;
 
-            var excerptService = document.Services.GetService<IDocumentExcerptService>();
+            var excerptService = document.DocumentServiceProvider.GetService<IDocumentExcerptService>();
 
             // Fetching options is expensive enough to try to avoid it if we can.  So only fetch this if absolutely necessary.
             ClassificationOptions? options = null;

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -75,7 +75,7 @@ internal partial class StreamingFindUsagesPresenter
 
         public static async Task<MappedSpanResult?> TryMapAndGetFirstAsync(DocumentSpan documentSpan, SourceText sourceText, CancellationToken cancellationToken)
         {
-            var service = documentSpan.Document.Services.GetService<ISpanMappingService>();
+            var service = documentSpan.Document.DocumentServiceProvider.GetService<ISpanMappingService>();
             if (service == null)
             {
                 return new MappedSpanResult(documentSpan.Document.FilePath, sourceText.Lines.GetLinePositionSpan(documentSpan.SourceSpan), documentSpan.SourceSpan);

--- a/src/VisualStudio/Core/Def/FindReferences/Entries/DocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Entries/DocumentSpanEntry.cs
@@ -183,7 +183,7 @@ internal partial class StreamingFindUsagesPresenter
             var controlService = document.Project.Solution.Services.GetRequiredService<IContentControlService>();
             var sourceText = document.GetTextSynchronously(CancellationToken.None);
 
-            var excerptService = document.Services.GetService<IDocumentExcerptService>();
+            var excerptService = document.DocumentServiceProvider.GetService<IDocumentExcerptService>();
             if (excerptService != null)
             {
                 var classificationOptions = Presenter._globalOptions.GetClassificationOptions(document.Project.Language);

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -679,7 +679,7 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
 
         bool ShouldApplyChangesToMappedDocuments(CodeAnalysis.Document document, [NotNullWhen(true)] out ISpanMappingService? spanMappingService)
         {
-            spanMappingService = document.Services.GetService<ISpanMappingService>();
+            spanMappingService = document.DocumentServiceProvider.GetService<ISpanMappingService>();
             // Only consider files that are mapped and that we are unable to apply changes to.
             // TODO - refactor how this is determined - https://github.com/dotnet/roslyn/issues/47908
             return spanMappingService != null && document?.CanApplyChange() == false;

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
@@ -205,7 +205,7 @@ internal sealed class VisualStudioDocumentNavigationService(
         }
 
         // Before attempting to open the document, check if the location maps to a different file that should be opened instead.
-        var spanMappingService = document.Services.GetService<ISpanMappingService>();
+        var spanMappingService = document.DocumentServiceProvider.GetService<ISpanMappingService>();
         if (spanMappingService != null)
         {
             var mappedSpan = await GetMappedSpanAsync(

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -199,7 +199,7 @@ internal sealed class DiagnosticData(
         var additionalLocations = GetAdditionalLocations(document, diagnostic);
         var additionalProperties = GetAdditionalProperties(document, diagnostic);
 
-        var documentPropertiesService = document.Services.GetService<DocumentPropertiesService>();
+        var documentPropertiesService = document.DocumentServiceProvider.GetService<DocumentPropertiesService>();
         var diagnosticsLspClientName = documentPropertiesService?.DiagnosticsLspClientName;
 
         if (diagnosticsLspClientName != null)

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -106,7 +106,7 @@ public static partial class Renamer
         if (document == null)
             throw new ArgumentNullException(nameof(document));
 
-        if (document.Services.GetService<ISpanMappingService>() != null)
+        if (document.DocumentServiceProvider.GetService<ISpanMappingService>() != null)
         {
             // Don't advertise that we can file rename generated documents that map to a different file.
             return new RenameDocumentActionSet([], document.Id, document.Name, [.. document.Folders], options);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocumentState.cs
@@ -27,7 +27,7 @@ internal sealed class AdditionalDocumentState : TextDocumentState
         SolutionServices solutionServices,
         DocumentInfo documentInfo,
         LoadTextOptions loadTextOptions)
-        : this(solutionServices, documentInfo.DocumentServiceProvider, documentInfo.Attributes, CreateTextAndVersionSource(solutionServices, documentInfo, loadTextOptions), loadTextOptions)
+        : this(solutionServices, documentInfo.DocumentServiceProvider, documentInfo.Attributes, CreateTextAndVersionSource(solutionServices, documentInfo.TextLoader, documentInfo.FilePath, loadTextOptions), loadTextOptions)
     {
     }
 
@@ -36,6 +36,14 @@ internal sealed class AdditionalDocumentState : TextDocumentState
             SolutionServices,
             DocumentServiceProvider,
             newAttributes,
+            TextAndVersionSource,
+            LoadTextOptions);
+
+    protected override TextDocumentState UpdateDocumentServiceProvider(IDocumentServiceProvider? newProvider)
+        => new AdditionalDocumentState(
+            SolutionServices,
+            newProvider,
+            Attributes,
             TextAndVersionSource,
             LoadTextOptions);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
@@ -33,7 +33,7 @@ internal sealed class AnalyzerConfigDocumentState : TextDocumentState
         SolutionServices solutionServices,
         DocumentInfo documentInfo,
         LoadTextOptions loadTextOptions)
-        : this(solutionServices, documentInfo.DocumentServiceProvider, documentInfo.Attributes, CreateTextAndVersionSource(solutionServices, documentInfo, loadTextOptions), loadTextOptions)
+        : this(solutionServices, documentInfo.DocumentServiceProvider, documentInfo.Attributes, CreateTextAndVersionSource(solutionServices, documentInfo.TextLoader, documentInfo.FilePath, loadTextOptions), loadTextOptions)
     {
     }
 
@@ -46,6 +46,16 @@ internal sealed class AnalyzerConfigDocumentState : TextDocumentState
             LoadTextOptions,
             // Reuse parsed config unless the path changed:
             Attributes.FilePath == newAttributes.FilePath ? _lazyAnalyzerConfig : null);
+
+    protected override TextDocumentState UpdateDocumentServiceProvider(IDocumentServiceProvider? newProvider)
+        => new AnalyzerConfigDocumentState(
+            SolutionServices,
+            DocumentServiceProvider,
+            Attributes,
+            TextAndVersionSource,
+            LoadTextOptions,
+            // Reuse parsed config:
+            _lazyAnalyzerConfig);
 
     public new AnalyzerConfigDocumentState UpdateText(TextLoader loader, PreservationMode mode)
         => (AnalyzerConfigDocumentState)base.UpdateText(loader, mode);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -336,7 +336,7 @@ internal partial class DocumentState : TextDocumentState
             newTreeSource);
     }
 
-    public DocumentState UpdateParseOptionsAndSourceCodeKind(ParseOptions? options, bool onlyPreprocessorDirectiveChange)
+    public DocumentState UpdateParseOptionsAndSourceCodeKind(ParseOptions options, bool onlyPreprocessorDirectiveChange)
     {
         Contract.ThrowIfFalse(SupportsSyntaxTree);
 
@@ -350,8 +350,6 @@ internal partial class DocumentState : TextDocumentState
         if (onlyPreprocessorDirectiveChange &&
             TreeSource.TryGetValue(out var existingTreeAndVersion))
         {
-            Debug.Assert(options != null);
-
             var existingTree = existingTreeAndVersion.Tree;
 
             SyntaxTree? newTree = null;
@@ -367,25 +365,18 @@ internal partial class DocumentState : TextDocumentState
                 newTreeSource = SimpleTreeAndVersionSource.Create(new TreeAndVersion(newTree, existingTreeAndVersion.Version));
         }
 
-        if (options != null)
-        {
-            // If we weren't able to reuse in a smart way, just reparse
-            newTreeSource ??= CreateLazyFullyParsedTree(
-                TextAndVersionSource,
-                LoadTextOptions,
-                Attributes.SyntaxTreeFilePath,
-                options,
-                LanguageServices);
-        }
-        else
-        {
-            newTreeSource = null;
-        }
+        // If we weren't able to reuse in a smart way, just reparse
+        newTreeSource ??= CreateLazyFullyParsedTree(
+            TextAndVersionSource,
+            LoadTextOptions,
+            Attributes.SyntaxTreeFilePath,
+            options,
+            LanguageServices);
 
         return new DocumentState(
             LanguageServices,
             DocumentServiceProvider,
-            (options != null) ? Attributes.With(sourceCodeKind: options.Kind) : Attributes,
+            Attributes.With(sourceCodeKind: options.Kind),
             TextAndVersionSource,
             LoadTextOptions,
             options,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -590,7 +590,7 @@ public partial class Project
     /// <summary>
     /// Creates a new instance of this project updated to have the specified parse options.
     /// </summary>
-    public Project WithParseOptions(ParseOptions? options)
+    public Project WithParseOptions(ParseOptions options)
         => this.Solution.WithProjectParseOptions(this.Id, options).GetRequiredProject(Id);
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -573,106 +573,113 @@ public partial class Project
     /// Creates a new instance of this project updated to have the new assembly name.
     /// </summary>
     public Project WithAssemblyName(string assemblyName)
-        => this.Solution.WithProjectAssemblyName(this.Id, assemblyName).GetProject(this.Id)!;
+        => this.Solution.WithProjectAssemblyName(this.Id, assemblyName).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to have the new default namespace.
     /// </summary>
     public Project WithDefaultNamespace(string defaultNamespace)
-        => this.Solution.WithProjectDefaultNamespace(this.Id, defaultNamespace).GetProject(this.Id)!;
+        => this.Solution.WithProjectDefaultNamespace(this.Id, defaultNamespace).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to have the specified compilation options.
     /// </summary>
     public Project WithCompilationOptions(CompilationOptions options)
-        => this.Solution.WithProjectCompilationOptions(this.Id, options).GetProject(this.Id)!;
+        => this.Solution.WithProjectCompilationOptions(this.Id, options).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to have the specified parse options.
     /// </summary>
-    public Project WithParseOptions(ParseOptions options)
-        => this.Solution.WithProjectParseOptions(this.Id, options).GetProject(this.Id)!;
+    public Project WithParseOptions(ParseOptions? options)
+        => this.Solution.WithProjectParseOptions(this.Id, options).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to include the specified project reference
     /// in addition to already existing ones.
     /// </summary>
     public Project AddProjectReference(ProjectReference projectReference)
-        => this.Solution.AddProjectReference(this.Id, projectReference).GetProject(this.Id)!;
+        => this.Solution.AddProjectReference(this.Id, projectReference).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to include the specified project references
     /// in addition to already existing ones.
     /// </summary>
     public Project AddProjectReferences(IEnumerable<ProjectReference> projectReferences)
-        => this.Solution.AddProjectReferences(this.Id, projectReferences).GetProject(this.Id)!;
+        => this.Solution.AddProjectReferences(this.Id, projectReferences).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to no longer include the specified project reference.
     /// </summary>
     public Project RemoveProjectReference(ProjectReference projectReference)
-        => this.Solution.RemoveProjectReference(this.Id, projectReference).GetProject(this.Id)!;
+        => this.Solution.RemoveProjectReference(this.Id, projectReference).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to replace existing project references 
     /// with the specified ones.
     /// </summary>
     public Project WithProjectReferences(IEnumerable<ProjectReference> projectReferences)
-        => this.Solution.WithProjectReferences(this.Id, projectReferences).GetProject(this.Id)!;
+        => this.Solution.WithProjectReferences(this.Id, projectReferences).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to include the specified metadata reference
     /// in addition to already existing ones.
     /// </summary>
     public Project AddMetadataReference(MetadataReference metadataReference)
-        => this.Solution.AddMetadataReference(this.Id, metadataReference).GetProject(this.Id)!;
+        => this.Solution.AddMetadataReference(this.Id, metadataReference).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to include the specified metadata references
     /// in addition to already existing ones.
     /// </summary>
     public Project AddMetadataReferences(IEnumerable<MetadataReference> metadataReferences)
-        => this.Solution.AddMetadataReferences(this.Id, metadataReferences).GetProject(this.Id)!;
+        => this.Solution.AddMetadataReferences(this.Id, metadataReferences).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to no longer include the specified metadata reference.
     /// </summary>
     public Project RemoveMetadataReference(MetadataReference metadataReference)
-        => this.Solution.RemoveMetadataReference(this.Id, metadataReference).GetProject(this.Id)!;
+        => this.Solution.RemoveMetadataReference(this.Id, metadataReference).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to replace existing metadata reference
     /// with the specified ones.
     /// </summary>
     public Project WithMetadataReferences(IEnumerable<MetadataReference> metadataReferences)
-        => this.Solution.WithProjectMetadataReferences(this.Id, metadataReferences).GetProject(this.Id)!;
+        => this.Solution.WithProjectMetadataReferences(this.Id, metadataReferences).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to include the specified analyzer reference 
     /// in addition to already existing ones.
     /// </summary>
     public Project AddAnalyzerReference(AnalyzerReference analyzerReference)
-        => this.Solution.AddAnalyzerReference(this.Id, analyzerReference).GetProject(this.Id)!;
+        => this.Solution.AddAnalyzerReference(this.Id, analyzerReference).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to include the specified analyzer references
     /// in addition to already existing ones.
     /// </summary>
     public Project AddAnalyzerReferences(IEnumerable<AnalyzerReference> analyzerReferences)
-        => this.Solution.AddAnalyzerReferences(this.Id, analyzerReferences).GetProject(this.Id)!;
+        => this.Solution.AddAnalyzerReferences(this.Id, analyzerReferences).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to no longer include the specified analyzer reference.
     /// </summary>
     public Project RemoveAnalyzerReference(AnalyzerReference analyzerReference)
-        => this.Solution.RemoveAnalyzerReference(this.Id, analyzerReference).GetProject(this.Id)!;
+        => this.Solution.RemoveAnalyzerReference(this.Id, analyzerReference).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to replace existing analyzer references 
     /// with the specified ones.
     /// </summary>
     public Project WithAnalyzerReferences(IEnumerable<AnalyzerReference> analyzerReferencs)
-        => this.Solution.WithProjectAnalyzerReferences(this.Id, analyzerReferencs).GetProject(this.Id)!;
+        => this.Solution.WithProjectAnalyzerReferences(this.Id, analyzerReferencs).GetRequiredProject(Id);
+
+    /// <summary>
+    /// Creates a new instance of this project updated to replace existing analyzer references 
+    /// with the specified ones.
+    /// </summary>
+    internal Project WithAttributes(ProjectInfo.ProjectAttributes attributes)
+        => Solution.WithProjectAttributes(attributes).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new document in a new instance of this project.
@@ -738,7 +745,7 @@ public partial class Project
     {
         // NOTE: the method isn't checking if documentId belongs to the project. This probably should be done, but may be a compat change.
         // https://github.com/dotnet/roslyn/issues/41211 tracks this investigation.
-        return this.Solution.RemoveDocument(documentId).GetProject(this.Id)!;
+        return this.Solution.RemoveDocument(documentId).GetRequiredProject(Id);
     }
 
     /// <summary>
@@ -757,7 +764,7 @@ public partial class Project
     public Project RemoveAdditionalDocument(DocumentId documentId)
         // NOTE: the method isn't checking if documentId belongs to the project. This probably should be done, but may be a compat change.
         // https://github.com/dotnet/roslyn/issues/41211 tracks this investigation.
-        => this.Solution.RemoveAdditionalDocument(documentId).GetProject(this.Id)!;
+        => this.Solution.RemoveAdditionalDocument(documentId).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new instance of this project updated to no longer include the specified additional documents.
@@ -775,7 +782,7 @@ public partial class Project
     public Project RemoveAnalyzerConfigDocument(DocumentId documentId)
         // NOTE: the method isn't checking if documentId belongs to the project. This probably should be done, but may be a compat change.
         // https://github.com/dotnet/roslyn/issues/41211 tracks this investigation.
-        => this.Solution.RemoveAnalyzerConfigDocument(documentId).GetProject(this.Id)!;
+        => this.Solution.RemoveAnalyzerConfigDocument(documentId).GetRequiredProject(Id);
 
     /// <summary>
     /// Creates a new solution instance that no longer includes the specified <see cref="AnalyzerConfigDocument"/>s.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -655,7 +655,7 @@ internal partial class ProjectState
     private TextDocumentStates<DocumentState> UpdateDocumentsChecksumAlgorithm(SourceHashAlgorithm checksumAlgorithm)
         => DocumentStates.UpdateStates(static (state, checksumAlgorithm) => state.UpdateChecksumAlgorithm(checksumAlgorithm), checksumAlgorithm);
 
-    public ProjectState WithCompilationOptions(CompilationOptions options)
+    public ProjectState WithCompilationOptions(CompilationOptions? options)
     {
         if (options == CompilationOptions)
         {
@@ -664,23 +664,25 @@ internal partial class ProjectState
 
         var newProvider = new ProjectSyntaxTreeOptionsProvider(_analyzerConfigOptionsCache);
 
-        return With(projectInfo: ProjectInfo.WithCompilationOptions(options.WithSyntaxTreeOptionsProvider(newProvider))
+        return With(projectInfo: ProjectInfo.WithCompilationOptions(options?.WithSyntaxTreeOptionsProvider(newProvider))
                    .WithVersion(Version.GetNewerVersion()));
     }
 
-    public ProjectState WithParseOptions(ParseOptions options)
+    public ProjectState WithParseOptions(ParseOptions? options)
     {
         if (options == ParseOptions)
         {
             return this;
         }
 
-        var onlyPreprocessorDirectiveChange = ParseOptions != null &&
+        var onlyPreprocessorDirectiveChange = options != null && ParseOptions != null &&
             LanguageServices.GetRequiredService<ISyntaxTreeFactoryService>().OptionsDifferOnlyByPreprocessorDirectives(options, ParseOptions);
 
         return With(
             projectInfo: ProjectInfo.WithParseOptions(options).WithVersion(Version.GetNewerVersion()),
-            documentStates: DocumentStates.UpdateStates(static (state, args) => state.UpdateParseOptionsAndSourceCodeKind(args.options, args.onlyPreprocessorDirectiveChange), (options, onlyPreprocessorDirectiveChange)));
+            documentStates: DocumentStates.UpdateStates(static (state, args) =>
+                state.UpdateParseOptionsAndSourceCodeKind(args.options, args.onlyPreprocessorDirectiveChange),
+                arg: (options, onlyPreprocessorDirectiveChange)));
     }
 
     public ProjectState WithFallbackAnalyzerOptions(StructuredAnalyzerConfigOptions options)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -662,9 +662,14 @@ internal partial class ProjectState
             return this;
         }
 
+        if (options == null)
+        {
+            throw new NotSupportedException(WorkspacesResources.Removing_compilation_options_is_not_supported);
+        }
+
         var newProvider = new ProjectSyntaxTreeOptionsProvider(_analyzerConfigOptionsCache);
 
-        return With(projectInfo: ProjectInfo.WithCompilationOptions(options?.WithSyntaxTreeOptionsProvider(newProvider))
+        return With(projectInfo: ProjectInfo.WithCompilationOptions(options.WithSyntaxTreeOptionsProvider(newProvider))
                    .WithVersion(Version.GetNewerVersion()));
     }
 
@@ -675,7 +680,12 @@ internal partial class ProjectState
             return this;
         }
 
-        var onlyPreprocessorDirectiveChange = options != null && ParseOptions != null &&
+        if (options == null)
+        {
+            throw new NotSupportedException(WorkspacesResources.Removing_parse_options_is_not_supported);
+        }
+
+        var onlyPreprocessorDirectiveChange = ParseOptions != null &&
             LanguageServices.GetRequiredService<ISyntaxTreeFactoryService>().OptionsDifferOnlyByPreprocessorDirectives(options, ParseOptions);
 
         return With(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -490,9 +490,15 @@ public partial class Solution
     /// Create a new solution instance with the project specified updated to have
     /// the specified parse options.
     /// </summary>
-    public Solution WithProjectParseOptions(ProjectId projectId, ParseOptions? options)
+    public Solution WithProjectParseOptions(ProjectId projectId, ParseOptions options)
     {
         CheckContainsProject(projectId);
+
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
         return WithCompilationState(_compilationState.WithProjectParseOptions(projectId, options));
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -490,15 +490,9 @@ public partial class Solution
     /// Create a new solution instance with the project specified updated to have
     /// the specified parse options.
     /// </summary>
-    public Solution WithProjectParseOptions(ProjectId projectId, ParseOptions options)
+    public Solution WithProjectParseOptions(ProjectId projectId, ParseOptions? options)
     {
         CheckContainsProject(projectId);
-
-        if (options == null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
-
         return WithCompilationState(_compilationState.WithProjectParseOptions(projectId, options));
     }
 
@@ -551,6 +545,24 @@ public partial class Solution
         }
 
         return WithCompilationState(_compilationState.WithProjectDocumentsOrder(projectId, documentIds));
+    }
+
+    /// <summary>
+    /// Updates the solution with project information stored in <paramref name="attributes"/>.
+    /// </summary>
+    internal Solution WithProjectAttributes(ProjectInfo.ProjectAttributes attributes)
+    {
+        CheckContainsProject(attributes.Id);
+        return WithCompilationState(_compilationState.WithProjectAttributes(attributes));
+    }
+
+    /// <summary>
+    /// Updates the solution with project information stored in <paramref name="info"/>.
+    /// </summary>
+    internal Solution WithProjectInfo(ProjectInfo info)
+    {
+        CheckContainsProject(info.Id);
+        return WithCompilationState(_compilationState.WithProjectInfo(info));
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.TranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.TranslationAction_Actions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -233,14 +234,21 @@ internal partial class SolutionCompilationState
             }
         }
 
-        internal sealed class ProjectCompilationOptionsAction(
-            ProjectState oldProjectState,
-            ProjectState newProjectState)
-            : TranslationAction(oldProjectState, newProjectState)
+        internal sealed class ProjectCompilationOptionsAction : TranslationAction
         {
+            public ProjectCompilationOptionsAction(
+                ProjectState oldProjectState,
+                ProjectState newProjectState) : base(oldProjectState, newProjectState)
+            {
+                if (NewProjectState.CompilationOptions == null)
+                {
+                    throw new NotSupportedException(WorkspacesResources.Removing_compilation_options_is_not_supported);
+                }
+            }
+
             public override Task<Compilation> TransformCompilationAsync(Compilation oldCompilation, CancellationToken cancellationToken)
             {
-                RoslynDebug.AssertNotNull(this.NewProjectState.CompilationOptions);
+                Contract.ThrowIfNull(this.NewProjectState.CompilationOptions);
                 return Task.FromResult(oldCompilation.WithOptions(this.NewProjectState.CompilationOptions));
             }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.TranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.TranslationAction_Actions.cs
@@ -234,18 +234,10 @@ internal partial class SolutionCompilationState
             }
         }
 
-        internal sealed class ProjectCompilationOptionsAction : TranslationAction
+        internal sealed class ProjectCompilationOptionsAction(
+            ProjectState oldProjectState,
+            ProjectState newProjectState) : TranslationAction(oldProjectState, newProjectState)
         {
-            public ProjectCompilationOptionsAction(
-                ProjectState oldProjectState,
-                ProjectState newProjectState) : base(oldProjectState, newProjectState)
-            {
-                if (NewProjectState.CompilationOptions == null)
-                {
-                    throw new NotSupportedException(WorkspacesResources.Removing_compilation_options_is_not_supported);
-                }
-            }
-
             public override Task<Compilation> TransformCompilationAsync(Compilation oldCompilation, CancellationToken cancellationToken)
             {
                 Contract.ThrowIfNull(this.NewProjectState.CompilationOptions);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -637,7 +637,7 @@ internal sealed partial class SolutionState
     /// Create a new solution instance with the project specified updated to have
     /// the specified compilation options.
     /// </summary>
-    public StateChange WithProjectCompilationOptions(ProjectId projectId, CompilationOptions options)
+    public StateChange WithProjectCompilationOptions(ProjectId projectId, CompilationOptions? options)
     {
         var oldProject = GetRequiredProjectState(projectId);
         var newProject = oldProject.WithCompilationOptions(options);
@@ -654,7 +654,7 @@ internal sealed partial class SolutionState
     /// Create a new solution instance with the project specified updated to have
     /// the specified parse options.
     /// </summary>
-    public StateChange WithProjectParseOptions(ProjectId projectId, ParseOptions options)
+    public StateChange WithProjectParseOptions(ProjectId projectId, ParseOptions? options)
     {
         var oldProject = GetRequiredProjectState(projectId);
         var newProject = oldProject.WithParseOptions(options);
@@ -1124,7 +1124,7 @@ internal sealed partial class SolutionState
 
     private StateChange UpdateDocumentState(DocumentState newDocument)
     {
-        var oldProject = GetProjectState(newDocument.Id.ProjectId)!;
+        var oldProject = GetRequiredProjectState(newDocument.Id.ProjectId);
         var newProject = oldProject.UpdateDocument(newDocument);
 
         // This method shouldn't have been called if the document has not changed.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -118,9 +118,6 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         GenerationDateTime = generationDateTime;
     }
 
-    protected override TextDocumentState UpdateAttributes(DocumentInfo.DocumentAttributes newAttributes)
-        => throw ExceptionUtilities.Unreachable();
-
     private static Checksum ComputeContentHash(SourceText text)
         => Checksum.From(text.GetContentHash());
 
@@ -129,6 +126,12 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
 
     public SourceGeneratedDocumentContentIdentity GetContentIdentity()
         => new(this.GetOriginalSourceTextContentHash(), this.SourceText.Encoding?.WebName, this.SourceText.ChecksumAlgorithm);
+
+    protected override TextDocumentState UpdateAttributes(DocumentInfo.DocumentAttributes newAttributes)
+        => throw new NotSupportedException(WorkspacesResources.The_contents_of_a_SourceGeneratedDocument_may_not_be_changed);
+
+    protected override TextDocumentState UpdateDocumentServiceProvider(IDocumentServiceProvider? newProvider)
+        => throw new NotSupportedException(WorkspacesResources.The_contents_of_a_SourceGeneratedDocument_may_not_be_changed);
 
     protected override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
         => throw new NotSupportedException(WorkspacesResources.The_contents_of_a_SourceGeneratedDocument_may_not_be_changed);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
@@ -56,7 +56,7 @@ public class TextDocument
     /// <summary>
     /// A <see cref="IDocumentServiceProvider"/> associated with this document
     /// </summary>
-    internal IDocumentServiceProvider Services => State.DocumentServiceProvider;
+    internal IDocumentServiceProvider DocumentServiceProvider => State.DocumentServiceProvider;
 
     /// <summary>
     /// Get the current text for the document if it is already loaded and available.

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -2021,7 +2021,7 @@ public abstract partial class Workspace : IDisposable
             filePath: doc.FilePath,
             isGenerated: doc.State.Attributes.IsGenerated)
             .WithDesignTimeOnly(doc.State.Attributes.DesignTimeOnly)
-            .WithDocumentServiceProvider(doc.Services);
+            .WithDocumentServiceProvider(doc.DocumentServiceProvider);
 
     /// <summary>
     /// This method is called during <see cref="TryApplyChanges(Solution)"/> to add a project to the current solution.

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -498,10 +498,13 @@
   <data name="Removing_compilation_options_is_not_supported" xml:space="preserve">
     <value>Removing compilation options is not supported</value>
   </data>
+  <data name="Removing_parse_options_is_not_supported" xml:space="preserve">
+    <value>Removing parse options is not supported</value>
+  </data>
   <data name="Changing_project_language_is_not_supported" xml:space="preserve">
     <value>Changing project language is not supported</value>
   </data>
-  <data name="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported" xml:space="preserve">
-    <value>Changing project from ordinary to interactive submission or vice versa is not supported</value>
+  <data name="Changing_project_between_ordinary_and_interactive_submission_is_not_supported" xml:space="preserve">
+    <value>Changing project between ordinary and interactive submission is not supported</value>
   </data>
 </root>

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -495,4 +495,13 @@
   <data name="Applying_changes_to_0" xml:space="preserve">
     <value>Applying changes to {0}</value>
   </data>
+  <data name="Removing_compilation_options_is_not_supported" xml:space="preserve">
+    <value>Removing compilation options is not supported</value>
+  </data>
+  <data name="Changing_project_language_is_not_supported" xml:space="preserve">
+    <value>Changing project language is not supported</value>
+  </data>
+  <data name="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported" xml:space="preserve">
+    <value>Changing project from ordinary to interactive submission or vice versa is not supported</value>
+  </data>
 </root>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
@@ -42,6 +42,16 @@
         <target state="translated">Změna dokumentu {0} není podporovaná.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">Příkaz CodeAction {0} nevytvořil změněné řešení.</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">Odebírání dokumentů konfigurace analyzátoru se nepodporuje.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
@@ -42,9 +42,9 @@
         <target state="translated">Změna dokumentu {0} není podporovaná.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
@@ -42,9 +42,9 @@
         <target state="translated">Das Ändern des Dokuments "{0}" wird nicht unterstützt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
@@ -42,6 +42,16 @@
         <target state="translated">Das Ändern des Dokuments "{0}" wird nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">Durch CodeAction "{0}" wurde keine geänderte Lösung erstellt.</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">Das Entfernen von Konfigurationsdokumenten des Analysetools wird nicht unterstützt.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
@@ -42,6 +42,16 @@
         <target state="translated">Documento cambiante '{0}' no es compatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">El tipo CodeAction "{0}" no generó una solución modificada</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">No se permite quitar documentos de configuración del analizador.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
@@ -42,9 +42,9 @@
         <target state="translated">Documento cambiante '{0}' no es compatible.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
@@ -42,9 +42,9 @@
         <target state="translated">Le changement du document '{0}' n'est pas pris en charge.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
@@ -42,6 +42,16 @@
         <target state="translated">Le changement du document '{0}' n'est pas pris en charge.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">Le CodeAction '{0}' n'a pas produit de solution contenant des changements</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">La suppression de documents de configuration de l'analyseur n'est pas prise en charge.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
@@ -42,9 +42,9 @@
         <target state="translated">La modifica del documento '{0}' non è supportata.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
@@ -42,6 +42,16 @@
         <target state="translated">La modifica del documento '{0}' non è supportata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">L'elemento CodeAction '{0}' non ha generato una soluzione modificata</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">La rimozione di documenti di configurazione dell'analizzatore non è supportata.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
@@ -42,9 +42,9 @@
         <target state="translated">ドキュメント '{0}' の変更はサポートされていません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
@@ -42,6 +42,16 @@
         <target state="translated">ドキュメント '{0}' の変更はサポートされていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">CodeAction '{0}' は変更されたソリューションを生成しませんでした</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">アナライザー構成ドキュメントの削除はサポートされていません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
@@ -42,6 +42,16 @@
         <target state="translated">'{0}' 문서 변경은 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">CodeAction '{0}'이(가) 변경된 솔루션을 생성하지 않았습니다.</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">분석기 구성 문서 제거는 지원되지 않습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
@@ -42,9 +42,9 @@
         <target state="translated">'{0}' 문서 변경은 지원되지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
@@ -42,6 +42,16 @@
         <target state="translated">Zmiana dokumentu „{0}” nie jest obsługiwana.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">Element CodeAction „{0}” nie utworzył zmienionego rozwiązania</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">Usuwanie dokumentów z konfiguracją analizatora nie jest obsługiwane.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
@@ -42,9 +42,9 @@
         <target state="translated">Zmiana dokumentu „{0}” nie jest obsługiwana.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
@@ -42,6 +42,16 @@
         <target state="translated">Não há suporte para alterar o documento '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">A CodeAction '{0}' não produziu uma solução alterada</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">Não há suporte para a remoção de documentos da configuração do analisador.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
@@ -42,9 +42,9 @@
         <target state="translated">Não há suporte para alterar o documento '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
@@ -42,6 +42,16 @@
         <target state="translated">Изменение документа "{0}" не поддерживается.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">Действие кода "{0}" не сформировало измененное решение.</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">Удаление документов конфигурации анализатора не поддерживается.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
@@ -42,9 +42,9 @@
         <target state="translated">Изменение документа "{0}" не поддерживается.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
@@ -42,9 +42,9 @@
         <target state="translated">Değişen belge '{0}' desteklenmiyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
@@ -42,6 +42,16 @@
         <target state="translated">Değişen belge '{0}' desteklenmiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">'{0}' CodeAction, değiştirilmiş çözüm üretmedi</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">Çözümleyici yapılandırma belgelerinin kaldırılması desteklenmiyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
@@ -42,9 +42,9 @@
         <target state="translated">不支持更改文档“{0}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
@@ -42,6 +42,16 @@
         <target state="translated">不支持更改文档“{0}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">CodeAction "{0}" 未生成更改的解决方案</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">不支持删除分析器配置文档。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
@@ -42,6 +42,16 @@
         <target state="translated">不支援變更文件 '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
+        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
+        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_project_language_is_not_supported">
+        <source>Changing project language is not supported</source>
+        <target state="new">Changing project language is not supported</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeAction_0_did_not_produce_a_changed_solution">
         <source>CodeAction '{0}' did not produce a changed solution</source>
         <target state="translated">CodeAction '{0}' 未產生變更的解決方案</target>
@@ -120,6 +130,11 @@
       <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
         <source>Removing analyzer config documents is not supported.</source>
         <target state="translated">不支援移除分析器組態文件。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_compilation_options_is_not_supported">
+        <source>Removing compilation options is not supported</source>
+        <target state="new">Removing compilation options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
@@ -42,9 +42,9 @@
         <target state="translated">不支援變更文件 '{0}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_project_from_ordinary_to_interactive_submission_or_vice_versa_is_not_supported">
-        <source>Changing project from ordinary to interactive submission or vice versa is not supported</source>
-        <target state="new">Changing project from ordinary to interactive submission or vice versa is not supported</target>
+      <trans-unit id="Changing_project_between_ordinary_and_interactive_submission_is_not_supported">
+        <source>Changing project between ordinary and interactive submission is not supported</source>
+        <target state="new">Changing project between ordinary and interactive submission is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_project_language_is_not_supported">
@@ -135,6 +135,11 @@
       <trans-unit id="Removing_compilation_options_is_not_supported">
         <source>Removing compilation options is not supported</source>
         <target state="new">Removing compilation options is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_parse_options_is_not_supported">
+        <source>Removing parse options is not supported</source>
+        <target state="new">Removing parse options is not supported</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_0_to_1">

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
@@ -25,6 +26,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
@@ -981,6 +983,327 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void WithProjectInfo()
+        {
+            var projectId = ProjectId.CreateNewId();
+            var projectId2 = ProjectId.CreateNewId();
+
+            using var workspace = CreateWorkspace();
+
+            var d1 = DocumentId.CreateNewId(projectId);
+            var d2 = DocumentId.CreateNewId(projectId);
+            var d3 = DocumentId.CreateNewId(projectId);
+            var a1 = DocumentId.CreateNewId(projectId);
+            var a2 = DocumentId.CreateNewId(projectId);
+            var a3 = DocumentId.CreateNewId(projectId);
+            var c1 = DocumentId.CreateNewId(projectId);
+            var c2 = DocumentId.CreateNewId(projectId);
+            var c3 = DocumentId.CreateNewId(projectId);
+
+            var solution = workspace.CurrentSolution
+                .AddProject(ProjectInfo.Create(projectId, VersionStamp.Default, "proj1", "proj1", LanguageNames.CSharp, Path.Combine(s_projectDir, "proj1.dll")))
+                .AddProject(ProjectInfo.Create(projectId2, VersionStamp.Default, "proj2", "proj2", LanguageNames.CSharp, Path.Combine(s_projectDir, "proj2.dll")))
+                .AddDocument(d1, "d1.cs", SourceText.From("class D1;", Encoding.UTF8, SourceHashAlgorithms.Default), filePath: Path.Combine(s_projectDir, "d1.cs"))
+                .AddDocument(d2, "d2.cs", SourceText.From("class D2;", Encoding.UTF8, SourceHashAlgorithms.Default), filePath: Path.Combine(s_projectDir, "d2.cs"))
+                .AddAdditionalDocument(a1, "a1.txt", SourceText.From("text1", Encoding.UTF8, SourceHashAlgorithms.Default))
+                .AddAdditionalDocument(a2, "a2.txt", SourceText.From("text2", Encoding.UTF8, SourceHashAlgorithms.Default))
+                .AddAnalyzerConfigDocument(c1, "c1", SourceText.From("#empty1", Encoding.UTF8, SourceHashAlgorithms.Default), filePath: Path.Combine(s_projectDir, "editorcfg"))
+                .AddAnalyzerConfigDocument(c2, "c2", SourceText.From("#empty2", Encoding.UTF8, SourceHashAlgorithms.Default), filePath: Path.Combine(s_projectDir, "editorcfg"));
+
+            var oldProject = solution.GetRequiredProject(projectId);
+            var documentIds = oldProject.DocumentIds;
+
+            var newDocumentInfo1 = DocumentInfo.Create(
+                d1,
+                name: "newD1",
+                folders: ["f", "g"],
+                sourceCodeKind: SourceCodeKind.Script,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("class NewD1;", Encoding.UTF32, SourceHashAlgorithm.Sha256), VersionStamp.Create(), filePath: Path.Combine(s_projectDir, "newD1.cs"))),
+                filePath: Path.Combine(s_projectDir, "newD1.cs"),
+                isGenerated: true);
+
+            var newDocumentInfo3 = DocumentInfo.Create(
+                d3,
+                name: "newD3",
+                folders: null,
+                sourceCodeKind: SourceCodeKind.Regular,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("class NewD3;", Encoding.UTF8, SourceHashAlgorithms.Default), VersionStamp.Create(), filePath: Path.Combine(s_projectDir, "newD3.cs"))),
+                filePath: Path.Combine(s_projectDir, "newD3.cs"),
+                isGenerated: false)
+                .WithDocumentServiceProvider(new TestDocumentServiceProvider());
+
+            var newAddDocumentInfo1 = DocumentInfo.Create(
+                a1,
+                name: "newA1",
+                folders: ["af", "ag"],
+                sourceCodeKind: SourceCodeKind.Script,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("new text1", Encoding.UTF32, SourceHashAlgorithm.Sha256), VersionStamp.Create(), filePath: Path.Combine(s_projectDir, "newD1.cs"))),
+                filePath: Path.Combine(s_projectDir, "newA1.txt"),
+                isGenerated: true);
+
+            var newAddDocumentInfo3 = DocumentInfo.Create(
+                a3,
+                name: "newA3",
+                folders: null,
+                sourceCodeKind: SourceCodeKind.Regular,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("new text3", Encoding.UTF8, SourceHashAlgorithms.Default), VersionStamp.Create(), filePath: Path.Combine(s_projectDir, "newD3.cs"))),
+                filePath: Path.Combine(s_projectDir, "newA3.txt"),
+                isGenerated: false)
+                .WithDocumentServiceProvider(new TestDocumentServiceProvider());
+
+            var newConfigDocumentInfo1 = DocumentInfo.Create(
+                c1,
+                name: "newC1",
+                folders: ["cf", "cg"],
+                sourceCodeKind: SourceCodeKind.Script,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("#new empty1", Encoding.UTF32, SourceHashAlgorithm.Sha256), VersionStamp.Create(), filePath: Path.Combine(s_projectDir, "newD1.cs"))),
+                filePath: Path.Combine(s_projectDir, "newC1"),
+                isGenerated: true);
+
+            var newConfigDocumentInfo3 = DocumentInfo.Create(
+                c3,
+                name: "newC3",
+                folders: null,
+                sourceCodeKind: SourceCodeKind.Regular,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("#new empty3", Encoding.UTF8, SourceHashAlgorithms.Default), VersionStamp.Create(), filePath: Path.Combine(s_projectDir, "newD3.cs"))),
+                filePath: Path.Combine(s_projectDir, "newC3"),
+                isGenerated: false)
+                .WithDocumentServiceProvider(new TestDocumentServiceProvider());
+
+            var metadataReference = MetadataReference.CreateFromImage([], filePath: "meta");
+            var projectReference = new ProjectReference(projectId2);
+            var analyzerReference = new TestAnalyzerReference();
+
+            var newInfo = ProjectInfo.Create(
+                projectId,
+                VersionStamp.Create(),
+                name: "newProjectName",
+                assemblyName: "newAssemblyName",
+                language: LanguageNames.CSharp,
+                filePath: "newFilePath.cs",
+                outputFilePath: "newOutputFilePath",
+                outputRefFilePath: "newOutputRef",
+                compilationOptions: new CSharpCompilationOptions(OutputKind.WindowsApplication, moduleName: "newModuleName"),
+                parseOptions: new CSharpParseOptions(CS.LanguageVersion.CSharp5),
+                documents:
+                [
+                    // update existing document:
+                    newDocumentInfo1,
+                    // add new document:
+                    newDocumentInfo3,
+                    // remove existing document (d2)
+                ],
+                additionalDocuments:
+                [
+                    // update existing document:
+                    newAddDocumentInfo1,
+                    // add new document:
+                    newAddDocumentInfo3,
+                    // remove existing document (a2)
+                ],
+                projectReferences: [projectReference],
+                metadataReferences: [metadataReference],
+                analyzerReferences: [analyzerReference],
+                isSubmission: false,
+                hostObjectType: null)
+                .WithAnalyzerConfigDocuments(
+                [
+                    // update existing document:
+                    newConfigDocumentInfo1,
+                    // add new document:
+                    newConfigDocumentInfo3,
+                    // remove existing document (c2)
+                ]);
+
+            var newSolution = solution.WithProjectInfo(newInfo);
+            var newProject = newSolution.GetRequiredProject(projectId);
+
+            // attributes:
+            Assert.True(newProject.Version.GetTestAccessor().IsNewerThan(oldProject.Version));
+            Assert.Equal(newInfo.Name, newProject.Name);
+            Assert.Equal(newInfo.AssemblyName, newProject.AssemblyName);
+            Assert.Equal(newInfo.Language, newProject.Language);
+            Assert.Equal(newInfo.FilePath, newProject.FilePath);
+            Assert.Equal(newInfo.OutputFilePath, newProject.OutputFilePath);
+            Assert.Equal(newInfo.CompilationOptions!.OutputKind, newProject.CompilationOptions!.OutputKind);
+            Assert.Equal(newInfo.CompilationOptions!.ModuleName, newProject.CompilationOptions!.ModuleName);
+            Assert.Equal(newInfo.ParseOptions!.LanguageVersion, newProject.ParseOptions!.LanguageVersion);
+            Assert.Equal(newInfo.OutputRefFilePath, newProject.OutputRefFilePath);
+
+            AssertEx.AreEqual([projectReference], newProject.ProjectReferences);
+            AssertEx.AreEqual([metadataReference], newProject.MetadataReferences);
+            AssertEx.AreEqual([analyzerReference], newProject.AnalyzerReferences);
+
+            // documents:
+            AssertEx.SetEqual([d1, d3], newProject.DocumentIds);
+
+            var newDocument1 = newProject.GetRequiredDocument(d1);
+            var newText1 = newDocument1.GetTextSynchronously(CancellationToken.None);
+            Assert.Equal(newDocumentInfo1.Name, newDocument1.Name);
+            Assert.Equal(newDocumentInfo1.FilePath, newDocument1.FilePath);
+            Assert.Same(DefaultTextDocumentServiceProvider.Instance, newDocument1.DocumentServiceProvider);
+            Assert.Equal("class NewD1;", newText1.ToString());
+            Assert.Same(Encoding.UTF32, newText1.Encoding);
+            Assert.Equal(SourceHashAlgorithm.Sha256, newText1.ChecksumAlgorithm);
+
+            var newDocument3 = newProject.GetRequiredDocument(d3);
+            var newText3 = newDocument3.GetTextSynchronously(CancellationToken.None);
+            Assert.Equal(newDocumentInfo3.Name, newDocument3.Name);
+            Assert.Equal(newDocumentInfo3.FilePath, newDocument3.FilePath);
+            Assert.Same(newDocumentInfo3.DocumentServiceProvider, newDocument3.DocumentServiceProvider);
+            Assert.Equal("class NewD3;", newDocument3.GetTextSynchronously(CancellationToken.None).ToString());
+            Assert.Same(Encoding.UTF8, newText3.Encoding);
+            Assert.Equal(SourceHashAlgorithms.Default, newText3.ChecksumAlgorithm);
+
+            // additional documents:
+            AssertEx.SetEqual([a1, a3], newProject.AdditionalDocumentIds);
+
+            var newAddDocument1 = newProject.GetRequiredAdditionalDocument(a1);
+            var newAddText1 = newAddDocument1.GetTextSynchronously(CancellationToken.None);
+            Assert.Equal(newAddDocumentInfo1.Name, newAddDocument1.Name);
+            Assert.Equal(newAddDocumentInfo1.FilePath, newAddDocument1.FilePath);
+            Assert.Same(DefaultTextDocumentServiceProvider.Instance, newAddDocument1.DocumentServiceProvider);
+            Assert.Equal("new text1", newAddText1.ToString());
+            Assert.Same(Encoding.UTF32, newAddText1.Encoding);
+            Assert.Equal(SourceHashAlgorithm.Sha256, newAddText1.ChecksumAlgorithm);
+
+            var newAddDocument3 = newProject.GetRequiredAdditionalDocument(a3);
+            var newAddText3 = newAddDocument3.GetTextSynchronously(CancellationToken.None);
+            Assert.Equal(newAddDocumentInfo3.Name, newAddDocument3.Name);
+            Assert.Equal(newAddDocumentInfo3.FilePath, newAddDocument3.FilePath);
+            Assert.Same(newAddDocumentInfo3.DocumentServiceProvider, newAddDocument3.DocumentServiceProvider);
+            Assert.Equal("new text3", newAddDocument3.GetTextSynchronously(CancellationToken.None).ToString());
+            Assert.Same(Encoding.UTF8, newAddText3.Encoding);
+            Assert.Equal(SourceHashAlgorithms.Default, newAddText3.ChecksumAlgorithm);
+
+            // analyzer config documents:
+            AssertEx.SetEqual([c1, c3], newProject.AnalyzerConfigDocumentIds);
+
+            var newConfigDocument1 = newProject.GetRequiredAnalyzerConfigDocument(c1);
+            var newConfigText1 = newConfigDocument1.GetTextSynchronously(CancellationToken.None);
+            Assert.Equal(newConfigDocumentInfo1.Name, newConfigDocument1.Name);
+            Assert.Equal(newConfigDocumentInfo1.FilePath, newConfigDocument1.FilePath);
+            Assert.Same(DefaultTextDocumentServiceProvider.Instance, newConfigDocument1.DocumentServiceProvider);
+            Assert.Equal("#new empty1", newConfigText1.ToString());
+            Assert.Same(Encoding.UTF32, newConfigText1.Encoding);
+            Assert.Equal(SourceHashAlgorithm.Sha256, newConfigText1.ChecksumAlgorithm);
+
+            var newConfigDocument3 = newProject.GetRequiredAnalyzerConfigDocument(c3);
+            var newConfigText3 = newConfigDocument3.GetTextSynchronously(CancellationToken.None);
+            Assert.Equal(newConfigDocumentInfo3.Name, newConfigDocument3.Name);
+            Assert.Equal(newConfigDocumentInfo3.FilePath, newConfigDocument3.FilePath);
+            Assert.Same(newConfigDocumentInfo3.DocumentServiceProvider, newConfigDocument3.DocumentServiceProvider);
+            Assert.Equal("#new empty3", newConfigDocument3.GetTextSynchronously(CancellationToken.None).ToString());
+            Assert.Same(Encoding.UTF8, newConfigText3.Encoding);
+            Assert.Equal(SourceHashAlgorithms.Default, newConfigText3.ChecksumAlgorithm);
+        }
+
+        [Fact]
+        public void WithProjectInfo_Unsupported_RemovingCompilationOptions()
+        {
+            var projectId = ProjectId.CreateNewId();
+
+            using var workspace = CreateWorkspace();
+
+            var solution = workspace.CurrentSolution
+                .AddProject(ProjectInfo.Create(projectId, VersionStamp.Default, "proj1", "proj1", LanguageNames.CSharp, Path.Combine(s_projectDir, "proj1.dll")));
+
+            var oldProject = solution.GetRequiredProject(projectId);
+            var documentIds = oldProject.DocumentIds;
+
+            var newInfo = ProjectInfo.Create(
+                projectId,
+                VersionStamp.Create(),
+                name: "newProjectName",
+                assemblyName: "newAssemblyName",
+                language: LanguageNames.CSharp,
+                filePath: "newFilePath.cs",
+                outputFilePath: "newOutputFilePath",
+                outputRefFilePath: "newOutputRef",
+                compilationOptions: null,
+                parseOptions: new CSharpParseOptions(CS.LanguageVersion.CSharp5),
+                documents: [],
+                additionalDocuments: [],
+                projectReferences: [],
+                metadataReferences: [],
+                analyzerReferences: [],
+                isSubmission: false,
+                hostObjectType: null);
+
+            Assert.Throws<NotSupportedException>(() => solution.WithProjectInfo(newInfo));
+        }
+
+        [Fact]
+        public void WithProjectInfo_Unsupported_ChangingLanguage()
+        {
+            var projectId = ProjectId.CreateNewId();
+
+            using var workspace = CreateWorkspace();
+
+            var solution = workspace.CurrentSolution
+                .AddProject(ProjectInfo.Create(projectId, VersionStamp.Default, "proj1", "proj1", LanguageNames.CSharp, Path.Combine(s_projectDir, "proj1.dll")));
+
+            var oldProject = solution.GetRequiredProject(projectId);
+            var documentIds = oldProject.DocumentIds;
+
+            var newInfo = ProjectInfo.Create(
+                projectId,
+                VersionStamp.Create(),
+                name: "newProjectName",
+                assemblyName: "newAssemblyName",
+                language: LanguageNames.VisualBasic,
+                filePath: "newFilePath.cs",
+                outputFilePath: "newOutputFilePath",
+                outputRefFilePath: "newOutputRef",
+                compilationOptions: null,
+                parseOptions: null,
+                documents: [],
+                additionalDocuments: [],
+                projectReferences: [],
+                metadataReferences: [],
+                analyzerReferences: [],
+                isSubmission: false,
+                hostObjectType: null);
+
+            Assert.Throws<NotSupportedException>(() => solution.WithProjectInfo(newInfo));
+        }
+
+        [Fact]
+        public void WithProjectInfo_Unsupported_ChangingIsSubmission()
+        {
+            var projectId = ProjectId.CreateNewId();
+
+            using var workspace = CreateWorkspace();
+
+            var solution = workspace.CurrentSolution
+                .AddProject(ProjectInfo.Create(projectId, VersionStamp.Default, "proj1", "proj1", LanguageNames.CSharp, Path.Combine(s_projectDir, "proj1.dll")));
+
+            var oldProject = solution.GetRequiredProject(projectId);
+            var documentIds = oldProject.DocumentIds;
+
+            var newInfo = ProjectInfo.Create(
+                projectId,
+                VersionStamp.Create(),
+                name: "newProjectName",
+                assemblyName: "newAssemblyName",
+                language: LanguageNames.CSharp,
+                filePath: "newFilePath.cs",
+                outputFilePath: "newOutputFilePath",
+                outputRefFilePath: "newOutputRef",
+                compilationOptions: new CSharpCompilationOptions(OutputKind.WindowsApplication, moduleName: "newModuleName"),
+                parseOptions: CS.CSharpParseOptions.Default,
+                documents: [],
+                additionalDocuments: [],
+                projectReferences: [],
+                metadataReferences: [],
+                analyzerReferences: [],
+                isSubmission: false,
+                hostObjectType: null);
+
+            Assert.Throws<NotSupportedException>(() => solution.WithProjectInfo(newInfo));
+        }
+
+        [Fact]
         public void WithProjectAssemblyName()
         {
             var projectId = ProjectId.CreateNewId();
@@ -1242,6 +1565,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var options = new CSharpCompilationOptions(OutputKind.NetModule);
 
             Assert.Throws<ArgumentNullException>("projectId", () => solution.WithProjectCompilationOptions(null!, options));
+            Assert.Throws<ArgumentNullException>("options", () => solution.WithProjectCompilationOptions(projectId, options: null!));
             Assert.Throws<InvalidOperationException>(() => solution.WithProjectCompilationOptions(ProjectId.CreateNewId(), options));
         }
 
@@ -1316,6 +1640,29 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(document.Project.ParseOptions, newTree.Options);
 
             Assert.False(oldTree.GetRoot().IsIncrementallyIdenticalTo(newTree.GetRoot()));
+        }
+
+        [Fact]
+        public async Task RemovingParseOptionsRemovesSyntaxTree()
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            using var workspace = CreateWorkspace();
+            var document = workspace.CurrentSolution
+                            .AddProject(projectId, "proj1", "proj1.dll", LanguageNames.CSharp)
+                            .AddDocument(documentId, "Test.cs", "// File")
+                            .GetRequiredDocument(documentId);
+
+            var oldTree = await document.GetRequiredSyntaxTreeAsync(CancellationToken.None);
+
+            Assert.Equal(document.Project.ParseOptions, oldTree.Options);
+
+            document = document.Project.WithParseOptions(null).GetRequiredDocument(documentId);
+            Assert.Null(document.Project.ParseOptions);
+            Assert.Null(await document.GetSyntaxTreeAsync(CancellationToken.None));
+            Assert.False(document.SupportsSyntaxTree);
+            Assert.Equal(SourceCodeKind.Regular, document.SourceCodeKind);
         }
 
         [Theory]

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -328,7 +328,6 @@ namespace Microsoft.CodeAnalysis.Remote
                                 assetPath: projectId, newProjectChecksums.Info, cancellationToken).ConfigureAwait(false));
                         }
 
-
                         solution = await UpdateProjectAsync(
                             solution.GetRequiredProject(projectId), oldProjectChecksums, newProjectChecksums, cancellationToken).ConfigureAwait(false);
                     }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -320,6 +320,15 @@ namespace Microsoft.CodeAnalysis.Remote
                         // If this project was in the old map, then the project must have changed.  Otherwise, we would
                         // have removed it earlier on.
                         Contract.ThrowIfTrue(oldProjectChecksums.Checksum == newProjectChecksums.Checksum);
+
+                        // changed info
+                        if (oldProjectChecksums.Info != newProjectChecksums.Info)
+                        {
+                            solution = solution.WithProjectAttributes(await _assetProvider.GetAssetAsync<ProjectInfo.ProjectAttributes>(
+                                assetPath: projectId, newProjectChecksums.Info, cancellationToken).ConfigureAwait(false));
+                        }
+
+
                         solution = await UpdateProjectAsync(
                             solution.GetRequiredProject(projectId), oldProjectChecksums, newProjectChecksums, cancellationToken).ConfigureAwait(false);
                     }
@@ -330,12 +339,6 @@ namespace Microsoft.CodeAnalysis.Remote
 
             private async Task<Solution> UpdateProjectAsync(Project project, ProjectStateChecksums oldProjectChecksums, ProjectStateChecksums newProjectChecksums, CancellationToken cancellationToken)
             {
-                // changed info
-                if (oldProjectChecksums.Info != newProjectChecksums.Info)
-                {
-                    project = await UpdateProjectInfoAsync(project, newProjectChecksums.Info, cancellationToken).ConfigureAwait(false);
-                }
-
                 // changed compilation options
                 if (oldProjectChecksums.CompilationOptions != newProjectChecksums.CompilationOptions)
                 {
@@ -410,71 +413,6 @@ namespace Microsoft.CodeAnalysis.Remote
                 }
 
                 return project.Solution;
-            }
-
-            private async Task<Project> UpdateProjectInfoAsync(Project project, Checksum infoChecksum, CancellationToken cancellationToken)
-            {
-                var newProjectAttributes = await _assetProvider.GetAssetAsync<ProjectInfo.ProjectAttributes>(
-                    assetPath: project.Id, infoChecksum, cancellationToken).ConfigureAwait(false);
-
-                // there is no API to change these once project is created
-                Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.Id == newProjectAttributes.Id);
-                Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.Language == newProjectAttributes.Language);
-                Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.IsSubmission == newProjectAttributes.IsSubmission);
-
-                var projectId = project.Id;
-
-                if (project.State.ProjectInfo.Attributes.Name != newProjectAttributes.Name)
-                {
-                    project = project.Solution.WithProjectName(projectId, newProjectAttributes.Name).GetRequiredProject(projectId);
-                }
-
-                if (project.State.ProjectInfo.Attributes.AssemblyName != newProjectAttributes.AssemblyName)
-                {
-                    project = project.Solution.WithProjectAssemblyName(projectId, newProjectAttributes.AssemblyName).GetRequiredProject(projectId);
-                }
-
-                if (project.State.ProjectInfo.Attributes.FilePath != newProjectAttributes.FilePath)
-                {
-                    project = project.Solution.WithProjectFilePath(projectId, newProjectAttributes.FilePath).GetRequiredProject(projectId);
-                }
-
-                if (project.State.ProjectInfo.Attributes.OutputFilePath != newProjectAttributes.OutputFilePath)
-                {
-                    project = project.Solution.WithProjectOutputFilePath(projectId, newProjectAttributes.OutputFilePath).GetRequiredProject(projectId);
-                }
-
-                if (project.State.ProjectInfo.Attributes.OutputRefFilePath != newProjectAttributes.OutputRefFilePath)
-                {
-                    project = project.Solution.WithProjectOutputRefFilePath(projectId, newProjectAttributes.OutputRefFilePath).GetRequiredProject(projectId);
-                }
-
-                if (project.State.ProjectInfo.Attributes.CompilationOutputInfo != newProjectAttributes.CompilationOutputInfo)
-                {
-                    project = project.Solution.WithProjectCompilationOutputInfo(project.Id, newProjectAttributes.CompilationOutputInfo).GetRequiredProject(project.Id);
-                }
-
-                if (project.State.ProjectInfo.Attributes.DefaultNamespace != newProjectAttributes.DefaultNamespace)
-                {
-                    project = project.Solution.WithProjectDefaultNamespace(projectId, newProjectAttributes.DefaultNamespace).GetRequiredProject(projectId);
-                }
-
-                if (project.State.ProjectInfo.Attributes.HasAllInformation != newProjectAttributes.HasAllInformation)
-                {
-                    project = project.Solution.WithHasAllInformation(projectId, newProjectAttributes.HasAllInformation).GetRequiredProject(projectId);
-                }
-
-                if (project.State.ProjectInfo.Attributes.RunAnalyzers != newProjectAttributes.RunAnalyzers)
-                {
-                    project = project.Solution.WithRunAnalyzers(projectId, newProjectAttributes.RunAnalyzers).GetRequiredProject(projectId);
-                }
-
-                if (project.State.ProjectInfo.Attributes.ChecksumAlgorithm != newProjectAttributes.ChecksumAlgorithm)
-                {
-                    project = project.Solution.WithProjectChecksumAlgorithm(projectId, newProjectAttributes.ChecksumAlgorithm).GetRequiredProject(projectId);
-                }
-
-                return project;
             }
 
             private async Task<Project> UpdateDocumentsAsync<TDocumentState>(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/AddImport/AddImportPlacementOptionsProviders.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/AddImport/AddImportPlacementOptionsProviders.cs
@@ -18,7 +18,7 @@ internal static class AddImportPlacementOptionsProviders
 #if CODE_STYLE
         => AddImportPlacementOptions.Default.AllowInHiddenRegions;
 #else
-        => document.Services.GetService<Host.ISpanMappingService>()?.SupportsMappingImportDirectives == true;
+        => document.DocumentServiceProvider.GetService<Host.ISpanMappingService>()?.SupportsMappingImportDirectives == true;
 #endif
 
     public static AddImportPlacementOptions GetAddImportPlacementOptions(this IOptionsReader options, Host.LanguageServices languageServices, bool? allowInHiddenRegions)


### PR DESCRIPTION
Returns a new `Solution` snapshot with the target project updated to values specified in `ProjectInfo`.

Makes it possible for `dotnet-watch` to incrementally update `Solution` based on information loaded from MSBuild. 