### PR TITLE
Fix SourceCodeKind setting

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -29,10 +29,10 @@ internal partial class DocumentState : TextDocumentState
 
     // properties inherited from the containing project:
     public LanguageServices LanguageServices { get; }
-    private readonly ParseOptions? _options;
+    public ParseOptions? ParseOptions { get; }
 
     // null if the document doesn't support syntax trees:
-    private readonly ITreeAndVersionSource? _treeSource;
+    public ITreeAndVersionSource? TreeSource { get; }
 
     private ImmutableArray<byte> _contentHash;
 
@@ -46,11 +46,11 @@ internal partial class DocumentState : TextDocumentState
         ITreeAndVersionSource? treeSource)
         : base(languageServices.SolutionServices, documentServiceProvider, attributes, textSource, loadTextOptions)
     {
-        Contract.ThrowIfFalse(_options is null == _treeSource is null);
+        Contract.ThrowIfFalse(ParseOptions is null == TreeSource is null);
 
         LanguageServices = languageServices;
-        _options = options;
-        _treeSource = treeSource;
+        ParseOptions = options;
+        TreeSource = treeSource;
     }
 
     public DocumentState(
@@ -61,19 +61,19 @@ internal partial class DocumentState : TextDocumentState
         : base(languageServices.SolutionServices, info, loadTextOptions)
     {
         LanguageServices = languageServices;
-        _options = options;
+        ParseOptions = options;
 
         // If this is document that doesn't support syntax, then don't even bother holding
         // onto any tree source.  It will never be used to get a tree, and can only hurt us
         // by possibly holding onto data that might cause a slow memory leak.
         if (languageServices.GetService<ISyntaxTreeFactoryService>() == null)
         {
-            _treeSource = null;
+            TreeSource = null;
         }
         else
         {
             Contract.ThrowIfNull(options);
-            _treeSource = CreateLazyFullyParsedTree(
+            TreeSource = CreateLazyFullyParsedTree(
                 TextAndVersionSource,
                 LoadTextOptions,
                 info.Attributes.SyntaxTreeFilePath,
@@ -82,20 +82,13 @@ internal partial class DocumentState : TextDocumentState
         }
     }
 
-    public ITreeAndVersionSource? TreeSource => _treeSource;
-
-    [MemberNotNullWhen(true, nameof(_treeSource))]
     [MemberNotNullWhen(true, nameof(TreeSource))]
-    [MemberNotNullWhen(true, nameof(_options))]
     [MemberNotNullWhen(true, nameof(ParseOptions))]
     internal bool SupportsSyntaxTree
-        => _treeSource != null;
-
-    public ParseOptions? ParseOptions
-        => _options;
+        => TreeSource != null;
 
     public SourceCodeKind SourceCodeKind
-        => ParseOptions == null ? Attributes.SourceCodeKind : ParseOptions.Kind;
+        => ParseOptions?.Kind ?? Attributes.SourceCodeKind;
 
     public bool IsGenerated
         => Attributes.IsGenerated;
@@ -293,7 +286,7 @@ internal partial class DocumentState : TextDocumentState
 
     public bool HasContentChanged(DocumentState oldState)
     {
-        return oldState._treeSource != _treeSource
+        return oldState.TreeSource != TreeSource
             || HasTextChanged(oldState, ignoreUnchangeableDocument: false);
     }
 
@@ -322,33 +315,20 @@ internal partial class DocumentState : TextDocumentState
             TextAndVersionSource,
             newLoadTextOptions,
             Attributes.SyntaxTreeFilePath,
-            _options,
+            ParseOptions,
             LanguageServices) : null;
 
         return new DocumentState(
             LanguageServices,
             Services,
             Attributes,
-            _options,
+            ParseOptions,
             TextAndVersionSource,
             newLoadTextOptions,
             newTreeSource);
     }
 
-    public DocumentState UpdateParseOptions(ParseOptions options, bool onlyPreprocessorDirectiveChange)
-    {
-        var originalSourceKind = this.SourceCodeKind;
-
-        var newState = this.SetParseOptions(options, onlyPreprocessorDirectiveChange);
-        if (newState.SourceCodeKind != originalSourceKind)
-        {
-            newState = newState.UpdateSourceCodeKind(originalSourceKind);
-        }
-
-        return newState;
-    }
-
-    private DocumentState SetParseOptions(ParseOptions options, bool onlyPreprocessorDirectiveChange)
+    public DocumentState UpdateParseOptionsAndSourceCodeKind(ParseOptions options, bool onlyPreprocessorDirectiveChange)
     {
         Contract.ThrowIfFalse(SupportsSyntaxTree);
 
@@ -360,7 +340,7 @@ internal partial class DocumentState : TextDocumentState
         // We only need to care about `#if` directives as those are the only sorts of directives that can affect how
         // a tree is parsed.
         if (onlyPreprocessorDirectiveChange &&
-            _treeSource.TryGetValue(out var existingTreeAndVersion))
+            TreeSource.TryGetValue(out var existingTreeAndVersion))
         {
             var existingTree = existingTreeAndVersion.Tree;
 
@@ -397,12 +377,17 @@ internal partial class DocumentState : TextDocumentState
 
     public DocumentState UpdateSourceCodeKind(SourceCodeKind kind)
     {
-        if (this.ParseOptions == null || kind == this.SourceCodeKind)
+        if (kind == SourceCodeKind)
         {
             return this;
         }
 
-        return this.SetParseOptions(this.ParseOptions.WithKind(kind), onlyPreprocessorDirectiveChange: false);
+        if (ParseOptions != null)
+        {
+            return UpdateParseOptionsAndSourceCodeKind(ParseOptions.WithKind(kind), onlyPreprocessorDirectiveChange: false);
+        }
+
+        return UpdateAttributes(Attributes.With(sourceCodeKind: kind));
     }
 
     public DocumentState UpdateName(string name)
@@ -429,19 +414,19 @@ internal partial class DocumentState : TextDocumentState
                     TextAndVersionSource,
                     LoadTextOptions,
                     newAttributes.SyntaxTreeFilePath,
-                    _options,
+                    ParseOptions,
                     LanguageServices) : null;
         }
         else
         {
-            newTreeSource = _treeSource;
+            newTreeSource = TreeSource;
         }
 
         return new DocumentState(
             LanguageServices,
             Services,
             newAttributes,
-            _options,
+            ParseOptions,
             TextAndVersionSource,
             LoadTextOptions,
             newTreeSource);
@@ -466,7 +451,7 @@ internal partial class DocumentState : TextDocumentState
         }
         else if (incremental)
         {
-            newTreeSource = CreateLazyIncrementallyParsedTree(_treeSource, newTextSource, LoadTextOptions);
+            newTreeSource = CreateLazyIncrementallyParsedTree(TreeSource, newTextSource, LoadTextOptions);
         }
         else
         {
@@ -474,7 +459,7 @@ internal partial class DocumentState : TextDocumentState
                 newTextSource,
                 LoadTextOptions,
                 Attributes.SyntaxTreeFilePath,
-                _options,
+                ParseOptions,
                 LanguageServices,
                 mode); // TODO: understand why the mode is given here. If we're preserving text by identity, why also preserve the tree?
         }
@@ -483,7 +468,7 @@ internal partial class DocumentState : TextDocumentState
             LanguageServices,
             Services,
             Attributes,
-            _options,
+            ParseOptions,
             textSource: newTextSource,
             LoadTextOptions,
             treeSource: newTreeSource);
@@ -519,14 +504,14 @@ internal partial class DocumentState : TextDocumentState
 
         var syntaxTreeFactory = LanguageServices.GetRequiredService<ISyntaxTreeFactoryService>();
 
-        Contract.ThrowIfNull(_options);
-        var (text, treeAndVersion) = CreateTreeWithLazyText(newRoot, newTextVersion, newTreeVersion, encoding, LoadTextOptions.ChecksumAlgorithm, Attributes, _options, syntaxTreeFactory);
+        Contract.ThrowIfNull(ParseOptions);
+        var (text, treeAndVersion) = CreateTreeWithLazyText(newRoot, newTextVersion, newTreeVersion, encoding, LoadTextOptions.ChecksumAlgorithm, Attributes, ParseOptions, syntaxTreeFactory);
 
         return new DocumentState(
             LanguageServices,
             Services,
             Attributes,
-            _options,
+            ParseOptions,
             textSource: text,
             LoadTextOptions,
             treeSource: SimpleTreeAndVersionSource.Create(treeAndVersion));
@@ -558,14 +543,14 @@ internal partial class DocumentState : TextDocumentState
 
     private VersionStamp GetNewTreeVersionForUpdatedTree(SyntaxNode newRoot, VersionStamp newTextVersion, PreservationMode mode)
     {
-        RoslynDebug.Assert(_treeSource != null);
+        RoslynDebug.Assert(TreeSource != null);
 
         if (mode != PreservationMode.PreserveIdentity)
         {
             return newTextVersion;
         }
 
-        if (!_treeSource.TryGetValue(out var oldTreeAndVersion) || !oldTreeAndVersion!.Tree.TryGetRoot(out var oldRoot))
+        if (!TreeSource.TryGetValue(out var oldTreeAndVersion) || !oldTreeAndVersion!.Tree.TryGetRoot(out var oldRoot))
         {
             return newTextVersion;
         }
@@ -590,7 +575,7 @@ internal partial class DocumentState : TextDocumentState
             return textAndVersion!.Version.GetNewerVersion();
         }
 
-        if (_treeSource != null && _treeSource.TryGetValue(out var treeAndVersion) && treeAndVersion != null)
+        if (TreeSource != null && TreeSource.TryGetValue(out var treeAndVersion) && treeAndVersion != null)
         {
             return treeAndVersion.Version.GetNewerVersion();
         }
@@ -601,7 +586,7 @@ internal partial class DocumentState : TextDocumentState
     public bool TryGetSyntaxTree([NotNullWhen(returnValue: true)] out SyntaxTree? syntaxTree)
     {
         syntaxTree = null;
-        if (_treeSource != null && _treeSource.TryGetValue(out var treeAndVersion) && treeAndVersion != null)
+        if (TreeSource != null && TreeSource.TryGetValue(out var treeAndVersion) && treeAndVersion != null)
         {
             syntaxTree = treeAndVersion.Tree;
             BindSyntaxTreeToId(syntaxTree, Id);
@@ -615,9 +600,9 @@ internal partial class DocumentState : TextDocumentState
     public async ValueTask<SyntaxTree> GetSyntaxTreeAsync(CancellationToken cancellationToken)
     {
         // operation should only be performed on documents that support syntax trees
-        RoslynDebug.Assert(_treeSource != null);
+        RoslynDebug.Assert(TreeSource != null);
 
-        var treeAndVersion = await _treeSource.GetValueAsync(cancellationToken).ConfigureAwait(false);
+        var treeAndVersion = await TreeSource.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
         // make sure there is an association between this tree and this doc id before handing it out
         BindSyntaxTreeToId(treeAndVersion.Tree, this.Id);
@@ -627,9 +612,9 @@ internal partial class DocumentState : TextDocumentState
     internal SyntaxTree GetSyntaxTree(CancellationToken cancellationToken)
     {
         // operation should only be performed on documents that support syntax trees
-        RoslynDebug.Assert(_treeSource != null);
+        RoslynDebug.Assert(TreeSource != null);
 
-        var treeAndVersion = _treeSource.GetValue(cancellationToken);
+        var treeAndVersion = TreeSource.GetValue(cancellationToken);
 
         // make sure there is an association between this tree and this doc id before handing it out
         BindSyntaxTreeToId(treeAndVersion.Tree, this.Id);
@@ -638,7 +623,7 @@ internal partial class DocumentState : TextDocumentState
 
     public bool TryGetTopLevelChangeTextVersion(out VersionStamp version)
     {
-        if (_treeSource != null && _treeSource.TryGetValue(out var treeAndVersion) && treeAndVersion != null)
+        if (TreeSource != null && TreeSource.TryGetValue(out var treeAndVersion) && treeAndVersion != null)
         {
             version = treeAndVersion.Version;
             return true;
@@ -652,17 +637,17 @@ internal partial class DocumentState : TextDocumentState
 
     public override async ValueTask<VersionStamp> GetTopLevelChangeTextVersionAsync(CancellationToken cancellationToken)
     {
-        if (_treeSource == null)
+        if (TreeSource == null)
         {
             return await GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        if (_treeSource.TryGetValue(out var treeAndVersion) && treeAndVersion != null)
+        if (TreeSource.TryGetValue(out var treeAndVersion) && treeAndVersion != null)
         {
             return treeAndVersion.Version;
         }
 
-        treeAndVersion = await _treeSource.GetValueAsync(cancellationToken).ConfigureAwait(false);
+        treeAndVersion = await TreeSource.GetValueAsync(cancellationToken).ConfigureAwait(false);
         return treeAndVersion.Version;
     }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
@@ -53,7 +53,7 @@ internal partial class DocumentState
                 LanguageServices,
                 Services,
                 Attributes,
-                _options,
+                ParseOptions,
                 siblingTextSource,
                 LoadTextOptions,
                 treeSource: null);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -664,7 +664,7 @@ internal partial class ProjectState
 
         return With(
             projectInfo: ProjectInfo.WithParseOptions(options).WithVersion(Version.GetNewerVersion()),
-            documentStates: DocumentStates.UpdateStates(static (state, args) => state.UpdateParseOptions(args.options, args.onlyPreprocessorDirectiveChange), (options, onlyPreprocessorDirectiveChange)));
+            documentStates: DocumentStates.UpdateStates(static (state, args) => state.UpdateParseOptionsAndSourceCodeKind(args.options, args.onlyPreprocessorDirectiveChange), (options, onlyPreprocessorDirectiveChange)));
     }
 
     public ProjectState WithFallbackAnalyzerOptions(StructuredAnalyzerConfigOptions options)


### PR DESCRIPTION
For documents that have ParseOptions the SourceCodeKind should be set on the options and also on DocumentAttributes, for other documents it should be set on just the attributes.