### PR TITLE
Revert "Remove semantic model keep-alive code in completion (#73844)"

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -214,14 +214,14 @@ public abstract partial class CompletionService : ILanguageService
 
         var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
 
-        document = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
-
+        // We don't need SemanticModel here, just want to make sure it won't get GC'd before CompletionProviders are able to get it.
+        (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
         var description = await extensionManager.PerformFunctionAsync(
             provider,
             cancellationToken => provider.GetDescriptionAsync(document, item, options, displayOptions, cancellationToken),
             defaultValue: null,
             cancellationToken).ConfigureAwait(false);
-
+        GC.KeepAlive(semanticModel);
         return description;
     }
 
@@ -245,7 +245,8 @@ public abstract partial class CompletionService : ILanguageService
         {
             var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
 
-            document = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
+            // We don't need SemanticModel here, just want to make sure it won't get GC'd before CompletionProviders are able to get it.
+            (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
 
             var change = await extensionManager.PerformFunctionAsync(
                 provider,
@@ -255,6 +256,7 @@ public abstract partial class CompletionService : ILanguageService
             if (change == null)
                 return CompletionChange.Create(new TextChange(new TextSpan(), ""));
 
+            GC.KeepAlive(semanticModel);
             Debug.Assert(item.Span == change.TextChange.Span || item.IsComplexTextEdit);
             return change;
         }

--- a/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
@@ -68,7 +68,8 @@ public abstract partial class CompletionService
          ImmutableHashSet<string>? roles = null,
          CancellationToken cancellationToken = default)
     {
-        document = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
+        // We don't need SemanticModel here, just want to make sure it won't get GC'd before CompletionProviders are able to get it.
+        (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
 
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
         var completionListSpan = GetDefaultCompletionListSpan(text, caretPosition);
@@ -113,6 +114,8 @@ public abstract partial class CompletionService
 
         var augmentingContexts = await ComputeNonEmptyCompletionContextsAsync(
             document, caretPosition, trigger, options, completionListSpan, augmentingProviders, sharedContext, cancellationToken).ConfigureAwait(false);
+
+        GC.KeepAlive(semanticModel);
 
         // Providers are ordered, but we processed them in our own order.  Ensure that the
         // groups are properly ordered based on the original providers.
@@ -169,20 +172,19 @@ public abstract partial class CompletionService
     }
 
     /// <summary>
-    /// Returns a document with frozen partial semantic model unless caller is test code require full semantics.
+    /// Returns a document with frozen partial semantic unless we already have a complete compilation available.
     /// Getting full semantic could be costly in certain scenarios and would cause significant delay in completion. 
     /// In most cases we'd still end up with complete document, but we'd consider it an acceptable trade-off even when 
     /// we get into this transient state.
     /// </summary>
-    private async Task<Document> GetDocumentWithFrozenPartialSemanticsAsync(Document document, CancellationToken cancellationToken)
+    private async Task<(Document document, SemanticModel? semanticModel)> GetDocumentWithFrozenPartialSemanticsAsync(Document document, CancellationToken cancellationToken)
     {
         if (_suppressPartialSemantics)
         {
-            var _ = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            return document;
+            return (document, await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false));
         }
 
-        return document.WithFrozenPartialSemantics(cancellationToken);
+        return await document.GetFullOrPartialSemanticModelAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static bool ValidatePossibleTriggerCharacterSet(CompletionTriggerKind completionTriggerKind, IEnumerable<CompletionProvider> triggeredProviders,


### PR DESCRIPTION
This reverts #73844 

The changes to completion were causing failing Linux DotNet 7 & 8 tests in the C# extension Roslyn insertion (see https://github.com/dotnet/vscode-csharp/pull/7273).

Test run with revert: https://dev.azure.com/dnceng-public/public/_build/results?buildId=735073&view=results