### PR TITLE
Avoid using constants for large string literals

### DIFF
--- a/src/Compilers/Test/Utilities/CSharp/TestSources.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestSources.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 {
     internal static class TestSources
     {
-        internal const string Span = @"
+        internal static readonly string Span = @"
 namespace System
 {
     public readonly ref struct Span<T>
@@ -300,7 +300,7 @@ namespace System
     }
 }";
 
-        internal const string Index = @"
+        internal static readonly string Index = @"
 
 namespace System
 {
@@ -396,7 +396,7 @@ namespace System
     }
 }";
 
-        internal const string Range = @"
+        internal static readonly string Range = @"
 namespace System
 {
     using System.Runtime.CompilerServices;
@@ -466,7 +466,7 @@ namespace System
     }
 }";
 
-        public const string GetSubArray = @"
+        public static readonly string GetSubArray = @"
 namespace System.Runtime.CompilerServices
 {
     public static class RuntimeHelpers
@@ -483,7 +483,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-        public const string ITuple = @"
+        public static readonly string ITuple = @"
 namespace System.Runtime.CompilerServices
 {
     public interface ITuple
@@ -493,7 +493,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-        public const string MemoryExtensions = @"
+        public static readonly string MemoryExtensions = @"
 namespace System
 {
     public static class MemoryExtensions


### PR DESCRIPTION
Follow up on https://github.com/dotnet/roslyn/pull/74281. Fixes:

> CSC : error CS8103: Combined length of user strings used by the program exceeds allowed limit. Try to decrease use of string literals. [D:\a\_work\1\s\src\Compilers\CSharp\Test\Emit2\Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests.csproj::TargetFramework=net9.0]
