### PR TITLE
Fix UseNullPropagationCodeFixProvider for parenthesized property access

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseNullPropagation/UseNullPropagationTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseNullPropagation/UseNullPropagationTests.cs
@@ -1949,6 +1949,46 @@ public partial class UseNullPropagationTests
             """);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74273")]
+    public async Task TestParenthesizedPropertyAccess()
+    {
+        await TestInRegularAndScript1Async("""
+            using System;
+            
+            class C
+            {
+                int? Length(Array array) => [|array == null ? null : (array.Length)|];
+            }
+            """, """
+            using System;
+            
+            class C
+            {
+                int? Length(Array array) => (array?.Length);
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74273")]
+    public async Task TestReversedParenthesizedPropertyAccess()
+    {
+        await TestInRegularAndScript1Async("""
+            using System;
+            
+            class C
+            {
+                int? Length(Array array) => [|array != null ? (array.Length) : null|];
+            }
+            """, """
+            using System;
+            
+            class C
+            {
+                int? Length(Array array) => (array?.Length);
+            }
+            """);
+    }
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/49517")]
     public async Task TestParenthesizedNull()
     {

--- a/src/Analyzers/Core/CodeFixes/UseNullPropagation/AbstractUseNullPropagationCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseNullPropagation/AbstractUseNullPropagationCodeFixProvider.cs
@@ -102,9 +102,8 @@ internal abstract class AbstractUseNullPropagationCodeFixProvider<
         var conditionalPart = root.FindNode(diagnostic.AdditionalLocations[1].SourceSpan, getInnermostNodeForTie: true);
         var whenPart = root.FindNode(diagnostic.AdditionalLocations[2].SourceSpan, getInnermostNodeForTie: true);
         syntaxFacts.GetPartsOfConditionalExpression(
-            conditionalExpression, out var condition, out var whenTrue, out var whenFalse);
+            conditionalExpression, out _, out var whenTrue, out _);
         whenTrue = syntaxFacts.WalkDownParentheses(whenTrue);
-        whenFalse = syntaxFacts.WalkDownParentheses(whenFalse);
 
         var whenPartIsNullable = diagnostic.Properties.ContainsKey(UseNullPropagationConstants.WhenPartIsNullable);
         editor.ReplaceNode(
@@ -116,12 +115,14 @@ internal abstract class AbstractUseNullPropagationCodeFixProvider<
 
                 var currentWhenPartToCheck = whenPart == whenTrue ? currentWhenTrue : currentWhenFalse;
 
+                var unwrappedCurrentWhenPartToCheck = syntaxFacts.WalkDownParentheses(currentWhenPartToCheck);
+
                 var match = AbstractUseNullPropagationDiagnosticAnalyzer<
                     TSyntaxKind, TExpressionSyntax, TStatementSyntax,
                     TConditionalExpressionSyntax, TBinaryExpressionSyntax, TInvocationExpressionSyntax,
                     TConditionalAccessExpressionSyntax, TElementAccessExpressionSyntax, TMemberAccessExpressionSyntax,
                     TIfStatementSyntax, TExpressionStatementSyntax>.GetWhenPartMatch(
-                        syntaxFacts, semanticModel, (TExpressionSyntax)conditionalPart, (TExpressionSyntax)currentWhenPartToCheck, cancellationToken);
+                        syntaxFacts, semanticModel, (TExpressionSyntax)conditionalPart, (TExpressionSyntax)unwrappedCurrentWhenPartToCheck, cancellationToken);
                 if (match == null)
                 {
                     return conditionalExpression;


### PR DESCRIPTION
The issue occurs when the code fix provider is calling the `GetWhenPartMatch` method on it's analyzer (I'm assuming this is done to make sure the analysis is still valid in case we are running multiple code fixes). While the analyzer calls the method with an expression that is already stripped of it's parentheses (`array.Length`), however the code fix itself calls it with the parentheses kept (`(array.Length)`). Simplest fix would be to remove the parentheses before the call from the code fix provider. Other solution would be looking into the method and making sure it takes this into consideration, not 100% sure which is correct.

Closes #74273 