### PR TITLE
Do not use memory mapped files on non-windows

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -237,7 +237,10 @@ internal sealed partial class VisualStudioMetadataReferenceManager : IWorkspaceS
             }
 
             // Now, read the data from the memory-mapped-file back into a stream that we load into the metadata value.
-            stream = storageHandle.ReadFromTemporaryStorage(CancellationToken.None);
+            // The ITemporaryStorageStreamHandle should have given us an UnmanagedMemoryStream
+            // since this only runs on Windows for VS.
+            stream = (UnmanagedMemoryStream)storageHandle.ReadFromTemporaryStorage(CancellationToken.None);
+
             // stream size must be same as what metadata reader said the size should be.
             Contract.ThrowIfFalse(stream.Length == size);
         }

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -438,7 +438,7 @@ internal partial class SerializerService
             CopyByteArrayToStream(reader, stream, cancellationToken);
 
             var length = stream.Length;
-            var storageHandle = _storageService.WriteToTemporaryStorage(stream, cancellationToken);
+            var storageHandle = _storageService.Value.WriteToTemporaryStorage(stream, cancellationToken);
             Contract.ThrowIfTrue(length != storageHandle.Identifier.Size);
             return ReadModuleMetadataFromStorage(storageHandle);
         }
@@ -449,7 +449,10 @@ internal partial class SerializerService
             // Now read in the module data using that identifier.  This will either be reading from the host's memory if
             // they passed us the information about that memory segment.  Or it will be reading from our own memory if they
             // sent us the full contents.
-            var unmanagedStream = storageHandle.ReadFromTemporaryStorage(cancellationToken);
+            //
+            // The ITemporaryStorageStreamHandle should have given us an UnmanagedMemoryStream
+            // since this only runs on Windows for VS.
+            var unmanagedStream = (UnmanagedMemoryStream)storageHandle.ReadFromTemporaryStorage(cancellationToken);
             Contract.ThrowIfFalse(storageHandle.Identifier.Size == unmanagedStream.Length);
 
             // For an unmanaged memory stream, ModuleMetadata can take ownership directly.  Stream will be kept alive as

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.Factory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.Factory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Host;
 
@@ -20,8 +21,18 @@ internal partial class TemporaryStorageService
         [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
-            var textFactory = workspaceServices.GetRequiredService<ITextFactoryService>();
-            return new TemporaryStorageService(workspaceThreadingService, textFactory);
+            // Only use the memory mapped file version of the temporary storage service on Windows.
+            // It is only required for OOP communication (Windows only) and can cause issues on Linux containers
+            // due to a small amount of space allocated by default to store memory mapped files.
+            if (PlatformInformation.IsWindows || PlatformInformation.IsRunningOnMono)
+            {
+                var textFactory = workspaceServices.GetRequiredService<ITextFactoryService>();
+                return new TemporaryStorageService(workspaceThreadingService, textFactory);
+            }
+            else
+            {
+                return TrivialTemporaryStorageService.Instance;
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.TemporaryStorageStreamHandle.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.TemporaryStorageStreamHandle.cs
@@ -18,7 +18,7 @@ internal sealed partial class TemporaryStorageService
     {
         public TemporaryStorageIdentifier Identifier => identifier;
 
-        public UnmanagedMemoryStream ReadFromTemporaryStorage(CancellationToken cancellationToken)
+        public Stream ReadFromTemporaryStorage(CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.TemporaryStorageServiceFactory_ReadStream, cancellationToken))
             {

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TrivialTemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TrivialTemporaryStorageService.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis;
+
+internal sealed class TrivialTemporaryStorageService : ITemporaryStorageServiceInternal
+{
+    public static readonly TrivialTemporaryStorageService Instance = new();
+
+    private TrivialTemporaryStorageService()
+    {
+    }
+
+    public ITemporaryStorageStreamHandle WriteToTemporaryStorage(Stream stream, CancellationToken cancellationToken)
+    {
+        var newStream = new MemoryStream();
+        stream.CopyTo(newStream);
+        return new StreamStorage(newStream);
+    }
+
+    public ITemporaryStorageTextHandle WriteToTemporaryStorage(SourceText text, CancellationToken cancellationToken)
+    {
+        return new TextStorage(text);
+    }
+
+    public Task<ITemporaryStorageTextHandle> WriteToTemporaryStorageAsync(SourceText text, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<ITemporaryStorageTextHandle>(new TextStorage(text));
+    }
+
+    private sealed class StreamStorage : ITemporaryStorageStreamHandle
+    {
+        private readonly MemoryStream _stream;
+
+        public TemporaryStorageIdentifier Identifier { get; }
+
+        public StreamStorage(MemoryStream stream)
+        {
+            _stream = stream;
+            Identifier = new TemporaryStorageIdentifier(Guid.NewGuid().ToString(), 0, _stream.Length);
+        }
+
+        public Stream ReadFromTemporaryStorage(CancellationToken cancellationToken)
+        {
+            // Return a read-only view of the underlying buffer to prevent users from overwriting or directly
+            // disposing the backing storage.
+            return new MemoryStream(_stream.GetBuffer(), 0, (int)_stream.Length, writable: false);
+        }
+    }
+
+    private sealed class TextStorage : ITemporaryStorageTextHandle
+    {
+        private readonly SourceText _sourceText;
+
+        public TemporaryStorageIdentifier Identifier { get; }
+
+        public TextStorage(SourceText sourceText)
+        {
+            _sourceText = sourceText;
+            Identifier = new TemporaryStorageIdentifier(Guid.NewGuid().ToString(), 0, _sourceText.Length);
+        }
+
+        public SourceText ReadFromTemporaryStorage(CancellationToken cancellationToken)
+        {
+            return _sourceText;
+        }
+
+        public Task<SourceText> ReadFromTemporaryStorageAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_sourceText);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorageStreamHandle.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorageStreamHandle.cs
@@ -22,5 +22,5 @@ internal interface ITemporaryStorageStreamHandle
     /// Reads the data indicated to by this handle into a stream.  This stream can be created in a different process
     /// than the one that wrote the data originally.
     /// </summary>
-    UnmanagedMemoryStream ReadFromTemporaryStorage(CancellationToken cancellationToken);
+    Stream ReadFromTemporaryStorage(CancellationToken cancellationToken);
 }


### PR DESCRIPTION
Different version of https://github.com/dotnet/roslyn/pull/73628
Resolves https://github.com/dotnet/vscode-csharp/issues/7119

Memory mapped files on linux are saved to /dev/shm/ which has a tiny size by default in docker containers.  This causes the server to crash.  Fix is to only use memory mapped files when OOP is required (Windows).