### PR TITLE
Remove 'open file only' concept from analyzer driver

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -32,17 +32,6 @@ internal abstract partial class CSharpTypeStyleDiagnosticAnalyzerBase :
 
     public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-    public override bool OpenFileOnly(SimplifierOptions? options)
-    {
-        // analyzer is only active in C# projects
-        Contract.ThrowIfNull(options);
-
-        var csOptions = (CSharpSimplifierOptions)options;
-        return !(csOptions.VarForBuiltInTypes.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error ||
-                 csOptions.VarWhenTypeIsApparent.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error ||
-                 csOptions.VarElsewhere.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error);
-    }
-
     protected override void InitializeWorker(AnalysisContext context)
         => context.RegisterSyntaxNodeAction(
             HandleVariableDeclaration, SyntaxKind.VariableDeclaration, SyntaxKind.ForEachStatement, SyntaxKind.DeclarationExpression);

--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
@@ -117,7 +117,4 @@ internal abstract partial class AbstractBuiltInCodeStyleDiagnosticAnalyzer
         => IDEDiagnosticIdToOptionMappingHelper.AddOptionMapping(diagnosticId, options);
 
     public abstract DiagnosticAnalyzerCategory GetAnalyzerCategory();
-
-    public virtual bool OpenFileOnly(SimplifierOptions? options)
-        => false;
 }

--- a/src/Analyzers/Core/Analyzers/AbstractCodeQualityDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractCodeQualityDiagnosticAnalyzer.cs
@@ -36,9 +36,6 @@ internal abstract class AbstractCodeQualityDiagnosticAnalyzer : DiagnosticAnalyz
 
     public abstract DiagnosticAnalyzerCategory GetAnalyzerCategory();
 
-    public bool OpenFileOnly(SimplifierOptions? options)
-        => false;
-
     protected static DiagnosticDescriptor CreateDescriptor(
         string id,
         EnforceOnBuild enforceOnBuild,

--- a/src/Analyzers/Core/Analyzers/AnalyzerOptionsProvider.cs
+++ b/src/Analyzers/Core/Analyzers/AnalyzerOptionsProvider.cs
@@ -83,13 +83,6 @@ internal readonly struct AnalyzerOptionsProvider(IOptionsReader options, string 
 
 internal static partial class AnalyzerOptionsProviders
 {
-    public static IdeAnalyzerOptions GetIdeOptions(this AnalyzerOptions options)
-#if CODE_STYLE
-        => IdeAnalyzerOptions.CommonDefault;
-#else
-        => (options is WorkspaceAnalyzerOptions workspaceOptions) ? workspaceOptions.IdeOptions : IdeAnalyzerOptions.CommonDefault;
-#endif
-
     public static AnalyzerOptionsProvider GetAnalyzerOptions(this AnalyzerOptions analyzerOptions, SyntaxTree syntaxTree)
         => new(analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree).GetOptionsReader(), syntaxTree.Options.Language);
 
@@ -107,10 +100,4 @@ internal static partial class AnalyzerOptionsProviders
 
     public static AnalyzerOptionsProvider GetAnalyzerOptions(this CodeBlockAnalysisContext context)
         => GetAnalyzerOptions(context.Options, context.CodeBlock.SyntaxTree);
-
-    public static IdeAnalyzerOptions GetIdeAnalyzerOptions(this SemanticModelAnalysisContext context)
-        => context.Options.GetIdeOptions();
-
-    public static IdeAnalyzerOptions GetIdeAnalyzerOptions(this SyntaxNodeAnalysisContext context)
-        => context.Options.GetIdeOptions();
 }

--- a/src/Analyzers/Core/Analyzers/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -36,18 +36,6 @@ internal abstract class AbstractQualifyMemberAccessDiagnosticAnalyzer<
     {
     }
 
-    public override bool OpenFileOnly(SimplifierOptions? options)
-    {
-        // analyzer is only active in C# and VB projects
-        Contract.ThrowIfNull(options);
-
-        return
-           !(options.QualifyFieldAccess.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error ||
-             options.QualifyPropertyAccess.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error ||
-             options.QualifyMethodAccess.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error ||
-             options.QualifyEventAccess.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error);
-    }
-
     /// <summary>
     /// Reports on whether the specified member is suitable for qualification. Some member
     /// access expressions cannot be qualified; for instance if they begin with <c>base.</c>,

--- a/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -81,16 +81,6 @@ internal abstract class SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnu
         out TextSpan issueSpan, out string diagnosticId, out bool inDeclaration,
         CancellationToken cancellationToken);
 
-    public override bool OpenFileOnly(SimplifierOptions? options)
-    {
-        // analyzer is only active in C# and VB projects
-        Contract.ThrowIfNull(options);
-
-        return
-            !(options.PreferPredefinedTypeKeywordInDeclaration.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error ||
-              options.PreferPredefinedTypeKeywordInMemberAccess.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error);
-    }
-
     protected static ImmutableArray<NotificationOption2> GetAllNotifications(SimplifierOptions options)
         => [
             options.PreferPredefinedTypeKeywordInDeclaration.Notification,

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -186,8 +186,6 @@ public class DiagnosticAnalyzerDriverTests
     {
         public bool IsHighPriority => false;
 
-        public bool OpenFileOnly(SimplifierOptions? options) => false;
-
         public DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis;
     }

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -945,21 +945,6 @@ class A
         }
     }
 
-    //private class OpenFileOnlyAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
-    //{
-    //    internal static readonly DiagnosticDescriptor s_syntaxRule = new DiagnosticDescriptor("syntax", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
-
-    //    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_syntaxRule);
-
-    //    public override void Initialize(AnalysisContext context)
-    //        => context.RegisterSyntaxTreeAction(c => c.ReportDiagnostic(Diagnostic.Create(s_syntaxRule, c.Tree.GetRoot().GetLocation())));
-
-    //    public DiagnosticAnalyzerCategory GetAnalyzerCategory()
-    //        => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
-
-    //    public bool IsHighPriority => false;
-    //}
-
     private class NoNameAnalyzer : DocumentDiagnosticAnalyzer
     {
         internal static readonly DiagnosticDescriptor s_syntaxRule = new DiagnosticDescriptor("syntax", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -702,7 +702,7 @@ class A
         workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
         var project = workspace.CurrentSolution.Projects.Single();
         var document = documentAnalysis ? project.Documents.Single() : null;
-        var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
+        var ideAnalyzerOptions = IdeAnalyzerOptions.CommonDefault;
         var diagnosticsMapResults = await DiagnosticComputer.GetDiagnosticsAsync(
             document, project, Checksum.Null, ideAnalyzerOptions, span: null, analyzerIdsToRequestDiagnostics,
             AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services,
@@ -750,7 +750,7 @@ class B
         workspace.TryApplyChanges(project.Solution);
 
         project = workspace.CurrentSolution.Projects.Single();
-        var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
+        var ideAnalyzerOptions = IdeAnalyzerOptions.CommonDefault;
         var document = project.Documents.Single();
         var additionalDocument = project.AdditionalDocuments.Single();
 
@@ -821,7 +821,7 @@ class A
         var document = project.Documents.Single();
         var diagnosticAnalyzerInfoCache = new DiagnosticAnalyzerInfoCache();
 
-        var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
+        var ideAnalyzerOptions = IdeAnalyzerOptions.CommonDefault;
         var kind = actionKind == AnalyzerRegisterActionKind.SyntaxTree ? AnalysisKind.Syntax : AnalysisKind.Semantic;
         var analyzerIds = new[] { analyzer.GetAnalyzerId() };
 

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -945,23 +945,20 @@ class A
         }
     }
 
-    private class OpenFileOnlyAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
-    {
-        internal static readonly DiagnosticDescriptor s_syntaxRule = new DiagnosticDescriptor("syntax", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
+    //private class OpenFileOnlyAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
+    //{
+    //    internal static readonly DiagnosticDescriptor s_syntaxRule = new DiagnosticDescriptor("syntax", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_syntaxRule);
+    //    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_syntaxRule);
 
-        public override void Initialize(AnalysisContext context)
-            => context.RegisterSyntaxTreeAction(c => c.ReportDiagnostic(Diagnostic.Create(s_syntaxRule, c.Tree.GetRoot().GetLocation())));
+    //    public override void Initialize(AnalysisContext context)
+    //        => context.RegisterSyntaxTreeAction(c => c.ReportDiagnostic(Diagnostic.Create(s_syntaxRule, c.Tree.GetRoot().GetLocation())));
 
-        public DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
+    //    public DiagnosticAnalyzerCategory GetAnalyzerCategory()
+    //        => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
 
-        public bool IsHighPriority => false;
-
-        public bool OpenFileOnly(SimplifierOptions options)
-            => true;
-    }
+    //    public bool IsHighPriority => false;
+    //}
 
     private class NoNameAnalyzer : DocumentDiagnosticAnalyzer
     {

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -183,7 +183,7 @@ public class GlobalOptionsTests
         using var workspace = CreateWorkspace(out var globalOptions);
         var languageServices = workspace.Services.SolutionServices.GetLanguageServices(language);
 
-        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetIdeAnalyzerOptions(languageServices), IdeAnalyzerOptions.GetDefault(languageServices), language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetIdeAnalyzerOptions(languageServices), IdeAnalyzerOptions.CommonDefault, language);
         VerifyDataMembersHaveNonDefaultValues(globalOptions.GetCodeActionOptions(languageServices), CodeActionOptions.GetDefault(languageServices), language);
         VerifyDataMembersHaveNonDefaultValues(globalOptions.GetBraceMatchingOptions(language), BraceMatchingOptions.Default, language);
         VerifyDataMembersHaveNonDefaultValues(globalOptions.GetFindUsagesOptions(language), FindUsagesOptions.Default, language);

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -164,7 +164,7 @@ public class PreviewWorkspaceTests
     {
         var analyzerOptions = new AnalyzerOptions(additionalFiles: ImmutableArray<AdditionalText>.Empty);
         var project = previewWorkspace.CurrentSolution.Projects.Single();
-        var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
+        var ideAnalyzerOptions = IdeAnalyzerOptions.CommonDefault;
         var workspaceAnalyzerOptions = new WorkspaceAnalyzerOptions(analyzerOptions, ideAnalyzerOptions);
         var compilationWithAnalyzersOptions = new CompilationWithAnalyzersOptions(workspaceAnalyzerOptions, onAnalyzerException: null, concurrentAnalysis: false, logAnalyzerExecutionTime: false);
         var compilation = project.GetRequiredCompilationAsync(CancellationToken.None).Result;

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -2391,10 +2391,6 @@ class MyClass
                 Return _category
             End Function
 
-            Public Function OpenFileOnly(options As SimplifierOptions) As Boolean Implements IBuiltInAnalyzer.OpenFileOnly
-                Return False
-            End Function
-
             Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
                 Get
                     Return ImmutableArray.Create(Descriptor)

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
@@ -37,9 +37,6 @@ internal abstract class UnboundIdentifiersDiagnosticAnalyzerBase<TLanguageKindEn
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         => [DiagnosticDescriptor];
 
-    public bool OpenFileOnly(SimplifierOptions? options)
-        => false;
-
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerExtensions.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerExtensions.cs
@@ -23,9 +23,6 @@ internal static class DiagnosticAnalyzerExtensions
     public static bool IsBuiltInAnalyzer(this DiagnosticAnalyzer analyzer)
         => analyzer is IBuiltInAnalyzer || analyzer.IsWorkspaceDiagnosticAnalyzer() || analyzer.IsCompilerAnalyzer();
 
-    public static bool IsOpenFileOnly(this DiagnosticAnalyzer analyzer, SimplifierOptions? options)
-        => analyzer is IBuiltInAnalyzer builtInAnalyzer && builtInAnalyzer.OpenFileOnly(options);
-
     public static ReportDiagnostic GetEffectiveSeverity(this DiagnosticDescriptor descriptor, CompilationOptions options)
     {
         return options == null

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
@@ -40,9 +40,6 @@ internal abstract class AbstractJsonDetectionAnalyzer : AbstractBuiltInCodeStyle
     public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
         => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-    public override bool OpenFileOnly(SimplifierOptions? options)
-        => false;
-
     protected override void InitializeWorker(AnalysisContext context)
         => context.RegisterSemanticModelAction(Analyze);
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDiagnosticAnalyzer.cs
@@ -33,9 +33,6 @@ internal abstract class AbstractJsonDiagnosticAnalyzer : AbstractBuiltInCodeStyl
     public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
         => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-    public override bool OpenFileOnly(SimplifierOptions? options)
-        => false;
-
     protected override void InitializeWorker(AnalysisContext context)
         => context.RegisterSemanticModelAction(Analyze);
 

--- a/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -36,16 +36,6 @@ internal abstract class PreferFrameworkTypeDiagnosticAnalyzerBase<
     {
     }
 
-    public override bool OpenFileOnly(SimplifierOptions? options)
-    {
-        // analyzer is only active in C# and VB projects
-        Contract.ThrowIfNull(options);
-
-        return
-            !(options.PreferPredefinedTypeKeywordInDeclaration.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error ||
-              options.PreferPredefinedTypeKeywordInMemberAccess.Notification.Severity is ReportDiagnostic.Warn or ReportDiagnostic.Error);
-    }
-
     public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
         => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 

--- a/src/Features/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
 #if !CODE_STYLE
             protected override AnalyzerOptions GetAnalyzerOptions(Project project)
-                => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), _sharedState.GetIdeAnalyzerOptions(project));
+                => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), _sharedState.GetIdeAnalyzerOptions());
 
             protected override CodeFixContext CreateCodeFixContext(Document document, TextSpan span, ImmutableArray<Diagnostic> diagnostics, Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix, CancellationToken cancellationToken)
                 => new(document, span, diagnostics, registerCodeFix, _sharedState.CodeActionOptions, cancellationToken);

--- a/src/Features/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 #if !CODE_STYLE
 
             protected override AnalyzerOptions GetAnalyzerOptions(Project project)
-                => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), _sharedState.GetIdeAnalyzerOptions(project));
+                => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), _sharedState.GetIdeAnalyzerOptions());
 
             protected override CodeRefactoringContext CreateCodeRefactoringContext(Document document, TextSpan span, Action<CodeAction> registerRefactoring, CancellationToken cancellationToken)
                 => new CodeRefactoringContext(document, span, (action, textSpan) => registerRefactoring(action), _sharedState.CodeActionOptions, cancellationToken);

--- a/src/Features/DiagnosticsTestUtilities/CodeActions/SharedVerifierState.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActions/SharedVerifierState.cs
@@ -51,8 +51,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         internal CodeActionOptionsProvider CodeActionOptions { get; set; } = CodeAnalysis.CodeActions.CodeActionOptions.DefaultProvider;
         internal IdeAnalyzerOptions? IdeAnalyzerOptions { get; set; }
 
-        internal IdeAnalyzerOptions GetIdeAnalyzerOptions(Project project)
-            => IdeAnalyzerOptions ?? IdeAnalyzerOptions.GetDefault(project.Services);
+        internal IdeAnalyzerOptions GetIdeAnalyzerOptions()
+            => IdeAnalyzerOptions ?? IdeAnalyzerOptions.CommonDefault;
 #endif
         internal void Apply()
         {

--- a/src/Features/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeFixVerifier`2+Test.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 #if !CODE_STYLE
 
             protected override AnalyzerOptions GetAnalyzerOptions(Project project)
-                => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), _sharedState.GetIdeAnalyzerOptions(project));
+                => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), _sharedState.GetIdeAnalyzerOptions());
 
             protected override CodeFixContext CreateCodeFixContext(Document document, TextSpan span, ImmutableArray<Diagnostic> diagnostics, Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix, CancellationToken cancellationToken)
                 => new(document, span, diagnostics, registerCodeFix, _sharedState.CodeActionOptions, cancellationToken);

--- a/src/Features/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 #if !CODE_STYLE
 
             protected override AnalyzerOptions GetAnalyzerOptions(Project project)
-                => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), _sharedState.GetIdeAnalyzerOptions(project));
+                => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), _sharedState.GetIdeAnalyzerOptions());
 
             protected override CodeRefactoringContext CreateCodeRefactoringContext(Document document, TextSpan span, Action<CodeAction> registerRefactoring, CancellationToken cancellationToken)
                 => new CodeRefactoringContext(document, span, (action, textSpan) => registerRefactoring(action), _sharedState.CodeActionOptions, cancellationToken);

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionAllCodeTests.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionAllCodeTests.cs
@@ -142,8 +142,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             public bool IsHighPriority => false;
 
-            public bool OpenFileOnly(SimplifierOptions options) => false;
-
             public ImmutableArray<SyntaxNode> AllNodes { get; set; }
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics

--- a/src/Features/ExternalAccess/OmniSharp/Analyzers/OmniSharpWorkspaceAnalyzerOptionsFactory.cs
+++ b/src/Features/ExternalAccess/OmniSharp/Analyzers/OmniSharpWorkspaceAnalyzerOptionsFactory.cs
@@ -8,7 +8,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Analyzers
 {
     internal static class OmniSharpWorkspaceAnalyzerOptionsFactory
     {
+#pragma warning disable IDE0060 // Remove unused parameter
         public static AnalyzerOptions Create(Solution solution, AnalyzerOptions options)
-            => new WorkspaceAnalyzerOptions(options, IdeAnalyzerOptions.GetDefault(solution.Services.GetLanguageServices(LanguageNames.CSharp)));
+            => new WorkspaceAnalyzerOptions(options, IdeAnalyzerOptions.CommonDefault);
+#pragma warning restore IDE0060 // Remove unused parameter
     }
 }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public static async Task<CompilationWithAnalyzers?> CreateCompilationWithAnalyzersAsync(
             Project project,
             IdeAnalyzerOptions ideOptions,
-            IEnumerable<DiagnosticAnalyzer> analyzers,
+            ImmutableArray<DiagnosticAnalyzer> analyzers,
             bool includeSuppressedDiagnostics,
             CancellationToken cancellationToken)
         {
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             // Create driver that holds onto compilation and associated analyzers
-            var filteredAnalyzers = analyzers.Where(a => !a.IsWorkspaceDiagnosticAnalyzer()).ToImmutableArrayOrEmpty();
+            var filteredAnalyzers = analyzers.WhereAsArray(a => !a.IsWorkspaceDiagnosticAnalyzer());
 
             // PERF: there is no analyzers for this compilation.
             //       compilationWithAnalyzer will throw if it is created with no analyzers which is perf optimization.

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -3,15 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 {
     internal partial class DiagnosticIncrementalAnalyzer
     {
         private static Task<CompilationWithAnalyzers?> CreateCompilationWithAnalyzersAsync(Project project, IdeAnalyzerOptions ideOptions, IEnumerable<StateSet> stateSets, bool includeSuppressedDiagnostics, CancellationToken cancellationToken)
-            => DocumentAnalysisExecutor.CreateCompilationWithAnalyzersAsync(project, ideOptions, stateSets.Select(s => s.Analyzer), includeSuppressedDiagnostics, cancellationToken);
+            => DocumentAnalysisExecutor.CreateCompilationWithAnalyzersAsync(project, ideOptions, stateSets.SelectAsArray(s => s.Analyzer), includeSuppressedDiagnostics, cancellationToken);
     }
 }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
             => AnalyzeAsync(documentAnalysisScope, documentAnalysisScope.TextDocument.Project, compilationWithAnalyzers,
-                isExplicit, forceExecuteAllAnalyzers: false, logPerformanceInfo, getTelemetryInfo, cancellationToken);
+                isExplicit, logPerformanceInfo, getTelemetryInfo, cancellationToken);
 
         public Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeProjectAsync(
             Project project,
@@ -54,14 +54,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
             => AnalyzeAsync(documentAnalysisScope: null, project, compilationWithAnalyzers,
-                isExplicit: false, forceExecuteAllAnalyzers: true, logPerformanceInfo, getTelemetryInfo, cancellationToken);
+                isExplicit: false, logPerformanceInfo, getTelemetryInfo, cancellationToken);
 
         private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeAsync(
             DocumentAnalysisScope? documentAnalysisScope,
             Project project,
             CompilationWithAnalyzers compilationWithAnalyzers,
             bool isExplicit,
-            bool forceExecuteAllAnalyzers,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
@@ -81,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (remoteHostClient != null)
                 {
                     return await AnalyzeOutOfProcAsync(documentAnalysisScope, project, compilationWithAnalyzers, remoteHostClient,
-                        isExplicit, forceExecuteAllAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
+                        isExplicit, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
                 }
 
                 return await AnalyzeInProcAsync(documentAnalysisScope, project, compilationWithAnalyzers,
@@ -185,7 +184,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             CompilationWithAnalyzers compilationWithAnalyzers,
             RemoteHostClient client,
             bool isExplicit,
-            bool forceExecuteAllAnalyzers,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
@@ -195,8 +193,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var ideOptions = ((WorkspaceAnalyzerOptions)compilationWithAnalyzers.AnalysisOptions.Options!).IdeOptions;
 
-            var analyzers = documentAnalysisScope?.Analyzers ??
-                compilationWithAnalyzers.Analyzers.Where(a => forceExecuteAllAnalyzers || !a.IsOpenFileOnly(ideOptions.SimplifierOptions));
+            var analyzers = documentAnalysisScope?.Analyzers ?? compilationWithAnalyzers.Analyzers;
 
             analyzerMap.AppendAnalyzerMap(analyzers);
 

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -266,12 +266,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // keep from build flag if full analysis is off
                 var fromBuild = fullAnalysis ? false : lastResult.FromBuild;
 
-                var simplifierOptions = globalOptions.GetSimplifierOptions(document.Project.Services);
-                var openFileOnlyAnalyzer = _owner.Analyzer.IsOpenFileOnly(simplifierOptions);
-
                 // if it is allowed to keep project state, check versions and if they are same, bail out.
                 // if full solution analysis is off or we are asked to reset document state, we always merge.
-                if (fullAnalysis && !openFileOnlyAnalyzer &&
+                if (fullAnalysis &&
                     syntax.Version != VersionStamp.Default &&
                     syntax.Version == semantic.Version &&
                     syntax.Version == lastResult.Version)

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -30,11 +30,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 // PERF: get analyzers that are not suppressed and marked as open file only
                 // this is perf optimization. we cache these result since we know the result. (no diagnostics)
-                var activeAnalyzers = stateSets.Select(s => s.Analyzer);
+                var activeAnalyzers = stateSets.SelectAsArray(s => s.Analyzer);
 
                 CompilationWithAnalyzers? compilationWithAnalyzers = null;
 
-                compilationWithAnalyzers = await DocumentAnalysisExecutor.CreateCompilationWithAnalyzersAsync(project, ideOptions, activeAnalyzers, includeSuppressedDiagnostics: true, cancellationToken).ConfigureAwait(false);
+                compilationWithAnalyzers = await DocumentAnalysisExecutor.CreateCompilationWithAnalyzersAsync(
+                    project, ideOptions, activeAnalyzers, includeSuppressedDiagnostics: true, cancellationToken).ConfigureAwait(false);
 
                 var result = await GetProjectAnalysisDataAsync(compilationWithAnalyzers, project, ideOptions, stateSets, cancellationToken).ConfigureAwait(false);
 

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -30,9 +30,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 // PERF: get analyzers that are not suppressed and marked as open file only
                 // this is perf optimization. we cache these result since we know the result. (no diagnostics)
-                var activeAnalyzers = stateSets
-                                        .Select(s => s.Analyzer)
-                                        .Where(a => !a.IsOpenFileOnly(ideOptions.SimplifierOptions));
+                var activeAnalyzers = stateSets.Select(s => s.Analyzer);
 
                 CompilationWithAnalyzers? compilationWithAnalyzers = null;
 

--- a/src/LanguageServer/Protocol/Features/Options/IdeAnalyzerOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/Features/Options/IdeAnalyzerOptionsStorage.cs
@@ -24,7 +24,6 @@ internal static class IdeAnalyzerOptionsStorage
         return new()
         {
             CrashOnAnalyzerException = globalOptions.GetOption(CrashOnAnalyzerException),
-            SimplifierOptions = supportsLanguageSpecificOptions ? globalOptions.GetSimplifierOptions(languageServices) : null,
         };
     }
 

--- a/src/Tools/AnalyzerRunner/DiagnosticAnalyzerRunner.cs
+++ b/src/Tools/AnalyzerRunner/DiagnosticAnalyzerRunner.cs
@@ -183,12 +183,11 @@ namespace AnalyzerRunner
             }
 
             var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
 
             var stopwatch = PerformanceTracker.StartNew();
             for (int i = 0; i < analyzerOptionsInternal.TestDocumentIterations; i++)
             {
-                var workspaceAnalyzerOptions = new WorkspaceAnalyzerOptions(project.AnalyzerOptions, ideAnalyzerOptions);
+                var workspaceAnalyzerOptions = new WorkspaceAnalyzerOptions(project.AnalyzerOptions, IdeAnalyzerOptions.CommonDefault);
                 CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(languageAnalyzers, new CompilationWithAnalyzersOptions(workspaceAnalyzerOptions, null, analyzerOptionsInternal.RunConcurrent, logAnalyzerExecutionTime: true, reportSuppressedDiagnostics: analyzerOptionsInternal.ReportSuppressedDiagnostics));
 
                 SyntaxTree tree = await project.GetDocument(documentId).GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
@@ -394,9 +393,8 @@ namespace AnalyzerRunner
             {
                 var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var newCompilation = compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(compilation.SyntaxTrees);
-                var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
 
-                var workspaceAnalyzerOptions = new WorkspaceAnalyzerOptions(project.AnalyzerOptions, ideAnalyzerOptions);
+                var workspaceAnalyzerOptions = new WorkspaceAnalyzerOptions(project.AnalyzerOptions, IdeAnalyzerOptions.CommonDefault);
                 var compilationWithAnalyzers = newCompilation.WithAnalyzers(analyzers, new CompilationWithAnalyzersOptions(workspaceAnalyzerOptions, null, analyzerOptionsInternal.RunConcurrent, logAnalyzerExecutionTime: true, reportSuppressedDiagnostics: analyzerOptionsInternal.ReportSuppressedDiagnostics));
                 var analystResult = await compilationWithAnalyzers.GetAnalysisResultAsync(cancellationToken).ConfigureAwait(false);
                 return analystResult;

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -139,7 +139,7 @@ End Class";
             var analyzerReference = new AnalyzerFileReference(analyzerType.Assembly.Location, new TestAnalyzerAssemblyLoader());
             workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
 
-            var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(workspace.Services.SolutionServices.GetLanguageServices(LanguageNames.CSharp));
+            var ideAnalyzerOptions = IdeAnalyzerOptions.CommonDefault;
             workspace.GlobalOptions.SetGlobalOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent, new CodeStyleOption<bool>(false, NotificationOption.Suggestion));
 
             // run analysis
@@ -184,7 +184,7 @@ End Class";
             var runner = CreateAnalyzerRunner();
             var analyzers = analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray();
 
-            var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
+            var ideAnalyzerOptions = IdeAnalyzerOptions.CommonDefault;
 
             var compilationWithAnalyzers = (await project.GetCompilationAsync())
                 .WithAnalyzers(analyzers, new WorkspaceAnalyzerOptions(project.AnalyzerOptions, ideAnalyzerOptions));
@@ -210,8 +210,8 @@ End Class";
             var project = workspace.CurrentSolution.GetProject(projectId).AddAnalyzerReference(analyzerReference);
 
             var analyzerDriver = (await project.GetCompilationAsync()).WithAnalyzers(
-                    analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray(),
-                    new WorkspaceAnalyzerOptions(project.AnalyzerOptions, IdeAnalyzerOptions.GetDefault(project.Services)));
+                analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray(),
+                new WorkspaceAnalyzerOptions(project.AnalyzerOptions, IdeAnalyzerOptions.CommonDefault));
 
             var result = await executor.AnalyzeProjectAsync(
                 project, analyzerDriver, logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken);

--- a/src/VisualStudio/ExternalAccess/FSharp/Internal/Diagnostics/FSharpDocumentDiagnosticAnalyzer.cs
+++ b/src/VisualStudio/ExternalAccess/FSharp/Internal/Diagnostics/FSharpDocumentDiagnosticAnalyzer.cs
@@ -96,10 +96,5 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
         {
             return DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
         }
-
-        public bool OpenFileOnly(SimplifierOptions options)
-        {
-            return true;
-        }
     }
 }

--- a/src/VisualStudio/ExternalAccess/FSharp/Internal/Diagnostics/FSharpSimplifyNameDiagnosticAnalyzer.cs
+++ b/src/VisualStudio/ExternalAccess/FSharp/Internal/Diagnostics/FSharpSimplifyNameDiagnosticAnalyzer.cs
@@ -74,10 +74,5 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
         {
             return DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
         }
-
-        public bool OpenFileOnly(SimplifierOptions options)
-        {
-            return true;
-        }
     }
 }

--- a/src/VisualStudio/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedDeclarationsAnalyzer.cs
+++ b/src/VisualStudio/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedDeclarationsAnalyzer.cs
@@ -76,10 +76,5 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
         {
             return DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
         }
-
-        public bool OpenFileOnly(SimplifierOptions options)
-        {
-            return true;
-        }
     }
 }

--- a/src/VisualStudio/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedOpensDiagnosticAnalyzer.cs
+++ b/src/VisualStudio/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedOpensDiagnosticAnalyzer.cs
@@ -69,12 +69,5 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
         {
             return DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
         }
-
-#pragma warning disable IDE0060 // Remove unused parameter
-        public bool OpenFileOnly(Workspace workspace)
-#pragma warning restore IDE0060 // Remove unused parameter
-        {
-            return true;
-        }
     }
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/WorkspaceAnalyzerOptions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/WorkspaceAnalyzerOptions.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 internal sealed class WorkspaceAnalyzerOptions(AnalyzerOptions options, IdeAnalyzerOptions ideOptions) : AnalyzerOptions(options.AdditionalFiles, options.AnalyzerConfigOptionsProvider)
 {
     /// <summary>
-    /// Currently needed to implement <see cref="IBuiltInAnalyzer.OpenFileOnly(SimplifierOptions?)"/>.
     /// Should be removed: https://github.com/dotnet/roslyn/issues/74048
     /// </summary>
     public IdeAnalyzerOptions IdeOptions { get; } = ideOptions;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IBuiltInAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IBuiltInAnalyzer.cs
@@ -25,11 +25,6 @@ internal interface IBuiltInAnalyzer
     DiagnosticAnalyzerCategory GetAnalyzerCategory();
 
     /// <summary>
-    /// This indicates whether this built-in analyzer will only run on opened files.
-    /// </summary>
-    bool OpenFileOnly(SimplifierOptions? options);
-
-    /// <summary>
     /// If this analyzer is privileged and should run with higher priority than other analyzers.
     /// </summary>
     bool IsHighPriority { get; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IdeAnalyzerOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IdeAnalyzerOptions.cs
@@ -3,12 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.Serialization;
-using Microsoft.CodeAnalysis.CodeStyle;
-
-#if !CODE_STYLE
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Simplification;
-#endif
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IdeAnalyzerOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IdeAnalyzerOptions.cs
@@ -21,18 +21,4 @@ internal sealed record class IdeAnalyzerOptions
     public static readonly IdeAnalyzerOptions CommonDefault = new();
 
     [DataMember] public bool CrashOnAnalyzerException { get; init; } = false;
-
-#if !CODE_STYLE
-    /// <summary>
-    /// Currently needed to implement <see cref="IBuiltInAnalyzer.OpenFileOnly(SimplifierOptions?)"/>.
-    /// Should be removed: https://github.com/dotnet/roslyn/issues/74048
-    /// </summary>
-    [DataMember] public SimplifierOptions? SimplifierOptions { get; init; } = null;
-
-    public static IdeAnalyzerOptions GetDefault(LanguageServices languageServices)
-        => new()
-        {
-            SimplifierOptions = SimplifierOptions.GetDefault(languageServices),
-        };
-#endif
 }


### PR DESCRIPTION
This logic existed at a time when we unilaterally ran all analyzers all the time.  This was far too slow for some of these analyzers, and so we had a special back-door to have them opt out of running.

We no longer need this as our move to pull diagnostics (with separate categories for analyzers vs compiler errors), and our user options around how/when analyzers and compiler diagnostics should run supersedes this.   