### PR TITLE
 Tests to verify ref safety bug fix

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -9529,7 +9529,7 @@ public struct Vec4
 
         [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/63852")]
-        public void  UserDefinedBinaryOperator_RefStruct_Compound_RegressionTest2()
+        public void UserDefinedBinaryOperator_RefStruct_Compound_RegressionTest2()
         {
             var tree = SyntaxFactory.ParseSyntaxTree("""
                 using System;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -9632,7 +9632,6 @@ public struct Vec4
                 );
         }
 
-
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71773")]
         public void UserDefinedUnaryOperator_RefStruct()
         {


### PR DESCRIPTION
These tests verify that issue https://github.com/dotnet/roslyn/issues/63852 is fixed. It was very likely fixed
as part of https://github.com/dotnet/roslyn/pull/73081

closes https://github.com/dotnet/roslyn/issues/63852