### PR TITLE
Fix UnscopedRef handling in indexers

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4624,6 +4624,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 uint receiverEscapeScope = CallingMethodScope;
                 foreach (var escapeValue in escapeValues)
                 {
+                    // This is a call to an indexer so the ref escape scope can only impact the escape value if it 
+                    // can be assigned to `this`. Return Only can't do this.
+                    if (escapeValue.IsRefEscape && escapeValue.EscapeLevel != EscapeLevel.CallingMethod)
+                    {
+                        continue;
+                    }
+
                     uint escapeScope = escapeValue.IsRefEscape
                         ? GetRefEscape(escapeValue.Argument, scopeOfTheContainingExpression)
                         : GetValEscape(escapeValue.Argument, scopeOfTheContainingExpression);

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4624,7 +4624,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 uint receiverEscapeScope = CallingMethodScope;
                 foreach (var escapeValue in escapeValues)
                 {
-                    // This is a call to an indexer so the ref escape scope can only impact the escape value if it 
+                    // This is a call to an indexer so the ref escape scope can only impact the escape value if it
                     // can be assigned to `this`. Return Only can't do this.
                     if (escapeValue.IsRefEscape && escapeValue.EscapeLevel != EscapeLevel.CallingMethod)
                     {


### PR DESCRIPTION
The object initializer logic wasn't completely handling the lifetime of
the `in` part of parameters. It was considering it escaping even if it
wasn't marked as `[UnscopedRef]`

closes https://github.com/dotnet/roslyn/issues/66056