### PR TITLE
Add IsEnabled property to IEditorInlineRenameService

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptEditorInlineRenameService.cs
@@ -14,5 +14,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 /// </summary>
 internal abstract class VSTypeScriptEditorInlineRenameServiceImplementation
 {
+    public virtual bool IsEnabled() => true;
+
     public abstract Task<VSTypeScriptInlineRenameInfo> GetRenameInfoAsync(Document document, int position, CancellationToken cancellationToken);
 }

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptEditorInlineRenameService.cs
@@ -24,6 +24,19 @@ internal sealed class VSTypeScriptEditorInlineRenameService(
 {
     private readonly Lazy<VSTypeScriptEditorInlineRenameServiceImplementation>? _service = service;
 
+    public bool IsEnabled
+    {
+        get
+        {
+            if (_service != null)
+            {
+                return _service.Value.IsEnabled();
+            }
+
+            return false;
+        }
+    }
+
     public Task<ImmutableDictionary<string, ImmutableArray<string>>> GetRenameContextAsync(IInlineRenameInfo inlineRenameInfo, IInlineRenameLocationSet inlineRenameLocationSet, CancellationToken cancellationToken)
     {
         return Task.FromResult(ImmutableDictionary<string, ImmutableArray<string>>.Empty);

--- a/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.cs
@@ -20,6 +20,8 @@ internal abstract partial class AbstractEditorInlineRenameService : IEditorInlin
         _refactorNotifyServices = refactorNotifyServices;
     }
 
+    public bool IsEnabled => true;
+
     public async Task<IInlineRenameInfo> GetRenameInfoAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var symbolicInfo = await SymbolicRenameInfo.GetRenameInfoAsync(document, position, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
@@ -9,7 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.BackgroundWorkIndicator;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Notification;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
@@ -120,6 +122,9 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
     {
         return args.SubjectBuffer.TryGetWorkspace(out var workspace) &&
             workspace.CanApplyChange(ApplyChangesKind.ChangeDocument) &&
+            args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges() is Document document &&
+            document.GetLanguageService<IEditorInlineRenameService>() is IEditorInlineRenameService inlineRenameService &&
+            inlineRenameService.IsEnabled &&
             args.SubjectBuffer.SupportsRename() && !args.SubjectBuffer.IsInLspEditorContext();
     }
 

--- a/src/EditorFeatures/Core/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/InlineRename/IEditorInlineRenameService.cs
@@ -255,6 +255,12 @@ internal interface IInlineRenameInfo
 internal interface IEditorInlineRenameService : ILanguageService
 {
     /// <summary>
+    /// Returns true if the service is currently enabled for the language (e.g. the value
+    /// might depend on a feature flag.)
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
     /// Returns <see cref="IInlineRenameInfo"/> necessary to establish the inline rename session.
     /// </summary>
     Task<IInlineRenameInfo> GetRenameInfoAsync(Document document, int position, CancellationToken cancellationToken);

--- a/src/VisualStudio/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
+++ b/src/VisualStudio/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
@@ -202,6 +202,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
             _service = service;
         }
 
+        public bool IsEnabled => true;
+
         public Task<ImmutableDictionary<string, ImmutableArray<string>>> GetRenameContextAsync(IInlineRenameInfo inlineRenameInfo, IInlineRenameLocationSet inlineRenameLocationSet, CancellationToken cancellationToken)
         {
             return Task.FromResult(ImmutableDictionary<string, ImmutableArray<string>>.Empty);

--- a/src/VisualStudio/Xaml/Impl/Features/InlineRename/XamlEditorInlineRenameService.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/InlineRename/XamlEditorInlineRenameService.cs
@@ -30,6 +30,8 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Features.InlineRename
             _renameService = renameService;
         }
 
+        public bool IsEnabled => true;
+
         public Task<ImmutableDictionary<string, ImmutableArray<string>>> GetRenameContextAsync(IInlineRenameInfo inlineRenameInfo, IInlineRenameLocationSet inlineRenameLocationSet, CancellationToken cancellationToken)
         {
             return Task.FromResult(ImmutableDictionary<string, ImmutableArray<string>>.Empty);


### PR DESCRIPTION
In order for TypeScript to enable LSP rename, we need the rename command handler to no-op when the respective language service has indicated so.