### PR TITLE
Put TArg before callbacks

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
@@ -24,8 +24,8 @@ internal static class MakeLocalFunctionStaticHelper
     {
         // If other local functions are called the it can't be made static unless the are static, or the local
         // function is recursive, or its calling a child local function
-        return !dataFlow.UsedLocalFunctions.Any(static (usedLocalFunction, localFunctionStatement) =>
-            !usedLocalFunction.IsStatic && !IsChildOrSelf(localFunctionStatement, usedLocalFunction), localFunction);
+        return !dataFlow.UsedLocalFunctions.Any(predicate: static (usedLocalFunction, localFunctionStatement) =>
+            !usedLocalFunction.IsStatic && !IsChildOrSelf(localFunctionStatement, usedLocalFunction), arg: localFunction);
 
         static bool IsChildOrSelf(LocalFunctionStatementSyntax containingLocalFunction, ISymbol calledLocationFunction)
         {

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveDiagnosticAnalyzer.cs
@@ -325,8 +325,8 @@ internal sealed class CSharpRemoveUnnecessaryNullableDirectiveDiagnosticAnalyzer
         {
             return _codeBlockIntervals.GetOrAdd(
                 tree,
-                static (tree, arg) => SyntaxTreeState.Create(arg.defaultCompleted, arg.options, tree, arg.cancellationToken),
-                (defaultCompleted, options: ((CSharpCompilationOptions)semanticModel.Compilation.Options).NullableContextOptions, cancellationToken));
+                valueFactory: static (tree, arg) => SyntaxTreeState.Create(arg.defaultCompleted, arg.options, tree, arg.cancellationToken),
+                factoryArgument: (defaultCompleted, options: ((CSharpCompilationOptions)semanticModel.Compilation.Options).NullableContextOptions, cancellationToken));
         }
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -160,7 +160,7 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
             current = memberAccess.Expression;
 
             // Now see if we have an item we're spreading matching 'x'.
-            var matchIndex = spreadElements.FindIndex(SyntaxFacts.AreEquivalent, current);
+            var matchIndex = spreadElements.FindIndex(match: SyntaxFacts.AreEquivalent, arg: current);
             if (matchIndex < 0)
                 return false;
 

--- a/src/Analyzers/CSharp/Analyzers/UseLocalFunction/CSharpUseLocalFunctionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseLocalFunction/CSharpUseLocalFunctionDiagnosticAnalyzer.cs
@@ -409,7 +409,7 @@ internal class CSharpUseLocalFunctionDiagnosticAnalyzer : AbstractBuiltInCodeSty
             var typeParams = localEnclosingSymbol.GetTypeParameters();
             if (typeParams.Any())
             {
-                if (typeParams.Any(static (p, delegateTypeParamNames) => delegateTypeParamNames.Contains(p.Name), delegateTypeParamNames))
+                if (typeParams.Any(predicate: static (p, delegateTypeParamNames) => delegateTypeParamNames.Contains(p.Name), arg: delegateTypeParamNames))
                 {
                     return false;
                 }

--- a/src/Analyzers/CSharp/Analyzers/UseSimpleUsingStatement/UseSimpleUsingStatementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseSimpleUsingStatement/UseSimpleUsingStatementDiagnosticAnalyzer.cs
@@ -150,7 +150,7 @@ internal class UseSimpleUsingStatementDiagnosticAnalyzer : AbstractBuiltInCodeSt
     }
 
     private static bool DeclaredLocalCausesCollision(ILookup<string, ISymbol> symbolNameToExistingSymbol, ImmutableArray<ILocalSymbol> locals)
-        => locals.Any(static (local, symbolNameToExistingSymbol) => symbolNameToExistingSymbol[local.Name].Any(otherLocal => !local.Equals(otherLocal)), symbolNameToExistingSymbol);
+        => locals.Any(predicate: static (local, symbolNameToExistingSymbol) => symbolNameToExistingSymbol[local.Name].Any(otherLocal => !local.Equals(otherLocal)), arg: symbolNameToExistingSymbol);
 
     private static bool PreservesSemantics(
         SemanticModel semanticModel,

--- a/src/Analyzers/CSharp/CodeFixes/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -162,7 +162,7 @@ internal sealed class CSharpMakeMethodAsynchronousCodeFixProvider() : AbstractMa
     }
 
     private static bool IsIterator(IMethodSymbol method, CancellationToken cancellationToken)
-        => method.Locations.Any(static (loc, cancellationToken) => loc.FindNode(cancellationToken).ContainsYield(), cancellationToken);
+        => method.Locations.Any(predicate: static (loc, cancellationToken) => loc.FindNode(cancellationToken).ContainsYield(), arg: cancellationToken);
 
     private static bool IsIAsyncEnumerableOrEnumerator(ITypeSymbol returnType, KnownTaskTypes knownTypes)
         => returnType.OriginalDefinition.Equals(knownTypes.IAsyncEnumerableOfTType) ||

--- a/src/Analyzers/CSharp/CodeFixes/ReplaceDefaultLiteral/CSharpReplaceDefaultLiteralCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ReplaceDefaultLiteral/CSharpReplaceDefaultLiteralCodeFixProvider.cs
@@ -123,7 +123,7 @@ internal sealed class CSharpReplaceDefaultLiteralCodeFixProvider() : CodeFixProv
         var flagsAttribute = compilation.GetTypeByMetadataName(typeof(FlagsAttribute).FullName!);
         return type.TypeKind == TypeKind.Enum &&
                flagsAttribute != null &&
-               type.GetAttributes().Any(static (attribute, flagsAttribute) => flagsAttribute.Equals(attribute.AttributeClass), flagsAttribute);
+               type.GetAttributes().Any(predicate: static (attribute, flagsAttribute) => flagsAttribute.Equals(attribute.AttributeClass), arg: flagsAttribute);
     }
 
     private static bool IsZero(object? o)

--- a/src/Analyzers/Core/Analyzers/MakeFieldReadonly/AbstractMakeFieldReadonlyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/MakeFieldReadonly/AbstractMakeFieldReadonlyDiagnosticAnalyzer.cs
@@ -170,8 +170,8 @@ internal abstract class AbstractMakeFieldReadonlyDiagnosticAnalyzer<
                     } &&
                     symbol.Type.IsMutableValueType() == false &&
                     !symbol.GetAttributes().Any(
-                       static (a, threadStaticAttribute) => SymbolEqualityComparer.Default.Equals(a.AttributeClass, threadStaticAttribute),
-                       threadStaticAttribute) &&
+                       predicate: static (a, threadStaticAttribute) => SymbolEqualityComparer.Default.Equals(a.AttributeClass, threadStaticAttribute),
+                       arg: threadStaticAttribute) &&
                     !IsDataContractSerializable(symbol, dataContractAttribute, dataMemberAttribute);
 
             static bool IsDataContractSerializable(IFieldSymbol symbol, INamedTypeSymbol? dataContractAttribute, INamedTypeSymbol? dataMemberAttribute)
@@ -179,8 +179,8 @@ internal abstract class AbstractMakeFieldReadonlyDiagnosticAnalyzer<
                 if (dataContractAttribute is null || dataMemberAttribute is null)
                     return false;
 
-                return symbol.GetAttributes().Any(static (x, dataMemberAttribute) => SymbolEqualityComparer.Default.Equals(x.AttributeClass, dataMemberAttribute), dataMemberAttribute)
-                    && symbol.ContainingType.GetAttributes().Any(static (x, dataContractAttribute) => SymbolEqualityComparer.Default.Equals(x.AttributeClass, dataContractAttribute), dataContractAttribute);
+                return symbol.GetAttributes().Any(predicate: static (x, dataMemberAttribute) => SymbolEqualityComparer.Default.Equals(x.AttributeClass, dataMemberAttribute), arg: dataMemberAttribute)
+                    && symbol.ContainingType.GetAttributes().Any(predicate: static (x, dataContractAttribute) => SymbolEqualityComparer.Default.Equals(x.AttributeClass, dataContractAttribute), arg: dataContractAttribute);
             }
 
             // Method to update the field state for a candidate field written outside constructor and field initializer.

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -433,7 +433,7 @@ internal abstract class AbstractRemoveUnusedMembersDiagnosticAnalyzer<
                 return;
             }
 
-            if (symbolEndContext.Symbol.GetAttributes().Any(static (a, self) => a.AttributeClass == self._structLayoutAttributeType, this))
+            if (symbolEndContext.Symbol.GetAttributes().Any(predicate: static (a, self) => a.AttributeClass == self._structLayoutAttributeType, arg: this))
             {
                 // Bail out for types with 'StructLayoutAttribute' as the ordering of the members is critical,
                 // and removal of unused members might break semantics.
@@ -827,7 +827,7 @@ internal abstract class AbstractRemoveUnusedMembersDiagnosticAnalyzer<
         }
 
         private bool IsMethodWithSpecialAttribute(IMethodSymbol methodSymbol)
-            => methodSymbol.GetAttributes().Any(static (a, self) => self._attributeSetForMethodsToIgnore.Contains(a.AttributeClass), this);
+            => methodSymbol.GetAttributes().Any(predicate: static (a, self) => self._attributeSetForMethodsToIgnore.Contains(a.AttributeClass), arg: this);
 
         private static bool IsShouldSerializeOrResetPropertyMethod(IMethodSymbol methodSymbol)
         {

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -237,7 +237,7 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
 
             // Ignore flagging parameters for methods with certain well-known attributes,
             // which are known to have unused parameters in real world code.
-            if (method.GetAttributes().Any(static (a, self) => self._attributeSetForMethodsToIgnore.Contains(a.AttributeClass), this))
+            if (method.GetAttributes().Any(predicate: static (a, self) => self._attributeSetForMethodsToIgnore.Contains(a.AttributeClass), arg: this))
             {
                 return false;
             }
@@ -269,7 +269,7 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
             // See https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.icustommarshaler#implementing-the-getinstance-method
             if (method is { MetadataName: "GetInstance", IsStatic: true, Parameters.Length: 1, ContainingType: { } containingType } methodSymbol &&
                 methodSymbol.Parameters[0].Type.SpecialType == SpecialType.System_String &&
-                containingType.AllInterfaces.Any((@interface, marshaler) => @interface.Equals(marshaler), _iCustomMarshaler))
+                containingType.AllInterfaces.Any(predicate: (@interface, marshaler) => @interface.Equals(marshaler), arg: _iCustomMarshaler))
             {
                 return false;
             }

--- a/src/Analyzers/Core/Analyzers/SimplifyLinqExpression/AbstractSimplifyLinqExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyLinqExpression/AbstractSimplifyLinqExpressionDiagnosticAnalyzer.cs
@@ -157,7 +157,7 @@ internal abstract class AbstractSimplifyLinqExpressionDiagnosticAnalyzer<TInvoca
             => whereMethod.Equals(invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod.OriginalDefinition, SymbolEqualityComparer.Default);
 
         bool IsInvocationNonEnumerableReturningLinqMethod(IInvocationOperation invocation)
-            => linqMethods.Any(static (m, invocation) => m.Equals(invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod.OriginalDefinition, SymbolEqualityComparer.Default), invocation);
+            => linqMethods.Any(predicate: static (m, invocation) => m.Equals(invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod.OriginalDefinition, SymbolEqualityComparer.Default), arg: invocation);
 
         INamedTypeSymbol? TryGetSymbolOfMemberAccess(IInvocationOperation invocation)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -189,8 +189,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (attributeTypeForBinding.IsErrorType())
             {
                 boundConstructorArguments = analyzedArguments.ConstructorArguments.Arguments.SelectAsArray(
-                    static (arg, attributeArgumentBinder) => attributeArgumentBinder.BindToTypeForErrorRecovery(arg),
-                    attributeArgumentBinder);
+                    map: static (arg, attributeArgumentBinder) => attributeArgumentBinder.BindToTypeForErrorRecovery(arg),
+                    arg: attributeArgumentBinder);
                 argsToParamsOpt = default;
             }
             else

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -512,7 +512,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                  BoundBadExpression);
 
             // Assert that the shape of the BoundBadExpression is sound and is not going to confuse NullableWalker for target-typed 'new'.
-            Debug.Assert(expr is not BoundBadExpression { ChildBoundNodes: var children } || !children.Any((child, node) => child.Syntax == node.Syntax, node));
+            Debug.Assert(expr is not BoundBadExpression { ChildBoundNodes: var children } || !children.Any(predicate: (child, node) => child.Syntax == node.Syntax, arg: node));
 
             if (wasCompilerGenerated)
             {
@@ -1181,7 +1181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // Overload resolution doesn't check the conversion when 'this' type refers to a type parameter
                             TypeSymbol? receiverType = methodGroup.ReceiverOpt.Type;
                             Debug.Assert(receiverType is not null);
-                            bool thisTypeIsOpen = typeParameters.Any((typeParameter, parameter) => parameter.Type.ContainsTypeParameter(typeParameter), member.Parameters[0]);
+                            bool thisTypeIsOpen = typeParameters.Any(predicate: (typeParameter, parameter) => parameter.Type.ContainsTypeParameter(typeParameter), arg: member.Parameters[0]);
                             MethodSymbol? constructed = null;
                             bool wasFullyInferred = false;
 
@@ -1194,7 +1194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (constructed is null || !wasFullyInferred)
                             {
                                 // It is quite possible that inference failed because we didn't supply type from the second argument
-                                if (!typeParameters.Any((typeParameter, parameter) => parameter.Type.ContainsTypeParameter(typeParameter), member.Parameters[1]))
+                                if (!typeParameters.Any(predicate: (typeParameter, parameter) => parameter.Type.ContainsTypeParameter(typeParameter), arg: member.Parameters[1]))
                                 {
                                     continue;
                                 }
@@ -1250,7 +1250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                             }
                         }
-                        else if (typeParameters.Any((typeParameter, parameter) => !parameter.Type.ContainsTypeParameter(typeParameter), member.Parameters[0]))
+                        else if (typeParameters.Any(predicate: (typeParameter, parameter) => !parameter.Type.ContainsTypeParameter(typeParameter), arg: member.Parameters[0]))
                         {
                             // A type parameter does not appear in the parameter type.
                             continue;
@@ -1996,7 +1996,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     delegateMethod,
                     lambdaOrMethod,
                     diagnostics,
-                    static (diagnostics, delegateMethod, lambdaOrMethod, parameter, _, typeAndSyntax) =>
+                    reportMismatchInParameterType: static (diagnostics, delegateMethod, lambdaOrMethod, parameter, _, typeAndSyntax) =>
                     {
                         diagnostics.Add(
                             SourceMemberContainerTypeSymbol.ReportInvalidScopedOverrideAsError(delegateMethod, lambdaOrMethod) ?
@@ -2006,7 +2006,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             new FormattedSymbol(parameter, SymbolDisplayFormat.ShortFormat),
                             typeAndSyntax.Type);
                     },
-                    (Type: targetType, Syntax: syntax),
+                    extraArgument: (Type: targetType, Syntax: syntax),
                     allowVariance: true,
                     invokedAsExtensionMethod: invokedAsExtensionMethod);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -299,8 +299,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol returnType = BindCrefParameterOrReturnType(syntax.Type, syntax, diagnostics);
 
             // Filter out methods with the wrong return type, since overload resolution won't catch these.
-            sortedSymbols = sortedSymbols.WhereAsArray((symbol, returnType) =>
-                symbol.Kind != SymbolKind.Method || TypeSymbol.Equals(((MethodSymbol)symbol).ReturnType, returnType, TypeCompareKind.ConsiderEverything2), returnType);
+            sortedSymbols = sortedSymbols.WhereAsArray(predicate: (symbol, returnType) =>
+                symbol.Kind != SymbolKind.Method || TypeSymbol.Equals(((MethodSymbol)symbol).ReturnType, returnType, TypeCompareKind.ConsiderEverything2), arg: returnType);
 
             if (!sortedSymbols.Any())
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundBadExpression(syntax,
                 resultKind,
                 symbols,
-                childNodes.SelectAsArray((e, self) => self.BindToTypeForErrorRecovery(e), this),
+                childNodes.SelectAsArray(map: (e, self) => self.BindToTypeForErrorRecovery(e), arg: this),
                 CreateErrorType())
             { WasCompilerGenerated = wasCompilerGenerated };
         }
@@ -1680,7 +1680,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (symbol.ContainingSymbol is NamedTypeSymbol { OriginalDefinition: var symbolContainerDefinition } &&
                     ContainingType is SourceMemberContainerTypeSymbol { IsRecord: false, IsRecordStruct: false, PrimaryConstructor: SynthesizedPrimaryConstructor { ParameterCount: not 0 } primaryConstructor, OriginalDefinition: var containingTypeDefinition } &&
                     this.ContainingMember() is { Kind: not SymbolKind.NamedType, IsStatic: false } && // We are in an instance member
-                    primaryConstructor.Parameters.Any(static (p, name) => p.Name == name, name) &&
+                    primaryConstructor.Parameters.Any(predicate: static (p, name) => p.Name == name, arg: name) &&
                     // And not shadowed by a member in the same type
                     symbolContainerDefinition != (object)containingTypeDefinition &&
                     !members.Any(static (m, containingTypeDefinition) => m.ContainingSymbol.OriginalDefinition == (object)containingTypeDefinition, containingTypeDefinition))
@@ -3710,8 +3710,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         diagnostics);
                 }
 
-                Debug.Assert(handlerParameterIndexes.All((index, paramLength) => index >= BoundInterpolatedStringArgumentPlaceholder.InstanceParameter && index < paramLength,
-                                                         parameters.Length));
+                Debug.Assert(handlerParameterIndexes.All(predicate: (index, paramLength) => index >= BoundInterpolatedStringArgumentPlaceholder.InstanceParameter && index < paramLength,
+                                                         arg: parameters.Length));
 
                 // We need to find the appropriate argument expression for every expected parameter, and error on any that occur after the current parameter
 
@@ -4586,7 +4586,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 boundInitExprOpt = BindArrayInitializerExpressions(initSyntax, diagnostics, dimension: 1, rank: 1);
             }
 
-            boundInitExprOpt = boundInitExprOpt.SelectAsArray((expr, t) => GenerateConversionForAssignment(t.elementType, expr, t.diagnostics), (elementType, diagnostics));
+            boundInitExprOpt = boundInitExprOpt.SelectAsArray(map: (expr, t) => GenerateConversionForAssignment(t.elementType, expr, t.diagnostics), arg: (elementType, diagnostics));
 
             if (sizeOpt != null)
             {
@@ -5099,7 +5099,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression result = bindObjectCreationExpression(node, diagnostics);
 
             // Assert that the shape of the BoundBadExpression is sound and is not going to confuse NullableWalker for target-typed 'new'.
-            Debug.Assert(result is not BoundBadExpression { ChildBoundNodes: var children } || !children.Any((child, node) => child.Syntax == node, node));
+            Debug.Assert(result is not BoundBadExpression { ChildBoundNodes: var children } || !children.Any(predicate: (child, node) => child.Syntax == node, arg: node));
 
             return result;
 
@@ -7986,7 +7986,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool ImplementsWinRTAsyncInterface(TypeSymbol type)
         {
-            return IsWinRTAsyncInterface(type) || type.AllInterfacesNoUseSiteDiagnostics.Any(static (i, self) => self.IsWinRTAsyncInterface(i), this);
+            return IsWinRTAsyncInterface(type) || type.AllInterfacesNoUseSiteDiagnostics.Any(predicate: static (i, self) => self.IsWinRTAsyncInterface(i), arg: this);
         }
 
         private bool IsWinRTAsyncInterface(TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1498,7 +1498,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 visitedParameters[paramsIndex] = true;
             }
 
-            bool haveDefaultArguments = !parameters.All(static (param, visitedParameters) => visitedParameters[param.Ordinal], visitedParameters);
+            bool haveDefaultArguments = !parameters.All(predicate: static (param, visitedParameters) => visitedParameters[param.Ordinal], arg: visitedParameters);
 
             if (!haveDefaultArguments && !expanded)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -463,7 +463,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var interfaces = inputType is TypeParameterSymbol typeParam ? typeParam.EffectiveInterfacesNoUseSiteDiagnostics : inputType.AllInterfacesNoUseSiteDiagnostics;
-            return interfaces.Any(static (i, _) => i.IsWellKnownINumberBaseType(), 0) || inputType.IsWellKnownINumberBaseType();
+            return interfaces.Any(predicate: static (i, _) => i.IsWellKnownINumberBaseType(), arg: 0) || inputType.IsWellKnownINumberBaseType();
         }
 
         private static ExpressionSyntax SkipParensAndNullSuppressions(ExpressionSyntax e, BindingDiagnosticBag diagnostics, ref bool hasErrors)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1132,7 +1132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var invalidDimensions = ArrayBuilder<BoundExpression>.GetInstance();
 
-                typeSyntax.VisitRankSpecifiers((rankSpecifier, args) =>
+                typeSyntax.VisitRankSpecifiers(action: (rankSpecifier, args) =>
                 {
                     bool _ = false;
                     foreach (var expressionSyntax in rankSpecifier.Sizes)
@@ -1143,7 +1143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             args.invalidDimensions.Add(size);
                         }
                     }
-                }, (binder: this, invalidDimensions: invalidDimensions, diagnostics: diagnostics));
+                }, argument: (binder: this, invalidDimensions: invalidDimensions, diagnostics: diagnostics));
 
                 boundDeclType = new BoundTypeExpression(typeSyntax, aliasOpt, dimensionsOpt: invalidDimensions.ToImmutableAndFree(), typeWithAnnotations: declTypeOpt);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // placeholder bound nodes with the proper types are sufficient to bind the element-wise binary operators
             TypeSymbol tupleType = expr.Type.StrippedType();
             ImmutableArray<BoundExpression> placeholders = tupleType.TupleElementTypesWithAnnotations
-                .SelectAsArray((t, s) => (BoundExpression)new BoundTupleOperandPlaceholder(s, t.Type), expr.Syntax);
+                .SelectAsArray(map: (t, s) => (BoundExpression)new BoundTupleOperandPlaceholder(s, t.Type), arg: expr.Syntax);
 
             return (placeholders, tupleType.TupleElementNames);
         }

--- a/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var locals = new ArrayBuilder<LocalSymbol>(_syntax.Declaration.Variables.Count);
 
-                _syntax.Declaration.Type.VisitRankSpecifiers((rankSpecifier, args) =>
+                _syntax.Declaration.Type.VisitRankSpecifiers(action: (rankSpecifier, args) =>
                 {
                     foreach (var size in rankSpecifier.Sizes)
                     {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ExpressionVariableFinder.FindExpressionVariables(args.binder, args.locals, size);
                         }
                     }
-                }, (binder: this, locals: locals));
+                }, argument: (binder: this, locals: locals));
 
                 foreach (VariableDeclaratorSyntax declarator in _syntax.Declaration.Variables)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Declaration and Initializers are mutually exclusive.
             if (_syntax.Declaration != null)
             {
-                _syntax.Declaration.Type.VisitRankSpecifiers((rankSpecifier, args) =>
+                _syntax.Declaration.Type.VisitRankSpecifiers(action: (rankSpecifier, args) =>
                 {
                     foreach (var size in rankSpecifier.Sizes)
                     {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ExpressionVariableFinder.FindExpressionVariables(args.binder, args.locals, size);
                         }
                     }
-                }, (binder: this, locals: locals));
+                }, argument: (binder: this, locals: locals));
 
                 foreach (var vdecl in _syntax.Declaration.Variables)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var replacedExternAliases = PooledHashSet<string>.GetInstance();
             replacedExternAliases.AddAll(externs2.Select(e => e.Alias.Name));
-            return externs1.WhereAsArray((e, replacedExternAliases) => !replacedExternAliases.Contains(e.Alias.Name), replacedExternAliases).AddRange(externs2);
+            return externs1.WhereAsArray(predicate: (e, replacedExternAliases) => !replacedExternAliases.Contains(e.Alias.Name), arg: replacedExternAliases).AddRange(externs2);
         }
 
         private class UsingTargetComparer : IEqualityComparer<NamespaceOrTypeAndUsingDirective>

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void VisitRankSpecifiers(TypeSyntax type, Binder enclosing)
         {
-            type.VisitRankSpecifiers((rankSpecifier, args) =>
+            type.VisitRankSpecifiers(action: (rankSpecifier, args) =>
             {
                 foreach (var size in rankSpecifier.Sizes)
                 {
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         args.localBinderFactory.Visit(size, args.binder);
                     }
                 }
-            }, (localBinderFactory: this, binder: enclosing));
+            }, argument: (localBinderFactory: this, binder: enclosing));
         }
 
         // Currently the types of these are restricted to only be whatever the syntax parameter is, plus any LocalFunctionStatementSyntax contained within it.

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -188,14 +188,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Binder localDeclarationBinder = enclosingBinder.GetBinder(innerStatement) ?? enclosingBinder;
                         var decl = (LocalDeclarationStatementSyntax)innerStatement;
 
-                        decl.Declaration.Type.VisitRankSpecifiers((rankSpecifier, args) =>
+                        decl.Declaration.Type.VisitRankSpecifiers(action: (rankSpecifier, args) =>
                         {
                             foreach (var expression in rankSpecifier.Sizes)
                             {
                                 findExpressionVariablesInRankSpecifier(expression, args);
                             }
 
-                        }, (localScopeBinder: this, locals: locals, localDeclarationBinder: localDeclarationBinder));
+                        }, argument: (localScopeBinder: this, locals: locals, localDeclarationBinder: localDeclarationBinder));
 
                         LocalDeclarationKind kind;
                         if (decl.IsConst)
@@ -229,13 +229,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         foreach (var parameter in decl.ParameterList.Parameters)
                         {
-                            parameter.Type?.VisitRankSpecifiers((rankSpecifier, args) =>
+                            parameter.Type?.VisitRankSpecifiers(action: (rankSpecifier, args) =>
                             {
                                 foreach (var expression in rankSpecifier.Sizes)
                                 {
                                     findExpressionVariablesInRankSpecifier(expression, args);
                                 }
-                            }, (localScopeBinder: this, locals: locals, localDeclarationBinder: localFunctionDeclarationBinder));
+                            }, argument: (localScopeBinder: this, locals: locals, localDeclarationBinder: localFunctionDeclarationBinder));
                         }
 
                         foreach (var constraintClause in decl.ConstraintClauses)
@@ -244,13 +244,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 if (constraint is TypeConstraintSyntax typeConstraint)
                                 {
-                                    typeConstraint.Type.VisitRankSpecifiers((rankSpecifier, args) =>
+                                    typeConstraint.Type.VisitRankSpecifiers(action: (rankSpecifier, args) =>
                                     {
                                         foreach (var expression in rankSpecifier.Sizes)
                                         {
                                             findExpressionVariablesInRankSpecifier(expression, args);
                                         }
-                                    }, (localScopeBinder: this, locals: locals, localDeclarationBinder: localFunctionDeclarationBinder));
+                                    }, argument: (localScopeBinder: this, locals: locals, localDeclarationBinder: localFunctionDeclarationBinder));
                                 }
                             }
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1687,7 +1687,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var allInterfaces = targetType.GetAllInterfacesOrEffectiveInterfaces();
                 var specialType = compilation.GetSpecialType(specialInterface);
-                return allInterfaces.Any(static (a, b) => ReferenceEquals(a.OriginalDefinition, b), specialType);
+                return allInterfaces.Any(predicate: static (a, b) => ReferenceEquals(a.OriginalDefinition, b), arg: specialType);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedExplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedExplicitConversions.cs
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)source != null)
             {
-                if (u.Any(static (conv, source) => TypeSymbol.Equals(conv.FromType, source, TypeCompareKind.ConsiderEverything2), source))
+                if (u.Any(predicate: static (conv, source) => TypeSymbol.Equals(conv.FromType, source, TypeCompareKind.ConsiderEverything2), arg: source))
                 {
                     return source;
                 }
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We have already written the "ToType" into the conversion analysis to
             // perpetuate this fiction.
 
-            if (u.Any(static (conv, target) => TypeSymbol.Equals(conv.ToType, target, TypeCompareKind.ConsiderEverything2), target))
+            if (u.Any(predicate: static (conv, target) => TypeSymbol.Equals(conv.ToType, target, TypeCompareKind.ConsiderEverything2), arg: target))
             {
                 return target;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: If any of the operators in U convert from S then SX is S.
             if ((object)source != null)
             {
-                if (u.Any(static (conv, source) => TypeSymbol.Equals(conv.FromType, source, TypeCompareKind.ConsiderEverything2), source))
+                if (u.Any(predicate: static (conv, source) => TypeSymbol.Equals(conv.FromType, source, TypeCompareKind.ConsiderEverything2), arg: source))
                 {
                     return source;
                 }
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We have previously written the appropriate "ToType" into the conversion analysis
             // to perpetuate this fiction.
 
-            if (u.Any(static (conv, target) => TypeSymbol.Equals(conv.ToType, target, TypeCompareKind.ConsiderEverything2), target))
+            if (u.Any(predicate: static (conv, target) => TypeSymbol.Equals(conv.ToType, target, TypeCompareKind.ConsiderEverything2), arg: target))
             {
                 return target;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -541,8 +541,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Both of those scenarios are legal.)
 
             var fixedArguments = _methodTypeParameters.SelectAsArray(
-                static (typeParameter, i, self) => self.IsUnfixed(i) ? TypeWithAnnotations.Create(typeParameter) : self._fixedResults[i].Type,
-                this);
+                map: static (typeParameter, i, self) => self.IsUnfixed(i) ? TypeWithAnnotations.Create(typeParameter) : self._fixedResults[i].Type,
+                arg: this);
             TypeMap typeMap = new TypeMap(_constructedContainingTypeOfMethod, _methodTypeParameters, fixedArguments);
             return typeMap.SubstituteType(delegateOrFunctionPointerType).Type;
         }

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // If no switch sections are subsumed, just return
-            if (!switchSections.Any(static (s, reachableLabels) => s.SwitchLabels.Any(isSubsumed, reachableLabels), reachableLabels))
+            if (!switchSections.Any(predicate: static (s, reachableLabels) => s.SwitchLabels.Any(predicate: isSubsumed, arg: reachableLabels), arg: reachableLabels))
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var locals = ArrayBuilder<LocalSymbol>.GetInstance(declarationSyntax.Variables.Count);
 
                 // gather expression-declared variables from invalid array dimensions. eg. using(int[x is var y] z = new int[0])
-                declarationSyntax.Type.VisitRankSpecifiers((rankSpecifier, args) =>
+                declarationSyntax.Type.VisitRankSpecifiers(action: (rankSpecifier, args) =>
                 {
                     foreach (var size in rankSpecifier.Sizes)
                     {
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ExpressionVariableFinder.FindExpressionVariables(args.binder, args.locals, size);
                         }
                     }
-                }, (binder: this, locals: locals));
+                }, argument: (binder: this, locals: locals));
 
                 foreach (VariableDeclaratorSyntax declarator in declarationSyntax.Variables)
                 {

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 receiverOpt: binder.BindToTypeForErrorRecovery(receiverOpt),
                 initialBindingReceiverIsSubjectToCloning: ThreeState.False,
                 method: method,
-                arguments: arguments.SelectAsArray((e, binder) => binder.BindToTypeForErrorRecovery(e), binder),
+                arguments: arguments.SelectAsArray(map: (e, binder) => binder.BindToTypeForErrorRecovery(e), arg: binder),
                 argumentNamesOpt: namedArguments,
                 argumentRefKindsOpt: refKinds,
                 isDelegateCall: isDelegateCall,

--- a/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
@@ -693,8 +693,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(((NamedTypeSymbol)readonlySpanOfByte).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.Single().Type.SpecialType is SpecialType.System_Byte);
 
             var utfConcatenation = _builtInUtf8Concatenation.Initialize(
-                static readonlySpanOfByte => new BinaryOperatorSignature(BinaryOperatorKind.Utf8Addition, readonlySpanOfByte, readonlySpanOfByte, readonlySpanOfByte),
-                readonlySpanOfByte);
+                valueFactory: static readonlySpanOfByte => new BinaryOperatorSignature(BinaryOperatorKind.Utf8Addition, readonlySpanOfByte, readonlySpanOfByte, readonlySpanOfByte),
+                arg: readonlySpanOfByte);
 
             operators.Add(utfConcatenation);
         }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return InterlockedOperations.Initialize(ref _lazyBuiltInOperators, static self => new BuiltInOperators(self), this);
+                return InterlockedOperations.Initialize(ref _lazyBuiltInOperators, valueFactory: static self => new BuiltInOperators(self), arg: this);
             }
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return InterlockedOperations.Initialize(ref _lazyAnonymousTypeManager, static self => new AnonymousTypeManager(self), this);
+                return InterlockedOperations.Initialize(ref _lazyAnonymousTypeManager, valueFactory: static self => new AnonymousTypeManager(self), arg: this);
             }
         }
 
@@ -1567,7 +1567,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Global imports (including those from previous submissions, if there are any).
         /// </summary>
         internal ImmutableArray<NamespaceOrTypeAndUsingDirective> GlobalImports
-            => InterlockedOperations.Initialize(ref _lazyGlobalImports, static self => self.BindGlobalImports(), arg: this);
+            => InterlockedOperations.Initialize(ref _lazyGlobalImports, createArray: static self => self.BindGlobalImports(), arg: this);
 
         private ImmutableArray<NamespaceOrTypeAndUsingDirective> BindGlobalImports()
         {
@@ -1607,7 +1607,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Global imports not including those from previous submissions.
         /// </summary>
         private UsingsFromOptionsAndDiagnostics UsingsFromOptions
-            => InterlockedOperations.Initialize(ref _lazyUsingsFromOptions, static self => self.BindUsingsFromOptions(), this);
+            => InterlockedOperations.Initialize(ref _lazyUsingsFromOptions, valueFactory: static self => self.BindUsingsFromOptions(), arg: this);
 
         private UsingsFromOptionsAndDiagnostics BindUsingsFromOptions() => UsingsFromOptionsAndDiagnostics.FromOptions(this);
 
@@ -1633,7 +1633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Imports from all previous submissions.
         /// </summary>
         internal Imports GetPreviousSubmissionImports()
-            => InterlockedOperations.Initialize(ref _lazyPreviousSubmissionImports, static self => self.ExpandPreviousSubmissionImports(), this);
+            => InterlockedOperations.Initialize(ref _lazyPreviousSubmissionImports, valueFactory: static self => self.ExpandPreviousSubmissionImports(), arg: this);
 
         private Imports ExpandPreviousSubmissionImports()
         {
@@ -1653,7 +1653,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return InterlockedOperations.Initialize(ref _lazyGlobalNamespaceAlias, static self => self.CreateGlobalNamespaceAlias(), this);
+                return InterlockedOperations.Initialize(ref _lazyGlobalNamespaceAlias, valueFactory: static self => self.CreateGlobalNamespaceAlias(), arg: this);
             }
         }
 
@@ -4073,7 +4073,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 type => TypeWithAnnotations.Create(type.EnsureCSharpSymbolOrNull(nameof(parameterTypes)), type.NullableAnnotation.ToInternalAnnotation()));
             var internalCallingConvention = callingConvention.FromSignatureConvention();
             var conventionModifiers = internalCallingConvention == CallingConvention.Unmanaged && !callingConventionTypes.IsDefaultOrEmpty
-                ? callingConventionTypes.SelectAsArray((type, i, @this) => getCustomModifierForType(type, @this, i), this)
+                ? callingConventionTypes.SelectAsArray(map: (type, i, @this) => getCustomModifierForType(type, @this, i), arg: this)
                 : ImmutableArray<CustomModifier>.Empty;
 
             return FunctionPointerTypeSymbol.CreateFromParts(

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4237,7 +4237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return methods.WhereAsArray((m, hiddenSymbols) => !hiddenSymbols.Contains(m), hiddenSymbols);
+            return methods.WhereAsArray(predicate: (m, hiddenSymbols) => !hiddenSymbols.Contains(m), arg: hiddenSymbols);
         }
 
         // Get the symbols and possible method group associated with a method group bound node, as
@@ -4342,7 +4342,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // If the bad expression has symbol(s) from this method group, it better indicates any problems.
                         ImmutableArray<Symbol> myMethodGroup = methodGroup;
 
-                        symbols = OneOrMany.Create(((BoundBadExpression)boundNodeForSyntacticParent).Symbols.WhereAsArray((sym, myMethodGroup) => myMethodGroup.Contains(sym), myMethodGroup));
+                        symbols = OneOrMany.Create(((BoundBadExpression)boundNodeForSyntacticParent).Symbols.WhereAsArray(predicate: (sym, myMethodGroup) => myMethodGroup.Contains(sym), arg: myMethodGroup));
                         if (symbols.Any())
                         {
                             resultKind = ((BoundBadExpression)boundNodeForSyntacticParent).ResultKind;
@@ -4443,7 +4443,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // If the bad expression has symbol(s) from this property group, it better indicates any problems.
                         ImmutableArray<Symbol> myPropertyGroup = propertyGroup;
 
-                        symbols = OneOrMany.Create(((BoundBadExpression)boundNodeForSyntacticParent).Symbols.WhereAsArray((sym, myPropertyGroup) => myPropertyGroup.Contains(sym), myPropertyGroup));
+                        symbols = OneOrMany.Create(((BoundBadExpression)boundNodeForSyntacticParent).Symbols.WhereAsArray(predicate: (sym, myPropertyGroup) => myPropertyGroup.Contains(sym), arg: myPropertyGroup));
                         if (symbols.Any())
                         {
                             resultKind = ((BoundBadExpression)boundNodeForSyntacticParent).ResultKind;

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
@@ -1040,7 +1040,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Avoid unnecessary allocation (as CWT on NET6 and prior has no non-allocating way to try to
                         // get an existing value, and only add if that particular KVP is not already present).
                         using PooledDelegates.Releaser _ = PooledDelegates.GetPooledCreateValueCallback(
-                            static (GreenNode _, BoxedMemberNames memberNames) => memberNames, memberNames, out var pooledCallback);
+                            unboundFunction: static (GreenNode _, BoxedMemberNames memberNames) => memberNames, argument: memberNames, boundFunction: out var pooledCallback);
                         memberNames = s_nodeToMemberNames.GetValue(greenNode, pooledCallback);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     var otherTypeParameters = otherDef.GetAllTypeParameters();
                     bool translationFailed = false;
 
-                    var otherTypeArguments = typeArguments.SelectAsArray((t, v) =>
+                    var otherTypeArguments = typeArguments.SelectAsArray(map: (t, v) =>
                     {
                         var newType = (TypeSymbol?)v.Visit(t.Type);
 
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                         }
 
                         return t.WithTypeAndModifiers(newType, v.VisitCustomModifiers(t.CustomModifiers));
-                    }, this);
+                    }, arg: this);
 
                     if (translationFailed)
                     {
@@ -880,9 +880,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 if ((object)originalDef != type)
                 {
                     var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-                    var translatedTypeArguments = type.GetAllTypeArguments(ref discardedUseSiteInfo).SelectAsArray((t, v) => t.WithTypeAndModifiers((TypeSymbol)v.Visit(t.Type),
+                    var translatedTypeArguments = type.GetAllTypeArguments(ref discardedUseSiteInfo).SelectAsArray(map: (t, v) => t.WithTypeAndModifiers((TypeSymbol)v.Visit(t.Type),
                                                                                                                                                   v.VisitCustomModifiers(t.CustomModifiers)),
-                                                                                                                 this);
+                                                                                                                 arg: this);
 
                     var translatedOriginalDef = (NamedTypeSymbol)this.Visit(originalDef);
                     var typeMap = new TypeMap(translatedOriginalDef.GetAllTypeParameters(), translatedTypeArguments, allowAlpha: true);

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1577,7 +1577,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 {
                     NamedTypeSymbol byteType = Compilation.GetSpecialType(SpecialType.System_Byte);
                     var byteArrayType = ArrayTypeSymbol.CreateSZArray(byteType.ContainingAssembly, TypeWithAnnotations.Create(byteType));
-                    var value = flagsBuilder.SelectAsArray((flag, byteType) => new TypedConstant(byteType, TypedConstantKind.Primitive, flag), byteType);
+                    var value = flagsBuilder.SelectAsArray(map: (flag, byteType) => new TypedConstant(byteType, TypedConstantKind.Primitive, flag), arg: byteType);
                     attribute = SynthesizeNullableAttribute(
                         WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags,
                         ImmutableArray.Create(new TypedConstant(byteArrayType, value)));
@@ -1661,7 +1661,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             {
                 NamedTypeSymbol booleanType = Compilation.GetSpecialType(SpecialType.System_Boolean);
                 Debug.Assert((object)booleanType != null);
-                var transformFlags = builder.SelectAsArray((flag, constantType) => new TypedConstant(constantType, TypedConstantKind.Primitive, flag), booleanType);
+                var transformFlags = builder.SelectAsArray(map: (flag, constantType) => new TypedConstant(constantType, TypedConstantKind.Primitive, flag), arg: booleanType);
                 var boolArray = ArrayTypeSymbol.CreateSZArray(booleanType.ContainingAssembly, TypeWithAnnotations.Create(booleanType));
                 var arguments = ImmutableArray.Create(new TypedConstant(boolArray, transformFlags));
                 attribute = SynthesizeNativeIntegerAttribute(WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags, arguments);
@@ -1820,14 +1820,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal MethodSymbol EnsureThrowSwitchExpressionExceptionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
         {
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName,
-                                                      static (privateImplClass, factory) =>
+                                                      createMethodSymbol: static (privateImplClass, factory) =>
                                                       {
                                                           TypeSymbol returnType = factory.SpecialType(SpecialType.System_Void);
                                                           TypeSymbol unmatchedValueType = factory.SpecialType(SpecialType.System_Object);
                                                           return new SynthesizedThrowSwitchExpressionExceptionMethod(privateImplClass, returnType, unmatchedValueType);
                                                       },
-                                                      factory,
-                                                      diagnostics);
+                                                      arg: factory,
+                                                      diagnostics: diagnostics);
         }
 
         private MethodSymbol EnsurePrivateImplClassMethodExists<TArg>(SyntaxNode syntaxNode, string methodName, Func<SynthesizedPrivateImplementationDetailsType, TArg, MethodSymbol> createMethodSymbol, TArg arg, DiagnosticBag diagnostics)
@@ -1867,7 +1867,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal MethodSymbol EnsureThrowSwitchExpressionExceptionParameterlessExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
         {
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName,
-                                                      static (privateImplClass, factory) =>
+                                                      createMethodSymbol: static (privateImplClass, factory) =>
                                                       {
                                                           TypeSymbol returnType = factory.SpecialType(SpecialType.System_Void);
 
@@ -1877,8 +1877,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                                               PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName,
                                                               factory.WellKnownMethod(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor));
                                                       },
-                                                      factory,
-                                                      diagnostics);
+                                                      arg: factory,
+                                                      diagnostics: diagnostics);
         }
 
         /// <summary>
@@ -1887,7 +1887,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal MethodSymbol EnsureThrowInvalidOperationExceptionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
         {
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedThrowInvalidOperationExceptionFunctionName,
-                                                      static (privateImplClass, factory) =>
+                                                      createMethodSymbol: static (privateImplClass, factory) =>
                                                       {
                                                           TypeSymbol returnType = factory.SpecialType(SpecialType.System_Void);
 
@@ -1897,8 +1897,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                                               PrivateImplementationDetails.SynthesizedThrowInvalidOperationExceptionFunctionName,
                                                               factory.WellKnownMethod(WellKnownMember.System_InvalidOperationException__ctor));
                                                       },
-                                                      factory,
-                                                      diagnostics);
+                                                      arg: factory,
+                                                      diagnostics: diagnostics);
         }
 
         internal MethodSymbol EnsureInlineArrayAsSpanExists(SyntaxNode syntaxNode, NamedTypeSymbol spanType, NamedTypeSymbol intType, DiagnosticBag diagnostics)
@@ -1906,7 +1906,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             Debug.Assert(intType.SpecialType == SpecialType.System_Int32);
 
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedInlineArrayAsSpanName,
-                                                      static (privateImplClass, arg) =>
+                                                      createMethodSymbol: static (privateImplClass, arg) =>
                                                       {
                                                           return new SynthesizedInlineArrayAsSpanMethod(
                                                               privateImplClass,
@@ -1914,8 +1914,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                                               arg.spanType,
                                                               arg.intType);
                                                       },
-                                                      (spanType, intType),
-                                                      diagnostics);
+                                                      arg: (spanType, intType),
+                                                      diagnostics: diagnostics);
         }
 
         internal NamedTypeSymbol EnsureInlineArrayTypeExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, int arrayLength, DiagnosticBag diagnostics)
@@ -1975,7 +1975,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             Debug.Assert(intType.SpecialType == SpecialType.System_Int32);
 
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedInlineArrayAsReadOnlySpanName,
-                                                      static (privateImplClass, arg) =>
+                                                      createMethodSymbol: static (privateImplClass, arg) =>
                                                       {
                                                           return new SynthesizedInlineArrayAsReadOnlySpanMethod(
                                                               privateImplClass,
@@ -1983,8 +1983,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                                               arg.spanType,
                                                               arg.intType);
                                                       },
-                                                      (spanType, intType),
-                                                      diagnostics);
+                                                      arg: (spanType, intType),
+                                                      diagnostics: diagnostics);
         }
 
         internal MethodSymbol EnsureInlineArrayElementRefExists(SyntaxNode syntaxNode, NamedTypeSymbol intType, DiagnosticBag diagnostics)
@@ -1992,15 +1992,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             Debug.Assert(intType.SpecialType == SpecialType.System_Int32);
 
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedInlineArrayElementRefName,
-                                                      static (privateImplClass, intType) =>
+                                                      createMethodSymbol: static (privateImplClass, intType) =>
                                                       {
                                                           return new SynthesizedInlineArrayElementRefMethod(
                                                               privateImplClass,
                                                               PrivateImplementationDetails.SynthesizedInlineArrayElementRefName,
                                                               intType);
                                                       },
-                                                      intType,
-                                                      diagnostics);
+                                                      arg: intType,
+                                                      diagnostics: diagnostics);
         }
 
         internal MethodSymbol EnsureInlineArrayElementRefReadOnlyExists(SyntaxNode syntaxNode, NamedTypeSymbol intType, DiagnosticBag diagnostics)
@@ -2008,41 +2008,41 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             Debug.Assert(intType.SpecialType == SpecialType.System_Int32);
 
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedInlineArrayElementRefReadOnlyName,
-                                                      static (privateImplClass, intType) =>
+                                                      createMethodSymbol: static (privateImplClass, intType) =>
                                                       {
                                                           return new SynthesizedInlineArrayElementRefReadOnlyMethod(
                                                               privateImplClass,
                                                               PrivateImplementationDetails.SynthesizedInlineArrayElementRefReadOnlyName,
                                                               intType);
                                                       },
-                                                      intType,
-                                                      diagnostics);
+                                                      arg: intType,
+                                                      diagnostics: diagnostics);
         }
 
         internal MethodSymbol EnsureInlineArrayFirstElementRefExists(SyntaxNode syntaxNode, DiagnosticBag diagnostics)
         {
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefName,
-                                                      static (privateImplClass, _) =>
+                                                      createMethodSymbol: static (privateImplClass, _) =>
                                                       {
                                                           return new SynthesizedInlineArrayFirstElementRefMethod(
                                                               privateImplClass,
                                                               PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefName);
                                                       },
-                                                      (object?)null,
-                                                      diagnostics);
+                                                      arg: (object?)null,
+                                                      diagnostics: diagnostics);
         }
 
         internal MethodSymbol EnsureInlineArrayFirstElementRefReadOnlyExists(SyntaxNode syntaxNode, DiagnosticBag diagnostics)
         {
             return EnsurePrivateImplClassMethodExists(syntaxNode, PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName,
-                                                      static (privateImplClass, _) =>
+                                                      createMethodSymbol: static (privateImplClass, _) =>
                                                       {
                                                           return new SynthesizedInlineArrayFirstElementRefReadOnlyMethod(
                                                               privateImplClass,
                                                               PrivateImplementationDetails.SynthesizedInlineArrayFirstElementRefReadOnlyName);
                                                       },
-                                                      (object?)null,
-                                                      diagnostics);
+                                                      arg: (object?)null,
+                                                      diagnostics: diagnostics);
         }
 
 #nullable disable

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1830,7 +1830,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                                       diagnostics: diagnostics);
         }
 
-        private MethodSymbol EnsurePrivateImplClassMethodExists<TArg>(SyntaxNode syntaxNode, string methodName, Func<SynthesizedPrivateImplementationDetailsType, TArg, MethodSymbol> createMethodSymbol, TArg arg, DiagnosticBag diagnostics)
+        private MethodSymbol EnsurePrivateImplClassMethodExists<TArg>(SyntaxNode syntaxNode, string methodName, TArg arg, Func<SynthesizedPrivateImplementationDetailsType, TArg, MethodSymbol> createMethodSymbol, DiagnosticBag diagnostics)
         {
             var privateImplClass = GetPrivateImplClass(syntaxNode, diagnostics);
             var methodAdapter = privateImplClass.PrivateImplementationDetails.GetMethod(methodName);

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedMethod.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedMethod.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
 
         protected override ImmutableArray<EmbeddedTypeParameter> GetTypeParameters()
         {
-            return UnderlyingMethod.AdaptedMethodSymbol.TypeParameters.SelectAsArray((t, m) => new EmbeddedTypeParameter(m, t.GetCciAdapter()), this);
+            return UnderlyingMethod.AdaptedMethodSymbol.TypeParameters.SelectAsArray(map: (t, m) => new EmbeddedTypeParameter(m, t.GetCciAdapter()), arg: this);
         }
 
         protected override bool IsAbstract

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypesManager.cs
@@ -629,7 +629,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             CommonEmbeddedMember containingPropertyOrMethod,
             ImmutableArray<ParameterSymbol> underlyingParameters)
         {
-            return underlyingParameters.SelectAsArray((p, c) => new EmbeddedParameter(c, p.GetCciAdapter()), containingPropertyOrMethod);
+            return underlyingParameters.SelectAsArray(map: (p, c) => new EmbeddedParameter(c, p.GetCciAdapter()), arg: containingPropertyOrMethod);
         }
 
         protected override CSharpAttributeData CreateCompilerGeneratedAttribute()

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -12272,7 +12272,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 };
             }
 
-            internal void ForEach<TArg>(Action<int, TArg> action, TArg arg)
+            internal void ForEach<TArg>(TArg arg, Action<int, TArg> action)
             {
                 _container?.Value.ForEach(action: action, arg: arg);
                 for (int index = 1; index < Capacity; index++)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to evaluate the patterns.  In this way we infer non-nullability of the original element's parts.
             // We do not extend such courtesy to nested tuple literals.
             var originalInputElementSlots = expression is BoundTupleExpression tuple
-                ? tuple.Arguments.SelectAsArray(static (a, w) => w.GetSlotForSwitchInputValue(a), this)
+                ? tuple.Arguments.SelectAsArray(map: static (a, w) => w.GetSlotForSwitchInputValue(a), arg: this)
                 : default;
             var originalInputMap = PooledDictionary<int, BoundExpression>.GetInstance();
             originalInputMap.Add(originalInputSlot, expression);

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -460,12 +460,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             var origAwaitCatchFrame = _currentAwaitCatchFrame;
             _currentAwaitCatchFrame = null;
 
-            var rewrittenCatches = node.CatchBlocks.SelectAsArray(static (catchBlock, arg) =>
+            var rewrittenCatches = node.CatchBlocks.SelectAsArray(map: static (catchBlock, arg) =>
             {
                 var (@this, origAwaitCatchFrame) = arg;
                 return (BoundCatchBlock)@this.VisitCatchBlock(catchBlock, parentAwaitCatchFrame: origAwaitCatchFrame);
             },
-            (this, origAwaitCatchFrame));
+            arg: (this, origAwaitCatchFrame));
 
             BoundStatement tryWithCatches = _F.Try(rewrittenTry, rewrittenCatches);
 

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
@@ -624,8 +624,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // frame pointers are organized in a linked list.
                 return proxyField.Replacement(
                     syntax,
-                    static (frameType, arg) => arg.self.FramePointer(arg.syntax, frameType),
-                    (syntax, self: this));
+                    makeFrame: static (frameType, arg) => arg.self.FramePointer(arg.syntax, frameType),
+                    arg: (syntax, self: this));
             }
 
             var localFrame = (LocalSymbol)framePointer;
@@ -782,8 +782,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var left = proxy.Replacement(
                     syntax,
-                    static (frameType1, arg) => new BoundLocal(arg.syntax, arg.framePointer, null, arg.framePointer.Type),
-                    (syntax, framePointer));
+                    makeFrame: static (frameType1, arg) => new BoundLocal(arg.syntax, arg.framePointer, null, arg.framePointer.Type),
+                    arg: (syntax, framePointer));
 
                 var assignToProxy = new BoundAssignmentOperator(syntax, left, value, value.Type);
                 if (_currentMethod.MethodKind == MethodKind.Constructor &&

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var mightAssignWalker = new WhenClauseMightAssignPatternVariableWalker();
                 bool canShareTemps =
                     !decisionDag.TopologicallySortedNodes
-                    .Any(static (node, mightAssignWalker) => node is BoundWhenDecisionDagNode w && mightAssignWalker.MightAssignSomething(w.WhenExpression), mightAssignWalker);
+                    .Any(predicate: static (node, mightAssignWalker) => node is BoundWhenDecisionDagNode w && mightAssignWalker.MightAssignSomething(w.WhenExpression), arg: mightAssignWalker);
 
                 if (canShareTemps)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -213,11 +213,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 method,
                 symbolForCompare,
                 _diagnostics,
-                static (diagnostics, method, interceptor, topLevel, attributeLocation) =>
+                reportMismatchInReturnType: static (diagnostics, method, interceptor, topLevel, attributeLocation) =>
                 {
                     diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnInterceptor, attributeLocation, method);
                 },
-                static (diagnostics, method, interceptor, implementingParameter, blameAttributes, attributeLocation) =>
+                reportMismatchInParameterType: static (diagnostics, method, interceptor, implementingParameter, blameAttributes, attributeLocation) =>
                 {
                     diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnInterceptor, attributeLocation, new FormattedSymbol(implementingParameter, SymbolDisplayFormat.ShortFormat), method);
                 },
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 method,
                 symbolForCompare,
                 this._diagnostics,
-                static (diagnostics, method, symbolForCompare, implementingParameter, blameAttributes, attributeLocation) =>
+                reportMismatchInParameterType: static (diagnostics, method, symbolForCompare, implementingParameter, blameAttributes, attributeLocation) =>
                 {
                     diagnostics.Add(ErrorCode.ERR_InterceptorScopedMismatch, attributeLocation, method, symbolForCompare);
                 },
@@ -1327,9 +1327,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         (LocalRewriter rewriter, bool forceLambdaSpilling, ArrayBuilder<BoundAssignmentOperator> storesToTemps) arg = (rewriter: this, forceLambdaSpilling, storesToTemps);
                         arguments[p] = RewriteParamsArray(
                                            argument,
-                                           static (BoundExpression element, ref (LocalRewriter rewriter, bool forceLambdaSpilling, ArrayBuilder<BoundAssignmentOperator> storesToTemps) arg) =>
+                                           elementRewriter: static (BoundExpression element, ref (LocalRewriter rewriter, bool forceLambdaSpilling, ArrayBuilder<BoundAssignmentOperator> storesToTemps) arg) =>
                                                arg.rewriter.StoreArgumentToTempIfNecessary(arg.forceLambdaSpilling, arg.storesToTemps, element, RefKind.None, RefKind.None),
-                                           ref arg);
+                                           arg: ref arg);
 
                         Debug.Assert(arguments[p].IsParamsArrayOrCollection);
                     }
@@ -1497,9 +1497,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     (ArrayBuilder<BoundAssignmentOperator> tempStores, int tempsRemainedInUse, int firstUnclaimedStore) arg = (tempStores, tempsRemainedInUse, firstUnclaimedStore);
                     arguments[a] = RewriteParamsArray(
                                        argument,
-                                       static (BoundExpression element, ref (ArrayBuilder<BoundAssignmentOperator> tempStores, int tempsRemainedInUse, int firstUnclaimedStore) arg) =>
+                                       elementRewriter: static (BoundExpression element, ref (ArrayBuilder<BoundAssignmentOperator> tempStores, int tempsRemainedInUse, int firstUnclaimedStore) arg) =>
                                            mergeArgumentAndSideEffect(element, arg.tempStores, ref arg.tempsRemainedInUse, ref arg.firstUnclaimedStore),
-                                       ref arg);
+                                       arg: ref arg);
                     tempsRemainedInUse = arg.tempsRemainedInUse;
                     firstUnclaimedStore = arg.firstUnclaimedStore;
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -1238,7 +1238,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private delegate BoundExpression ParamsArrayElementRewriter<TArg>(BoundExpression element, ref TArg arg);
-        private static BoundExpression RewriteParamsArray<TArg>(BoundExpression paramsArray, ParamsArrayElementRewriter<TArg> elementRewriter, ref TArg arg)
+        private static BoundExpression RewriteParamsArray<TArg>(BoundExpression paramsArray, ref TArg arg, ParamsArrayElementRewriter<TArg> elementRewriter)
         {
             Debug.Assert(paramsArray.IsParamsArrayOrCollection);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -567,7 +567,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// NOTE: We're assuming that sequence points have already been generated.
         /// Otherwise, lowering to for-loops would generated spurious ones.
         /// </remarks>
-        private BoundStatement RewriteForEachStatementAsFor<TArg>(BoundForEachStatement node, GetForEachStatementAsForPreamble? getPreamble, GetForEachStatementAsForItem<TArg> getItem, GetForEachStatementAsForLength<TArg> getLength, TArg arg)
+        private BoundStatement RewriteForEachStatementAsFor<TArg>(BoundForEachStatement node, GetForEachStatementAsForPreamble? getPreamble, TArg arg, GetForEachStatementAsForItem<TArg> getItem, GetForEachStatementAsForLength<TArg> getLength)
         {
             var forEachSyntax = (CommonForEachStatementSyntax)node.Syntax;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -604,9 +604,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     (LocalRewriter rewriter, ArrayBuilder<BoundExpression> sideeffects, ArrayBuilder<LocalSymbol>? temps) elementArg = (rewriter: this, sideeffects, temps);
                     replacement = RewriteParamsArray(
                                       arg,
-                                      static (BoundExpression element, ref (LocalRewriter rewriter, ArrayBuilder<BoundExpression> sideeffects, ArrayBuilder<LocalSymbol>? temps) elementArg) =>
+                                      elementRewriter: static (BoundExpression element, ref (LocalRewriter rewriter, ArrayBuilder<BoundExpression> sideeffects, ArrayBuilder<LocalSymbol>? temps) elementArg) =>
                                           elementArg.rewriter.EvaluateSideEffects(element, RefKind.None, elementArg.sideeffects, ref elementArg.temps),
-                                      ref elementArg);
+                                      arg: ref elementArg);
                     temps = elementArg.temps;
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else if (appendShouldProceedLocal is not null && resultExpressions.Count > 0)
             {
                 // appendCalls as expressionStatements
-                var appendCallsStatements = resultExpressions.SelectAsArray(static (appendCall, @this) => (BoundStatement)@this._factory.ExpressionStatement(appendCall), this);
+                var appendCallsStatements = resultExpressions.SelectAsArray(map: static (appendCall, @this) => (BoundStatement)@this._factory.ExpressionStatement(appendCall), arg: this);
                 resultExpressions.Free();
 
                 // if (appendShouldProceedLocal) { appendCallsStatements }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -371,8 +371,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 replacement = proxy.Replacement(
                     syntax,
-                    static (frameType, arg) => arg.self.FramePointer(arg.syntax, frameType),
-                    (syntax, self: this));
+                    makeFrame: static (frameType, arg) => arg.self.FramePointer(arg.syntax, frameType),
+                    arg: (syntax, self: this));
 
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/CapturedSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/CapturedSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Rewrite the replacement expression for the hoisted local so all synthesized field are accessed as members
         /// of the appropriate frame.
         /// </summary>
-        public abstract BoundExpression Replacement<TArg>(SyntaxNode node, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame, TArg arg);
+        public abstract BoundExpression Replacement<TArg>(SyntaxNode node, TArg arg, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame);
     }
 
     internal sealed class CapturedToFrameSymbolReplacement : CapturedSymbolReplacement
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.HoistedField = hoistedField;
         }
 
-        public override BoundExpression Replacement<TArg>(SyntaxNode node, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame, TArg arg)
+        public override BoundExpression Replacement<TArg>(SyntaxNode node, TArg arg, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame)
         {
             var frame = makeFrame(this.HoistedField.ContainingType, arg);
             var field = this.HoistedField.AsMember((NamedTypeSymbol)frame.Type);
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.HoistedField = hoistedField;
         }
 
-        public override BoundExpression Replacement<TArg>(SyntaxNode node, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame, TArg arg)
+        public override BoundExpression Replacement<TArg>(SyntaxNode node, TArg arg, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame)
         {
             var frame = makeFrame(this.HoistedField.ContainingType, arg);
             var field = this.HoistedField.AsMember((NamedTypeSymbol)frame.Type);
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.HoistedFields = hoistedFields;
         }
 
-        public override BoundExpression Replacement<TArg>(SyntaxNode node, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame, TArg arg)
+        public override BoundExpression Replacement<TArg>(SyntaxNode node, TArg arg, Func<NamedTypeSymbol, TArg, BoundExpression> makeFrame)
         {
             // By returning the same replacement each time, it is possible we
             // are constructing a DAG instead of a tree for the translation.

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 proxies.TryGetValue(thisParameter, out thisProxy) &&
                 F.Compilation.Options.OptimizationLevel == OptimizationLevel.Release)
             {
-                BoundExpression thisProxyReplacement = thisProxy.Replacement(F.Syntax, static (frameType, F) => F.This(), F);
+                BoundExpression thisProxyReplacement = thisProxy.Replacement(F.Syntax, makeFrame: static (frameType, F) => F.This(), arg: F);
                 Debug.Assert(thisProxyReplacement.Type is not null);
                 this.cachedThis = F.SynthesizedLocal(thisProxyReplacement.Type, syntax: F.Syntax, kind: SynthesizedLocalKind.FrameCache);
             }
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 translatedStatement = F.Block(
                     translatedStatement,
-                    F.Block(variableCleanup.SelectAsArray((e, f) => (BoundStatement)f.ExpressionStatement(e), F)));
+                    F.Block(variableCleanup.SelectAsArray(map: (e, f) => (BoundStatement)f.ExpressionStatement(e), arg: F)));
             }
 
             variableCleanup.Free();
@@ -925,7 +925,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)this.cachedThis != null)
             {
                 CapturedSymbolReplacement proxy = proxies[this.OriginalMethod.ThisParameter];
-                var fetchThis = proxy.Replacement(F.Syntax, static (frameType, F) => F.This(), F);
+                var fetchThis = proxy.Replacement(F.Syntax, makeFrame: static (frameType, F) => F.This(), arg: F);
                 return F.Assignment(F.Local(this.cachedThis), fetchThis);
             }
 
@@ -961,7 +961,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 Debug.Assert(proxy != null);
-                return proxy.Replacement(F.Syntax, static (frameType, F) => F.This(), F);
+                return proxy.Replacement(F.Syntax, makeFrame: static (frameType, F) => F.This(), arg: F);
             }
         }
 
@@ -977,7 +977,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             CapturedSymbolReplacement proxy = proxies[this.OriginalMethod.ThisParameter];
             Debug.Assert(proxy != null);
-            return proxy.Replacement(F.Syntax, static (frameType, F) => F.This(), F);
+            return proxy.Replacement(F.Syntax, makeFrame: static (frameType, F) => F.This(), arg: F);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -313,8 +313,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var leftExpression = proxy.Replacement(
                         F.Syntax,
-                        static (frameType1, arg) => arg.F.Local(arg.stateMachineVariable),
-                        (F, stateMachineVariable));
+                        makeFrame: static (frameType1, arg) => arg.F.Local(arg.stateMachineVariable),
+                        arg: (F, stateMachineVariable));
 
                     bodyBuilder.Add(F.Assignment(leftExpression, F.This()));
                 }
@@ -327,8 +327,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var leftExpression = proxy.Replacement(
                         F.Syntax,
-                        static (frameType1, arg) => arg.F.Local(arg.stateMachineVariable),
-                        (F, stateMachineVariable));
+                        makeFrame: static (frameType1, arg) => arg.F.Local(arg.stateMachineVariable),
+                        arg: (F, stateMachineVariable));
 
                     bodyBuilder.Add(F.Assignment(leftExpression, F.Parameter(parameter)));
                 }
@@ -467,10 +467,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var leftExpression = proxy.Replacement(
                         F.Syntax,
-                        static (stateMachineType, arg) => arg.F.Local(arg.resultVariable),
-                        (F, resultVariable));
+                        makeFrame: static (stateMachineType, arg) => arg.F.Local(arg.resultVariable),
+                        arg: (F, resultVariable));
 
-                    var rightExpression = copySrc[method.ThisParameter].Replacement(F.Syntax, static (stateMachineType, F) => F.This(), F);
+                    var rightExpression = copySrc[method.ThisParameter].Replacement(F.Syntax, makeFrame: static (stateMachineType, F) => F.This(), arg: F);
 
                     bodyBuilder.Add(F.Assignment(leftExpression, rightExpression));
                 }
@@ -486,11 +486,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // result.parameter
                     BoundExpression resultParameter = proxy.Replacement(
                         F.Syntax,
-                        static (stateMachineType, arg) => arg.F.Local(arg.resultVariable),
-                        (F, resultVariable));
+                        makeFrame: static (stateMachineType, arg) => arg.F.Local(arg.resultVariable),
+                        arg: (F, resultVariable));
 
                     // this.parameterProxy
-                    BoundExpression parameterProxy = copySrc[parameter].Replacement(F.Syntax, static (stateMachineType, F) => F.This(), F);
+                    BoundExpression parameterProxy = copySrc[parameter].Replacement(F.Syntax, makeFrame: static (stateMachineType, F) => F.This(), arg: F);
                     BoundStatement copy = InitializeParameterField(getEnumeratorMethod, parameter, resultParameter, parameterProxy);
 
                     bodyBuilder.Add(copy);

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1334,7 +1334,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public ImmutableArray<BoundExpression> TypeOfs(ImmutableArray<TypeWithAnnotations> typeArguments, TypeSymbol systemType)
         {
-            return typeArguments.SelectAsArray(Typeof, systemType);
+            return typeArguments.SelectAsArray(map: Typeof, arg: systemType);
         }
 
         public BoundExpression TypeofDynamicOperationContextType()
@@ -1786,8 +1786,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (discardsPresent)
             {
                 arguments = arguments.SelectAsArray(
-                    (arg, t) => arg.Kind == BoundKind.DiscardExpression ? t.factory.MakeTempForDiscard((BoundDiscardExpression)arg, t.builder) : arg,
-                    (factory: this, builder: builder));
+                    map: (arg, t) => arg.Kind == BoundKind.DiscardExpression ? t.factory.MakeTempForDiscard((BoundDiscardExpression)arg, t.builder) : arg,
+                    arg: (factory: this, builder: builder));
             }
 
             return arguments;

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2301,8 +2301,8 @@ top:
                         TextWindow.LexemeRelativeStart,
                         width,
                         hashCode,
-                        CreateWhitespaceTrivia,
-                        TextWindow);
+                        createTriviaFunction: CreateWhitespaceTrivia,
+                        data: TextWindow);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Parser/LexerCache.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LexerCache.cs
@@ -66,8 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             int keyStart,
             int keyLength,
             int hashCode,
-            Func<TArg, SyntaxTrivia> createTriviaFunction,
-            TArg data)
+            TArg data,
+            Func<TArg, SyntaxTrivia> createTriviaFunction)
         {
             var value = _triviaMap.FindItem(textBuffer, keyStart, keyLength, hashCode);
 
@@ -106,8 +106,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             int keyStart,
             int keyLength,
             int hashCode,
-            Func<TArg, SyntaxToken> createTokenFunction,
-            TArg data)
+            TArg data,
+            Func<TArg, SyntaxToken> createTokenFunction)
         {
             var value = _tokenMap.FindItem(textBuffer, keyStart, keyLength, hashCode);
 

--- a/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
+++ b/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
@@ -242,8 +242,8 @@ exitWhile:
                     TextWindow.LexemeRelativeStart,
                     i - TextWindow.LexemeRelativeStart,
                     hashCode,
-                    CreateQuickToken,
-                    this);
+                    createTokenFunction: CreateQuickToken,
+                    data: this);
                 return token;
             }
             else

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal ImmutableArray<TypeParameterSymbol> SubstituteTypeParameters(ImmutableArray<TypeParameterSymbol> original)
         {
-            return original.SelectAsArray((tp, m) => (TypeParameterSymbol)m.SubstituteTypeParameter(tp).AsTypeSymbolOnly(), this);
+            return original.SelectAsArray(map: (tp, m) => (TypeParameterSymbol)m.SubstituteTypeParameter(tp).AsTypeSymbolOnly(), arg: this);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -249,8 +249,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var key = new SynthesizedDelegateKey(genericTypeDescr);
                     var namedTemplate = this.AnonymousDelegates.GetOrAdd(
                         key,
-                        static (key, @this) => new AnonymousDelegateTemplateSymbol(@this, key.TypeDescriptor),
-                        this);
+                        valueFactory: static (key, @this) => new AnonymousDelegateTemplateSymbol(@this, key.TypeDescriptor),
+                        factoryArgument: this);
 
                     return namedTemplate.Construct(typeArguments);
                 }
@@ -575,7 +575,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (GeneratedNames.TryParseSynthesizedDelegateName(key.Name, out var refKinds, out var returnsVoid, out var generation, out var parameterCount))
                 {
                     var delegateKey = new SynthesizedDelegateKey(parameterCount, refKinds, returnsVoid, generation);
-                    this.AnonymousDelegates.GetOrAdd(delegateKey, (k, args) => CreatePlaceholderSynthesizedDelegateValue(key.Name, args.refKinds, args.returnsVoid, args.parameterCount), (refKinds, returnsVoid, parameterCount));
+                    this.AnonymousDelegates.GetOrAdd(delegateKey, valueFactory: (k, args) => CreatePlaceholderSynthesizedDelegateValue(key.Name, args.refKinds, args.returnsVoid, args.parameterCount), factoryArgument: (refKinds, returnsVoid, parameterCount));
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.DelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.DelegatePublicSymbol.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ImmutableArray.Create<Symbol>(constructor, invokeMethod);
             }
 
-            public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray((member, name) => member.Name == name, name);
+            public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray(predicate: (member, name) => member.Name == name, arg: name);
 
             public override bool IsImplicitlyDeclared => true;
 

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 typeDescr.AssertIsGood();
 
                 var fields = typeDescr.Fields;
-                var properties = fields.SelectAsArray((field, i, type) => new AnonymousTypePropertySymbol(type, field, i), this);
+                var properties = fields.SelectAsArray(map: (field, i, type) => new AnonymousTypePropertySymbol(type, field, i), arg: this);
 
                 //  members
                 int membersCount = fields.Length * 2 + 1;

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override ImmutableArray<Symbol> GetMembers() => _members;
 
-            public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray((member, name) => member.Name == name, name);
+            public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray(predicate: (member, name) => member.Name == name, arg: name);
 
             internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => SpecializedCollections.EmptyEnumerable<FieldSymbol>();
 

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -520,7 +520,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             protected override ArrayTypeSymbol WithElementTypeCore(TypeWithAnnotations newElementType)
             {
-                var newInterfaces = _interfaces.SelectAsArray((i, t) => i.OriginalDefinition.Construct(t), newElementType.Type);
+                var newInterfaces = _interfaces.SelectAsArray(map: (i, t) => i.OriginalDefinition.Construct(t), arg: newElementType.Type);
                 return new SZArray(newElementType, BaseTypeNoUseSiteDiagnostics, newInterfaces);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool _needsGeneratedAttributes_IsFrozen;
 
         internal WellKnownMembersSignatureComparer WellKnownMemberSignatureComparer
-            => InterlockedOperations.Initialize(ref _lazyWellKnownMemberSignatureComparer, static self => new WellKnownMembersSignatureComparer(self), this);
+            => InterlockedOperations.Initialize(ref _lazyWellKnownMemberSignatureComparer, valueFactory: static self => new WellKnownMembersSignatureComparer(self), arg: this);
 
         /// <summary>
         /// Returns a value indicating which embedded attributes should be generated during emit phase.
@@ -845,8 +845,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return default;
                 }
 
-                var names = namesBuilder.SelectAsArray((name, constantType) =>
-                    new TypedConstant(constantType, TypedConstantKind.Primitive, name), stringType);
+                var names = namesBuilder.SelectAsArray(map: (name, constantType) =>
+                    new TypedConstant(constantType, TypedConstantKind.Primitive, name), arg: stringType);
                 namesBuilder.Free();
                 return names;
             }
@@ -893,7 +893,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(flagsBuilder.Any());
                 Debug.Assert(flagsBuilder.Contains(true));
 
-                var result = flagsBuilder.SelectAsArray((flag, constantType) => new TypedConstant(constantType, TypedConstantKind.Primitive, flag), booleanType);
+                var result = flagsBuilder.SelectAsArray(map: (flag, constantType) => new TypedConstant(constantType, TypedConstantKind.Primitive, flag), arg: booleanType);
                 flagsBuilder.Free();
                 return result;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// no members with this name, returns an empty ImmutableArray. Never returns Null.</returns>
         public override ImmutableArray<Symbol> GetMembers(string name)
         {
-            return GetMembers().WhereAsArray((m, name) => m.Name == name, name);
+            return GetMembers().WhereAsArray(predicate: (m, name) => m.Name == name, arg: name);
         }
 
         internal sealed override IEnumerable<FieldSymbol> GetFieldsToEmit()

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -1598,7 +1598,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name, int arity)
         {
-            return GetTypeMembers(name).WhereAsArray((type, arity) => type.Arity == arity, arity);
+            return GetTypeMembers(name).WhereAsArray(predicate: (type, arity) => type.Arity == arity, arg: arity);
         }
 
         public override ImmutableArray<Location> Locations

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public sealed override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name, int arity)
         {
-            return GetTypeMembers(name).WhereAsArray((type, arity) => type.Arity == arity, arity);
+            return GetTypeMembers(name).WhereAsArray(predicate: (type, arity) => type.Arity == arity, arg: arity);
         }
 
         public sealed override ImmutableArray<Location> Locations

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -892,7 +892,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         break;
 
                     default:
-                        var param = parameters.FirstOrDefault(static (p, name) => string.Equals(p.Name, name, StringComparison.Ordinal), name);
+                        var param = parameters.FirstOrDefault(predicate: static (p, name) => string.Equals(p.Name, name, StringComparison.Ordinal), arg: name);
                         if (param is not null && (object)param != this)
                         {
                             builder.Add(param.Ordinal);

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // default implementation does a post-filter. We can override this if its a performance burden, but 
             // experience is that it won't be.
-            return GetTypeMembers(name).WhereAsArray(static (t, arity) => t.Arity == arity, arity);
+            return GetTypeMembers(name).WhereAsArray(predicate: static (t, arity) => t.Arity == arity, arg: arity);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray((member, name) => member.Name == name, name);
+        public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray(predicate: (member, name) => member.Name == name, arg: name);
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => ImmutableArray<NamedTypeSymbol>.Empty;
 
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (_lazyInterfaces.IsDefault)
             {
-                var interfaces = _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved).SelectAsArray((type, map) => map.SubstituteNamedType(type), GetTypeMap());
+                var interfaces = _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved).SelectAsArray(map: (type, map) => map.SubstituteNamedType(type), arg: GetTypeMap());
                 ImmutableInterlocked.InterlockedInitialize(ref _lazyInterfaces, interfaces);
             }
             return _lazyInterfaces;
@@ -356,7 +356,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (_lazyParameters.IsDefault)
                 {
-                    var parameters = UnderlyingMethod.Parameters.SelectAsArray((p, m) => (ParameterSymbol)new NativeIntegerParameterSymbol(m._container, m, p), this);
+                    var parameters = UnderlyingMethod.Parameters.SelectAsArray(map: (p, m) => (ParameterSymbol)new NativeIntegerParameterSymbol(m._container, m, p), arg: this);
                     ImmutableInterlocked.InterlockedInitialize(ref _lazyParameters, parameters);
                 }
                 return _lazyParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
@@ -103,8 +103,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
             {
                 return InterlockedOperations.Initialize(
                     ref _lazyTypeArguments,
-                    static underlying => underlying.TypeArgumentsWithAnnotations.GetPublicSymbols(),
-                    _underlying);
+                    createArray: static underlying => underlying.TypeArgumentsWithAnnotations.GetPublicSymbols(),
+                    arg: _underlying);
             }
         }
 
@@ -125,8 +125,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
             {
                 return InterlockedOperations.Initialize(
                     ref _lazyParameters,
-                    static underlying => underlying.Parameters.GetPublicSymbols(),
-                    _underlying);
+                    createArray: static underlying => underlying.Parameters.GetPublicSymbols(),
+                    arg: _underlying);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -259,14 +259,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var assembly = metadata.GetAssembly();
                 Debug.Assert(assembly is object);
-                var peReferences = assembly.AssemblyReferences.SelectAsArray(MapAssemblyIdentityToResolvedSymbol, referencedAssembliesByIdentity);
+                var peReferences = assembly.AssemblyReferences.SelectAsArray(map: MapAssemblyIdentityToResolvedSymbol, arg: referencedAssembliesByIdentity);
 
                 assemblyReferenceIdentityMap = GetAssemblyReferenceIdentityBaselineMap(peReferences, assembly.AssemblyReferences);
 
                 var assemblySymbol = new PEAssemblySymbol(assembly, DocumentationProvider.Default, isLinked: false, importOptions: importOptions);
 
                 var unifiedAssemblies = this.UnifiedAssemblies.WhereAsArray(
-                    (unified, referencedAssembliesByIdentity) => referencedAssembliesByIdentity.Contains(unified.OriginalReference, allowHigherVersion: false), referencedAssembliesByIdentity);
+                    predicate: (unified, referencedAssembliesByIdentity) => referencedAssembliesByIdentity.Contains(unified.OriginalReference, allowHigherVersion: false), arg: referencedAssembliesByIdentity);
 
                 InitializeAssemblyReuseData(assemblySymbol, peReferences, unifiedAssemblies);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -329,14 +329,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!unboundLambda.HasSignature || unboundLambda.ParameterCount == 0)
             {
                 // The parameters may be omitted in source, but they are still present on the symbol.
-                return parameterTypes.SelectAsArray((type, ordinal, arg) =>
+                return parameterTypes.SelectAsArray(map: (type, ordinal, arg) =>
                                                         SynthesizedParameterSymbol.Create(
                                                             arg.owner,
                                                             type,
                                                             ordinal,
                                                             arg.refKinds[ordinal],
                                                             GeneratedNames.LambdaCopyParameterName(ordinal)), // Make sure nothing binds to this.
-                                                     (owner: this, refKinds: parameterRefKinds));
+                                                     arg: (owner: this, refKinds: parameterRefKinds));
             }
 
             var builder = ArrayBuilder<ParameterSymbol>.GetInstance(unboundLambda.ParameterCount);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -1352,7 +1352,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return (BoundInterpolatedStringArgumentPlaceholder.InstanceParameter, null);
                 }
 
-                var parameter = containingSymbolParameters.FirstOrDefault(static (param, name) => string.Equals(param.Name, name, StringComparison.Ordinal), name);
+                var parameter = containingSymbolParameters.FirstOrDefault(predicate: static (param, name) => string.Equals(param.Name, name, StringComparison.Ordinal), arg: name);
                 if (parameter is null)
                 {
                     // '{0}' is not a valid parameter name from '{1}'.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1294,7 +1294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name, int arity)
         {
-            return GetTypeMembers(name).WhereAsArray((t, arity) => t.Arity == arity, arity);
+            return GetTypeMembers(name).WhereAsArray(predicate: (t, arity) => t.Arity == arity, arg: arity);
         }
 
         private Dictionary<ReadOnlyMemory<char>, ImmutableArray<NamedTypeSymbol>> GetTypeMembersDictionary()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -967,8 +967,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             CheckValidNullableEventOverride(overridingEvent.DeclaringCompilation, overriddenEvent, overridingEvent,
                                                             diagnostics,
-                                                            (diagnostics, overriddenEvent, overridingEvent, location) => diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, location),
-                                                            overridingMemberLocation);
+                                                            reportMismatch: (diagnostics, overriddenEvent, overridingEvent, location) => diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, location),
+                                                            extraArgument: overridingMemberLocation);
                         }
                     }
                     else
@@ -1155,7 +1155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         overriddenMethod,
                         overridingMethod,
                         diagnostics,
-                        static (diagnostics, overriddenMethod, overridingMethod, overridingParameter, _, location) =>
+                        reportMismatchInParameterType: static (diagnostics, overriddenMethod, overridingMethod, overridingParameter, _, location) =>
                             {
                                 diagnostics.Add(
                                     ReportInvalidScopedOverrideAsError(overriddenMethod, overridingMethod) ?
@@ -1164,15 +1164,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     location,
                                     new FormattedSymbol(overridingParameter, SymbolDisplayFormat.ShortFormat));
                             },
-                        overridingMemberLocation,
+                        extraArgument: overridingMemberLocation,
                         allowVariance: true,
                         invokedAsExtensionMethod: false);
                 }
 
                 CheckValidNullableMethodOverride(overridingMethod.DeclaringCompilation, overriddenMethod, overridingMethod, diagnostics,
-                                                 ReportBadReturn,
-                                                 ReportBadParameter,
-                                                 overridingMemberLocation);
+                                                 reportMismatchInReturnType: ReportBadReturn,
+                                                 reportMismatchInParameterType: ReportBadParameter,
+                                                 extraArgument: overridingMemberLocation);
 
                 CheckRefReadonlyInMismatch(
                     overriddenMethod, overridingMethod, diagnostics,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1235,9 +1235,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             MethodSymbol baseMethod,
             MethodSymbol overrideMethod,
             BindingDiagnosticBag diagnostics,
+            TArg extraArgument,
             ReportMismatchInReturnType<TArg> reportMismatchInReturnType,
             ReportMismatchInParameterType<TArg> reportMismatchInParameterType,
-            TArg extraArgument,
             bool invokedAsExtensionMethod = false)
         {
             if (!PerformValidNullableOverrideCheck(compilation, baseMethod, overrideMethod))
@@ -1433,8 +1433,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             MethodSymbol? baseMethod,
             MethodSymbol? overrideMethod,
             BindingDiagnosticBag diagnostics,
-            ReportMismatchInParameterType<TArg> reportMismatchInParameterType,
             TArg extraArgument,
+            ReportMismatchInParameterType<TArg> reportMismatchInParameterType,
             bool allowVariance,
             bool invokedAsExtensionMethod)
         {
@@ -1532,8 +1532,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             EventSymbol overriddenEvent,
             EventSymbol overridingEvent,
             BindingDiagnosticBag diagnostics,
-            Action<BindingDiagnosticBag, EventSymbol, EventSymbol, TArg> reportMismatch,
-            TArg extraArgument)
+            TArg extraArgument,
+            Action<BindingDiagnosticBag, EventSymbol, EventSymbol, TArg> reportMismatch)
         {
             if (!PerformValidNullableOverrideCheck(compilation, overriddenEvent, overridingEvent))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -1022,7 +1022,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var interceptorsNamespaces = ((CSharpParseOptions)attributeNameSyntax.SyntaxTree.Options).InterceptorsPreviewNamespaces;
             var thisNamespaceNames = getNamespaceNames(this);
-            var foundAnyMatch = interceptorsNamespaces.Any(static (ns, thisNamespaceNames) => isDeclaredInNamespace(thisNamespaceNames, ns), thisNamespaceNames);
+            var foundAnyMatch = interceptorsNamespaces.Any(predicate: static (ns, thisNamespaceNames) => isDeclaredInNamespace(thisNamespaceNames, ns), arg: thisNamespaceNames);
             if (!foundAnyMatch)
             {
                 reportFeatureNotEnabled(diagnostics, attributeLocation, thisNamespaceNames);
@@ -1234,11 +1234,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // if we expect '/src/Program.cs':
                 // we might get: 'Program.cs' <-- suffix match
                 var syntaxTrees = DeclaringCompilation.SyntaxTrees;
-                var suffixMatch = syntaxTrees.FirstOrDefault(static (tree, attributeFilePathWithForwardSlashes)
+                var suffixMatch = syntaxTrees.FirstOrDefault(predicate: static (tree, attributeFilePathWithForwardSlashes)
                     => tree.FilePath
                         .Replace('\\', '/')
                         .EndsWith(attributeFilePathWithForwardSlashes),
-                    attributeFilePath.Replace('\\', '/'));
+                    arg: attributeFilePath.Replace('\\', '/'));
                 if (suffixMatch != null)
                 {
                     var recommendedPath = PathUtilities.IsAbsolute(SyntaxTree.FilePath)
@@ -1438,8 +1438,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // member results in an Ambiguous Member error, and we never get to this piece of code at all.
                         // See UnmanagedCallersOnly_PropertyAndFieldNamedCallConvs for an example
                         bool isField = attribute.AttributeClass.GetMembers(key).Any(
-                            static (m, systemType) => m is FieldSymbol { Type: ArrayTypeSymbol { ElementType: NamedTypeSymbol elementType } } && elementType.Equals(systemType, TypeCompareKind.ConsiderEverything),
-                            systemType);
+                            predicate: static (m, systemType) => m is FieldSymbol { Type: ArrayTypeSymbol { ElementType: NamedTypeSymbol elementType } } && elementType.Equals(systemType, TypeCompareKind.ConsiderEverything),
+                            arg: systemType);
 
                         var namedArgumentDecoded = TryDecodeUnmanagedCallersOnlyCallConvsField(key, value, isField, location, diagnostics);
 
@@ -1581,7 +1581,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var cancellationTokenType = DeclaringCompilation.GetWellKnownType(WellKnownType.System_Threading_CancellationToken);
                     var enumeratorCancellationCount = Parameters.Count(p => p.IsSourceParameterWithEnumeratorCancellationAttribute());
                     if (enumeratorCancellationCount == 0 &&
-                        ParameterTypesWithAnnotations.Any(static (p, cancellationTokenType) => p.Type.Equals(cancellationTokenType), cancellationTokenType))
+                        ParameterTypesWithAnnotations.Any(predicate: static (p, cancellationTokenType) => p.Type.Equals(cancellationTokenType), arg: cancellationTokenType))
                     {
                         // Warn for CancellationToken parameters in async-iterators with no parameter decorated with [EnumeratorCancellation]
                         // There could be more than one parameter that could be decorated with [EnumeratorCancellation] so we warn on the method instead

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name, int arity)
         {
-            return GetTypeMembers(name).WhereAsArray((s, arity) => s.Arity == arity, arity);
+            return GetTypeMembers(name).WhereAsArray(predicate: (s, arity) => s.Arity == arity, arg: arity);
         }
 
         internal override ModuleSymbol ContainingModule
@@ -386,11 +386,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var leftTree = possibleFileLocalType.MergedDeclaration.Declarations[0].Location.SourceTree;
                 if (otherSymbol is SourceNamedTypeSymbol { MergedDeclaration.NameLocations: var typeNameLocations })
                 {
-                    return !typeNameLocations.Any(static (loc, leftTree) => (object)loc.SourceTree == leftTree, leftTree);
+                    return !typeNameLocations.Any(predicate: static (loc, leftTree) => (object)loc.SourceTree == leftTree, arg: leftTree);
                 }
                 else if (otherSymbol is SourceNamespaceSymbol { MergedDeclaration.NameLocations: var namespaceNameLocations })
                 {
-                    return !namespaceNameLocations.Any(static (loc, leftTree) => (object)loc.SourceTree == leftTree, leftTree);
+                    return !namespaceNameLocations.Any(predicate: static (loc, leftTree) => (object)loc.SourceTree == leftTree, arg: leftTree);
                 }
 
                 throw ExceptionUtilities.UnexpectedValue(otherSymbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -537,7 +537,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 constructedDefinition,
                 implementation,
                 diagnostics,
-                static (diagnostics, implementedMethod, implementingMethod, implementingParameter, blameAttributes, arg) =>
+                reportMismatchInParameterType: static (diagnostics, implementedMethod, implementingMethod, implementingParameter, blameAttributes, arg) =>
                 {
                     diagnostics.Add(ErrorCode.ERR_ScopedMismatchInParameterOfPartial, implementingMethod.GetFirstLocation(), new FormattedSymbol(implementingParameter, SymbolDisplayFormat.ShortFormat));
                 },
@@ -553,12 +553,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 constructedDefinition,
                 implementation,
                 diagnostics,
-                static (diagnostics, implementedMethod, implementingMethod, topLevel, arg) =>
+                reportMismatchInReturnType: static (diagnostics, implementedMethod, implementingMethod, topLevel, arg) =>
                 {
                     // report only if this is an unsafe *nullability* difference
                     diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, implementingMethod.GetFirstLocation());
                 },
-                static (diagnostics, implementedMethod, implementingMethod, implementingParameter, blameAttributes, arg) =>
+                reportMismatchInParameterType: static (diagnostics, implementedMethod, implementingMethod, implementingParameter, blameAttributes, arg) =>
                 {
                     diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, implementingMethod.GetFirstLocation(), new FormattedSymbol(implementingParameter, SymbolDisplayFormat.ShortFormat));
                 },

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -703,8 +703,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(containingType.IsDefinition);
             return type is TypeParameterSymbol p &&
                 (object)p.ContainingSymbol == containingType &&
-                p.ConstraintTypesNoUseSiteDiagnostics.Any((typeArgument, containingType) => typeArgument.Type.Equals(containingType, ComparisonForUserDefinedOperators),
-                                                          containingType);
+                p.ConstraintTypesNoUseSiteDiagnostics.Any(predicate: (typeArgument, containingType) => typeArgument.Type.Equals(containingType, ComparisonForUserDefinedOperators),
+                                                          arg: containingType);
         }
 
         private bool IsSelfConstrainedTypeParameter(TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -208,22 +208,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override ImmutableArray<NamedTypeSymbol> GetTypeMembersUnordered()
         {
-            return OriginalDefinition.GetTypeMembersUnordered().SelectAsArray((t, self) => t.AsMember(self), this);
+            return OriginalDefinition.GetTypeMembersUnordered().SelectAsArray(map: (t, self) => t.AsMember(self), arg: this);
         }
 
         public sealed override ImmutableArray<NamedTypeSymbol> GetTypeMembers()
         {
-            return OriginalDefinition.GetTypeMembers().SelectAsArray((t, self) => t.AsMember(self), this);
+            return OriginalDefinition.GetTypeMembers().SelectAsArray(map: (t, self) => t.AsMember(self), arg: this);
         }
 
         public sealed override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name)
         {
-            return OriginalDefinition.GetTypeMembers(name).SelectAsArray((t, self) => t.AsMember(self), this);
+            return OriginalDefinition.GetTypeMembers(name).SelectAsArray(map: (t, self) => t.AsMember(self), arg: this);
         }
 
         public sealed override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name, int arity)
         {
-            return OriginalDefinition.GetTypeMembers(name, arity).SelectAsArray((t, self) => t.AsMember(self), this);
+            return OriginalDefinition.GetTypeMembers(name, arity).SelectAsArray(map: (t, self) => t.AsMember(self), arg: this);
         }
 
         internal sealed override bool HasDeclaredRequiredMembers => !_unbound && OriginalDefinition.HasDeclaredRequiredMembers;
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (IsTupleType)
             {
-                var result = GetMembers().WhereAsArray((m, name) => m.Name == name, name);
+                var result = GetMembers().WhereAsArray(predicate: (m, name) => m.Name == name, arg: name);
                 cacheResult(result);
                 return result;
             }
@@ -388,7 +388,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return _unbound
                 ? GetMembers()
-                : OriginalDefinition.GetEarlyAttributeDecodingMembers().SelectAsArray(s_symbolAsMemberFunc, this);
+                : OriginalDefinition.GetEarlyAttributeDecodingMembers().SelectAsArray(map: s_symbolAsMemberFunc, arg: this);
         }
 
         internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListEnumeratorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListEnumeratorTypeSymbol.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<Symbol> GetMembers() => _members;
 
-        public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray(static (m, name) => m.Name == name, name);
+        public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray(predicate: static (m, name) => m.Name == name, arg: name);
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListProperty.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListProperty.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _containingType = containingType;
             _interfaceProperty = interfaceProperty;
             Name = ExplicitInterfaceHelpers.GetMemberName(interfaceProperty.Name, interfaceProperty.ContainingType, aliasQualifierOpt: null);
-            Parameters = interfaceProperty.Parameters.SelectAsArray(static (p, t) => SynthesizedParameterSymbol.DeriveParameter(t, p), this);
+            Parameters = interfaceProperty.Parameters.SelectAsArray(map: static (p, t) => SynthesizedParameterSymbol.DeriveParameter(t, p), arg: this);
             GetMethod = new SynthesizedReadOnlyListMethod(containingType, interfaceProperty.GetMethod, getAccessorBody);
             SetMethod = interfaceProperty.SetMethod is null ? null : new SynthesizedReadOnlyListMethod(containingType, interfaceProperty.SetMethod, setAccessorBody!);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
@@ -875,7 +875,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<Symbol> GetMembers() => _members;
 
-        public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray(static (m, name) => m.Name == name, name);
+        public override ImmutableArray<Symbol> GetMembers(string name) => GetMembers().WhereAsArray(predicate: static (m, name) => m.Name == name, arg: name);
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers()
             => _enumeratorType is not null
@@ -883,10 +883,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 : ImmutableArray<NamedTypeSymbol>.Empty;
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name, int arity)
-            => GetTypeMembers(name).WhereAsArray(static (type, arity) => type.Arity == arity, arity);
+            => GetTypeMembers(name).WhereAsArray(predicate: static (type, arity) => type.Arity == arity, arg: arity);
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name)
-            => GetTypeMembers().WhereAsArray(static (type, name) => type.Name.AsSpan().SequenceEqual(name.Span), name);
+            => GetTypeMembers().WhereAsArray(predicate: static (type, name) => type.Name.AsSpan().SequenceEqual(name.Span), arg: name);
 
         protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData) => throw ExceptionUtilities.Unreachable();
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordDeconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordDeconstruct.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var location = ReturnTypeLocation;
             return (ReturnType: TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Void, location, diagnostics)),
                     Parameters: _ctor.Parameters.SelectAsArray<ParameterSymbol, ImmutableArray<Location>, ParameterSymbol>(
-                                        (param, locations) =>
+                                        map: (param, locations) =>
                                             new SourceSimpleParameterSymbol(owner: this,
                                                 param.TypeWithAnnotations,
                                                 param.Ordinal,

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPropertySymbol.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool HaveCorrespondingSynthesizedRecordPropertySymbol(SourceParameterSymbol parameter)
         {
             return parameter.ContainingSymbol is SynthesizedPrimaryConstructor &&
-                   parameter.ContainingType.GetMembersUnordered().Any((s, parameter) => (s as SynthesizedRecordPropertySymbol)?.BackingParameter == (object)parameter, parameter);
+                   parameter.ContainingType.GetMembersUnordered().Any(predicate: (s, parameter) => (s as SynthesizedRecordPropertySymbol)?.BackingParameter == (object)parameter, arg: parameter);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedAccessorValueParameterSymbol.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _lazyParameterType.Initialize(static (SourceEventAccessorSymbol accessor) =>
+                return _lazyParameterType.Initialize(valueFactory: static (SourceEventAccessorSymbol accessor) =>
                                                      {
                                                          SourceEventSymbol @event = accessor.AssociatedEvent;
 
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                              return @event.TypeWithAnnotations;
                                                          }
                                                      },
-                                                     (SourceEventAccessorSymbol)this.ContainingSymbol);
+                                                     arg: (SourceEventAccessorSymbol)this.ContainingSymbol);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -60,9 +60,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             _containingType = containingType;
 
-            Parameters = parameterDescriptions.SelectAsArrayWithIndex(static (p, i, a) =>
+            Parameters = parameterDescriptions.SelectAsArrayWithIndex(map: static (p, i, a) =>
                 SynthesizedParameterSymbol.Create(a.Method, p.Type, i, p.RefKind, GeneratedNames.AnonymousDelegateParameterName(i, a.ParameterCount), p.Scope, p.DefaultValue, isParams: p.IsParams, hasUnscopedRefAttribute: p.HasUnscopedRefAttribute),
-                (Method: this, ParameterCount: parameterDescriptions.Count));
+                arg: (Method: this, ParameterCount: parameterDescriptions.Count));
             ReturnTypeWithAnnotations = returnType;
             RefKind = refKind;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var binder = compilation.GetBinder(_userMainReturnTypeSyntax);
                 _parameters = SynthesizedParameterSymbol.DeriveParameters(userMain, this);
 
-                var arguments = Parameters.SelectAsArray((p, s) => (BoundExpression)new BoundParameter(s, p, p.Type), _userMainReturnTypeSyntax);
+                var arguments = Parameters.SelectAsArray(map: (p, s) => (BoundExpression)new BoundParameter(s, p, p.Type), arg: _userMainReturnTypeSyntax);
 
                 // Main(args) or Main()
                 BoundCall userMainInvocation = new BoundCall(

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -298,8 +298,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static ImmutableArray<ParameterSymbol> DeriveParameters(MethodSymbol sourceMethod, MethodSymbol destinationMethod)
         {
             return sourceMethod.Parameters.SelectAsArray(
-                static (oldParam, destinationMethod) => DeriveParameter(destinationMethod, oldParam),
-                destinationMethod);
+                map: static (oldParam, destinationMethod) => DeriveParameter(destinationMethod, oldParam),
+                arg: destinationMethod);
         }
 
         internal static ParameterSymbol DeriveParameter(Symbol destination, ParameterSymbol oldParam)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1772,7 +1772,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var implementedEvent = (EventSymbol)interfaceMember;
                     SourceMemberContainerTypeSymbol.CheckValidNullableEventOverride(compilation, implementedEvent, implementingEvent,
                                                                                     diagnostics,
-                                                                                    (diagnostics, implementedEvent, implementingEvent, arg) =>
+                                                                                    reportMismatch: (diagnostics, implementedEvent, implementingEvent, arg) =>
                                                                                     {
                                                                                         if (arg.isExplicit)
                                                                                         {
@@ -1787,7 +1787,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                                                                             new FormattedSymbol(implementedEvent, SymbolDisplayFormat.MinimallyQualifiedFormat));
                                                                                         }
                                                                                     },
-                                                                                    (implementingType, isExplicit));
+                                                                                    extraArgument: (implementingType, isExplicit));
                 }
                 else
                 {
@@ -1851,9 +1851,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             implementedMethod,
                             implementingMethod,
                             diagnostics,
-                            reportMismatchInReturnType,
-                            reportMismatchInParameterType,
-                            (implementingType, isExplicit));
+                            reportMismatchInReturnType: reportMismatchInReturnType,
+                            reportMismatchInParameterType: reportMismatchInParameterType,
+                            extraArgument: (implementingType, isExplicit));
 
                         if (SourceMemberContainerTypeSymbol.RequiresValidScopedOverrideForRefSafety(implementedMethod))
                         {
@@ -1861,7 +1861,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 implementedMethod,
                                 implementingMethod,
                                 diagnostics,
-                                static (diagnostics, implementedMethod, implementingMethod, implementingParameter, _, arg) =>
+                                reportMismatchInParameterType: static (diagnostics, implementedMethod, implementingMethod, implementingParameter, _, arg) =>
                                     {
                                         diagnostics.Add(
                                             SourceMemberContainerTypeSymbol.ReportInvalidScopedOverrideAsError(implementedMethod, implementingMethod) ?
@@ -1870,7 +1870,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                             GetImplicitImplementationDiagnosticLocation(implementedMethod, arg.implementingType, implementingMethod),
                                             new FormattedSymbol(implementingParameter, SymbolDisplayFormat.ShortFormat));
                                     },
-                                (implementingType, isExplicit),
+                                extraArgument: (implementingType, isExplicit),
                                 allowVariance: true,
                                 invokedAsExtensionMethod: false);
                         }

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -712,7 +712,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private NullableContextStateMap GetNullableContextStateMap()
             // Create the #nullable directive map on demand.
-            => _lazyNullableContextStateMap.Initialize(static @this => NullableContextStateMap.Create(@this), this);
+            => _lazyNullableContextStateMap.Initialize(valueFactory: static @this => NullableContextStateMap.Create(@this), arg: this);
 
         internal NullableContextState GetNullableContextState(int position)
             => GetNullableContextStateMap().GetContextState(position);

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="type"></param>
         /// <param name="action"></param>
         /// <param name="argument">The argument that is passed to the action whenever it is invoked</param>
-        internal static void VisitRankSpecifiers<TArg>(this TypeSyntax type, Action<ArrayRankSpecifierSyntax, TArg> action, in TArg argument)
+        internal static void VisitRankSpecifiers<TArg>(this TypeSyntax type, in TArg argument, Action<ArrayRankSpecifierSyntax, TArg> action)
         {
             // Use a manual stack here to avoid deeply nested recursion which can blow the real stack
             var stack = ArrayBuilder<SyntaxNode>.GetInstance();

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -11987,7 +11987,7 @@ class C
 System.NotImplementedException: 28
    at TestAnalyzer.get_SupportedDiagnostics()
    at Microsoft.CodeAnalysis.Diagnostics.AnalyzerManager.AnalyzerExecutionContext.<>c__DisplayClass21_0.<ComputeDiagnosticDescriptors_NoLock>b__0(Object _)
-   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info, CancellationToken cancellationToken)
+   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, TArg argument, Action`1 analyze, Nullable`1 info, CancellationToken cancellationToken)
 -----
 Analyzer 'TestAnalyzer' threw an exception of type 'System.NotImplementedException' with message '28'.
 System.NotImplementedException: 28

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ArrayBuilderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ArrayBuilderTests.cs
@@ -18,22 +18,22 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         {
             var builder = new ArrayBuilder<int> { 6, 5, 1, 2, 3, 2, 4, 5, 1, 7 };
 
-            builder.RemoveAll((_, _) => false, arg: 0);
+            builder.RemoveAll(match: (_, _) => false, arg: 0);
             AssertEx.Equal([6, 5, 1, 2, 3, 2, 4, 5, 1, 7], builder);
 
-            builder.RemoveAll((i, arg) => i == arg, arg: 6);
+            builder.RemoveAll(match: (i, arg) => i == arg, arg: 6);
             AssertEx.Equal([5, 1, 2, 3, 2, 4, 5, 1, 7], builder);
 
-            builder.RemoveAll((i, arg) => i == arg, arg: 7);
+            builder.RemoveAll(match: (i, arg) => i == arg, arg: 7);
             AssertEx.Equal([5, 1, 2, 3, 2, 4, 5, 1], builder);
 
-            builder.RemoveAll((i, arg) => i < arg, arg: 3);
+            builder.RemoveAll(match: (i, arg) => i < arg, arg: 3);
             AssertEx.Equal([5, 3, 4, 5], builder);
 
-            builder.RemoveAll((_, _) => true, arg: 0);
+            builder.RemoveAll(match: (_, _) => true, arg: 0);
             AssertEx.Equal([], builder);
 
-            builder.RemoveAll((_, _) => true, arg: 0);
+            builder.RemoveAll(match: (_, _) => true, arg: 0);
             AssertEx.Equal([], builder);
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
@@ -156,15 +156,15 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         [Fact]
         public void Single_Arg()
         {
-            Assert.Throws<NullReferenceException>(() => default(ImmutableArray<int>).Single((_, _) => true, 1));
-            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>().Single((x, a) => x == a, 1));
-            Assert.Equal(1, ImmutableArray.Create<int>(1).Single((x, a) => x == a, 1));
-            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>(1, 1).Single((x, a) => x == a, 1));
+            Assert.Throws<NullReferenceException>(() => default(ImmutableArray<int>).Single(predicate: (_, _) => true, arg: 1));
+            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>().Single(predicate: (x, a) => x == a, arg: 1));
+            Assert.Equal(1, ImmutableArray.Create<int>(1).Single(predicate: (x, a) => x == a, arg: 1));
+            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>(1, 1).Single(predicate: (x, a) => x == a, arg: 1));
 
-            Assert.Throws<NullReferenceException>(() => default(ImmutableArray<int>).Single((x, a) => x % a == 1, 2));
-            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>().Single((x, a) => x % a == 1, 2));
-            Assert.Equal(1, ImmutableArray.Create<int>(1, 2).Single((x, a) => x % a == 1, 2));
-            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>(1, 2, 3).Single((x, a) => x % a == 1, 2));
+            Assert.Throws<NullReferenceException>(() => default(ImmutableArray<int>).Single(predicate: (x, a) => x % a == 1, arg: 2));
+            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>().Single(predicate: (x, a) => x % a == 1, arg: 2));
+            Assert.Equal(1, ImmutableArray.Create<int>(1, 2).Single(predicate: (x, a) => x % a == 1, arg: 2));
+            Assert.Throws<InvalidOperationException>(() => ImmutableArray.Create<int>(1, 2, 3).Single(predicate: (x, a) => x % a == 1, arg: 2));
         }
 
         [Fact]
@@ -359,21 +359,21 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         {
             var empty = ImmutableArray.Create<object>();
             Assert.True(empty.SequenceEqual(empty.SelectAsArray(item => item)));
-            Assert.True(empty.SequenceEqual(empty.SelectAsArray((item, arg) => item, 1)));
-            Assert.True(empty.SequenceEqual(empty.SelectAsArray((item, arg) => arg, 2)));
-            Assert.True(empty.SequenceEqual(empty.SelectAsArray((item, index, arg) => item, 1)));
-            Assert.True(empty.SequenceEqual(empty.SelectAsArray((item, index, arg) => arg, 2)));
-            Assert.True(empty.SequenceEqual(empty.SelectAsArray((item, index, arg) => index, 3)));
+            Assert.True(empty.SequenceEqual(empty.SelectAsArray(map: (item, arg) => item, arg: 1)));
+            Assert.True(empty.SequenceEqual(empty.SelectAsArray(map: (item, arg) => arg, arg: 2)));
+            Assert.True(empty.SequenceEqual(empty.SelectAsArray(map: (item, index, arg) => item, arg: 1)));
+            Assert.True(empty.SequenceEqual(empty.SelectAsArray(map: (item, index, arg) => arg, arg: 2)));
+            Assert.True(empty.SequenceEqual(empty.SelectAsArray(map: (item, index, arg) => index, arg: 3)));
 
             var a = ImmutableArray.Create<int>(3, 2, 1, 0);
             var b = ImmutableArray.Create<int>(0, 1, 2, 3);
             var c = ImmutableArray.Create<int>(2, 2, 2, 2);
             Assert.True(a.SequenceEqual(a.SelectAsArray(item => item)));
-            Assert.True(a.SequenceEqual(a.SelectAsArray((item, arg) => item, 1)));
-            Assert.True(c.SequenceEqual(a.SelectAsArray((item, arg) => arg, 2)));
-            Assert.True(a.SequenceEqual(a.SelectAsArray((item, index, arg) => item, 1)));
-            Assert.True(c.SequenceEqual(a.SelectAsArray((item, index, arg) => arg, 2)));
-            Assert.True(b.SequenceEqual(a.SelectAsArray((item, index, arg) => index, 3)));
+            Assert.True(a.SequenceEqual(a.SelectAsArray(map: (item, arg) => item, arg: 1)));
+            Assert.True(c.SequenceEqual(a.SelectAsArray(map: (item, arg) => arg, arg: 2)));
+            Assert.True(a.SequenceEqual(a.SelectAsArray(map: (item, index, arg) => item, arg: 1)));
+            Assert.True(c.SequenceEqual(a.SelectAsArray(map: (item, index, arg) => arg, arg: 2)));
+            Assert.True(b.SequenceEqual(a.SelectAsArray(map: (item, index, arg) => index, arg: 3)));
 
             AssertEx.Equal(new[] { 10 }, ImmutableArray.Create(1).SelectAsArray(i => 10 * i));
             AssertEx.Equal(new[] { 10, 20 }, ImmutableArray.Create(1, 2).SelectAsArray(i => 10 * i));
@@ -493,10 +493,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         public void WhereAsArray_WithArg()
         {
             var x = new C();
-            Assert.Same(x, ImmutableArray.Create<object>(x).WhereAsArray((o, arg) => o == arg, x)[0]);
+            Assert.Same(x, ImmutableArray.Create<object>(x).WhereAsArray(predicate: (o, arg) => o == arg, arg: x)[0]);
 
             var a = ImmutableArray.Create(0, 1, 2, 3, 4, 5);
-            AssertEx.Equal(new[] { 3, 4, 5 }, a.WhereAsArray((i, j) => i > j, 2));
+            AssertEx.Equal(new[] { 3, 4, 5 }, a.WhereAsArray(predicate: (i, j) => i > j, arg: 2));
         }
 
         private class C

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/TemporaryArrayTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/TemporaryArrayTests.cs
@@ -312,13 +312,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             array.Add(3);
 
             Assert.Equal(3, array.SingleOrDefault(p => p > 2));
-            Assert.Equal(3, array.SingleOrDefault((p, arg) => p > arg, arg: 2));
+            Assert.Equal(3, array.SingleOrDefault(predicate: (p, arg) => p > arg, arg: 2));
 
             Assert.Equal(0, array.SingleOrDefault(p => p > 5));
-            Assert.Equal(0, array.SingleOrDefault((p, arg) => p > arg, arg: 5));
+            Assert.Equal(0, array.SingleOrDefault(predicate: (p, arg) => p > arg, arg: 5));
 
             Assert.Throws<InvalidOperationException>(() => array.SingleOrDefault(p => p > 1));
-            Assert.Throws<InvalidOperationException>(() => array.SingleOrDefault((p, arg) => p > arg, arg: 1));
+            Assert.Throws<InvalidOperationException>(() => array.SingleOrDefault(predicate: (p, arg) => p > arg, arg: 1));
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/OneOrManyTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/OneOrManyTests.cs
@@ -114,10 +114,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
         [Fact]
         public void Select_WithArg()
         {
-            Verify(OneOrMany.Create(1).Select((i, a) => i + a, 1), 2);
-            Verify(OneOrMany.Create(ImmutableArray<int>.Empty).Select((i, a) => i + a, 1));
-            Verify(OneOrMany.Create(ImmutableArray.Create(1)).Select((i, a) => i + a, 1), 2);
-            Verify(OneOrMany.Create(ImmutableArray.Create(1, 2)).Select((i, a) => i + a, 1), 2, 3);
+            Verify(OneOrMany.Create(1).Select(selector: (i, a) => i + a, arg: 1), 2);
+            Verify(OneOrMany.Create(ImmutableArray<int>.Empty).Select(selector: (i, a) => i + a, arg: 1));
+            Verify(OneOrMany.Create(ImmutableArray.Create(1)).Select(selector: (i, a) => i + a, arg: 1), 2);
+            Verify(OneOrMany.Create(ImmutableArray.Create(1, 2)).Select(selector: (i, a) => i + a, arg: 1), 2, 3);
         }
 
         [Fact]
@@ -135,13 +135,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
         [Fact]
         public void FirstOrDefault_WithArg()
         {
-            Assert.Equal(1, OneOrMany.Create(1).FirstOrDefault((i, a) => i < a, 2));
-            Assert.Equal(0, OneOrMany.Create(1).FirstOrDefault((i, a) => i > a, 2));
-            Assert.Equal(0, OneOrMany.Create(ImmutableArray<int>.Empty).FirstOrDefault((i, a) => i > a, 2));
-            Assert.Equal(1, OneOrMany.Create(ImmutableArray.Create(1)).FirstOrDefault((i, a) => i < a, 2));
-            Assert.Equal(0, OneOrMany.Create(ImmutableArray.Create(1)).FirstOrDefault((i, a) => i > a, 2));
-            Assert.Equal(1, OneOrMany.Create(ImmutableArray.Create(1, 3)).FirstOrDefault((i, a) => i < a, 2));
-            Assert.Equal(3, OneOrMany.Create(ImmutableArray.Create(1, 3)).FirstOrDefault((i, a) => i > a, 2));
+            Assert.Equal(1, OneOrMany.Create(1).FirstOrDefault(predicate: (i, a) => i < a, arg: 2));
+            Assert.Equal(0, OneOrMany.Create(1).FirstOrDefault(predicate: (i, a) => i > a, arg: 2));
+            Assert.Equal(0, OneOrMany.Create(ImmutableArray<int>.Empty).FirstOrDefault(predicate: (i, a) => i > a, arg: 2));
+            Assert.Equal(1, OneOrMany.Create(ImmutableArray.Create(1)).FirstOrDefault(predicate: (i, a) => i < a, arg: 2));
+            Assert.Equal(0, OneOrMany.Create(ImmutableArray.Create(1)).FirstOrDefault(predicate: (i, a) => i > a, arg: 2));
+            Assert.Equal(1, OneOrMany.Create(ImmutableArray.Create(1, 3)).FirstOrDefault(predicate: (i, a) => i < a, arg: 2));
+            Assert.Equal(3, OneOrMany.Create(ImmutableArray.Create(1, 3)).FirstOrDefault(predicate: (i, a) => i > a, arg: 2));
         }
 
         [Fact]
@@ -160,14 +160,14 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
         [Fact]
         public void All_WithArg()
         {
-            Assert.True(OneOrMany<int>.Empty.All((_, _) => false, 0));
-            Assert.True(OneOrMany<int>.Empty.All((_, _) => true, 0));
+            Assert.True(OneOrMany<int>.Empty.All(predicate: (_, _) => false, arg: 0));
+            Assert.True(OneOrMany<int>.Empty.All(predicate: (_, _) => true, arg: 0));
 
-            Assert.False(OneOrMany.Create(1).All((i, a) => i > a, 1));
-            Assert.True(OneOrMany.Create(1).All((i, a) => i > a, 0));
+            Assert.False(OneOrMany.Create(1).All(predicate: (i, a) => i > a, arg: 1));
+            Assert.True(OneOrMany.Create(1).All(predicate: (i, a) => i > a, arg: 0));
 
-            Assert.False(OneOrMany.Create(1, 2).All((i, a) => i > a, 1));
-            Assert.True(OneOrMany.Create(1, 2).All((i, a) => i > a, 0));
+            Assert.False(OneOrMany.Create(1, 2).All(predicate: (i, a) => i > a, arg: 1));
+            Assert.True(OneOrMany.Create(1, 2).All(predicate: (i, a) => i > a, arg: 0));
         }
 
         [Fact]
@@ -194,14 +194,14 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
         [Fact]
         public void Any_Predicate_WithArg()
         {
-            Assert.False(OneOrMany<int>.Empty.Any((_, _) => false, 0));
-            Assert.False(OneOrMany<int>.Empty.Any((_, _) => true, 0));
+            Assert.False(OneOrMany<int>.Empty.Any(predicate: (_, _) => false, arg: 0));
+            Assert.False(OneOrMany<int>.Empty.Any(predicate: (_, _) => true, arg: 0));
 
-            Assert.False(OneOrMany.Create(1).Any((i, a) => i > a, 1));
-            Assert.True(OneOrMany.Create(1).Any((i, a) => i > a, 0));
+            Assert.False(OneOrMany.Create(1).Any(predicate: (i, a) => i > a, arg: 1));
+            Assert.True(OneOrMany.Create(1).Any(predicate: (i, a) => i > a, arg: 0));
 
-            Assert.False(OneOrMany.Create(1, 2).Any((i, a) => i < a, 0));
-            Assert.True(OneOrMany.Create(1, 2).Any((i, a) => i > a, 1));
+            Assert.False(OneOrMany.Create(1, 2).Any(predicate: (i, a) => i < a, arg: 0));
+            Assert.True(OneOrMany.Create(1, 2).Any(predicate: (i, a) => i > a, arg: 1));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="map">The mapping delegate</param>
         /// <param name="arg">The extra input used by mapping delegate</param>
         /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
-        public static ImmutableArray<TResult> SelectAsArray<TItem, TArg, TResult>(this ArrayBuilder<TItem> items, Func<TItem, TArg, TResult> map, TArg arg)
+        public static ImmutableArray<TResult> SelectAsArray<TItem, TArg, TResult>(this ArrayBuilder<TItem> items, TArg arg, Func<TItem, TArg, TResult> map)
         {
             switch (items.Count)
             {
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="map">The mapping delegate</param>
         /// <param name="arg">The extra input used by mapping delegate</param>
         /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
-        public static ImmutableArray<TResult> SelectAsArrayWithIndex<TItem, TArg, TResult>(this ArrayBuilder<TItem> items, Func<TItem, int, TArg, TResult> map, TArg arg)
+        public static ImmutableArray<TResult> SelectAsArrayWithIndex<TItem, TArg, TResult>(this ArrayBuilder<TItem> items, TArg arg, Func<TItem, int, TArg, TResult> map)
         {
             switch (items.Count)
             {

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="array">The array to process</param>
         /// <param name="predicate">The delegate that defines the conditions of the element to search for.</param>
         public static ImmutableArray<T> WhereAsArray<T, TArg>(this ImmutableArray<T> array, Func<T, TArg, bool> predicate, TArg arg)
-            => WhereAsArrayImpl(array, predicateWithoutArg: null, predicate, arg);
+            => WhereAsArrayImpl(array, predicateWithoutArg: null, predicateWithArg: predicate, arg: arg);
 
         private static ImmutableArray<T> WhereAsArrayImpl<T, TArg>(ImmutableArray<T> array, Func<T, bool>? predicateWithoutArg, Func<T, TArg, bool>? predicateWithArg, TArg arg)
         {

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="map">The mapping delegate</param>
         /// <param name="arg">The extra input used by mapping delegate</param>
         /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
-        public static ImmutableArray<TResult> SelectAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> items, Func<TItem, TArg, TResult> map, TArg arg)
+        public static ImmutableArray<TResult> SelectAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> items, TArg arg, Func<TItem, TArg, TResult> map)
         {
             return ImmutableArray.CreateRange(items, map, arg);
         }
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="map">The mapping delegate</param>
         /// <param name="arg">The extra input used by mapping delegate</param>
         /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
-        public static ImmutableArray<TResult> SelectAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> items, Func<TItem, int, TArg, TResult> map, TArg arg)
+        public static ImmutableArray<TResult> SelectAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> items, TArg arg, Func<TItem, int, TArg, TResult> map)
         {
             switch (items.Length)
             {
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="selector">A transform function to apply to each element that is not filtered out by <paramref name="predicate"/>.</param>
         /// <param name="arg">The extra input used by <paramref name="predicate"/> and <paramref name="selector"/>.</param>
         /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
-        public static ImmutableArray<TResult> SelectAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> array, Func<TItem, TArg, bool> predicate, Func<TItem, TArg, TResult> selector, TArg arg)
+        public static ImmutableArray<TResult> SelectAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> array, TArg arg, Func<TItem, TArg, bool> predicate, Func<TItem, TArg, TResult> selector)
         {
             if (array.Length == 0)
             {
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Maps an immutable array through a function that returns ValueTasks, returning the new ImmutableArray.
         /// </summary>
-        public static async ValueTask<ImmutableArray<TResult>> SelectAsArrayAsync<TItem, TArg, TResult>(this ImmutableArray<TItem> array, Func<TItem, TArg, CancellationToken, ValueTask<TResult>> selector, TArg arg, CancellationToken cancellationToken)
+        public static async ValueTask<ImmutableArray<TResult>> SelectAsArrayAsync<TItem, TArg, TResult>(this ImmutableArray<TItem> array, TArg arg, Func<TItem, TArg, CancellationToken, ValueTask<TResult>> selector, CancellationToken cancellationToken)
         {
             if (array.IsEmpty)
                 return ImmutableArray<TResult>.Empty;
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
-        public static ValueTask<ImmutableArray<TResult>> SelectManyAsArrayAsync<TItem, TArg, TResult>(this ImmutableArray<TItem> source, Func<TItem, TArg, CancellationToken, ValueTask<ImmutableArray<TResult>>> selector, TArg arg, CancellationToken cancellationToken)
+        public static ValueTask<ImmutableArray<TResult>> SelectManyAsArrayAsync<TItem, TArg, TResult>(this ImmutableArray<TItem> source, TArg arg, Func<TItem, TArg, CancellationToken, ValueTask<ImmutableArray<TResult>>> selector, CancellationToken cancellationToken)
         {
             if (source.Length == 0)
             {
@@ -471,10 +471,10 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="array">The array to process</param>
         /// <param name="predicate">The delegate that defines the conditions of the element to search for.</param>
-        public static ImmutableArray<T> WhereAsArray<T, TArg>(this ImmutableArray<T> array, Func<T, TArg, bool> predicate, TArg arg)
+        public static ImmutableArray<T> WhereAsArray<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
             => WhereAsArrayImpl(array, predicateWithoutArg: null, predicateWithArg: predicate, arg: arg);
 
-        private static ImmutableArray<T> WhereAsArrayImpl<T, TArg>(ImmutableArray<T> array, Func<T, bool>? predicateWithoutArg, Func<T, TArg, bool>? predicateWithArg, TArg arg)
+        private static ImmutableArray<T> WhereAsArrayImpl<T, TArg>(ImmutableArray<T> array, Func<T, bool>? predicateWithoutArg, TArg arg, Func<T, TArg, bool>? predicateWithArg)
         {
             Debug.Assert(!array.IsDefault);
             Debug.Assert(predicateWithArg != null ^ predicateWithoutArg != null);
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static bool Any<T, TArg>(this ImmutableArray<T> array, Func<T, TArg, bool> predicate, TArg arg)
+        public static bool Any<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
         {
             int n = array.Length;
             for (int i = 0; i < n; i++)
@@ -559,7 +559,7 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
-        public static bool All<T, TArg>(this ImmutableArray<T> array, Func<T, TArg, bool> predicate, TArg arg)
+        public static bool All<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
         {
             int n = array.Length;
             for (int i = 0; i < n; i++)
@@ -591,7 +591,7 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
-        public static async Task<bool> AnyAsync<T, TArg>(this ImmutableArray<T> array, Func<T, TArg, Task<bool>> predicateAsync, TArg arg)
+        public static async Task<bool> AnyAsync<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, Task<bool>> predicateAsync)
         {
             int n = array.Length;
             for (int i = 0; i < n; i++)
@@ -623,7 +623,7 @@ namespace Microsoft.CodeAnalysis
             return default;
         }
 
-        public static TValue? FirstOrDefault<TValue, TArg>(this ImmutableArray<TValue> array, Func<TValue, TArg, bool> predicate, TArg arg)
+        public static TValue? FirstOrDefault<TValue, TArg>(this ImmutableArray<TValue> array, TArg arg, Func<TValue, TArg, bool> predicate)
         {
             foreach (var val in array)
             {
@@ -636,7 +636,7 @@ namespace Microsoft.CodeAnalysis
             return default;
         }
 
-        public static TValue? Single<TValue, TArg>(this ImmutableArray<TValue> array, Func<TValue, TArg, bool> predicate, TArg arg)
+        public static TValue? Single<TValue, TArg>(this ImmutableArray<TValue> array, TArg arg, Func<TValue, TArg, bool> predicate)
         {
             var hasValue = false;
             TValue? value = default;

--- a/src/Compilers/Core/Portable/Collections/OrderPreservingMultiDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/OrderPreservingMultiDictionary.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Collections
             }
         }
 
-        public bool TryGetValue<TArg>(K key, Func<V, TArg, bool> predicate, TArg arg, [MaybeNullWhen(false)] out V value)
+        public bool TryGetValue<TArg>(K key, TArg arg, Func<V, TArg, bool> predicate, [MaybeNullWhen(false)] out V value)
         {
             if (_dictionary is not null && _dictionary.TryGetValue(key, out var valueSet))
             {

--- a/src/Compilers/Core/Portable/Collections/TemporaryArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/TemporaryArrayExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             return result;
         }
 
-        public static T? SingleOrDefault<T, TArg>(this in TemporaryArray<T> array, Func<T, TArg, bool> predicate, TArg arg)
+        public static T? SingleOrDefault<T, TArg>(this in TemporaryArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
         {
             var first = true;
             T? result = default;
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
         public static T? FirstOrDefault<T>(this in TemporaryArray<T> array)
             => array.Count > 0 ? array[0] : default;
 
-        public static T? FirstOrDefault<T, TArg>(this in TemporaryArray<T> array, Func<T, TArg, bool> predicate, TArg arg)
+        public static T? FirstOrDefault<T, TArg>(this in TemporaryArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
         {
             foreach (var item in array)
             {
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             return default;
         }
 
-        public static int IndexOf<T, TArg>(this in TemporaryArray<T> array, Func<T, TArg, bool> predicate, TArg arg)
+        public static int IndexOf<T, TArg>(this in TemporaryArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
         {
             var index = 0;
             foreach (var item in array)

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis
         /// Gets an <see cref="AnalyzerConfigOptionsResult"/> that contain the options that apply globally
         /// </summary>
         public AnalyzerConfigOptionsResult GlobalConfigOptions
-            => _lazyConfigOptions.Initialize(static @this => @this.ParseGlobalConfigOptions(), this);
+            => _lazyConfigOptions.Initialize(valueFactory: static @this => @this.ParseGlobalConfigOptions(), arg: this);
 
         /// <summary>
         /// Returns a <see cref="AnalyzerConfigOptionsResult"/> for a source file. This computes which <see cref="AnalyzerConfig"/> rules applies to this file, and correctly applies

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     : null;
 
                 return analyzers.WhereAsArray(
-                    static (analyzer, arg) =>
+                    predicate: static (analyzer, arg) =>
                     {
                         // If the analyzer has not executed for the entire compilation, or we are computing
                         // pending analyzers for a specific filterScope and the analyzer has not executed on
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                         return false;
                     },
-                    (self: this, completedAnalyzersForFile));
+                    arg: (self: this, completedAnalyzersForFile));
             }
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActions.cs
@@ -56,8 +56,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 Debug.Assert(!analyzers.IsDefaultOrEmpty);
 
                 var groups = analyzers.SelectAsArray(
-                    (analyzer, analyzerActions) => (analyzer, new GroupedAnalyzerActionsForAnalyzer(analyzer, analyzerActions, analyzerActionsNeedFiltering: true)),
-                    analyzerActions);
+                    map: (analyzer, analyzerActions) => (analyzer, new GroupedAnalyzerActionsForAnalyzer(analyzer, analyzerActions, analyzerActionsNeedFiltering: true)),
+                    arg: analyzerActions);
                 return new GroupedAnalyzerActions(groups, in analyzerActions);
             }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActionsForAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActionsForAnalyzer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     return actions;
                 }
 
-                return actions.WhereAsArray((action, analyzer) => action.Analyzer == analyzer, analyzer);
+                return actions.WhereAsArray(predicate: (action, analyzer) => action.Analyzer == analyzer, arg: analyzer);
             }
 
             public ImmutableSegmentedDictionary<TLanguageKindEnum, ImmutableArray<SyntaxNodeAnalyzerAction<TLanguageKindEnum>>> NodeActionsByAnalyzerAndKind

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -205,10 +205,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // The Initialize method should be run asynchronously in case it is not well behaved, e.g. does not terminate.
             ExecuteAndCatchIfThrows(
                 analyzer,
-                data => data.analyzer.Initialize(data.context),
-                (analyzer, context),
+                analyze: data => data.analyzer.Initialize(data.context),
+                argument: (analyzer, context),
                 contextInfo: null,
-                cancellationToken);
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -228,10 +228,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 ExecuteAndCatchIfThrows(
                     startAction.Analyzer,
-                    data => data.action(data.context),
-                    (action: startAction.Action, context),
-                    new AnalysisContextInfo(Compilation),
-                    cancellationToken);
+                    analyze: data => data.action(data.context),
+                    argument: (action: startAction.Action, context),
+                    contextInfo: new AnalysisContextInfo(Compilation),
+                    cancellationToken: cancellationToken);
             }
         }
 
@@ -270,10 +270,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 ExecuteAndCatchIfThrows(
                     startAction.Analyzer,
-                    data => data.action(data.context),
-                    (action: startAction.Action, context),
-                    new AnalysisContextInfo(Compilation, symbol),
-                    cancellationToken);
+                    analyze: data => data.action(data.context),
+                    argument: (action: startAction.Action, context),
+                    contextInfo: new AnalysisContextInfo(Compilation, symbol),
+                    cancellationToken: cancellationToken);
             }
         }
 
@@ -302,10 +302,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             ExecuteAndCatchIfThrows(
                 suppressor,
-                data => data.action(data.context),
-                (action, context),
-                new AnalysisContextInfo(Compilation),
-                cancellationToken);
+                analyze: data => data.action(data.context),
+                argument: (action, context),
+                contextInfo: new AnalysisContextInfo(Compilation),
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var addDiagnostic = GetAddCompilationDiagnostic(analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var endAction in compilationActions)
             {
@@ -337,10 +337,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 ExecuteAndCatchIfThrows(
                     endAction.Analyzer,
-                    data => data.action(data.context),
-                    (action: endAction.Action, context),
-                    new AnalysisContextInfo(Compilation),
-                    cancellationToken);
+                    analyze: data => data.action(data.context),
+                    argument: (action: endAction.Action, context),
+                    contextInfo: new AnalysisContextInfo(Compilation),
+                    cancellationToken: cancellationToken);
             }
         }
 
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var symbol = symbolDeclaredEvent.Symbol;
             var addDiagnostic = GetAddDiagnostic(symbol, symbolDeclaredEvent.DeclaringSyntaxReferences, analyzer, getTopMostNodeForAnalysis, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var symbolAction in symbolActions)
             {
@@ -391,10 +391,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     ExecuteAndCatchIfThrows(
                         symbolAction.Analyzer,
-                        data => data.action(data.context),
-                        (action, context),
-                        new AnalysisContextInfo(Compilation, symbol),
-                        cancellationToken);
+                        analyze: data => data.action(data.context),
+                        argument: (action, context),
+                        contextInfo: new AnalysisContextInfo(Compilation, symbol),
+                        cancellationToken: cancellationToken);
                 }
             }
         }
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var symbol = symbolDeclaredEvent.Symbol;
             var addDiagnostic = GetAddDiagnostic(symbol, symbolDeclaredEvent.DeclaringSyntaxReferences, analyzer, getTopMostNodeForAnalysis, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var symbolAction in symbolEndActions)
             {
@@ -493,10 +493,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 ExecuteAndCatchIfThrows(
                     symbolAction.Analyzer,
-                    data => data.action(data.context),
-                    (action, context),
-                    new AnalysisContextInfo(Compilation, symbol),
-                    cancellationToken);
+                    analyze: data => data.action(data.context),
+                    argument: (action, context),
+                    contextInfo: new AnalysisContextInfo(Compilation, symbol),
+                    cancellationToken: cancellationToken);
             }
 
             _analyzerManager.MarkSymbolEndAnalysisComplete(symbol, analyzer);
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var diagReporter = GetAddSemanticDiagnostic(semanticModel.SyntaxTree, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var semanticModelAction in semanticModelActions)
             {
@@ -539,10 +539,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Catch Exception from action.
                 ExecuteAndCatchIfThrows(
                     semanticModelAction.Analyzer,
-                    data => data.action(data.context),
-                    (action: semanticModelAction.Action, context),
-                    new AnalysisContextInfo(semanticModel),
-                    cancellationToken);
+                    analyze: data => data.action(data.context),
+                    argument: (action: semanticModelAction.Action, context),
+                    contextInfo: new AnalysisContextInfo(semanticModel),
+                    cancellationToken: cancellationToken);
             }
 
             diagReporter.Free();
@@ -576,7 +576,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var diagReporter = GetAddSyntaxDiagnostic(file, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var syntaxTreeAction in syntaxTreeActions)
             {
@@ -587,10 +587,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Catch Exception from action.
                 ExecuteAndCatchIfThrows(
                     syntaxTreeAction.Analyzer,
-                    data => data.action(data.context),
-                    (action: syntaxTreeAction.Action, context),
-                    new AnalysisContextInfo(Compilation, file),
-                    cancellationToken);
+                    analyze: data => data.action(data.context),
+                    argument: (action: syntaxTreeAction.Action, context),
+                    contextInfo: new AnalysisContextInfo(Compilation, file),
+                    cancellationToken: cancellationToken);
             }
 
             diagReporter.Free();
@@ -616,7 +616,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var diagReporter = GetAddSyntaxDiagnostic(file, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
             foreach (var additionalFileAction in additionalFileActions)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -626,10 +626,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Catch Exception from action.
                 ExecuteAndCatchIfThrows(
                     additionalFileAction.Analyzer,
-                    data => data.action(data.context),
-                    (action: additionalFileAction.Action, context),
-                    new AnalysisContextInfo(Compilation, file),
-                    cancellationToken);
+                    analyze: data => data.action(data.context),
+                    argument: (action: additionalFileAction.Action, context),
+                    contextInfo: new AnalysisContextInfo(Compilation, file),
+                    cancellationToken: cancellationToken);
             }
 
             diagReporter.Free();
@@ -655,10 +655,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             ExecuteAndCatchIfThrows(
                 syntaxNodeAction.Analyzer,
-                data => data.action(data.context),
-                (action: syntaxNodeAction.Action, context: syntaxNodeContext),
-                new AnalysisContextInfo(Compilation, node),
-                cancellationToken);
+                analyze: data => data.action(data.context),
+                argument: (action: syntaxNodeAction.Action, context: syntaxNodeContext),
+                contextInfo: new AnalysisContextInfo(Compilation, node),
+                cancellationToken: cancellationToken);
         }
 
         private void ExecuteOperationAction(
@@ -679,10 +679,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     AnalyzerOptions, addDiagnostic, isSupportedDiagnostic, GetControlFlowGraph, filterSpan, isGeneratedCode, cancellationToken);
             ExecuteAndCatchIfThrows(
                 operationAction.Analyzer,
-                data => data.action(data.context),
-                (action: operationAction.Action, context: operationContext),
-                new AnalysisContextInfo(Compilation, operation),
-                cancellationToken);
+                analyze: data => data.action(data.context),
+                argument: (action: operationAction.Action, context: operationContext),
+                contextInfo: new AnalysisContextInfo(Compilation, operation),
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -806,15 +806,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     // Catch Exception from the start action.
                     ExecuteAndCatchIfThrows(
                         startAction.Analyzer,
-                        data =>
+                        analyze: data =>
                         {
                             data.action(data.context);
                             data.blockEndActions?.AddAll(data.scope.CodeBlockEndActions);
                             data.syntaxNodeActions?.AddRange(data.scope.SyntaxNodeActions);
                         },
-                        (action: codeBlockStartAction.Action, context: blockStartContext, scope: codeBlockScope, blockEndActions: codeBlockEndActions, syntaxNodeActions),
-                        new AnalysisContextInfo(Compilation, declaredSymbol, declaredNode),
-                        cancellationToken);
+                        argument: (action: codeBlockStartAction.Action, context: blockStartContext, scope: codeBlockScope, blockEndActions: codeBlockEndActions, syntaxNodeActions),
+                        contextInfo: new AnalysisContextInfo(Compilation, declaredSymbol, declaredNode),
+                        cancellationToken: cancellationToken);
                 }
                 else
                 {
@@ -829,20 +829,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         // Catch Exception from the start action.
                         ExecuteAndCatchIfThrows(
                             startAction.Analyzer,
-                            data =>
+                            analyze: data =>
                             {
                                 data.action(data.context);
                                 data.blockEndActions?.AddAll(data.scope.OperationBlockEndActions);
                                 data.operationActions?.AddRange(data.scope.OperationActions);
                             },
-                            (action: operationBlockStartAction.Action, context: operationStartContext, scope: operationBlockScope, blockEndActions: operationBlockEndActions, operationActions: operationActions),
-                            new AnalysisContextInfo(Compilation, declaredSymbol),
-                            cancellationToken);
+                            argument: (action: operationBlockStartAction.Action, context: operationStartContext, scope: operationBlockScope, blockEndActions: operationBlockEndActions, operationActions: operationActions),
+                            contextInfo: new AnalysisContextInfo(Compilation, declaredSymbol),
+                            cancellationToken: cancellationToken);
                     }
                 }
             }
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             // Execute stateful executable node analyzers, if any.
             if (executableNodeActions.Any())
@@ -898,10 +898,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     ExecuteAndCatchIfThrows(
                         codeBlockAction.Analyzer,
-                        data => data.action(data.context),
-                        (action: codeBlockAction.Action, context: context),
-                        new AnalysisContextInfo(Compilation, declaredSymbol, declaredNode),
-                        cancellationToken);
+                        analyze: data => data.action(data.context),
+                        argument: (action: codeBlockAction.Action, context: context),
+                        contextInfo: new AnalysisContextInfo(Compilation, declaredSymbol, declaredNode),
+                        cancellationToken: cancellationToken);
                 }
                 else
                 {
@@ -913,10 +913,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                         ExecuteAndCatchIfThrows(
                             operationBlockAction.Analyzer,
-                            data => data.action(data.context),
-                            (action: operationBlockAction.Action, context),
-                            new AnalysisContextInfo(Compilation, declaredSymbol),
-                            cancellationToken);
+                            analyze: data => data.action(data.context),
+                            argument: (action: operationBlockAction.Action, context),
+                            contextInfo: new AnalysisContextInfo(Compilation, declaredSymbol),
+                            cancellationToken: cancellationToken);
                     }
                 }
             }
@@ -975,7 +975,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var diagReporter = GetAddSemanticDiagnostic(model.SyntaxTree, spanForContainingTopmostNodeForAnalysis, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
             ExecuteSyntaxNodeActions(nodesToAnalyze, nodeActionsByKind, analyzer, declaredSymbol, model, getKind, diagReporter, isSupportedDiagnostic, filterSpan, isGeneratedCode, hasCodeBlockStartOrSymbolStartActions, cancellationToken);
             diagReporter.Free();
         }
@@ -1076,7 +1076,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var diagReporter = GetAddSemanticDiagnostic(model.SyntaxTree, spanForContainingOperationBlock, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: (d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), argument: (self: this, analyzer), boundFunction: out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
             ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, model, diagReporter, isSupportedDiagnostic, filterSpan, isGeneratedCode, hasOperationBlockStartOrSymbolStartActions, cancellationToken);
             diagReporter.Free();
         }
@@ -1158,12 +1158,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 lock (gate)
                 {
-                    ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, argument, contextInfo, cancellationToken);
+                    ExecuteAndCatchIfThrows_NoLock(analyzer, analyze: analyze, argument: argument, info: contextInfo, cancellationToken: cancellationToken);
                 }
             }
             else
             {
-                ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, argument, contextInfo, cancellationToken);
+                ExecuteAndCatchIfThrows_NoLock(analyzer, analyze: analyze, argument: argument, info: contextInfo, cancellationToken: cancellationToken);
             }
 
             if (_analyzerExecutionTimeMap != null)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1145,7 +1145,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        internal void ExecuteAndCatchIfThrows<TArg>(DiagnosticAnalyzer analyzer, Action<TArg> analyze, TArg argument, AnalysisContextInfo? contextInfo, CancellationToken cancellationToken)
+        internal void ExecuteAndCatchIfThrows<TArg>(DiagnosticAnalyzer analyzer, TArg argument, Action<TArg> analyze, AnalysisContextInfo? contextInfo, CancellationToken cancellationToken)
         {
             SharedStopwatch timer = default;
             if (_analyzerExecutionTimeMap != null)
@@ -1177,7 +1177,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         [PerformanceSensitive(
             "https://github.com/dotnet/roslyn/issues/23582",
             AllowCaptures = false)]
-        private void ExecuteAndCatchIfThrows_NoLock<TArg>(DiagnosticAnalyzer analyzer, Action<TArg> analyze, TArg argument, AnalysisContextInfo? info, CancellationToken cancellationToken)
+        private void ExecuteAndCatchIfThrows_NoLock<TArg>(DiagnosticAnalyzer analyzer, TArg argument, Action<TArg> analyze, AnalysisContextInfo? info, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Catch Exception from analyzer.SupportedDiagnostics
                 analyzerExecutor.ExecuteAndCatchIfThrows(
                     analyzer,
-                    _ =>
+                    analyze: _ =>
                     {
                         var supportedDiagnosticsLocal = analyzer.SupportedDiagnostics;
                         if (!supportedDiagnosticsLocal.IsDefaultOrEmpty)
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     },
                     argument: (object?)null,
                     contextInfo: null,
-                    cancellationToken);
+                    cancellationToken: cancellationToken);
 
                 // Force evaluate and report exception diagnostics from LocalizableString.ToString().
                 var onAnalyzerException = analyzerExecutor.OnAnalyzerException;
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     // Catch Exception from suppressor.SupportedSuppressions
                     analyzerExecutor.ExecuteAndCatchIfThrows(
                         analyzer,
-                        _ =>
+                        analyze: _ =>
                         {
                             var descriptorsLocal = suppressor.SupportedSuppressions;
                             if (!descriptorsLocal.IsDefaultOrEmpty)
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         },
                         argument: (object?)null,
                         contextInfo: null,
-                        cancellationToken);
+                        cancellationToken: cancellationToken);
                 }
 
                 return descriptors;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             VerifyAnalyzersArgumentForStaticApis(analyzers);
 
-            if (analyzers.Any(static (a, self) => !self._analyzers.Contains(a), this))
+            if (analyzers.Any(predicate: static (a, self) => !self._analyzers.Contains(a), arg: this))
             {
                 throw new ArgumentException(CodeAnalysisResources.UnsupportedAnalyzerInstance, nameof(_analyzers));
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => InterlockedOperations.Initialize(
                 ref _supportedDiagnostics,
-                static @this =>
+                createArray: static @this =>
                 {
                     var messageProvider = @this.MessageProvider;
                     var errorCodes = @this.GetSupportedErrorCodes();
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     builder.Add(AnalyzerExecutor.GetAnalyzerExceptionDiagnosticDescriptor());
                     return builder.ToImmutableAndFree();
-                }, this);
+                }, arg: this);
 
         public sealed override void Initialize(AnalysisContext context)
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SymbolDeclaredCompilationEvent.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SymbolDeclaredCompilationEvent.cs
@@ -41,8 +41,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 return InterlockedOperations.Initialize(
                     ref _lazyCachedDeclaringReferences,
-                    static self => self.Symbol.DeclaringSyntaxReferences,
-                    this);
+                    createArray: static self => self.Symbol.DeclaringSyntaxReferences,
+                    arg: this);
             }
         }
 

--- a/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
@@ -315,8 +315,8 @@ namespace Roslyn.Utilities
 
         public static T RethrowExceptionsAsIOException<T>(Func<T> operation)
             => RethrowExceptionsAsIOException(
-                static operation => operation(),
-                operation);
+                operation: static operation => operation(),
+                arg: operation);
 
         public static T RethrowExceptionsAsIOException<T, TArg>(Func<TArg, T> operation, TArg arg)
         {
@@ -332,8 +332,8 @@ namespace Roslyn.Utilities
 
         public static Task<T> RethrowExceptionsAsIOExceptionAsync<T>(Func<Task<T>> operation)
             => RethrowExceptionsAsIOExceptionAsync(
-                static operation => operation(),
-                operation);
+                operation: static operation => operation(),
+                arg: operation);
 
         public static async Task<T> RethrowExceptionsAsIOExceptionAsync<T, TArg>(Func<TArg, Task<T>> operation, TArg arg)
         {

--- a/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
@@ -318,7 +318,7 @@ namespace Roslyn.Utilities
                 operation: static operation => operation(),
                 arg: operation);
 
-        public static T RethrowExceptionsAsIOException<T, TArg>(Func<TArg, T> operation, TArg arg)
+        public static T RethrowExceptionsAsIOException<T, TArg>(TArg arg, Func<TArg, T> operation)
         {
             try
             {
@@ -335,7 +335,7 @@ namespace Roslyn.Utilities
                 operation: static operation => operation(),
                 arg: operation);
 
-        public static async Task<T> RethrowExceptionsAsIOExceptionAsync<T, TArg>(Func<TArg, Task<T>> operation, TArg arg)
+        public static async Task<T> RethrowExceptionsAsIOExceptionAsync<T, TArg>(TArg arg, Func<TArg, Task<T>> operation)
         {
             try
             {

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -10511,8 +10511,8 @@ namespace Microsoft.CodeAnalysis.Operations
         [return: NotNullIfNotNull("node")]
         private T? Visit<T>(T? node) where T : IOperation? => (T?)Visit(node, argument: null);
         public override IOperation DefaultVisit(IOperation operation, object? argument) => throw ExceptionUtilities.Unreachable();
-        private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> nodes) where T : IOperation => nodes.SelectAsArray(map: (n, @this) => @this.Visit(n), arg: this)!;
-        private ImmutableArray<(ISymbol, T)> VisitArray<T>(ImmutableArray<(ISymbol, T)> nodes) where T : IOperation => nodes.SelectAsArray(map: (n, @this) => (n.Item1, @this.Visit(n.Item2)), arg: this)!;
+        private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> nodes) where T : IOperation => nodes.SelectAsArray(this, (n, @this) => @this.Visit(n))!;
+        private ImmutableArray<(ISymbol, T)> VisitArray<T>(ImmutableArray<(ISymbol, T)> nodes) where T : IOperation => nodes.SelectAsArray(this, (n, @this) => (n.Item1, @this.Visit(n.Item2)))!;
         public override IOperation VisitBlock(IBlockOperation operation, object? argument)
         {
             var internalOperation = (BlockOperation)operation;

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -10511,8 +10511,8 @@ namespace Microsoft.CodeAnalysis.Operations
         [return: NotNullIfNotNull("node")]
         private T? Visit<T>(T? node) where T : IOperation? => (T?)Visit(node, argument: null);
         public override IOperation DefaultVisit(IOperation operation, object? argument) => throw ExceptionUtilities.Unreachable();
-        private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> nodes) where T : IOperation => nodes.SelectAsArray((n, @this) => @this.Visit(n), this)!;
-        private ImmutableArray<(ISymbol, T)> VisitArray<T>(ImmutableArray<(ISymbol, T)> nodes) where T : IOperation => nodes.SelectAsArray((n, @this) => (n.Item1, @this.Visit(n.Item2)), this)!;
+        private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> nodes) where T : IOperation => nodes.SelectAsArray(map: (n, @this) => @this.Visit(n), arg: this)!;
+        private ImmutableArray<(ISymbol, T)> VisitArray<T>(ImmutableArray<(ISymbol, T)> nodes) where T : IOperation => nodes.SelectAsArray(map: (n, @this) => (n.Item1, @this.Visit(n.Item2)), arg: this)!;
         public override IOperation VisitBlock(IBlockOperation operation, object? argument)
         {
             var internalOperation = (BlockOperation)operation;

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentDictionaryExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentDictionaryExtensions.cs
@@ -25,7 +25,7 @@ namespace Roslyn.Utilities
             }
         }
 
-        public static TValue GetOrAdd<TKey, TArg, TValue>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+        public static TValue GetOrAdd<TKey, TArg, TValue>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, TArg factoryArgument, Func<TKey, TArg, TValue> valueFactory)
             where TKey : notnull
         {
 #if NETCOREAPP
@@ -44,9 +44,9 @@ namespace Roslyn.Utilities
         public static TValue AddOrUpdate<TKey, TValue, TArg>(
             this ConcurrentDictionary<TKey, TValue> dictionary,
             TKey key,
+            TArg factoryArgument,
             Func<TKey, TArg, TValue> addValueFactory,
-            Func<TKey, TValue, TArg, TValue> updateValueFactory,
-            TArg factoryArgument)
+            Func<TKey, TValue, TArg, TValue> updateValueFactory)
             where TKey : notnull
         {
 #if NETCOREAPP

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentDictionaryExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentDictionaryExtensions.cs
@@ -34,7 +34,7 @@ namespace Roslyn.Utilities
             if (dictionary.TryGetValue(key, out var value))
                 return value;
 
-            using var _ = PooledDelegates.GetPooledFunction(valueFactory, factoryArgument, out var boundFunction);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: valueFactory, argument: factoryArgument, boundFunction: out var boundFunction);
             return dictionary.GetOrAdd(key, boundFunction);
 #endif
         }
@@ -52,8 +52,8 @@ namespace Roslyn.Utilities
 #if NETCOREAPP
             return dictionary.AddOrUpdate(key, addValueFactory, updateValueFactory, factoryArgument);
 #else
-            using var _a = PooledDelegates.GetPooledFunction(addValueFactory, factoryArgument, out var pooledAddValueFactory);
-            using var _b = PooledDelegates.GetPooledFunction(updateValueFactory, factoryArgument, out var pooledUpdateValueFactory);
+            using var _a = PooledDelegates.GetPooledFunction(unboundFunction: addValueFactory, argument: factoryArgument, boundFunction: out var pooledAddValueFactory);
+            using var _b = PooledDelegates.GetPooledFunction(unboundFunction: updateValueFactory, argument: factoryArgument, boundFunction: out var pooledUpdateValueFactory);
             return dictionary.AddOrUpdate(key, pooledAddValueFactory, pooledUpdateValueFactory);
 #endif
         }

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -19,7 +19,7 @@ namespace Roslyn.Utilities
 {
     internal static partial class EnumerableExtensions
     {
-        public static int Count<T, TArg>(this IEnumerable<T> source, Func<T, TArg, bool> predicate, TArg arg)
+        public static int Count<T, TArg>(this IEnumerable<T> source, TArg arg, Func<T, TArg, bool> predicate)
         {
             var count = 0;
             foreach (var v in source)
@@ -180,7 +180,7 @@ namespace Roslyn.Utilities
         public static IReadOnlyCollection<T> ToCollection<T>(this IEnumerable<T> sequence)
             => (sequence is IReadOnlyCollection<T> collection) ? collection : sequence.ToList();
 
-        public static T? FirstOrDefault<T, TArg>(this IEnumerable<T> source, Func<T, TArg, bool> predicate, TArg arg)
+        public static T? FirstOrDefault<T, TArg>(this IEnumerable<T> source, TArg arg, Func<T, TArg, bool> predicate)
         {
             foreach (var item in source)
             {
@@ -191,7 +191,7 @@ namespace Roslyn.Utilities
             return default;
         }
 
-        public static bool Any<T, TArg>(this IEnumerable<T> source, Func<T, TArg, bool> predicate, TArg arg)
+        public static bool Any<T, TArg>(this IEnumerable<T> source, TArg arg, Func<T, TArg, bool> predicate)
         {
             foreach (var item in source)
             {
@@ -229,7 +229,7 @@ namespace Roslyn.Utilities
             return source.Cast<T?>().FirstOrDefault(predicate: static (v, predicate) => predicate(v!.Value), arg: predicate);
         }
 
-        public static T? FirstOrNull<T, TArg>(this IEnumerable<T> source, Func<T, TArg, bool> predicate, TArg arg)
+        public static T? FirstOrNull<T, TArg>(this IEnumerable<T> source, TArg arg, Func<T, TArg, bool> predicate)
             where T : struct
         {
             if (source == null)
@@ -404,7 +404,7 @@ namespace Roslyn.Utilities
             return builder.ToImmutableAndFree();
         }
 
-        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this IEnumerable<TItem>? source, Func<TItem, TArg, IEnumerable<TResult>> selector, TArg arg)
+        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this IEnumerable<TItem>? source, TArg arg, Func<TItem, TArg, IEnumerable<TResult>> selector)
         {
             if (source == null)
                 return ImmutableArray<TResult>.Empty;
@@ -429,7 +429,7 @@ namespace Roslyn.Utilities
             return builder.ToImmutableAndFree();
         }
 
-        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this IReadOnlyCollection<TItem>? source, Func<TItem, TArg, IEnumerable<TResult>> selector, TArg arg)
+        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this IReadOnlyCollection<TItem>? source, TArg arg, Func<TItem, TArg, IEnumerable<TResult>> selector)
         {
             if (source == null)
                 return ImmutableArray<TResult>.Empty;
@@ -475,7 +475,7 @@ namespace Roslyn.Utilities
         /// <summary>
         /// Maps an immutable array through a function that returns ValueTask, returning the new ImmutableArray.
         /// </summary>
-        public static async ValueTask<ImmutableArray<TResult>> SelectAsArrayAsync<TItem, TArg, TResult>(this IEnumerable<TItem> source, Func<TItem, TArg, CancellationToken, ValueTask<TResult>> selector, TArg arg, CancellationToken cancellationToken)
+        public static async ValueTask<ImmutableArray<TResult>> SelectAsArrayAsync<TItem, TArg, TResult>(this IEnumerable<TItem> source, TArg arg, Func<TItem, TArg, CancellationToken, ValueTask<TResult>> selector, CancellationToken cancellationToken)
         {
             var builder = ArrayBuilder<TResult>.GetInstance();
 
@@ -487,7 +487,7 @@ namespace Roslyn.Utilities
             return builder.ToImmutableAndFree();
         }
 
-        public static async ValueTask<ImmutableArray<TResult>> SelectManyAsArrayAsync<TItem, TArg, TResult>(this IEnumerable<TItem> source, Func<TItem, TArg, CancellationToken, ValueTask<IEnumerable<TResult>>> selector, TArg arg, CancellationToken cancellationToken)
+        public static async ValueTask<ImmutableArray<TResult>> SelectManyAsArrayAsync<TItem, TArg, TResult>(this IEnumerable<TItem> source, TArg arg, Func<TItem, TArg, CancellationToken, ValueTask<IEnumerable<TResult>>> selector, CancellationToken cancellationToken)
         {
             var builder = ArrayBuilder<TResult>.GetInstance();
 

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -226,7 +226,7 @@ namespace Roslyn.Utilities
                 throw new ArgumentNullException(nameof(predicate));
             }
 
-            return source.Cast<T?>().FirstOrDefault(static (v, predicate) => predicate(v!.Value), predicate);
+            return source.Cast<T?>().FirstOrDefault(predicate: static (v, predicate) => predicate(v!.Value), arg: predicate);
         }
 
         public static T? FirstOrNull<T, TArg>(this IEnumerable<T> source, Func<T, TArg, bool> predicate, TArg arg)
@@ -242,7 +242,7 @@ namespace Roslyn.Utilities
                 throw new ArgumentNullException(nameof(predicate));
             }
 
-            return source.Cast<T?>().FirstOrDefault(static (v, arg) => arg.predicate(v!.Value, arg.arg), (predicate, arg));
+            return source.Cast<T?>().FirstOrDefault(predicate: static (v, arg) => arg.predicate(v!.Value, arg.arg), arg: (predicate, arg));
         }
 
         public static T? LastOrNull<T>(this IEnumerable<T> source)

--- a/src/Compilers/Core/Portable/InternalUtilities/InterlockedOperations.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/InterlockedOperations.cs
@@ -168,7 +168,7 @@ namespace Roslyn.Utilities
         /// <returns>The value of <paramref name="target"/> after initialization.  If <paramref name="target"/> is
         /// already initialized, that value value will be returned.</returns>
         public static ImmutableArray<T> Initialize<T>(ref ImmutableArray<T> target, Func<ImmutableArray<T>> createArray)
-            => Initialize(ref target, static createArray => createArray(), createArray);
+            => Initialize(ref target, createArray: static createArray => createArray(), arg: createArray);
 
         /// <summary>
         /// Initialize the immutable array referenced by <paramref name="target"/> in a thread-safe manner.
@@ -187,7 +187,7 @@ namespace Roslyn.Utilities
                 return target;
             }
 
-            return Initialize_Slow(ref target, createArray, arg);
+            return Initialize_Slow(ref target, createArray: createArray, arg: arg);
         }
 
         private static ImmutableArray<T> Initialize_Slow<T, TArg>(ref ImmutableArray<T> target, Func<TArg, ImmutableArray<T>> createArray, TArg arg)

--- a/src/Compilers/Core/Portable/InternalUtilities/InterlockedOperations.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/InterlockedOperations.cs
@@ -43,7 +43,7 @@ namespace Roslyn.Utilities
         /// more than once by multiple threads, but only one of those values will successfully be written to the target.</param>
         /// <param name="arg">An argument passed to the value factory.</param>
         /// <returns>The target value.</returns>
-        public static T Initialize<T, TArg>([NotNull] ref T? target, Func<TArg, T> valueFactory, TArg arg)
+        public static T Initialize<T, TArg>([NotNull] ref T? target, TArg arg, Func<TArg, T> valueFactory)
             where T : class
         {
             return Volatile.Read(ref target!) ?? GetOrStore(ref target, valueFactory(arg));
@@ -63,7 +63,7 @@ namespace Roslyn.Utilities
         /// calls to the same method may recalculate the target value.
         /// </remarks>
         /// <returns>The target value.</returns>
-        public static int Initialize<TArg>(ref int target, int uninitializedValue, Func<TArg, int> valueFactory, TArg arg)
+        public static int Initialize<TArg>(ref int target, int uninitializedValue, TArg arg, Func<TArg, int> valueFactory)
         {
             var existingValue = Volatile.Read(ref target);
             if (existingValue != uninitializedValue)
@@ -100,7 +100,7 @@ namespace Roslyn.Utilities
         /// more than once by multiple threads, but only one of those values will successfully be written to the target.</param>
         /// <param name="arg">An argument passed to the value factory.</param>
         /// <returns>The target value.</returns>
-        public static T? Initialize<T, TArg>([NotNull] ref StrongBox<T?>? target, Func<TArg, T?> valueFactory, TArg arg)
+        public static T? Initialize<T, TArg>([NotNull] ref StrongBox<T?>? target, TArg arg, Func<TArg, T?> valueFactory)
         {
             var box = Volatile.Read(ref target!) ?? GetOrStore(ref target, new StrongBox<T?>(valueFactory(arg)));
             return box.Value;
@@ -180,7 +180,7 @@ namespace Roslyn.Utilities
         /// called if 'target' is already not 'default' at the time this is called.</param>
         /// <returns>The value of <paramref name="target"/> after initialization.  If <paramref name="target"/> is
         /// already initialized, that value value will be returned.</returns>
-        public static ImmutableArray<T> Initialize<T, TArg>(ref ImmutableArray<T> target, Func<TArg, ImmutableArray<T>> createArray, TArg arg)
+        public static ImmutableArray<T> Initialize<T, TArg>(ref ImmutableArray<T> target, TArg arg, Func<TArg, ImmutableArray<T>> createArray)
         {
             if (!target.IsDefault)
             {
@@ -190,7 +190,7 @@ namespace Roslyn.Utilities
             return Initialize_Slow(ref target, createArray: createArray, arg: arg);
         }
 
-        private static ImmutableArray<T> Initialize_Slow<T, TArg>(ref ImmutableArray<T> target, Func<TArg, ImmutableArray<T>> createArray, TArg arg)
+        private static ImmutableArray<T> Initialize_Slow<T, TArg>(ref ImmutableArray<T> target, TArg arg, Func<TArg, ImmutableArray<T>> createArray)
         {
             ImmutableInterlocked.Update(
                 ref target,

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -126,7 +126,7 @@ namespace Roslyn.Utilities
                 OneOrMany.Create(_many.SelectAsArray(selector));
         }
 
-        public OneOrMany<TResult> Select<TResult, TArg>(Func<T, TArg, TResult> selector, TArg arg)
+        public OneOrMany<TResult> Select<TResult, TArg>(TArg arg, Func<T, TArg, TResult> selector)
         {
             return HasOneItem ?
                 OneOrMany.Create(selector(_one, arg)) :
@@ -148,7 +148,7 @@ namespace Roslyn.Utilities
             return _many.FirstOrDefault(predicate);
         }
 
-        public T? FirstOrDefault<TArg>(Func<T, TArg, bool> predicate, TArg arg)
+        public T? FirstOrDefault<TArg>(TArg arg, Func<T, TArg, bool> predicate)
         {
             if (HasOneItem)
             {
@@ -168,7 +168,7 @@ namespace Roslyn.Utilities
         public bool All(Func<T, bool> predicate)
             => HasOneItem ? predicate(_one) : _many.All(predicate);
 
-        public bool All<TArg>(Func<T, TArg, bool> predicate, TArg arg)
+        public bool All<TArg>(TArg arg, Func<T, TArg, bool> predicate)
             => HasOneItem ? predicate(_one, arg) : _many.All(predicate: predicate, arg: arg);
 
         public bool Any()
@@ -177,7 +177,7 @@ namespace Roslyn.Utilities
         public bool Any(Func<T, bool> predicate)
             => HasOneItem ? predicate(_one) : _many.Any(predicate);
 
-        public bool Any<TArg>(Func<T, TArg, bool> predicate, TArg arg)
+        public bool Any<TArg>(TArg arg, Func<T, TArg, bool> predicate)
             => HasOneItem ? predicate(_one, arg) : _many.Any(predicate: predicate, arg: arg);
 
         public ImmutableArray<T> ToImmutable()

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -116,7 +116,7 @@ namespace Roslyn.Utilities
                 return EqualityComparer<T>.Default.Equals(item, _one) ? Empty : this;
             }
 
-            return OneOrMany.Create(_many.WhereAsArray(static (value, item) => !EqualityComparer<T>.Default.Equals(value, item), item));
+            return OneOrMany.Create(_many.WhereAsArray(predicate: static (value, item) => !EqualityComparer<T>.Default.Equals(value, item), arg: item));
         }
 
         public OneOrMany<TResult> Select<TResult>(Func<T, TResult> selector)
@@ -130,7 +130,7 @@ namespace Roslyn.Utilities
         {
             return HasOneItem ?
                 OneOrMany.Create(selector(_one, arg)) :
-                OneOrMany.Create(_many.SelectAsArray(selector, arg));
+                OneOrMany.Create(_many.SelectAsArray(map: selector, arg: arg));
         }
 
         public T First() => this[0];
@@ -155,7 +155,7 @@ namespace Roslyn.Utilities
                 return predicate(_one, arg) ? _one : default;
             }
 
-            return _many.FirstOrDefault(predicate, arg);
+            return _many.FirstOrDefault(predicate: predicate, arg: arg);
         }
 
         public static OneOrMany<T> CastUp<TDerived>(OneOrMany<TDerived> from) where TDerived : class, T
@@ -169,7 +169,7 @@ namespace Roslyn.Utilities
             => HasOneItem ? predicate(_one) : _many.All(predicate);
 
         public bool All<TArg>(Func<T, TArg, bool> predicate, TArg arg)
-            => HasOneItem ? predicate(_one, arg) : _many.All(predicate, arg);
+            => HasOneItem ? predicate(_one, arg) : _many.All(predicate: predicate, arg: arg);
 
         public bool Any()
             => !IsEmpty;
@@ -178,7 +178,7 @@ namespace Roslyn.Utilities
             => HasOneItem ? predicate(_one) : _many.Any(predicate);
 
         public bool Any<TArg>(Func<T, TArg, bool> predicate, TArg arg)
-            => HasOneItem ? predicate(_one, arg) : _many.Any(predicate, arg);
+            => HasOneItem ? predicate(_one, arg) : _many.Any(predicate: predicate, arg: arg);
 
         public ImmutableArray<T> ToImmutable()
             => HasOneItem ? ImmutableArray.Create(_one) : _many;

--- a/src/Compilers/Core/Portable/InternalUtilities/SingleInitNullable.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SingleInitNullable.cs
@@ -44,7 +44,7 @@ internal struct SingleInitNullable<T>
     /// resilient to failure paths (including cancellation), ensuring that the type reset itself <em>safely</em> to the
     /// initial state so that other threads were not perpetually stuck in the busy state.
     /// </remarks>
-    public T Initialize<TArg>(Func<TArg, T> valueFactory, TArg arg)
+    public T Initialize<TArg>(TArg arg, Func<TArg, T> valueFactory)
         => ReadIfInitialized() ?? GetOrStore(valueFactory(arg));
 
     private T? ReadIfInitialized()

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -7621,7 +7621,7 @@ oneMoreTime:
             return new ListPatternOperation(
                 operation.LengthSymbol,
                 operation.IndexerSymbol,
-                operation.Patterns.SelectAsArray((p, @this) => (IPatternOperation)@this.VisitRequired(p), this),
+                operation.Patterns.SelectAsArray(map: (p, @this) => (IPatternOperation)@this.VisitRequired(p), arg: this),
                 operation.DeclaredSymbol,
                 operation.InputType,
                 operation.NarrowedType,
@@ -7635,8 +7635,8 @@ oneMoreTime:
             return new RecursivePatternOperation(
                 operation.MatchedType,
                 operation.DeconstructSymbol,
-                operation.DeconstructionSubpatterns.SelectAsArray((p, @this) => (IPatternOperation)@this.VisitRequired(p), this),
-                operation.PropertySubpatterns.SelectAsArray((p, @this) => (IPropertySubpatternOperation)@this.VisitRequired(p), this),
+                operation.DeconstructionSubpatterns.SelectAsArray(map: (p, @this) => (IPatternOperation)@this.VisitRequired(p), arg: this),
+                operation.PropertySubpatterns.SelectAsArray(map: (p, @this) => (IPropertySubpatternOperation)@this.VisitRequired(p), arg: this),
                 operation.DeclaredSymbol,
                 operation.InputType,
                 operation.NarrowedType,

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -126,6 +126,6 @@ namespace Microsoft.CodeAnalysis
 
         internal ImmutableArray<(string Key, string Value)> HostOutputs { get; }
 
-        internal bool RequiresPostInitReparse(ParseOptions parseOptions) => PostInitTrees.Any(static (t, parseOptions) => t.Tree.Options != parseOptions, parseOptions);
+        internal bool RequiresPostInitReparse(ParseOptions parseOptions) => PostInitTrees.Any(predicate: static (t, parseOptions) => t.Tree.Options != parseOptions, arg: parseOptions);
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/MarshalPseudoCustomAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/MarshalPseudoCustomAttributeData.cs
@@ -191,7 +191,8 @@ namespace Microsoft.CodeAnalysis
         /// Returns this instance if it doesn't hold on any types.
         /// </summary>
         internal MarshalPseudoCustomAttributeData WithTranslatedTypes<TTypeSymbol, TArg>(
-            Func<TTypeSymbol, TArg, TTypeSymbol> translator, TArg arg)
+            TArg arg,
+            Func<TTypeSymbol, TArg, TTypeSymbol> translator)
             where TTypeSymbol : ITypeSymbolInternal
         {
             if (_marshalType != Cci.Constants.UnmanagedType_SafeArray || _marshalTypeNameOrSymbol == null)

--- a/src/Compilers/Test/Core/InstrumentationChecker.cs
+++ b/src/Compilers/Test/Core/InstrumentationChecker.cs
@@ -348,14 +348,14 @@ End Namespace
         {
             var actualSpans = reader.GetSpans(reader.Methods[method - 1].Blob);
 
-            return actualSpans.SelectAsArray((span, lines) =>
+            return actualSpans.SelectAsArray(map: (span, lines) =>
             {
                 if (span.StartLine >= lines.Length)
                 {
                     return null;
                 }
                 return lines[span.StartLine].Substring(span.StartColumn).TrimEnd(new[] { '\r', '\n', ' ' });
-            }, sourceLines);
+            }, arg: sourceLines);
         }
 
         public class MethodChecker

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -249,15 +249,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                     Dim otherTypeParameters As ImmutableArray(Of TypeParameterSymbol) = otherDef.GetAllTypeParameters()
                     Dim translationFailed As Boolean = False
                     Dim otherTypeArguments = type.GetAllTypeArgumentsWithModifiers().SelectAsArray(map:=Function(t, v)
-                                                                                                       Dim newType = DirectCast(v.Visit(t.Type), TypeSymbol)
-                                                                                                       If newType Is Nothing Then
-                                                                                                           ' For a newly added type, there is no match in the previous generation, so it could be Nothing.
-                                                                                                           translationFailed = True
-                                                                                                           newType = t.Type
-                                                                                                       End If
+                                                                                                            Dim newType = DirectCast(v.Visit(t.Type), TypeSymbol)
+                                                                                                            If newType Is Nothing Then
+                                                                                                                ' For a newly added type, there is no match in the previous generation, so it could be Nothing.
+                                                                                                                translationFailed = True
+                                                                                                                newType = t.Type
+                                                                                                            End If
 
-                                                                                                       Return New TypeWithModifiers(newType, v.VisitCustomModifiers(t.CustomModifiers))
-                                                                                                   End Function, arg:=Me)
+                                                                                                            Return New TypeWithModifiers(newType, v.VisitCustomModifiers(t.CustomModifiers))
+                                                                                                        End Function, arg:=Me)
                     If translationFailed Then
                         ' There is no match in the previous generation.
                         Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -248,7 +248,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                     Dim otherTypeParameters As ImmutableArray(Of TypeParameterSymbol) = otherDef.GetAllTypeParameters()
                     Dim translationFailed As Boolean = False
-                    Dim otherTypeArguments = type.GetAllTypeArgumentsWithModifiers().SelectAsArray(Function(t, v)
+                    Dim otherTypeArguments = type.GetAllTypeArgumentsWithModifiers().SelectAsArray(map:=Function(t, v)
                                                                                                        Dim newType = DirectCast(v.Visit(t.Type), TypeSymbol)
                                                                                                        If newType Is Nothing Then
                                                                                                            ' For a newly added type, there is no match in the previous generation, so it could be Nothing.
@@ -257,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                                                                                                        End If
 
                                                                                                        Return New TypeWithModifiers(newType, v.VisitCustomModifiers(t.CustomModifiers))
-                                                                                                   End Function, Me)
+                                                                                                   End Function, arg:=Me)
                     If translationFailed Then
                         ' There is no match in the previous generation.
                         Return Nothing
@@ -593,8 +593,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                 Dim originalDef As NamedTypeSymbol = type.OriginalDefinition
                 If originalDef IsNot type Then
-                    Dim translatedTypeArguments = type.GetAllTypeArgumentsWithModifiers().SelectAsArray(Function(t, v) New TypeWithModifiers(DirectCast(v.Visit(t.Type), TypeSymbol),
-                                                                                                                                             v.VisitCustomModifiers(t.CustomModifiers)), Me)
+                    Dim translatedTypeArguments = type.GetAllTypeArgumentsWithModifiers().SelectAsArray(map:=Function(t, v) New TypeWithModifiers(DirectCast(v.Visit(t.Type), TypeSymbol),
+                                                                                                                                             v.VisitCustomModifiers(t.CustomModifiers)), arg:=Me)
 
                     Dim translatedOriginalDef = DirectCast(Me.Visit(originalDef), NamedTypeSymbol)
                     Dim typeMap = TypeSubstitution.Create(translatedOriginalDef, translatedOriginalDef.GetAllTypeParameters(), translatedTypeArguments, False)

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedMethod.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
         End Function
 
         Protected Overrides Function GetTypeParameters() As ImmutableArray(Of EmbeddedTypeParameter)
-            Return UnderlyingMethod.AdaptedMethodSymbol.TypeParameters.SelectAsArray(Function(typeParameter, container) New EmbeddedTypeParameter(container, typeParameter.GetCciAdapter()), Me)
+            Return UnderlyingMethod.AdaptedMethodSymbol.TypeParameters.SelectAsArray(map:=Function(typeParameter, container) New EmbeddedTypeParameter(container, typeParameter.GetCciAdapter()), arg:=Me)
         End Function
 
         Protected Overrides ReadOnly Property IsAbstract As Boolean

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -530,7 +530,7 @@ checksForAllEmbedabbleTypes:
         End Function
 
         Friend Shared Function EmbedParameters(containingPropertyOrMethod As CommonEmbeddedMember, underlyingParameters As ImmutableArray(Of ParameterSymbol)) As ImmutableArray(Of EmbeddedParameter)
-            Return underlyingParameters.SelectAsArray(Function(parameter, container) New EmbeddedParameter(container, parameter.GetCciAdapter()), containingPropertyOrMethod)
+            Return underlyingParameters.SelectAsArray(map:=Function(parameter, container) New EmbeddedParameter(container, parameter.GetCciAdapter()), arg:=containingPropertyOrMethod)
         End Function
 
         Protected Overrides Function CreateCompilerGeneratedAttribute() As VisualBasicAttributeData

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseScan.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseScan.vb
@@ -198,7 +198,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function PeekAheadFor(ParamArray kinds As SyntaxKind()) As SyntaxKind
             Dim token As SyntaxToken = Nothing
-            PeekAheadFor(s_isTokenOrKeywordFunc, kinds, token)
+            PeekAheadFor(predicate:=s_isTokenOrKeywordFunc, arg:=kinds, token:=token)
             Return If(token Is Nothing, Nothing, token.Kind)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
@@ -792,7 +792,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                         Case SyntaxKind.OpenParenToken
                             Dim lookAhead As SyntaxToken = Nothing
-                            Dim i = PeekAheadFor(s_isTokenOrKeywordFunc, {SyntaxKind.AsKeyword, SyntaxKind.InKeyword, SyntaxKind.EqualsToken}, lookAhead)
+                            Dim i = PeekAheadFor(predicate:=s_isTokenOrKeywordFunc, arg:={SyntaxKind.AsKeyword, SyntaxKind.InKeyword, SyntaxKind.EqualsToken}, token:=lookAhead)
                             If lookAhead IsNot Nothing AndAlso
                                 lookAhead.Kind = SyntaxKind.AsKeyword AndAlso
                                 PeekToken(i - 1).Kind = SyntaxKind.CloseParenToken Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
@@ -517,7 +517,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     If Me.IsSZArray Then
                         Dim newInterfaces As ImmutableArray(Of NamedTypeSymbol) = Me.InterfacesNoUseSiteDiagnostics
                         If newInterfaces.Length > 0 Then
-                            newInterfaces = newInterfaces.SelectAsArray(Function([interface], map) DirectCast([interface].InternalSubstituteTypeParameters(map).AsTypeSymbolOnly(), NamedTypeSymbol), substitution)
+                            newInterfaces = newInterfaces.SelectAsArray(map:=Function([interface], map) DirectCast([interface].InternalSubstituteTypeParameters(map).AsTypeSymbolOnly(), NamedTypeSymbol), arg:=substitution)
                         End If
 
                         newArray = New SZArray(newElementType.Type, newElementType.CustomModifiers, _systemArray, newInterfaces)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
@@ -812,7 +812,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Function
 
         Public Overloads Overrides Function GetTypeMembers(name As String, arity As Integer) As ImmutableArray(Of NamedTypeSymbol)
-            Return GetTypeMembers(name).WhereAsArray(Function(type, arity_) type.Arity = arity_, arity)
+            Return GetTypeMembers(name).WhereAsArray(predicate:=Function(type, arity_) type.Arity = arity_, arg:=arity)
         End Function
 
         Public Overrides ReadOnly Property Locations As ImmutableArray(Of Location)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
@@ -126,7 +126,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Function
 
         Public Overloads Overrides Function GetTypeMembers(name As String, arity As Integer) As ImmutableArray(Of NamedTypeSymbol)
-            Return GetTypeMembers(name).WhereAsArray(Function(type, arity_) type.Arity = arity_, arity)
+            Return GetTypeMembers(name).WhereAsArray(predicate:=Function(type, arity_) type.Arity = arity_, arg:=arity)
         End Function
 
         Public NotOverridable Overrides ReadOnly Property Locations As ImmutableArray(Of Location)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
@@ -190,7 +190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Dim typeArgsChanged = typeArgs <> decodedArgs
             If typeArgsChanged OrElse containerChanged Then
                 Dim newTypeArgs = If(type.HasTypeArgumentsCustomModifiers,
-                                     decodedArgs.SelectAsArray(Function(t, i, m) New TypeWithModifiers(t, m.GetTypeArgumentCustomModifiers(i)), type),
+                                     decodedArgs.SelectAsArray(map:=Function(t, i, m) New TypeWithModifiers(t, m.GetTypeArgumentCustomModifiers(i)), arg:=type),
                                      decodedArgs.SelectAsArray(Function(t) New TypeWithModifiers(t, Nothing)))
 
                 If containerChanged Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamespaceOrTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamespaceOrTypeSymbol.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overridable Function GetTypeMembers(name As String, arity As Integer) As ImmutableArray(Of NamedTypeSymbol)
             ' default implementation does a post-filter. We can override this if its a performance burden, but 
             ' experience is that it won't be.
-            Return GetTypeMembers(name).WhereAsArray(Function(type, arity_) type.Arity = arity_, arity)
+            Return GetTypeMembers(name).WhereAsArray(predicate:=Function(type, arity_) type.Arity = arity_, arg:=arity)
         End Function
 
         ' Only the compiler can create new instances.

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -218,14 +218,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
 
                 Dim assembly = metadata.GetAssembly
-                Dim peReferences = assembly.AssemblyReferences.SelectAsArray(AddressOf MapAssemblyIdentityToResolvedSymbol, referencedAssembliesByIdentity)
+                Dim peReferences = assembly.AssemblyReferences.SelectAsArray(map:=AddressOf MapAssemblyIdentityToResolvedSymbol, arg:=referencedAssembliesByIdentity)
 
                 assemblyReferenceIdentityMap = GetAssemblyReferenceIdentityBaselineMap(peReferences, assembly.AssemblyReferences)
 
                 Dim assemblySymbol = New PEAssemblySymbol(assembly, DocumentationProvider.Default, isLinked:=False, importOptions:=importOptions)
 
                 Dim unifiedAssemblies = Me.UnifiedAssemblies.WhereAsArray(
-                    Function(unified, refAsmByIdentity) refAsmByIdentity.Contains(unified.OriginalReference, allowHigherVersion:=False), referencedAssembliesByIdentity)
+                    predicate:=Function(unified, refAsmByIdentity) refAsmByIdentity.Contains(unified.OriginalReference, allowHigherVersion:=False), arg:=referencedAssembliesByIdentity)
 
                 InitializeAssemblyReuseData(assemblySymbol, peReferences, unifiedAssemblies)
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -137,7 +137,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
                 ' Retarget by type code - primitive types are encoded in short form in an attribute signature:
                 Return marshallingInfo.WithTranslatedTypes(Of TypeSymbol, RetargetingSymbolTranslator)(
-                    Function(type, translator) translator.Retarget(DirectCast(type, TypeSymbol), RetargetOptions.RetargetPrimitiveTypesByTypeCode), Me)
+                    translator:=Function(type, translator) translator.Retarget(DirectCast(type, TypeSymbol), RetargetOptions.RetargetPrimitiveTypesByTypeCode), arg:=Me)
             End Function
 
             Public Function Retarget(symbol As TypeSymbol, options As RetargetOptions) As TypeSymbol
@@ -656,7 +656,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             End Function
 
             Private Function RetargetAttributes(oldAttributes As ImmutableArray(Of VisualBasicAttributeData)) As ImmutableArray(Of VisualBasicAttributeData)
-                Return oldAttributes.SelectAsArray(Function(a, t) t.RetargetAttributeData(a), Me)
+                Return oldAttributes.SelectAsArray(map:=Function(a, t) t.RetargetAttributeData(a), arg:=Me)
             End Function
 
             Friend Iterator Function RetargetAttributes(attributes As IEnumerable(Of VisualBasicAttributeData)) As IEnumerable(Of VisualBasicAttributeData)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -1637,7 +1637,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Public Overrides Function GetTypeMembers(name As String, arity As Integer) As ImmutableArray(Of NamedTypeSymbol)
-            Return GetTypeMembers(name).WhereAsArray(Function(t, arity_) t.Arity = arity_, arity)
+            Return GetTypeMembers(name).WhereAsArray(predicate:=Function(t, arity_) t.Arity = arity_, arg:=arity)
         End Function
 
         Friend Overrides ReadOnly Property DefaultPropertyName As String

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
@@ -407,24 +407,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overrides Function GetMembers(name As String) As ImmutableArray(Of Symbol)
             ' TODO - Perf
-            Return OriginalDefinition.GetMembers(name).SelectAsArray(Function(member, self) self.SubstituteTypeParametersInMember(member), Me)
+            Return OriginalDefinition.GetMembers(name).SelectAsArray(map:=Function(member, self) self.SubstituteTypeParametersInMember(member), arg:=Me)
         End Function
 
         Friend Overrides Function GetTypeMembersUnordered() As ImmutableArray(Of NamedTypeSymbol)
-            Return OriginalDefinition.GetTypeMembersUnordered().SelectAsArray(Function(nestedType, self) self.SubstituteTypeParametersForMemberType(nestedType), Me)
+            Return OriginalDefinition.GetTypeMembersUnordered().SelectAsArray(map:=Function(nestedType, self) self.SubstituteTypeParametersForMemberType(nestedType), arg:=Me)
         End Function
 
         Public Overrides Function GetTypeMembers() As ImmutableArray(Of NamedTypeSymbol)
-            Return OriginalDefinition.GetTypeMembers().SelectAsArray(Function(nestedType, self) self.SubstituteTypeParametersForMemberType(nestedType), Me)
+            Return OriginalDefinition.GetTypeMembers().SelectAsArray(map:=Function(nestedType, self) self.SubstituteTypeParametersForMemberType(nestedType), arg:=Me)
         End Function
 
         Public Overrides Function GetTypeMembers(name As String) As ImmutableArray(Of NamedTypeSymbol)
             ' TODO - Perf
-            Return OriginalDefinition.GetTypeMembers(name).SelectAsArray(Function(nestedType, self) self.SubstituteTypeParametersForMemberType(nestedType), Me)
+            Return OriginalDefinition.GetTypeMembers(name).SelectAsArray(map:=Function(nestedType, self) self.SubstituteTypeParametersForMemberType(nestedType), arg:=Me)
         End Function
 
         Public Overrides Function GetTypeMembers(name As String, arity As Integer) As ImmutableArray(Of NamedTypeSymbol)
-            Return OriginalDefinition.GetTypeMembers(name, arity).SelectAsArray(Function(nestedType, self) self.SubstituteTypeParametersForMemberType(nestedType), Me)
+            Return OriginalDefinition.GetTypeMembers(name, arity).SelectAsArray(map:=Function(nestedType, self) self.SubstituteTypeParametersForMemberType(nestedType), arg:=Me)
         End Function
 
         Friend NotOverridable Overrides Function GetFieldsToEmit() As IEnumerable(Of FieldSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedClonedTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedClonedTypeParameterSymbol.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend Shared Function MakeTypeParameters(origParameters As ImmutableArray(Of TypeParameterSymbol), container As Symbol,
                                                   mapFunction As Func(Of TypeParameterSymbol, Symbol, TypeParameterSymbol)) As ImmutableArray(Of TypeParameterSymbol)
-            Return origParameters.SelectAsArray(mapFunction, container)
+            Return origParameters.SelectAsArray(map:=mapFunction, arg:=container)
         End Function
 
         Friend Sub New(correspondingMethodTypeParameter As TypeParameterSymbol, container As Symbol, name As String, typeMapFactory As Func(Of Symbol, TypeSubstitution))

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -942,7 +942,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Public Overrides Function GetMembers(name As String) As ImmutableArray(Of Symbol)
-            Return Me.GetMembers().WhereAsArray(Function(member, name_) IdentifierComparison.Equals(member.Name, name_), name)
+            Return Me.GetMembers().WhereAsArray(predicate:=Function(member, name_) IdentifierComparison.Equals(member.Name, name_), arg:=name)
         End Function
 
         Public Overrides Function GetTypeMembers() As ImmutableArray(Of NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
@@ -347,7 +347,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Return an array of substituted type parameters with duplicates removed.
         ''' </summary>
         Friend Shared Function InternalSubstituteTypeParametersDistinct(substitution As TypeSubstitution, types As ImmutableArray(Of TypeSymbol)) As ImmutableArray(Of TypeSymbol)
-            Return types.SelectAsArray(s_substituteFunc, substitution).Distinct()
+            Return types.SelectAsArray(map:=s_substituteFunc, arg:=substitution).Distinct()
         End Function
 
         Private Shared ReadOnly s_substituteFunc As Func(Of TypeSymbol, TypeSubstitution, TypeSymbol) = Function(type, substitution) type.InternalSubstituteTypeParameters(substitution).Type

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -733,10 +733,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return Nothing
                 End If
 
-                Dim names = namesBuilder.SelectAsArray(Function(name, constantType)
+                Dim names = namesBuilder.SelectAsArray(map:=Function(name, constantType)
                                                            Return New TypedConstant(constantType, TypedConstantKind.Primitive, name)
                                                        End Function,
-                                                       stringType)
+                                                       arg:=stringType)
 
                 namesBuilder.Free()
                 Return names

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -734,8 +734,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Dim names = namesBuilder.SelectAsArray(map:=Function(name, constantType)
-                                                           Return New TypedConstant(constantType, TypedConstantKind.Primitive, name)
-                                                       End Function,
+                                                                Return New TypedConstant(constantType, TypedConstantKind.Primitive, name)
+                                                            End Function,
                                                        arg:=stringType)
 
                 namesBuilder.Free()

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
@@ -106,7 +106,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         Friend Shared Function GetAllLocals(compilation As VisualBasicCompilation, method As IMethodSymbol) As ImmutableArray(Of KeyValuePair(Of ILocalSymbol, Integer))
             Dim locals = GetAllLocals(compilation, DirectCast(method, MethodSymbol))
-            Return locals.SelectAsArray(Function(local, index, arg) New KeyValuePair(Of ILocalSymbol, Integer)(local, index), DirectCast(Nothing, Object))
+            Return locals.SelectAsArray(map:=Function(local, index, arg) New KeyValuePair(Of ILocalSymbol, Integer)(local, index), arg:=DirectCast(Nothing, Object))
         End Function
 
         Friend Shared Function GetAllLocals(method As SourceMethodSymbol) As ImmutableArray(Of VisualBasicSyntaxNode)

--- a/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
+++ b/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <paramref name="transformer"/> function; otherwise, <see langword="false"/> if the location's value remained
         /// the same because the last invocation of <paramref name="transformer"/> returned the existing value.
         /// </returns>
-        public static bool Update<T, TArg>(ref ImmutableSegmentedList<T> location, Func<ImmutableSegmentedList<T>, TArg, ImmutableSegmentedList<T>> transformer, TArg transformerArgument)
+        public static bool Update<T, TArg>(ref ImmutableSegmentedList<T> location, TArg transformerArgument, Func<ImmutableSegmentedList<T>, TArg, ImmutableSegmentedList<T>> transformer)
         {
             if (transformer is null)
                 throw new ArgumentNullException(nameof(transformer));
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <paramref name="transformer"/> function; otherwise, <see langword="false"/> if the location's value remained
         /// the same because the last invocation of <paramref name="transformer"/> returned the existing value.
         /// </returns>
-        public static bool Update<T, TArg>(ref ImmutableSegmentedHashSet<T> location, Func<ImmutableSegmentedHashSet<T>, TArg, ImmutableSegmentedHashSet<T>> transformer, TArg transformerArgument)
+        public static bool Update<T, TArg>(ref ImmutableSegmentedHashSet<T> location, TArg transformerArgument, Func<ImmutableSegmentedHashSet<T>, TArg, ImmutableSegmentedHashSet<T>> transformer)
         {
             if (transformer is null)
                 throw new ArgumentNullException(nameof(transformer));
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <paramref name="transformer"/> function; otherwise, <see langword="false"/> if the location's value remained
         /// the same because the last invocation of <paramref name="transformer"/> returned the existing value.
         /// </returns>
-        public static bool Update<TKey, TValue, TArg>(ref ImmutableSegmentedDictionary<TKey, TValue> location, Func<ImmutableSegmentedDictionary<TKey, TValue>, TArg, ImmutableSegmentedDictionary<TKey, TValue>> transformer, TArg transformerArgument)
+        public static bool Update<TKey, TValue, TArg>(ref ImmutableSegmentedDictionary<TKey, TValue> location, TArg transformerArgument, Func<ImmutableSegmentedDictionary<TKey, TValue>, TArg, ImmutableSegmentedDictionary<TKey, TValue>> transformer)
             where TKey : notnull
         {
             if (transformer is null)
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.Collections
         }
 
         /// <inheritdoc cref="ImmutableInterlocked.GetOrAdd{TKey, TValue, TArg}(ref ImmutableDictionary{TKey, TValue}, TKey, Func{TKey, TArg, TValue}, TArg)"/>
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableSegmentedDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableSegmentedDictionary<TKey, TValue> location, TKey key, TArg factoryArgument, Func<TKey, TArg, TValue> valueFactory)
             where TKey : notnull
         {
             if (valueFactory is null)

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -230,10 +230,10 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         }
 
         public int FindIndex<TArg>(Func<T, TArg, bool> match, TArg arg)
-            => FindIndex(0, Count, match, arg);
+            => FindIndex(0, Count, match: match, arg: arg);
 
         public int FindIndex<TArg>(int startIndex, Func<T, TArg, bool> match, TArg arg)
-            => FindIndex(startIndex, Count - startIndex, match, arg);
+            => FindIndex(startIndex, Count - startIndex, match: match, arg: arg);
 
         public int FindIndex<TArg>(int startIndex, int count, Func<T, TArg, bool> match, TArg arg)
         {

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -229,13 +229,13 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return -1;
         }
 
-        public int FindIndex<TArg>(Func<T, TArg, bool> match, TArg arg)
+        public int FindIndex<TArg>(TArg arg, Func<T, TArg, bool> match)
             => FindIndex(0, Count, match: match, arg: arg);
 
-        public int FindIndex<TArg>(int startIndex, Func<T, TArg, bool> match, TArg arg)
+        public int FindIndex<TArg>(int startIndex, TArg arg, Func<T, TArg, bool> match)
             => FindIndex(startIndex, Count - startIndex, match: match, arg: arg);
 
-        public int FindIndex<TArg>(int startIndex, int count, Func<T, TArg, bool> match, TArg arg)
+        public int FindIndex<TArg>(int startIndex, int count, TArg arg, Func<T, TArg, bool> match)
         {
             var endIndex = startIndex + count;
             for (var i = startIndex; i < endIndex; i++)
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             _builder.RemoveAll(match);
         }
 
-        public void RemoveAll<TArg>(Func<T, TArg, bool> match, TArg arg)
+        public void RemoveAll<TArg>(TArg arg, Func<T, TArg, bool> match)
         {
             var i = 0;
             for (var j = 0; j < _builder.Count; j++)

--- a/src/Dependencies/PooledObjects/PooledDelegates.cs
+++ b/src/Dependencies/PooledObjects/PooledDelegates.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <param name="boundAction">A delegate which calls <paramref name="unboundAction"/> with the specified
         /// <paramref name="argument"/>.</param>
         /// <returns>A disposable <see cref="Releaser"/> which returns the object to the delegate pool.</returns>
-        public static Releaser GetPooledAction<TArg>(Action<TArg> unboundAction, TArg argument, out Action boundAction)
+        public static Releaser GetPooledAction<TArg>(TArg argument, Action<TArg> unboundAction, out Action boundAction)
             => GetPooledDelegate<ActionWithBoundArgument<TArg>, TArg, Action<TArg>, Action>(unboundAction, argument, out boundAction);
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <param name="boundAction">A delegate which calls <paramref name="unboundAction"/> with the specified
         /// <paramref name="argument"/>.</param>
         /// <returns>A disposable <see cref="Releaser"/> which returns the object to the delegate pool.</returns>
-        public static Releaser GetPooledAction<T1, TArg>(Action<T1, TArg> unboundAction, TArg argument, out Action<T1> boundAction)
+        public static Releaser GetPooledAction<T1, TArg>(TArg argument, Action<T1, TArg> unboundAction, out Action<T1> boundAction)
             => GetPooledDelegate<ActionWithBoundArgument<T1, TArg>, TArg, Action<T1, TArg>, Action<T1>>(unboundAction, argument, out boundAction);
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <param name="boundAction">A delegate which calls <paramref name="unboundAction"/> with the specified
         /// <paramref name="argument"/>.</param>
         /// <returns>A disposable <see cref="Releaser"/> which returns the object to the delegate pool.</returns>
-        public static Releaser GetPooledAction<T1, T2, TArg>(Action<T1, T2, TArg> unboundAction, TArg argument, out Action<T1, T2> boundAction)
+        public static Releaser GetPooledAction<T1, T2, TArg>(TArg argument, Action<T1, T2, TArg> unboundAction, out Action<T1, T2> boundAction)
             => GetPooledDelegate<ActionWithBoundArgument<T1, T2, TArg>, TArg, Action<T1, T2, TArg>, Action<T1, T2>>(unboundAction, argument, out boundAction);
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <param name="boundAction">A delegate which calls <paramref name="unboundAction"/> with the specified
         /// <paramref name="argument"/>.</param>
         /// <returns>A disposable <see cref="Releaser"/> which returns the object to the delegate pool.</returns>
-        public static Releaser GetPooledAction<T1, T2, T3, TArg>(Action<T1, T2, T3, TArg> unboundAction, TArg argument, out Action<T1, T2, T3> boundAction)
+        public static Releaser GetPooledAction<T1, T2, T3, TArg>(TArg argument, Action<T1, T2, T3, TArg> unboundAction, out Action<T1, T2, T3> boundAction)
             => GetPooledDelegate<ActionWithBoundArgument<T1, T2, T3, TArg>, TArg, Action<T1, T2, T3, TArg>, Action<T1, T2, T3>>(unboundAction, argument, out boundAction);
 
         /// <summary>
@@ -195,16 +195,16 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <param name="boundFunction">A delegate which calls <paramref name="unboundFunction"/> with the specified
         /// <paramref name="argument"/>.</param>
         /// <returns>A disposable <see cref="Releaser"/> which returns the object to the delegate pool.</returns>
-        public static Releaser GetPooledFunction<TArg, TResult>(Func<TArg, TResult> unboundFunction, TArg argument, out Func<TResult> boundFunction)
+        public static Releaser GetPooledFunction<TArg, TResult>(TArg argument, Func<TArg, TResult> unboundFunction, out Func<TResult> boundFunction)
             => GetPooledDelegate<FuncWithBoundArgument<TArg, TResult>, TArg, Func<TArg, TResult>, Func<TResult>>(unboundFunction, argument, out boundFunction);
 
         /// <summary>
-        /// Equivalent to <see cref="GetPooledFunction{TArg, TResult}(Func{TArg, TResult}, TArg, out Func{TResult})"/>,
+        /// Equivalent to <see cref="GetPooledFunction{TArg, TResult}(TArg, Func{TArg, TResult}, out Func{TResult})"/>,
         /// except typed such that it can be used to create a pooled <see cref="ConditionalWeakTable{TKey,
         /// TValue}.CreateValueCallback"/>.
         /// </summary>
         public static Releaser GetPooledCreateValueCallback<TKey, TArg, TValue>(
-            Func<TKey, TArg, TValue> unboundFunction, TArg argument,
+            TArg argument, Func<TKey, TArg, TValue> unboundFunction,
             out ConditionalWeakTable<TKey, TValue>.CreateValueCallback boundFunction) where TKey : class where TValue : class
 
         {
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <param name="boundFunction">A delegate which calls <paramref name="unboundFunction"/> with the specified
         /// <paramref name="argument"/>.</param>
         /// <returns>A disposable <see cref="Releaser"/> which returns the object to the delegate pool.</returns>
-        public static Releaser GetPooledFunction<T1, TArg, TResult>(Func<T1, TArg, TResult> unboundFunction, TArg argument, out Func<T1, TResult> boundFunction)
+        public static Releaser GetPooledFunction<T1, TArg, TResult>(TArg argument, Func<T1, TArg, TResult> unboundFunction, out Func<T1, TResult> boundFunction)
             => GetPooledDelegate<FuncWithBoundArgument<T1, TArg, TResult>, TArg, Func<T1, TArg, TResult>, Func<T1, TResult>>(unboundFunction, argument, out boundFunction);
 
         /// <summary>
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <param name="boundFunction">A delegate which calls <paramref name="unboundFunction"/> with the specified
         /// <paramref name="argument"/>.</param>
         /// <returns>A disposable <see cref="Releaser"/> which returns the object to the delegate pool.</returns>
-        public static Releaser GetPooledFunction<T1, T2, TArg, TResult>(Func<T1, T2, TArg, TResult> unboundFunction, TArg argument, out Func<T1, T2, TResult> boundFunction)
+        public static Releaser GetPooledFunction<T1, T2, TArg, TResult>(TArg argument, Func<T1, T2, TArg, TResult> unboundFunction, out Func<T1, T2, TResult> boundFunction)
             => GetPooledDelegate<FuncWithBoundArgument<T1, T2, TArg, TResult>, TArg, Func<T1, T2, TArg, TResult>, Func<T1, T2, TResult>>(unboundFunction, argument, out boundFunction);
 
         /// <summary>
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <param name="boundFunction">A delegate which calls <paramref name="unboundFunction"/> with the specified
         /// <paramref name="argument"/>.</param>
         /// <returns>A disposable <see cref="Releaser"/> which returns the object to the delegate pool.</returns>
-        public static Releaser GetPooledFunction<T1, T2, T3, TArg, TResult>(Func<T1, T2, T3, TArg, TResult> unboundFunction, TArg argument, out Func<T1, T2, T3, TResult> boundFunction)
+        public static Releaser GetPooledFunction<T1, T2, T3, TArg, TResult>(TArg argument, Func<T1, T2, T3, TArg, TResult> unboundFunction, out Func<T1, T2, T3, TResult> boundFunction)
             => GetPooledDelegate<FuncWithBoundArgument<T1, T2, T3, TArg, TResult>, TArg, Func<T1, T2, T3, TArg, TResult>, Func<T1, T2, T3, TResult>>(unboundFunction, argument, out boundFunction);
 
         /// <summary>

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_UpdateModel.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_UpdateModel.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                     if (name != null)
                     {
                         var comparer = isCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
-                        return item.Parameters.Any(static (p, arg) => arg.comparer.Equals(p.Name, arg.name), (comparer, name));
+                        return item.Parameters.Any(predicate: static (p, arg) => arg.comparer.Equals(p.Name, arg.name), arg: (comparer, name));
                     }
 
                     // An item is applicable if it has at least as many parameters as the selected

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller_TypeChar.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             else
             {
                 var computed = false;
-                if (allProviders.Any(static (p, args) => p.IsRetriggerCharacter(args.TypedChar), args))
+                if (allProviders.Any(predicate: static (p, args) => p.IsRetriggerCharacter(args.TypedChar), arg: args))
                 {
                     // The user typed a character that might close the scope of the current model.
                     // In this case, we should requery all providers.

--- a/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -151,11 +151,11 @@ internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
                     new NormalizedSnapshotSpanCollection(spanToTag),
                     mergedTags,
                     // We should only be asking for a single span when getting the syntactic classifications
-                    GetTaggingFunction(requireSingleSpan: true, (span, buffer) => classificationService.AddSyntacticClassificationsAsync(document, span, buffer, cancellationToken)),
+                    addSyntacticSpansAsync: GetTaggingFunction(requireSingleSpan: true, (span, buffer) => classificationService.AddSyntacticClassificationsAsync(document, span, buffer, cancellationToken)),
                     // We should only be asking for a single span when getting the semantic classifications
-                    GetTaggingFunction(requireSingleSpan: true, (span, buffer) => classificationService.AddSemanticClassificationsAsync(document, span, options, buffer, cancellationToken)),
+                    addSemanticSpansAsync: GetTaggingFunction(requireSingleSpan: true, (span, buffer) => classificationService.AddSemanticClassificationsAsync(document, span, options, buffer, cancellationToken)),
                     //  Note: many string literal spans may be passed in when getting embedded classifications
-                    GetTaggingFunction(requireSingleSpan: false, (span, buffer) => classificationService.AddEmbeddedLanguageClassificationsAsync(document, span, options, buffer, cancellationToken)),
+                    addEmbeddedSpansAsync: GetTaggingFunction(requireSingleSpan: false, (span, buffer) => classificationService.AddEmbeddedLanguageClassificationsAsync(document, span, options, buffer, cancellationToken)),
                     arg: default).ConfigureAwait(false);
             });
 

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -93,7 +93,7 @@ internal sealed class TotalClassificationAggregateTagger(
                 arg.embeddedTagger.AddTags(spans, tags);
                 return Task.CompletedTask;
             },
-            (syntacticTagger, semanticTagger, embeddedTagger)).VerifyCompleted();
+            arg: (syntacticTagger, semanticTagger, embeddedTagger)).VerifyCompleted();
     }
 
     public static async Task AddTagsAsync<TArg>(

--- a/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Classification/TotalClassificationTaggerProvider.cs
@@ -99,10 +99,10 @@ internal sealed class TotalClassificationAggregateTagger(
     public static async Task AddTagsAsync<TArg>(
         NormalizedSnapshotSpanCollection spans,
         SegmentedList<TagSpan<IClassificationTag>> totalTags,
+        TArg arg,
         Func<NormalizedSnapshotSpanCollection, SegmentedList<TagSpan<IClassificationTag>>, TArg, Task> addSyntacticSpansAsync,
         Func<NormalizedSnapshotSpanCollection, SegmentedList<TagSpan<IClassificationTag>>, TArg, Task> addSemanticSpansAsync,
-        Func<NormalizedSnapshotSpanCollection, SegmentedList<TagSpan<IClassificationTag>>, TArg, Task> addEmbeddedSpansAsync,
-        TArg arg)
+        Func<NormalizedSnapshotSpanCollection, SegmentedList<TagSpan<IClassificationTag>>, TArg, Task> addEmbeddedSpansAsync)
     {
         // First, get all the syntactic tags.  While they are generally overridden by semantic tags (since semantics
         // allows us to understand better what things like identifiers mean), they do take precedence for certain

--- a/src/EditorFeatures/Core/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/CodeActions/CodeActionEditHandlerService.cs
@@ -235,9 +235,9 @@ internal class CodeActionEditHandlerService(
             return null;
         }
 
-        if (changedDocuments.Any(static (id, arg) => arg.newSolution.GetRequiredDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredDocument(id)), (oldSolution, newSolution)) ||
-            changedAdditionalDocuments.Any(static (id, arg) => arg.newSolution.GetRequiredAdditionalDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredAdditionalDocument(id)), (oldSolution, newSolution)) ||
-            changedAnalyzerConfigDocuments.Any(static (id, arg) => arg.newSolution.GetRequiredAnalyzerConfigDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredAnalyzerConfigDocument(id)), (oldSolution, newSolution)))
+        if (changedDocuments.Any(predicate: static (id, arg) => arg.newSolution.GetRequiredDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredDocument(id)), arg: (oldSolution, newSolution)) ||
+            changedAdditionalDocuments.Any(predicate: static (id, arg) => arg.newSolution.GetRequiredAdditionalDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredAdditionalDocument(id)), arg: (oldSolution, newSolution)) ||
+            changedAnalyzerConfigDocuments.Any(predicate: static (id, arg) => arg.newSolution.GetRequiredAnalyzerConfigDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredAnalyzerConfigDocument(id)), arg: (oldSolution, newSolution)))
         {
             return null;
         }

--- a/src/EditorFeatures/Core/CommentSelection/ToggleLineCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommentSelection/ToggleLineCommentCommandHandler.cs
@@ -175,7 +175,7 @@ internal class ToggleLineCommentCommandHandler(
     }
 
     private static bool SelectionHasUncommentedLines(ImmutableArray<ITextSnapshotLine> linesInSelection, CommentSelectionInfo commentInfo)
-        => linesInSelection.Any(static (l, commentInfo) => !IsLineCommentedOrEmpty(l, commentInfo), commentInfo);
+        => linesInSelection.Any(predicate: static (l, commentInfo) => !IsLineCommentedOrEmpty(l, commentInfo), arg: commentInfo);
 
     private static bool IsLineCommentedOrEmpty(ITextSnapshotLine line, CommentSelectionInfo info)
     {

--- a/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingService.cs
@@ -255,7 +255,7 @@ internal sealed class ActiveStatementTrackingService(Workspace workspace, IAsync
         }
 
         private static ImmutableArray<ActiveStatementTrackingSpan> CreateTrackingSpans(ITextSnapshot snapshot, ImmutableArray<ActiveStatementSpan> activeStatementSpans)
-            => activeStatementSpans.SelectAsArray((span, snapshot) => ActiveStatementTrackingSpan.Create(snapshot, span), snapshot);
+            => activeStatementSpans.SelectAsArray(map: (span, snapshot) => ActiveStatementTrackingSpan.Create(snapshot, span), arg: snapshot);
 
         private static ImmutableArray<ActiveStatementTrackingSpan> UpdateTrackingSpans(
             ITextSnapshot snapshot,

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -420,7 +420,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         {
             var documents = textBuffer.AsTextContainer().GetRelatedDocuments();
 
-            if (!documents.Any(static (d, locationsByDocument) => locationsByDocument.Contains(d.Id), locationsByDocument))
+            if (!documents.Any(predicate: static (d, locationsByDocument) => locationsByDocument.Contains(d.Id), arg: locationsByDocument))
             {
                 _openTextBuffers[textBuffer].SetReferenceSpans([]);
             }

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs
@@ -35,7 +35,7 @@ internal static class Helpers
             return item;
 
         Debug.Assert(item.DisplayText.StartsWith(Completion.Utilities.UnicodeStarAndSpace));
-        var newProperties = item.GetProperties().WhereAsArray((kvp, propName) => kvp.Key != propName, PromotedItemOriginalIndexPropertyName);
+        var newProperties = item.GetProperties().WhereAsArray(predicate: (kvp, propName) => kvp.Key != propName, arg: PromotedItemOriginalIndexPropertyName);
         return item
             .WithDisplayText(item.DisplayText[Completion.Utilities.UnicodeStarAndSpace.Length..])
             .WithProperties(newProperties);
@@ -160,7 +160,7 @@ internal static class Helpers
     {
         if (textTypedSoFar.Length > 0)
         {
-            using var _ = PooledDelegates.GetPooledFunction(static (filterText, pattern) => filterText.StartsWith(pattern, StringComparison.CurrentCultureIgnoreCase), textTypedSoFar, out Func<string, bool> isPrefixMatch);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: static (filterText, pattern) => filterText.StartsWith(pattern, StringComparison.CurrentCultureIgnoreCase), argument: textTypedSoFar, boundFunction: out Func<string, bool> isPrefixMatch);
 
             // Note that StartsWith ignores \0 at the end of textTypedSoFar on VS Mac and Mono.
             return item.DisplayText.StartsWith(textTypedSoFar, StringComparison.CurrentCultureIgnoreCase) ||

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -611,7 +611,7 @@ internal partial class ItemManager
                 {
                     // Since VS item's display text is created as Prefix + DisplayText + Suffix, 
                     // we can calculate the highlighted span by adding an offset that is the length of the Prefix.
-                    return patternMatch.Value.MatchedSpans.SelectAsArray(GetOffsetSpan, matchResult.CompletionItem);
+                    return patternMatch.Value.MatchedSpans.SelectAsArray(map: GetOffsetSpan, arg: matchResult.CompletionItem);
                 }
 
                 // If there's no match for Roslyn item's filter text which is identical to its display text,
@@ -979,7 +979,7 @@ internal partial class ItemManager
                 => ShouldBeFilteredOutOfCompletionList(item) || ShouldBeFilteredOutOfExpandedCompletionList(item);
 
             private bool ShouldBeFilteredOutOfCompletionList(VSCompletionItem item)
-                => _needToFilter && !item.Filters.Any(static (filter, self) => self._selectedNonExpanderFilters.Contains(filter), this);
+                => _needToFilter && !item.Filters.Any(predicate: static (filter, self) => self._selectedNonExpanderFilters.Contains(filter), arg: this);
 
             private bool ShouldBeFilteredOutOfExpandedCompletionList(VSCompletionItem item)
             {

--- a/src/EditorFeatures/Core/Interactive/InteractiveSession.cs
+++ b/src/EditorFeatures/Core/Interactive/InteractiveSession.cs
@@ -184,8 +184,8 @@ internal sealed class InteractiveSession : IDisposable
 
             var metadataService = _workspace.Services.GetRequiredService<IMetadataService>();
             references = initResult.MetadataReferencePaths.ToImmutableArrayOrEmpty().SelectAsArray(
-                (path, metadataService) => (MetadataReference)metadataService.GetReference(path, MetadataReferenceProperties.Assembly),
-                metadataService);
+                map: (path, metadataService) => (MetadataReference)metadataService.GetReference(path, MetadataReferenceProperties.Assembly),
+                arg: metadataService);
 
             // if a script was specified in .rps file insert a project with a document that represents it:
             initializationScriptPath = initResult!.ScriptPath;

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
@@ -47,7 +47,7 @@ internal sealed partial class RenameTrackingTaggerProvider
             _undoHistoryRegistry = undoHistoryRegistry;
             _displayText = displayText;
             _renameSymbolResultGetter = AsyncLazy.Create(
-                static (self, c) => self.RenameSymbolWorkerAsync(c),
+                asynchronousComputeFunction: static (self, c) => self.RenameSymbolWorkerAsync(c),
                 arg: this);
         }
 

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -250,7 +250,7 @@ internal sealed partial class RenameTrackingTaggerProvider
                 return TriggerIdentifierKind.NotRenamable;
             }
 
-            return sourceSymbol.Locations.Any(static (loc, token) => loc == token.GetLocation(), token)
+            return sourceSymbol.Locations.Any(predicate: static (loc, token) => loc == token.GetLocation(), arg: token)
                     ? TriggerIdentifierKind.RenamableDeclaration
                     : TriggerIdentifierKind.RenamableReference;
         }

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
@@ -35,7 +35,7 @@ internal partial class TaggerEventSources
                     {
                         var relatedDocumentIds = e.NewSolution.GetRelatedDocumentIds(documentId);
 
-                        if (relatedDocumentIds.Any(static (d, e) => d.ProjectId == e.ProjectId, e))
+                        if (relatedDocumentIds.Any(predicate: static (d, e) => d.ProjectId == e.ProjectId, arg: e))
                         {
                             RaiseChanged();
                         }

--- a/src/EditorFeatures/Core/Structure/StructureTag.cs
+++ b/src/EditorFeatures/Core/Structure/StructureTag.cs
@@ -34,7 +34,7 @@ internal sealed class StructureTag(AbstractStructureTaggerProvider tagProvider, 
 
     public IReadOnlyList<SubHeadingStructureData>? SubHeadings { get; } = blockSpan.SubHeadings.IsDefault
         ? null
-        : blockSpan.SubHeadings.SelectAsArray(CreateSubHeading, snapshot);
+        : blockSpan.SubHeadings.SelectAsArray(map: CreateSubHeading, arg: snapshot);
 
     public Span? GuideLineSpan => null;
     public int? GuideLineHorizontalAnchorPoint => null;

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -420,7 +420,7 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                 {
                     var snapshot = spanToTag.Snapshot;
                     var (foundSnapshot, document) = snapshotToDocument.FirstOrDefault(
-                        static (t, snapshot) => t.snapshot == snapshot, snapshot);
+                        predicate: static (t, snapshot) => t.snapshot == snapshot, arg: snapshot);
 
                     // If this is the first time looking at this snapshot, then go fetch the document (which we may or
                     // may not have), and freeze it if necessary..
@@ -592,8 +592,8 @@ internal partial class AbstractAsynchronousTaggerProvider<TTag>
                 foreach (var (latestBuffer, latestSpans) in newTagTrees)
                 {
                     var snapshot = spansToTag.FirstOrDefault(
-                        static (span, latestBuffer) => span.SnapshotSpan.Snapshot.TextBuffer == latestBuffer,
-                        latestBuffer).SnapshotSpan.Snapshot;
+                        predicate: static (span, latestBuffer) => span.SnapshotSpan.Snapshot.TextBuffer == latestBuffer,
+                        arg: latestBuffer).SnapshotSpan.Snapshot;
                     Contract.ThrowIfNull(snapshot);
 
                     if (oldTagTrees.TryGetValue(latestBuffer, out var previousSpans))

--- a/src/EditorFeatures/DiagnosticsTestUtilities/MoveType/AbstractMoveTypeTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/MoveType/AbstractMoveTypeTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MoveType
 
                 if (actions.Length > 0)
                 {
-                    var renameFileAction = actions.Any(static (action, self) => action.Title.StartsWith(self.RenameTypeCodeActionTitle), this);
+                    var renameFileAction = actions.Any(predicate: static (action, self) => action.Title.StartsWith(self.RenameTypeCodeActionTitle), arg: this);
                     Assert.False(renameFileAction, "Rename Type to match file name code action was not expected, but shows up.");
                 }
             }
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MoveType
 
                 if (actions.Length > 0)
                 {
-                    var renameFileAction = actions.Any(static (action, self) => action.Title.StartsWith(self.RenameFileCodeActionTitle), this);
+                    var renameFileAction = actions.Any(predicate: static (action, self) => action.Title.StartsWith(self.RenameFileCodeActionTitle), arg: this);
                     Assert.False(renameFileAction, "Rename File to match type code action was not expected, but shows up.");
                 }
             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             // (Necessary for VB in particular since the EENamedTypeSymbol.Locations
             // is tied to the expression syntax in VB.)
             var synthesizedTypes = syntaxNodes.SelectAsArray(
-                (syntax, i, _) => (NamedTypeSymbol)CreateSynthesizedType(syntax, typeNameBase + i, methodName, ImmutableArray<Alias>.Empty),
+                map: (syntax, i, _) => (NamedTypeSymbol)CreateSynthesizedType(syntax, typeNameBase + i, methodName, ImmutableArray<Alias>.Empty),
                 arg: (object?)null);
 
             if (synthesizedTypes.Length == 0)
@@ -321,7 +321,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     ExpressionCompilerConstants.TypeVariablesClassName,
                     (m, t) => ImmutableArray.Create<MethodSymbol>(new EEConstructorSymbol(t)),
                     allTypeParameters,
-                    (t1, t2) => allTypeParameters.SelectAsArray((tp, i, t) => (TypeParameterSymbol)new SimpleTypeParameterSymbol(t, i, tp.Name), t2));
+                    (t1, t2) => allTypeParameters.SelectAsArray(map: (tp, i, t) => (TypeParameterSymbol)new SimpleTypeParameterSymbol(t, i, tp.Name), arg: t2));
                 additionalTypes.Add(typeVariablesType);
             }
 
@@ -462,7 +462,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         foreach (var local in _localsForBindingOutside)
                         {
                             if (!itemsAdded.Contains(local.Name) &&
-                                !_locals.Any(static (l, name) => l.Name == name, local.Name)) // Not captured locals inside the method shadow outside locals
+                                !_locals.Any(predicate: static (l, name) => l.Name == name, arg: local.Name)) // Not captured locals inside the method shadow outside locals
                             {
                                 AppendLocalAndMethod(localBuilder, methodBuilder, local, container, localIndex, GetLocalResultFlags(local));
                             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EETypeNameDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EETypeNameDecoder.cs
@@ -33,12 +33,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 // Find placeholder Windows.winmd assembly (created
                 // in MetadataUtilities.MakeAssemblyReferences).
                 var assemblies = Module.GetReferencedAssemblySymbols();
-                index = assemblies.IndexOf((assembly, unused) => assembly.Identity.IsWindowsRuntime(), arg: (object?)null);
+                index = assemblies.IndexOf(predicate: (assembly, unused) => assembly.Identity.IsWindowsRuntime(), arg: (object?)null);
                 if (index >= 0)
                 {
                     // Find module in Windows.winmd matching identity.
                     var modules = assemblies[index].Modules;
-                    var moduleIndex = modules.IndexOf((m, id) => id.Equals(GetComponentAssemblyIdentity(m)), identity);
+                    var moduleIndex = modules.IndexOf(predicate: (m, id) => id.Equals(GetComponentAssemblyIdentity(m)), arg: identity);
                     if (moduleIndex >= 0)
                     {
                         return index;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override BoundNode VisitBlock(BoundBlock node)
         {
-            var rewrittenLocals = node.Locals.WhereAsArray((local, rewriter) => local.IsCompilerGenerated || local.Name == null || rewriter.GetVariable(local.Name) == null, this);
+            var rewrittenLocals = node.Locals.WhereAsArray(predicate: (local, rewriter) => local.IsCompilerGenerated || local.Name == null || rewriter.GetVariable(local.Name) == null, arg: this);
             var rewrittenLocalFunctions = node.LocalFunctions;
             var rewrittenStatements = VisitList(node.Statements);
             return node.Update(rewrittenLocals, rewrittenLocalFunctions, node.HasUnsafeModifier, instrumentation: null, rewrittenStatements);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -115,8 +115,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             var getTypeMap = new Func<TypeMap>(() => this.TypeMap);
             _typeParameters = sourceMethodTypeParameters.SelectAsArray(
-                (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
-                (object)null);
+                map: (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
+                arg: (object)null);
             _allTypeParameters = container.TypeParameters.Concat(_typeParameters).Concat(_typeParameters);
             this.TypeMap = new TypeMap(allSourceTypeParameters, _allTypeParameters, allowAlpha: true);
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -81,8 +81,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             TypeMap typeMap = null;
             var getTypeMap = new Func<TypeMap>(() => typeMap);
             _typeParameters = this.SourceTypeParameters.SelectAsArray(
-                (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
-                (object)null);
+                map: (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
+                arg: (object)null);
 
             typeMap = new TypeMap(this.SourceTypeParameters, _typeParameters);
 
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             // Should not be requesting generated members
             // by name other than constructors.
             Debug.Assert((name == WellKnownMemberNames.InstanceConstructorName) || (name == WellKnownMemberNames.StaticConstructorName));
-            return this.GetMembers().WhereAsArray((m, name) => m.Name == name, name);
+            return this.GetMembers().WhereAsArray(predicate: (m, name) => m.Name == name, arg: name);
         }
 
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers()

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ImmutableArrayExtensions.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ImmutableArrayExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
     internal static class ImmutableArrayExtensions
     {
-        internal static int IndexOf<TItem, TArg>(this ImmutableArray<TItem> array, Func<TItem, TArg, bool> predicate, TArg arg)
+        internal static int IndexOf<TItem, TArg>(this ImmutableArray<TItem> array, TArg arg, Func<TItem, TArg, bool> predicate)
         {
             for (int i = 0; i < array.Length; i++)
             {

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -219,7 +219,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         Return ImmutableArray.Create(Of MethodSymbol)(constructor)
                     End Function,
                     allTypeParameters,
-                    Function(t1, t2) allTypeParameters.SelectAsArray(Function(tp, i, t) DirectCast(New SimpleTypeParameterSymbol(t, i, tp.GetUnmangledName()), TypeParameterSymbol), t2))
+                    Function(t1, t2) allTypeParameters.SelectAsArray(map:=Function(tp, i, t) DirectCast(New SimpleTypeParameterSymbol(t, i, tp.GetUnmangledName()), TypeParameterSymbol), arg:=t2))
                 additionalTypes.Add(typeVariablesType)
             End If
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EETypeNameDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EETypeNameDecoder.vb
@@ -30,11 +30,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 ' Find placeholder Windows.winmd assembly (created
                 ' in MetadataUtilities.MakeAssemblyReferences).
                 Dim assemblies = Me.Module.GetReferencedAssemblySymbols()
-                index = assemblies.IndexOf(Function(assembly, unused) assembly.Identity.IsWindowsRuntime(), DirectCast(Nothing, Object))
+                index = assemblies.IndexOf(predicate:=Function(assembly, unused) assembly.Identity.IsWindowsRuntime(), arg:=DirectCast(Nothing, Object))
                 If index >= 0 Then
                     ' Find module in Windows.winmd matching identity.
                     Dim modules = assemblies(index).Modules
-                    Dim moduleIndex = modules.IndexOf(Function(m, id) id.Equals(GetComponentAssemblyIdentity(m)), identity)
+                    Dim moduleIndex = modules.IndexOf(predicate:=Function(m, id) id.Equals(GetComponentAssemblyIdentity(m)), arg:=identity)
                     If moduleIndex >= 0 Then
                         Return index
                     End If

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -85,8 +85,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             Dim getTypeMap As New Func(Of TypeSubstitution)(Function() TypeMap)
             _typeParameters = sourceMethodTypeParameters.SelectAsArray(
-                Function(tp As TypeParameterSymbol, i As Integer, arg As Object) DirectCast(New EETypeParameterSymbol(Me, tp, i, getTypeMap), TypeParameterSymbol),
-                DirectCast(Nothing, Object))
+                map:=Function(tp As TypeParameterSymbol, i As Integer, arg As Object) DirectCast(New EETypeParameterSymbol(Me, tp, i, getTypeMap), TypeParameterSymbol),
+                arg:=DirectCast(Nothing, Object))
             _allTypeParameters = container.TypeParameters.Concat(_typeParameters)
             Me.TypeMap = TypeSubstitution.Create(sourceMethod, allSourceTypeParameters, ImmutableArrayExtensions.Cast(Of TypeParameterSymbol, TypeSymbol)(_allTypeParameters))
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.vb
@@ -85,8 +85,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim typeMap As TypeSubstitution = Nothing
             Dim getTypeMap = New Func(Of TypeSubstitution)(Function() typeMap)
             _typeParameters = SourceTypeParameters.SelectAsArray(
-                Function(tp As TypeParameterSymbol, i As Integer, arg As Object) DirectCast(New EETypeParameterSymbol(Me, tp, i, getTypeMap), TypeParameterSymbol),
-                DirectCast(Nothing, Object))
+                map:=Function(tp As TypeParameterSymbol, i As Integer, arg As Object) DirectCast(New EETypeParameterSymbol(Me, tp, i, getTypeMap), TypeParameterSymbol),
+                arg:=DirectCast(Nothing, Object))
 
             typeMap = TypeSubstitution.Create(sourceType, SourceTypeParameters, ImmutableArrayExtensions.Cast(Of TypeParameterSymbol, TypeSymbol)(_typeParameters))
 
@@ -171,7 +171,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Public Overrides Function GetMembers(name As String) As ImmutableArray(Of Symbol)
             ' Should not be requesting generated members by name other than constructors.
             Debug.Assert(name = WellKnownMemberNames.InstanceConstructorName OrElse name = WellKnownMemberNames.StaticConstructorName)
-            Return GetMembers().WhereAsArray(Function(member, name_) member.Name = name_, name)
+            Return GetMembers().WhereAsArray(predicate:=Function(member, name_) member.Name = name_, arg:=name)
         End Function
 
         Public Overrides Function GetTypeMembers() As ImmutableArray(Of NamedTypeSymbol)

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -87,7 +87,7 @@ internal partial class CSharpInlineTemporaryCodeRefactoringProvider
         // If the variable is itself referenced in its own initializer then don't offer anything here.  This
         // practically does not occur (though the language allows it), and it only serves to add a huge amount
         // of complexity to this feature.
-        if (references.Any(static (r, variableDeclarator) => variableDeclarator.Initializer.Span.Contains(r.Span), variableDeclarator))
+        if (references.Any(predicate: static (r, variableDeclarator) => variableDeclarator.Initializer.Span.Contains(r.Span), arg: variableDeclarator))
             return;
 
         context.RegisterRefactoring(

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CSharpSuggestionModeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CSharpSuggestionModeCompletionProvider.cs
@@ -184,7 +184,7 @@ internal class CSharpSuggestionModeCompletionProvider : AbstractSuggestionModeCo
         // If we're an argument to a function with multiple overloads, 
         // open the builder if any overload takes a delegate at our argument position
         var inferredTypeInfo = typeInferrer.GetTypeInferenceInfo(semanticModel, position, cancellationToken: cancellationToken);
-        return inferredTypeInfo.Any(static (type, semanticModel) => GetDelegateType(type, semanticModel.Compilation).IsDelegateType(), semanticModel);
+        return inferredTypeInfo.Any(predicate: static (type, semanticModel) => GetDelegateType(type, semanticModel.Compilation).IsDelegateType(), arg: semanticModel);
     }
 
     private static ITypeSymbol? GetDelegateType(TypeInferenceInfo typeInferenceInfo, Compilation compilation)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
@@ -69,7 +69,7 @@ internal partial class PartialTypeCompletionProvider : AbstractPartialTypeComple
 
         // The base class applies a broad filter when finding candidates, but since C# requires
         // that all parts have the "partial" modifier, the results can be trimmed further here.
-        return candidates?.Where(symbol => symbol.DeclaringSyntaxReferences.Any(static (reference, cancellationToken) => IsPartialTypeDeclaration(reference.GetSyntax(cancellationToken)), cancellationToken));
+        return candidates?.Where(symbol => symbol.DeclaringSyntaxReferences.Any(predicate: static (reference, cancellationToken) => IsPartialTypeDeclaration(reference.GetSyntax(cancellationToken)), arg: cancellationToken));
     }
 
     private static bool IsPartialTypeDeclaration(SyntaxNode syntax)

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
@@ -25,7 +25,7 @@ internal abstract class AbstractSpecialTypePreselectingKeywordRecommender(
     protected override int PreselectMatchPriority => SymbolMatchPriority.PreferType;
 
     protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
-        => context.InferredTypes.Any(static (t, self) => t.SpecialType == self.SpecialType, this);
+        => context.InferredTypes.Any(predicate: static (t, self) => t.SpecialType == self.SpecialType, arg: this);
 
     protected sealed override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
@@ -82,6 +82,6 @@ internal class ThisKeywordRecommender : AbstractSyntacticSingleKeywordRecommende
     protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
     {
         var outerType = context.SemanticModel.GetEnclosingNamedType(context.Position, cancellationToken);
-        return context.InferredTypes.Any(static (t, outerType) => Equals(t, outerType), outerType);
+        return context.InferredTypes.Any(predicate: static (t, outerType) => Equals(t, outerType), arg: outerType);
     }
 }

--- a/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_ProgramMain.cs
+++ b/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_ProgramMain.cs
@@ -82,7 +82,7 @@ internal static partial class ConvertProgramTransform
         var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
 
         // See if we have an existing part in another file.  If so, we'll have to generate our declaration as partial.
-        var hasExistingPart = programType.DeclaringSyntaxReferences.Any(static (d, cancellationToken) => d.GetSyntax(cancellationToken) is TypeDeclarationSyntax, cancellationToken);
+        var hasExistingPart = programType.DeclaringSyntaxReferences.Any(predicate: static (d, cancellationToken) => d.GetSyntax(cancellationToken) is TypeDeclarationSyntax, arg: cancellationToken);
 
         var method = (MethodDeclarationSyntax)generator.MethodDeclaration(
             mainMethod, WellKnownMemberNames.EntryPointMethodName,

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -813,7 +813,7 @@ internal partial class CSharpMethodExtractor
             var localFunctionKind = new SymbolSpecification.SymbolKindOrTypeKind(MethodKind.LocalFunction);
             if (LocalFunction)
             {
-                if (namingRules.Any(static (rule, arg) => rule.NamingStyle.CapitalizationScheme.Equals(Capitalization.CamelCase) && rule.SymbolSpecification.AppliesTo(arg.localFunctionKind, arg.self.CreateMethodModifiers(), null), (self: this, localFunctionKind)))
+                if (namingRules.Any(predicate: static (rule, arg) => rule.NamingStyle.CapitalizationScheme.Equals(Capitalization.CamelCase) && rule.SymbolSpecification.AppliesTo(arg.localFunctionKind, arg.self.CreateMethodModifiers(), null), arg: (self: this, localFunctionKind)))
                 {
                     methodName = NewMethodCamelCaseStr;
                 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -138,6 +138,6 @@ internal partial class CSharpSelectionResult
         }
 
         // let's see whether this interface has coclass attribute
-        return info.ConvertedType.GetAttributes().Any(static (c, coclassSymbol) => c.AttributeClass?.Equals(coclassSymbol) == true, coclassSymbol);
+        return info.ConvertedType.GetAttributes().Any(predicate: static (c, coclassSymbol) => c.AttributeClass?.Equals(coclassSymbol) == true, arg: coclassSymbol);
     }
 }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -77,7 +77,7 @@ internal abstract class CSharpGenerateParameterizedMemberService<TService> : Abs
             {
                 var typeParameter = GetUniqueTypeParameter(
                     genericName.TypeArgumentList.Arguments.First(),
-                    s => !State.TypeToGenerateIn.GetAllTypeParameters().Any(static (t, s) => t.Name == s, s),
+                    s => !State.TypeToGenerateIn.GetAllTypeParameters().Any(predicate: static (t, s) => t.Name == s, arg: s),
                     cancellationToken);
 
                 return [typeParameter];
@@ -92,7 +92,7 @@ internal abstract class CSharpGenerateParameterizedMemberService<TService> : Abs
                 {
                     var typeParameter = GetUniqueTypeParameter(
                         type,
-                        s => !usedIdentifiers.Contains(s) && !State.TypeToGenerateIn.GetAllTypeParameters().Any(static (t, s) => t.Name == s, s),
+                        s => !usedIdentifiers.Contains(s) && !State.TypeToGenerateIn.GetAllTypeParameters().Any(predicate: static (t, s) => t.Name == s, arg: s),
                         cancellationToken);
 
                     usedIdentifiers.Add(typeParameter.Name);

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementImplicitlyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementImplicitlyCodeRefactoringProvider.cs
@@ -42,7 +42,7 @@ internal class CSharpImplementImplicitlyCodeRefactoringProvider :
         var containingTypeInterfaces = member.ContainingType.AllInterfaces;
         if (containingTypeInterfaces.Length == 0)
             return false;
-        return memberInterfaceImplementations.Any(static (impl, containingTypeInterfaces) => containingTypeInterfaces.Contains(impl.ContainingType), containingTypeInterfaces);
+        return memberInterfaceImplementations.Any(predicate: static (impl, containingTypeInterfaces) => containingTypeInterfaces.Contains(impl.ContainingType), arg: containingTypeInterfaces);
     }
 
     // When converting to implicit, we don't need to update any references.

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceLocalForExpressionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceLocalForExpressionCodeRefactoringProvider.cs
@@ -100,7 +100,7 @@ internal class CSharpIntroduceLocalForExpressionCodeRefactoringProvider :
 
         // Generate the names for the locals.  For Tuples that have user provided names, keep that name.
         // Otherwise, generate a reasonable local name for the type of the field, using our helpers.
-        var localTypesAndDesignations = tupleType.TupleElements.SelectAsArray((field, index, _) =>
+        var localTypesAndDesignations = tupleType.TupleElements.SelectAsArray(map: (field, index, _) =>
             {
                 var name = field.Name.ToCamelCase();
                 if (field.Name == tupleUnderlyingType.TupleElements[index].Name)

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProviderBase_MethodGroup.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProviderBase_MethodGroup.cs
@@ -63,7 +63,7 @@ internal partial class InvocationExpressionSignatureHelpProviderBase
 
             var includeStatic = throughSymbol is INamedTypeSymbol ||
                 (throughExpression.IsKind(SyntaxKind.IdentifierName) &&
-                semanticModel.LookupNamespacesAndTypes(throughExpression.SpanStart, name: throughSymbol?.Name).Any(static (t, throughType) => Equals(t.GetSymbolType(), throughType), throughType));
+                semanticModel.LookupNamespacesAndTypes(throughExpression.SpanStart, name: throughSymbol?.Name).Any(predicate: static (t, throughType) => Equals(t.GetSymbolType(), throughType), arg: throughType));
 
             Contract.ThrowIfFalse(includeInstance || includeStatic);
             methodGroup = methodGroup.Where(m => (m.IsStatic && includeStatic) || (!m.IsStatic && includeInstance));

--- a/src/Features/Core/Portable/AddImport/SearchScopes/SourceSymbolsProjectSearchScope.cs
+++ b/src/Features/Core/Portable/AddImport/SearchScopes/SourceSymbolsProjectSearchScope.cs
@@ -48,7 +48,7 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
             return declarations;
 
             static AsyncLazy<IAssemblySymbol?> CreateLazyAssembly(Project project)
-                => AsyncLazy.Create(static async (project, c) =>
+                => AsyncLazy.Create(asynchronousComputeFunction: static async (project, c) =>
                        {
                            var compilation = await project.GetRequiredCompilationAsync(c).ConfigureAwait(false);
                            return (IAssemblySymbol?)compilation.Assembly;

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -327,9 +327,9 @@ internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSynta
         private bool HasAccessibleStaticFieldOrProperty(INamedTypeSymbol namedType, string fieldOrPropertyName)
         {
             return namedType.GetMembers(fieldOrPropertyName)
-                            .Any(static (m, self) => (m is IFieldSymbol || m is IPropertySymbol) &&
+                            .Any(predicate: static (m, self) => (m is IFieldSymbol || m is IPropertySymbol) &&
                                       m.IsStatic &&
-                                      m.IsAccessibleWithin(self._semanticModel.Compilation.Assembly), this);
+                                      m.IsAccessibleWithin(self._semanticModel.Compilation.Assembly), arg: this);
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -562,7 +562,7 @@ internal abstract class AbstractChangeSignatureService : ILanguageService
                 break;
             }
 
-            if (!arguments[i].IsNamed || updatedSignature.UpdatedConfiguration.ToListOfParameters().Any(static (p, arg) => p.Name == arg.arguments[arg.i].GetName(), (arguments, i)))
+            if (!arguments[i].IsNamed || updatedSignature.UpdatedConfiguration.ToListOfParameters().Any(predicate: static (p, arg) => p.Name == arg.arguments[arg.i].GetName(), arg: (arguments, i)))
             {
                 newArguments.Add(arguments[i]);
             }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
@@ -83,5 +83,5 @@ internal static class SuppressionHelpers
         => HasCustomTag(diagnostic.Descriptor.ImmutableCustomTags(), SynthesizedExternalSourceDiagnosticTag);
 
     public static bool HasCustomTag(ImmutableArray<string> customTags, string tagToFind)
-        => customTags.Any(static (c, tagToFind) => CultureInfo.InvariantCulture.CompareInfo.Compare(c, tagToFind) == 0, tagToFind);
+        => customTags.Any(predicate: static (c, tagToFind) => CultureInfo.InvariantCulture.CompareInfo.Compare(c, tagToFind) == 0, arg: tagToFind);
 }

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -351,8 +351,8 @@ internal abstract class AbstractChangeNamespaceService<TNamespaceDeclarationSynt
 
         // If we found a linked document which is part of a project with different project file,
         // then it's an actual linked file (i.e. not a multi-targeting project). We don't support that for now.
-        if (linkedDocumentIds.Any(static (id, arg) =>
-                !PathUtilities.PathsEqual(arg.solution.GetRequiredDocument(id).Project.FilePath!, arg.document.Project.FilePath!), (solution, document)))
+        if (linkedDocumentIds.Any(predicate: static (id, arg) =>
+                !PathUtilities.PathsEqual(arg.solution.GetRequiredDocument(id).Project.FilePath!, arg.document.Project.FilePath!), arg: (solution, document)))
         {
             allDocumentIds = default;
             return false;

--- a/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
+++ b/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
@@ -87,7 +87,7 @@ internal abstract class AbstractProjectExtensionProvider<TProvider, TExtension, 
 
     public static ImmutableArray<TExtension> FilterExtensions(TextDocument document, ImmutableArray<TExtension> extensions, Func<TExportAttribute, ExtensionInfo> getExtensionInfoForFiltering)
     {
-        return extensions.WhereAsArray(ShouldIncludeExtension, (document, getExtensionInfoForFiltering));
+        return extensions.WhereAsArray(predicate: ShouldIncludeExtension, arg: (document, getExtensionInfoForFiltering));
 
         static bool ShouldIncludeExtension(TExtension extension, (TextDocument, Func<TExportAttribute, ExtensionInfo>) args)
         {

--- a/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
@@ -156,7 +156,7 @@ public abstract partial class CompletionService
             if (_nameToProvider.Value.TryGetValue(item.ProviderName, out var provider))
                 return provider;
 
-            using var _ = PooledDelegates.GetPooledFunction(static (p, n) => p.Name == n, item.ProviderName, out Func<CompletionProvider, bool> isNameMatchingProviderPredicate);
+            using var _ = PooledDelegates.GetPooledFunction(unboundFunction: static (p, n) => p.Name == n, argument: item.ProviderName, boundFunction: out Func<CompletionProvider, bool> isNameMatchingProviderPredicate);
 
             // Publicly available options will not impact this call, since the completion item must have already
             // existed if it produced the input completion item.

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -98,7 +98,7 @@ internal abstract partial class AbstractPartialTypeCompletionProvider<TSyntaxCon
     }
 
     private static bool InSameProject(INamedTypeSymbol symbol, Compilation compilation)
-        => symbol.DeclaringSyntaxReferences.Any(static (r, compilation) => compilation.SyntaxTrees.Contains(r.SyntaxTree), compilation);
+        => symbol.DeclaringSyntaxReferences.Any(predicate: static (r, compilation) => compilation.SyntaxTrees.Contains(r.SyntaxTree), arg: compilation);
 
     private static bool NotNewDeclaredMember(INamedTypeSymbol symbol, TSyntaxContext context)
     {

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -63,7 +63,7 @@ internal abstract class AbstractRecommendationServiceBasedCompletionProvider<TSy
             var inferredTypes = context.InferredTypes.Where(t => t.SpecialType != SpecialType.System_Void).ToSet();
 
             return recommendedSymbols.NamedSymbols.SelectAsArray(
-                static (symbol, args) =>
+                map: static (symbol, args) =>
                 {
                     // Don't preselect intrinsic type symbols so we can preselect their keywords instead. We will also
                     // ignore nullability for purposes of preselection -- if a method is returning a string? but we've
@@ -71,7 +71,7 @@ internal abstract class AbstractRecommendationServiceBasedCompletionProvider<TSy
                     var preselect = args.inferredTypes.Contains(GetSymbolType(symbol), SymbolEqualityComparer.Default) && !args.self.IsInstrinsic(symbol);
                     return new SymbolAndSelectionInfo(symbol, preselect);
                 },
-                (inferredTypes, self: this));
+                arg: (inferredTypes, self: this));
         }
     }
 
@@ -98,7 +98,7 @@ internal abstract class AbstractRecommendationServiceBasedCompletionProvider<TSy
         }
 
         return namedType.IsAwaitableNonDynamic(context.SemanticModel, context.Position) ||
-               namedType.GetTypeMembers().Any(static (m, context) => IsValidForTaskLikeTypeOnlyContext(m, context), context);
+               namedType.GetTypeMembers().Any(predicate: static (m, context) => IsValidForTaskLikeTypeOnlyContext(m, context), arg: context);
     }
 
     private static bool IsValidForGenericConstraintContext(ISymbol symbol)

--- a/src/Features/Core/Portable/Completion/SharedSyntaxContextsWithSpeculativeModel.cs
+++ b/src/Features/Core/Portable/Completion/SharedSyntaxContextsWithSpeculativeModel.cs
@@ -43,8 +43,8 @@ internal sealed class SharedSyntaxContextsWithSpeculativeModel
         // Extract a local function to avoid creating a closure for code path of cache hit.
         static AsyncLazy<SyntaxContext> GetLazySyntaxContextWithSpeculativeModel(Document document, SharedSyntaxContextsWithSpeculativeModel self)
         {
-            return self._cache.GetOrAdd(document, d => AsyncLazy.Create(static (arg, cancellationToken)
-                => Utilities.CreateSyntaxContextWithExistingSpeculativeModelAsync(arg.d, arg._position, cancellationToken), (d, self._position)));
+            return self._cache.GetOrAdd(document, d => AsyncLazy.Create(asynchronousComputeFunction: static (arg, cancellationToken)
+                => Utilities.CreateSyntaxContextWithExistingSpeculativeModelAsync(arg.d, arg._position, cancellationToken), arg: (d, self._position)));
         }
     }
 }

--- a/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
@@ -94,7 +94,7 @@ internal sealed partial class DesignerAttributeDiscoveryService() : IDesignerAtt
             }
 
             var asyncLazy = s_metadataIdToDesignerAttributeInfo.GetValue(
-                metadataId, _ => AsyncLazy.Create(static (arg, cancellationToken) =>
+                metadataId, _ => AsyncLazy.Create(asynchronousComputeFunction: static (arg, cancellationToken) =>
                     ComputeHasDesignerCategoryTypeAsync(arg.solutionServices, arg.solutionKey, arg.peReference, cancellationToken),
                     arg: (solutionServices, solutionKey, peReference)));
             return await asyncLazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
@@ -137,7 +137,7 @@ internal sealed partial class DesignerAttributeDiscoveryService() : IDesignerAtt
 
         using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
         {
-            var lazyProjectVersion = AsyncLazy.Create(static (frozenProject, c) =>
+            var lazyProjectVersion = AsyncLazy.Create(asynchronousComputeFunction: static (frozenProject, c) =>
                 frozenProject.GetSemanticVersionAsync(c),
                 arg: frozenProject);
 
@@ -185,7 +185,7 @@ internal sealed partial class DesignerAttributeDiscoveryService() : IDesignerAtt
         // The top level project version for this project.  We only care if anything top level changes here.
         // Downstream impact will already happen due to us keying off of the references a project has (which will
         // change if anything it depends on changes).
-        var lazyProjectVersion = AsyncLazy.Create(static (project, c) =>
+        var lazyProjectVersion = AsyncLazy.Create(asynchronousComputeFunction: static (project, c) =>
             project.GetSemanticVersionAsync(c),
             arg: project);
 

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -85,7 +85,7 @@ internal abstract partial class AbstractDocumentHighlightsService :
         // position the caller was asking for.  For example, if the user had `$$new X();` then 
         // SymbolFinder will consider that the symbol `X`. However, the doc highlights won't include
         // the `new` part, so it's not appropriate for us to highlight `X` in that case.
-        if (!tags.Any(static (t, position) => t.HighlightSpans.Any(static (hs, position) => hs.TextSpan.IntersectsWith(position), position), position))
+        if (!tags.Any(predicate: static (t, position) => t.HighlightSpans.Any(predicate: static (hs, position) => hs.TextSpan.IntersectsWith(position), arg: position), arg: position))
             return [];
 
         return tags;

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -501,7 +501,7 @@ internal sealed class DebuggingSession : IDisposable
             EditSession.Telemetry.LogRudeEditDiagnostics(analysis.RudeEdits, project.State.Attributes.TelemetryId);
 
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            return analysis.RudeEdits.SelectAsArray((e, t) => e.ToDiagnostic(t), tree);
+            return analysis.RudeEdits.SelectAsArray(map: (e, t) => e.ToDiagnostic(t), arg: tree);
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
         {
@@ -805,7 +805,7 @@ internal sealed class DebuggingSession : IDisposable
                 {
                     foreach (var activeStatement in analysis.ActiveStatements)
                     {
-                        var i = adjustedMappedSpans.FindIndex(static (s, id) => s.Id == id, activeStatement.Id);
+                        var i = adjustedMappedSpans.FindIndex(match: static (s, id) => s.Id == id, arg: activeStatement.Id);
                         if (i >= 0)
                         {
                             adjustedMappedSpans[i] = new ActiveStatementSpan(activeStatement.Id, activeStatement.Span, activeStatement.Flags, unmappedDocumentId);

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
@@ -147,7 +147,7 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
             }
 
             // all baseline spans are being tracked in their corresponding mapped documents (if a span is deleted it's still tracked as empty):
-            var newMappedDocumentActiveSpan = newMappedDocumentSpans.Single(static (s, id) => s.Id == id, oldActiveStatement.Statement.Id);
+            var newMappedDocumentActiveSpan = newMappedDocumentSpans.Single(predicate: static (s, id) => s.Id == id, arg: oldActiveStatement.Statement.Id);
             Debug.Assert(newMappedDocumentActiveSpan.UnmappedDocumentId == null || newMappedDocumentActiveSpan.UnmappedDocumentId == newDocument.Id);
 
             // TODO: optimize
@@ -182,7 +182,7 @@ internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveState
         }
 
         var lazyResults = AsyncLazy.Create(
-            static async (arg, cancellationToken) =>
+            asynchronousComputeFunction: static async (arg, cancellationToken) =>
             {
                 try
                 {

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
@@ -193,7 +193,7 @@ internal sealed class EditAndContinueService : IEditAndContinueService
         DebuggingSession? debuggingSession;
         lock (_debuggingSessions)
         {
-            _debuggingSessions.TryRemoveFirst((s, sessionId) => s.Id == sessionId, sessionId, out debuggingSession);
+            _debuggingSessions.TryRemoveFirst(selector: (s, sessionId) => s.Id == sessionId, arg: sessionId, removedItem: out debuggingSession);
         }
 
         Contract.ThrowIfNull(debuggingSession, "Debugging session has not started.");
@@ -213,9 +213,9 @@ internal sealed class EditAndContinueService : IEditAndContinueService
     public ValueTask<ImmutableArray<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
     {
         return GetDiagnosticReportingDebuggingSessions().SelectManyAsArrayAsync(
-            (s, arg, cancellationToken) => s.GetDocumentDiagnosticsAsync(arg.document, arg.activeStatementSpanProvider, cancellationToken),
-            (document, activeStatementSpanProvider),
-            cancellationToken);
+            selector: (s, arg, cancellationToken) => s.GetDocumentDiagnosticsAsync(arg.document, arg.activeStatementSpanProvider, cancellationToken),
+            arg: (document, activeStatementSpanProvider),
+            cancellationToken: cancellationToken);
     }
 
     public ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -100,12 +100,12 @@ internal sealed class EditSession
         telemetry.SetBreakState(inBreakState);
 
         BaseActiveStatements = lazyActiveStatementMap ?? (inBreakState
-            ? AsyncLazy.Create(static (self, cancellationToken) =>
+            ? AsyncLazy.Create(asynchronousComputeFunction: static (self, cancellationToken) =>
                 self.GetBaseActiveStatementsAsync(cancellationToken),
                 arg: this)
             : AsyncLazy.Create(ActiveStatementsMap.Empty));
 
-        Capabilities = AsyncLazy.Create(static (self, cancellationToken) =>
+        Capabilities = AsyncLazy.Create(asynchronousComputeFunction: static (self, cancellationToken) =>
             self.GetCapabilitiesAsync(cancellationToken),
             arg: this);
         Analyses = new EditAndContinueDocumentAnalysesCache(BaseActiveStatements, Capabilities);
@@ -748,8 +748,8 @@ internal sealed class EditSession
             {
                 var newMaps = partialTypeEdits.Where(static edit => edit.SyntaxMaps.HasMap).SelectAsArray(static edit => edit.SyntaxMaps);
 
-                mergedMatchingNodes = node => newMaps[newMaps.IndexOf(static (m, node) => m.NewTree == node.SyntaxTree, node)].MatchingNodes!(node);
-                mergedRuntimeRudeEdits = node => newMaps[newMaps.IndexOf(static (m, node) => m.NewTree == node.SyntaxTree, node)].RuntimeRudeEdits?.Invoke(node);
+                mergedMatchingNodes = node => newMaps[newMaps.IndexOf(predicate: static (m, node) => m.NewTree == node.SyntaxTree, arg: node)].MatchingNodes!(node);
+                mergedRuntimeRudeEdits = node => newMaps[newMaps.IndexOf(predicate: static (m, node) => m.NewTree == node.SyntaxTree, arg: node)].RuntimeRudeEdits?.Invoke(node);
             }
             else
             {

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeLanguageDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeLanguageDetector.cs
@@ -166,7 +166,7 @@ internal sealed class DateAndTimeLanguageDetector(
 
         var parameters = method.Parameters;
         if (argName != null)
-            return parameters.Any(static (p, argName) => p.Name == argName, argName);
+            return parameters.Any(predicate: static (p, argName) => p.Name == argName, arg: argName);
 
         var parameter = argIndex < parameters.Length ? parameters[argIndex.Value] : null;
         return parameter?.Name == FormatName;

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingLowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingLowPriorityProcessor.cs
@@ -129,7 +129,7 @@ internal sealed partial class UnitTestingSolutionCrawlerRegistrationService
 
                     try
                     {
-                        using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessProjectAsync, w => w.ToString(), workItem, cancellationToken))
+                        using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessProjectAsync, messageGetter: w => w.ToString(), arg: workItem, token: cancellationToken))
                         {
                             var project = processingSolution.GetProject(projectId);
                             if (project != null)

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingNormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingNormalPriorityProcessor.cs
@@ -202,7 +202,7 @@ internal sealed partial class UnitTestingSolutionCrawlerRegistrationService
                     var solution = Processor._registration.GetSolutionToAnalyze();
                     try
                     {
-                        using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessDocumentAsync, w => w.ToString(), workItem, cancellationToken))
+                        using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessDocumentAsync, messageGetter: w => w.ToString(), arg: workItem, token: cancellationToken))
                         {
                             var textDocument = solution.GetTextDocument(documentId) ?? await solution.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -157,7 +157,7 @@ internal abstract partial class MethodExtractor<TSelectionResult, TStatementSynt
             var thisParameterBeingRead = (IParameterSymbol?)dataFlowAnalysisData.ReadInside.FirstOrDefault(IsThisParameter);
             var isThisParameterWritten = dataFlowAnalysisData.WrittenInside.Any(static s => IsThisParameter(s));
 
-            var localFunctionCallsNotWithinSpan = symbolMap.Keys.Where(s => s.IsLocalFunction() && !s.Locations.Any(static (l, self) => self.SelectionResult.FinalSpan.Contains(l.SourceSpan), this));
+            var localFunctionCallsNotWithinSpan = symbolMap.Keys.Where(s => s.IsLocalFunction() && !s.Locations.Any(predicate: static (l, self) => self.SelectionResult.FinalSpan.Contains(l.SourceSpan), arg: this));
 
             // Checks to see if selection includes a local function call + if the given local function declaration is not included in the selection.
             var containsAnyLocalFunctionCallNotWithinSpan = localFunctionCallsNotWithinSpan.Any();

--- a/src/Features/Core/Portable/FindUsages/DefinitionItemFactory.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItemFactory.cs
@@ -245,11 +245,11 @@ internal static class DefinitionItemFactory
     }
 
     private static ValueTask<ImmutableArray<ClassifiedSpansAndHighlightSpan?>> ClassifyDocumentSpansAsync(OptionsProvider<ClassificationOptions> optionsProvider, ImmutableArray<DocumentSpan> unclassifiedSpans, CancellationToken cancellationToken)
-        => unclassifiedSpans.SelectAsArrayAsync(static async (documentSpan, optionsProvider, cancellationToken) =>
+        => unclassifiedSpans.SelectAsArrayAsync(selector: static async (documentSpan, optionsProvider, cancellationToken) =>
         {
             var options = await optionsProvider.GetOptionsAsync(documentSpan.Document.Project.Services, cancellationToken).ConfigureAwait(false);
             return (ClassifiedSpansAndHighlightSpan?)await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(documentSpan, classifiedSpans: null, options, cancellationToken).ConfigureAwait(false);
-        }, optionsProvider, cancellationToken);
+        }, arg: optionsProvider, cancellationToken: cancellationToken);
 
     private static ImmutableDictionary<string, string> GetProperties(ISymbol definition, bool isPrimary)
     {

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -232,7 +232,7 @@ internal readonly struct SerializableDefinitionItem(
 
     public async ValueTask<DefinitionItem.DefaultDefinitionItem> RehydrateAsync(Solution solution, CancellationToken cancellationToken)
     {
-        var sourceSpans = await SourceSpans.SelectAsArrayAsync(static (ss, solution, cancellationToken) => ss.RehydrateAsync(solution, cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+        var sourceSpans = await SourceSpans.SelectAsArrayAsync(selector: static (ss, solution, cancellationToken) => ss.RehydrateAsync(solution, cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return new DefinitionItem.DefaultDefinitionItem(
             Tags,

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
@@ -235,7 +235,7 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
             Contract.ThrowIfNull(TypeToGenerateIn);
 
             var syntaxFacts = _document.Project.Solution.Services.GetRequiredLanguageService<ISyntaxFactsService>(TypeToGenerateIn.Language);
-            return TypeToGenerateIn.InstanceConstructors.Any(static (c, arg) => arg.self.Matches(c, arg.syntaxFacts), (self: this, syntaxFacts));
+            return TypeToGenerateIn.InstanceConstructors.Any(predicate: static (c, arg) => arg.self.Matches(c, arg.syntaxFacts), arg: (self: this, syntaxFacts));
         }
 
         private bool Matches(IMethodSymbol ctor, ISyntaxFactsService service)

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -127,7 +127,7 @@ internal abstract partial class AbstractGenerateTypeService<TService, TSimpleNam
             // caller.
             if (_state.IsException &&
                 _state.BaseTypeOrInterfaceOpt.InstanceConstructors.Any(
-                    static (c, parameterTypes) => c.Parameters.Select(p => p.Type).SequenceEqual(parameterTypes, SymbolEqualityComparer.Default), parameterTypes))
+                    predicate: static (c, parameterTypes) => c.Parameters.Select(p => p.Type).SequenceEqual(parameterTypes, SymbolEqualityComparer.Default), arg: parameterTypes))
             {
                 return;
             }

--- a/src/Features/Core/Portable/ImplementInterface/ImplementHelpers.cs
+++ b/src/Features/Core/Portable/ImplementInterface/ImplementHelpers.cs
@@ -235,7 +235,7 @@ internal static class ImplementHelpers
         var unimplementedMembers = explicitly
             ? state.MembersWithoutExplicitImplementation
             : state.MembersWithoutExplicitOrImplicitImplementationWhichCanBeImplicitlyImplemented;
-        if (!unimplementedMembers.Any(static (m, idisposableType) => m.type.Equals(idisposableType), idisposableType))
+        if (!unimplementedMembers.Any(predicate: static (m, idisposableType) => m.type.Equals(idisposableType), arg: idisposableType))
             return false;
 
         // The dispose pattern is only applicable if the implementing type does

--- a/src/Features/Core/Portable/ImplementInterface/ImplementInterfaceGenerator.cs
+++ b/src/Features/Core/Portable/ImplementInterface/ImplementInterfaceGenerator.cs
@@ -148,7 +148,7 @@ internal abstract partial class AbstractImplementInterfaceService
         {
             return
                 IdentifiersMatch(State.ClassOrStructType.Name, name) ||
-                State.ClassOrStructType.TypeParameters.Any(static (t, arg) => arg.self.IdentifiersMatch(t.Name, arg.name), (self: this, name));
+                State.ClassOrStructType.TypeParameters.Any(predicate: static (t, arg) => arg.self.IdentifiersMatch(t.Name, arg.name), arg: (self: this, name));
         }
 
         private string DetermineMemberName(ISymbol member, ArrayBuilder<ISymbol> implementedVisibleMembers)
@@ -262,7 +262,7 @@ internal abstract partial class AbstractImplementInterfaceService
             bool allowDelegateAndEnumConstraints)
         {
             var condition1 = typeParameter.ConstraintTypes.Count(t => t.TypeKind == TypeKind.Class) >= 2;
-            var condition2 = typeParameter.ConstraintTypes.Any(static (ts, allowDelegateAndEnumConstraints) => ts.IsUnexpressibleTypeParameterConstraint(allowDelegateAndEnumConstraints), allowDelegateAndEnumConstraints);
+            var condition2 = typeParameter.ConstraintTypes.Any(predicate: static (ts, allowDelegateAndEnumConstraints) => ts.IsUnexpressibleTypeParameterConstraint(allowDelegateAndEnumConstraints), arg: allowDelegateAndEnumConstraints);
             var condition3 = typeParameter.HasReferenceTypeConstraint && typeParameter.ConstraintTypes.Any(static ts => ts.IsReferenceType && ts.SpecialType != SpecialType.System_Object);
 
             return condition1 || condition2 || condition3;

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -406,20 +406,20 @@ internal abstract partial class AbstractInheritanceMarginService
         var baseSymbolItems = await baseSymbols
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+            .SelectAsArrayAsync(selector: static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
                 solution,
                 symbol,
                 InheritanceRelationship.InheritedInterface,
-                cancellationToken), solution, cancellationToken)
+                cancellationToken), arg: solution, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         var derivedTypeItems = await derivedTypesSymbols
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(solution,
+            .SelectAsArrayAsync(selector: static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(solution,
                 symbol,
                 InheritanceRelationship.ImplementingType,
-                cancellationToken), solution, cancellationToken)
+                cancellationToken), arg: solution, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         var nonNullBaseSymbolItems = GetNonNullTargetItems(baseSymbolItems);
@@ -443,11 +443,11 @@ internal abstract partial class AbstractInheritanceMarginService
         var implementedMemberItems = await implementingMembers
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+            .SelectAsArrayAsync(selector: static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
                 solution,
                 symbol,
                 InheritanceRelationship.ImplementingMember,
-                cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+                cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var nonNullImplementedMemberItems = GetNonNullTargetItems(implementedMemberItems);
         return InheritanceMarginItem.CreateOrdered(
@@ -471,19 +471,19 @@ internal abstract partial class AbstractInheritanceMarginService
         var baseSymbolItems = await baseSymbols
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+            .SelectAsArrayAsync(selector: static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
                 solution,
                 symbol,
                 symbol.IsInterfaceType() ? InheritanceRelationship.ImplementedInterface : InheritanceRelationship.BaseType,
-                cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+                cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var derivedTypeItems = await derivedTypesSymbols
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(solution,
+            .SelectAsArrayAsync(selector: static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(solution,
                 symbol,
                 InheritanceRelationship.DerivedType,
-                cancellationToken), solution, cancellationToken)
+                cancellationToken), arg: solution, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         var nonNullBaseSymbolItems = GetNonNullTargetItems(baseSymbolItems);
@@ -509,29 +509,29 @@ internal abstract partial class AbstractInheritanceMarginService
         var implementedMemberItems = await implementedMembers
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+            .SelectAsArrayAsync(selector: static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
                 solution,
                 symbol,
                 InheritanceRelationship.ImplementedMember,
-                cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+                cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var overriddenMemberItems = await overriddenMembers
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+            .SelectAsArrayAsync(selector: static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
                 solution,
                 symbol,
                 InheritanceRelationship.OverriddenMember,
-                cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+                cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var overridingMemberItems = await overridingMembers
             .SelectAsArray(symbol => symbol.OriginalDefinition)
             .Distinct()
-            .SelectAsArrayAsync(static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
+            .SelectAsArrayAsync(selector: static (symbol, solution, cancellationToken) => CreateInheritanceItemAsync(
                 solution,
                 symbol,
                 InheritanceRelationship.OverridingMember,
-                cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+                cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var nonNullImplementedMemberItems = GetNonNullTargetItems(implementedMemberItems);
         var nonNullOverriddenMemberItems = GetNonNullTargetItems(overriddenMemberItems);

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.CachedDocumentSearch.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.CachedDocumentSearch.cs
@@ -177,7 +177,7 @@ internal abstract partial class AbstractNavigateToSearchService
         // match on disk anymore.
         var asyncLazy = cachedIndexMap.GetOrAdd(
             (storageService, documentKey, stringTable),
-            static t => AsyncLazy.Create(static (t, c) =>
+            static t => AsyncLazy.Create(asynchronousComputeFunction: static (t, c) =>
                 TopLevelSyntaxTreeIndex.LoadAsync(t.service, t.documentKey, checksum: null, t.stringTable, c),
                 arg: t));
         return asyncLazy.GetValueAsync(cancellationToken);

--- a/src/Features/Core/Portable/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
+++ b/src/Features/Core/Portable/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
@@ -28,7 +28,7 @@ internal partial class NavigableItemFactory
         /// <summary>
         /// Lazily-initialized backing field for <see cref="Document"/>.
         /// </summary>
-        /// <seealso cref="InterlockedOperations.Initialize{T, U}(ref StrongBox{T}, Func{U, T}, U)"/>
+        /// <seealso cref="InterlockedOperations.Initialize{T, U}(ref StrongBox{T}, U, Func{U, T})"/>
         private StrongBox<INavigableItem.NavigableDocument> _lazyDocument;
 
         public bool DisplayFileLocation => true;
@@ -45,13 +45,13 @@ internal partial class NavigableItemFactory
             {
                 return InterlockedOperations.Initialize(
                     ref _lazyDocument,
-                    static self =>
+                    valueFactory: static self =>
                     {
                         return (self._location.IsInSource && self._solution.GetDocument(self._location.SourceTree) is { } document)
                             ? INavigableItem.NavigableDocument.FromDocument(document)
                             : null;
                     },
-                    this);
+                    arg: this);
             }
         }
 

--- a/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
@@ -21,7 +21,7 @@ internal static class MemberAndDestinationValidator
         // Don't provide any refactoring option if the destination is not in source.
         // If the destination is generated code, also don't provide refactoring since we can't make sure if we won't break it.
         var isDestinationInSourceAndNotGeneratedCode =
-            destination.Locations.Any(static (location, arg) => location.IsInSource && !arg.solution.GetRequiredDocument(location.SourceTree).IsGeneratedCode(arg.cancellationToken), (solution, cancellationToken));
+            destination.Locations.Any(predicate: static (location, arg) => location.IsInSource && !arg.solution.GetRequiredDocument(location.SourceTree).IsGeneratedCode(arg.cancellationToken), arg: (solution, cancellationToken));
         return isDestinationInSourceAndNotGeneratedCode;
     }
 

--- a/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
@@ -43,7 +43,7 @@ internal static class MembersPuller
             selectedMembers.SelectAsArray(m => (member: m, makeAbstract: false)));
 
         if (result.PullUpOperationNeedsToDoExtraChanges ||
-            selectedMembers.Any(IsSelectedMemberDeclarationAlreadyInDestination, destination))
+            selectedMembers.Any(predicate: IsSelectedMemberDeclarationAlreadyInDestination, arg: destination))
         {
             return null;
         }

--- a/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
@@ -204,12 +204,12 @@ internal static class ExtractTypeHelpers
                 return DoesTypeReferenceTypeParameter(@event.Type, typeParameter, checkedTypes);
             case SymbolKind.Method:
                 var method = member as IMethodSymbol;
-                return method.Parameters.Any(static (t, arg) => DoesTypeReferenceTypeParameter(t.Type, arg.typeParameter, arg.checkedTypes), (typeParameter, checkedTypes)) ||
-                    method.TypeParameters.Any(static (t, arg) => t.ConstraintTypes.Any(static (c, arg) => DoesTypeReferenceTypeParameter(c, arg.typeParameter, arg.checkedTypes), (arg.typeParameter, arg.checkedTypes)), (typeParameter, checkedTypes)) ||
+                return method.Parameters.Any(predicate: static (t, arg) => DoesTypeReferenceTypeParameter(t.Type, arg.typeParameter, arg.checkedTypes), arg: (typeParameter, checkedTypes)) ||
+                    method.TypeParameters.Any(predicate: static (t, arg) => t.ConstraintTypes.Any(predicate: static (c, arg) => DoesTypeReferenceTypeParameter(c, arg.typeParameter, arg.checkedTypes), arg: (arg.typeParameter, arg.checkedTypes)), arg: (typeParameter, checkedTypes)) ||
                     DoesTypeReferenceTypeParameter(method.ReturnType, typeParameter, checkedTypes);
             case SymbolKind.Property:
                 var property = member as IPropertySymbol;
-                return property.Parameters.Any(static (t, arg) => DoesTypeReferenceTypeParameter(t.Type, arg.typeParameter, arg.checkedTypes), (typeParameter, checkedTypes)) ||
+                return property.Parameters.Any(predicate: static (t, arg) => DoesTypeReferenceTypeParameter(t.Type, arg.typeParameter, arg.checkedTypes), arg: (typeParameter, checkedTypes)) ||
                     DoesTypeReferenceTypeParameter(property.Type, typeParameter, checkedTypes);
             case SymbolKind.Field:
                 var field = member as IFieldSymbol;
@@ -229,7 +229,7 @@ internal static class ExtractTypeHelpers
 
         // We want to ignore nullability when comparing as T and T? both are references to the type parameter
         if (type.Equals(typeParameter, SymbolEqualityComparer.Default) ||
-            type.GetTypeArguments().Any(static (t, arg) => DoesTypeReferenceTypeParameter(t, arg.typeParameter, arg.checkedTypes), (typeParameter, checkedTypes)))
+            type.GetTypeArguments().Any(predicate: static (t, arg) => DoesTypeReferenceTypeParameter(t, arg.typeParameter, arg.checkedTypes), arg: (typeParameter, checkedTypes)))
         {
             return true;
         }

--- a/src/Features/Core/Portable/UnusedReferences/UnusedReferencesRemover.cs
+++ b/src/Features/Core/Portable/UnusedReferences/UnusedReferencesRemover.cs
@@ -149,7 +149,7 @@ internal static class UnusedReferencesRemover
 
                 // We will look at the project assemblies brought in directly by the
                 // references to see if they are used.
-                if (!projectAssemblyFileNames.Any(static (name, usedProjectFileNames) => usedProjectFileNames.Contains(name), usedProjectFileNames))
+                if (!projectAssemblyFileNames.Any(predicate: static (name, usedProjectFileNames) => usedProjectFileNames.Contains(name), arg: usedProjectFileNames))
                 {
                     // None of the project assemblies brought into this compilation are in the
                     // used assemblies list, so we will consider the reference unused.
@@ -164,7 +164,7 @@ internal static class UnusedReferencesRemover
             {
                 // We will look at the compilation assemblies brought in directly by the
                 // references to see if they are used.
-                if (!reference.CompilationAssemblies.Any(static (name, usedAssemblyFilePaths) => usedAssemblyFilePaths.Contains(name), usedAssemblyFilePaths))
+                if (!reference.CompilationAssemblies.Any(predicate: static (name, usedAssemblyFilePaths) => usedAssemblyFilePaths.Contains(name), arg: usedAssemblyFilePaths))
                 {
                     // None of the assemblies brought into this compilation are in the
                     // used assemblies list, so we will consider the reference unused.
@@ -234,12 +234,12 @@ internal static class UnusedReferencesRemover
 
     internal static bool ContainsAnyCompilationAssembly(ReferenceInfo reference, HashSet<string> usedAssemblyFilePaths)
     {
-        if (reference.CompilationAssemblies.Any(static (name, usedAssemblyFilePaths) => usedAssemblyFilePaths.Contains(name), usedAssemblyFilePaths))
+        if (reference.CompilationAssemblies.Any(predicate: static (name, usedAssemblyFilePaths) => usedAssemblyFilePaths.Contains(name), arg: usedAssemblyFilePaths))
         {
             return true;
         }
 
-        return reference.Dependencies.Any(static (dependency, usedAssemblyFilePaths) => ContainsAnyCompilationAssembly(dependency, usedAssemblyFilePaths), usedAssemblyFilePaths);
+        return reference.Dependencies.Any(predicate: static (dependency, usedAssemblyFilePaths) => ContainsAnyCompilationAssembly(dependency, usedAssemblyFilePaths), arg: usedAssemblyFilePaths);
     }
 
     internal static void RemoveAllCompilationAssemblies(ReferenceInfo reference, HashSet<string> usedAssemblyFilePaths)

--- a/src/Features/Core/Portable/ValueTracking/ValueTracker.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTracker.cs
@@ -39,7 +39,7 @@ internal static partial class ValueTracker
 
             // If the selection is within a declaration of the symbol, we want to include
             // all declarations and assignments of the symbol
-            if (declaringSyntaxReferences.Any(static (r, selection) => r.Span.IntersectsWith(selection), selection))
+            if (declaringSyntaxReferences.Any(predicate: static (r, selection) => r.Span.IntersectsWith(selection), arg: selection))
             {
                 // Add all initializations of the symbol. Those are not caught in 
                 // the reference finder but should still show up in the tree

--- a/src/Features/Core/Portable/ValueTracking/ValueTrackingService.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTrackingService.cs
@@ -46,7 +46,7 @@ internal partial class ValueTrackingService : IValueTrackingService
             }
 
             return await result.Value.SelectAsArrayAsync(
-                static (item, solution, cancellationToken) => item.RehydrateAsync(solution, cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+                selector: static (item, solution, cancellationToken) => item.RehydrateAsync(solution, cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         var progressTracker = new ValueTrackingProgressCollector();
@@ -76,7 +76,7 @@ internal partial class ValueTrackingService : IValueTrackingService
             }
 
             return await result.Value.SelectAsArrayAsync(
-                static (item, solution, cancellationToken) => item.RehydrateAsync(solution, cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+                selector: static (item, solution, cancellationToken) => item.RehydrateAsync(solution, cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         var progressTracker = new ValueTrackingProgressCollector();

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Host
             }
 
             return OneOrMany.Create(s_razorSourceGeneratorFileNamePrefixes.SelectAsArray(
-                static (prefix, relativeDocumentPath) => GetGeneratedDocumentPath(prefix, relativeDocumentPath), relativeDocumentPath));
+                map: static (prefix, relativeDocumentPath) => GetGeneratedDocumentPath(prefix, relativeDocumentPath), arg: relativeDocumentPath));
 
             static string GetGeneratedDocumentPath(string prefix, string relativeDocumentPath)
             {

--- a/src/Features/ExternalAccess/OmniSharp/GoToDefinition/OmniSharpFindDefinitionService.cs
+++ b/src/Features/ExternalAccess/OmniSharp/GoToDefinition/OmniSharpFindDefinitionService.cs
@@ -21,8 +21,8 @@ internal static class OmniSharpFindDefinitionService
 
         var result = await service.GetNavigableItemsAsync(document, position, cancellationToken).ConfigureAwait(false);
         return await result.NullToEmpty().SelectAsArrayAsync(
-            async (original, solution, cancellationToken) => new OmniSharpNavigableItem(original.DisplayTaggedParts, await original.Document.GetRequiredDocumentAsync(solution, cancellationToken).ConfigureAwait(false), original.SourceSpan),
-            document.Project.Solution,
-            cancellationToken).ConfigureAwait(false);
+            selector: async (original, solution, cancellationToken) => new OmniSharpNavigableItem(original.DisplayTaggedParts, await original.Document.GetRequiredDocumentAsync(solution, cancellationToken).ConfigureAwait(false), original.SourceSpan),
+            arg: document.Project.Solution,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 return null;
 
             // Find the syntax node that declared the symbol in the tree we're processing
-            var syntaxReference = declaredSymbol.DeclaringSyntaxReferences.FirstOrDefault(static (r, arg) => r.SyntaxTree == arg.syntaxTree && r.Span.Contains(arg.SpanStart), arg: (syntaxTree, syntaxToken.SpanStart));
+            var syntaxReference = declaredSymbol.DeclaringSyntaxReferences.FirstOrDefault(predicate: static (r, arg) => r.SyntaxTree == arg.syntaxTree && r.Span.Contains(arg.SpanStart), arg: (syntaxTree, syntaxToken.SpanStart));
             var syntaxNode = syntaxReference?.GetSyntax(cancellationToken);
 
             if (syntaxNode is null)
@@ -430,10 +430,10 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             // The containing range is supposed to be "the full range of the declaration not including leading/trailing whitespace, but everything else,
             // e.g. comments and code", so produce our start/end points looking through trivia
-            var firstNonWhitespaceTrivia = syntaxNode.GetLeadingTrivia().FirstOrNull(static (t, syntaxFacts) => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t), syntaxFacts);
+            var firstNonWhitespaceTrivia = syntaxNode.GetLeadingTrivia().FirstOrNull(predicate: static (t, syntaxFacts) => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t), arg: syntaxFacts);
             var fullRangeStart = firstNonWhitespaceTrivia?.SpanStart ?? syntaxNode.SpanStart;
 
-            var lastNonWhitespaceTrivia = syntaxNode.GetTrailingTrivia().Reverse().FirstOrNull(static (t, syntaxFacts) => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t), syntaxFacts);
+            var lastNonWhitespaceTrivia = syntaxNode.GetTrailingTrivia().Reverse().FirstOrNull(predicate: static (t, syntaxFacts) => !syntaxFacts.IsWhitespaceOrEndOfLineTrivia(t), arg: syntaxFacts);
             var fullRangeEnd = lastNonWhitespaceTrivia?.Span.End ?? syntaxNode.Span.End;
 
             var fullRangeSpan = TextSpan.FromBounds(fullRangeStart, fullRangeEnd);

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -735,7 +735,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             newSymbols As OneOrMany(Of ISymbol)) As IEnumerable(Of (ISymbol, ISymbol))
 
             For Each oldSymbol In oldSymbols
-                Dim newSymbol = newSymbols.FirstOrDefault(Function(s, o) CaseInsensitiveComparison.Equals(s.Name, o.Name), oldSymbol)
+                Dim newSymbol = newSymbols.FirstOrDefault(predicate:=Function(s, o) CaseInsensitiveComparison.Equals(s.Name, o.Name), arg:=oldSymbol)
                 If newSymbol IsNot Nothing Then
                     Yield (oldSymbol, newSymbol)
                 End If

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
             public LazyRemoteService(InteractiveHost host, InteractiveHostOptions options, int instanceId, bool skipInitialization)
             {
-                _lazyInitializedService = AsyncLazy.Create(static (self, cancellationToken) => self.TryStartAndInitializeProcessAsync(cancellationToken), this);
+                _lazyInitializedService = AsyncLazy.Create(asynchronousComputeFunction: static (self, cancellationToken) => self.TryStartAndInitializeProcessAsync(cancellationToken), arg: this);
                 _cancellationSource = new CancellationTokenSource();
                 InstanceId = instanceId;
                 Options = options;

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     var lineSpan = diagnostic.Location.GetLineSpan();
 
                     var documentIds = targetTextDocument.Project.Solution.GetDocumentIdsWithFilePath(lineSpan.Path);
-                    return documentIds.Any(static (id, targetTextDocument) => id == targetTextDocument.Id, targetTextDocument);
+                    return documentIds.Any(predicate: static (id, targetTextDocument) => id == targetTextDocument.Id, arg: targetTextDocument);
                 }
 
                 return false;

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return result;
             }
 
-            Logger.Log(FunctionId.Diagnostics_ProjectDiagnostic, p => $"Failed to Load Successfully ({p.FilePath ?? p.Name})", project);
+            Logger.Log(FunctionId.Diagnostics_ProjectDiagnostic, messageGetter: p => $"Failed to Load Successfully ({p.FilePath ?? p.Name})", arg: project);
 
             // get rid of any result except syntax from compiler analyzer result
             var newCompilerAnalysisResult = analysisResult.DropExceptSyntax();

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 => _activeFileStates.GetOrAdd(documentId, id => new ActiveFileState(id));
 
             public ProjectState GetOrCreateProjectState(ProjectId projectId)
-                => _projectStates.GetOrAdd(projectId, static (id, self) => new ProjectState(self, id), this);
+                => _projectStates.GetOrAdd(projectId, valueFactory: static (id, self) => new ProjectState(self, id), factoryArgument: this);
 
             public async Task<bool> OnDocumentOpenedAsync(TextDocument document)
             {

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     // Skip analyzer if none of its reported diagnostics should be included.
                     if (shouldIncludeDiagnostic != null &&
-                        !owner.DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(analyzer).Any(static (a, shouldIncludeDiagnostic) => shouldIncludeDiagnostic(a.Id), shouldIncludeDiagnostic))
+                        !owner.DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(analyzer).Any(predicate: static (a, shouldIncludeDiagnostic) => shouldIncludeDiagnostic(a.Id), arg: shouldIncludeDiagnostic))
                     {
                         return false;
                     }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         private async Task TextDocumentOpenAsync(TextDocument document, CancellationToken cancellationToken)
         {
-            using (Logger.LogBlock(FunctionId.Diagnostics_DocumentOpen, GetOpenLogMessage, document, cancellationToken))
+            using (Logger.LogBlock(FunctionId.Diagnostics_DocumentOpen, messageGetter: GetOpenLogMessage, arg: document, token: cancellationToken))
             {
                 var stateSets = _stateManager.GetStateSets(document.Project);
 
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             var descriptors = DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(analyzer);
             var analyzerConfigOptions = project.GetAnalyzerConfigOptions();
 
-            return descriptors.Any(static (d, arg) => d.GetEffectiveSeverity(arg.CompilationOptions, arg.analyzerConfigOptions?.ConfigOptions, arg.analyzerConfigOptions?.TreeOptions) != ReportDiagnostic.Hidden, (project.CompilationOptions, analyzerConfigOptions));
+            return descriptors.Any(predicate: static (d, arg) => d.GetEffectiveSeverity(arg.CompilationOptions, arg.analyzerConfigOptions?.ConfigOptions, arg.analyzerConfigOptions?.TreeOptions) != ReportDiagnostic.Hidden, arg: (project.CompilationOptions, analyzerConfigOptions));
         }
 
         public TestAccessor GetTestAccessor()

--- a/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_OpenDocument.cs
+++ b/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_OpenDocument.cs
@@ -33,7 +33,7 @@ internal static partial class EditAndContinueDiagnosticSource
                 return [];
             }
 
-            var applyDiagnostics = sessionStateTracker.ApplyChangesDiagnostics.WhereAsArray(static (data, id) => data.DocumentId == id, designTimeDocument.Id);
+            var applyDiagnostics = sessionStateTracker.ApplyChangesDiagnostics.WhereAsArray(predicate: static (data, id) => data.DocumentId == id, arg: designTimeDocument.Id);
 
             var compileTimeSolution = services.GetRequiredService<ICompileTimeSolutionProvider>().GetCompileTimeSolution(designTimeSolution);
 

--- a/src/Scripting/Core/Hosting/AssemblyLoader/MetadataShadowCopyProvider.cs
+++ b/src/Scripting/Core/Hosting/AssemblyLoader/MetadataShadowCopyProvider.cs
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 return false;
             }
 
-            return !_noShadowCopyDirectories.Any(static (dir, directory) => directory.StartsWith(dir, StringComparison.Ordinal), directory);
+            return !_noShadowCopyDirectories.Any(predicate: static (dir, directory) => directory.StartsWith(dir, StringComparison.Ordinal), arg: directory);
         }
 
         private CacheEntry<MetadataShadowCopy> CreateMetadataShadowCopy(string originalPath, MetadataImageKind kind)

--- a/src/Tools/ExternalAccess/Razor/RazorDocumentServiceProviderWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDocumentServiceProviderWrapper.cs
@@ -34,12 +34,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             {
                 var spanMappingService = InterlockedOperations.Initialize(
                     ref _lazySpanMappingService,
-                    static documentServiceProvider =>
+                    valueFactory: static documentServiceProvider =>
                     {
                         var razorMappingService = documentServiceProvider.GetService<IRazorSpanMappingService>();
                         return razorMappingService != null ? new RazorSpanMappingServiceWrapper(razorMappingService) : null;
                     },
-                    _innerDocumentServiceProvider);
+                    arg: _innerDocumentServiceProvider);
 
                 return (TService?)spanMappingService;
             }
@@ -48,12 +48,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             {
                 var excerptService = InterlockedOperations.Initialize(
                     ref _lazyExcerptService,
-                    static documentServiceProvider =>
+                    valueFactory: static documentServiceProvider =>
                     {
                         var impl = documentServiceProvider.GetService<IRazorDocumentExcerptServiceImplementation>();
                         return (impl != null) ? new RazorDocumentExcerptServiceWrapper(impl) : null;
                     },
-                    _innerDocumentServiceProvider);
+                    arg: _innerDocumentServiceProvider);
 
                 return (TService?)excerptService;
             }
@@ -62,12 +62,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             {
                 var documentPropertiesService = InterlockedOperations.Initialize(
                     ref _lazyDocumentPropertiesService,
-                    static documentServiceProvider =>
+                    valueFactory: static documentServiceProvider =>
                     {
                         var razorDocumentPropertiesService = documentServiceProvider.GetService<IRazorDocumentPropertiesService>();
                         return razorDocumentPropertiesService is not null ? new RazorDocumentPropertiesServiceWrapper(razorDocumentPropertiesService) : null;
                     },
-                    _innerDocumentServiceProvider);
+                    arg: _innerDocumentServiceProvider);
 
                 return (TService?)(object?)documentPropertiesService;
             }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -936,8 +936,8 @@ namespace IOperationGenerator
             WriteLine(@"[return: NotNullIfNotNull(""node"")]");
             WriteLine("private T? Visit<T>(T? node) where T : IOperation? => (T?)Visit(node, argument: null);");
             WriteLine("public override IOperation DefaultVisit(IOperation operation, object? argument) => throw ExceptionUtilities.Unreachable();");
-            WriteLine("private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> nodes) where T : IOperation => nodes.SelectAsArray((n, @this) => @this.Visit(n), this)!;");
-            WriteLine("private ImmutableArray<(ISymbol, T)> VisitArray<T>(ImmutableArray<(ISymbol, T)> nodes) where T : IOperation => nodes.SelectAsArray((n, @this) => (n.Item1, @this.Visit(n.Item2)), this)!;");
+            WriteLine("private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> nodes) where T : IOperation => nodes.SelectAsArray(this, (n, @this) => @this.Visit(n))!;");
+            WriteLine("private ImmutableArray<(ISymbol, T)> VisitArray<T>(ImmutableArray<(ISymbol, T)> nodes) where T : IOperation => nodes.SelectAsArray(this, (n, @this) => (n.Item1, @this.Visit(n.Item2)))!;");
 
             foreach (var node in _tree.Types.OfType<Node>())
             {

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             }
 
             // Local: return the name if it's the declaration, otherwise the type
-            if (symbol is ILocalSymbol localSymbol && !symbol.DeclaringSyntaxReferences.Any(static (d, token) => d.GetSyntax().DescendantTokens().Contains(token), token))
+            if (symbol is ILocalSymbol localSymbol && !symbol.DeclaringSyntaxReferences.Any(predicate: static (d, token) => d.GetSyntax().DescendantTokens().Contains(token), arg: token))
             {
                 symbol = localSymbol.Type;
             }

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -144,7 +144,7 @@ internal sealed partial class ColorSchemeApplier
     {
         return _colorSchemes.Values.Any(
             scheme => scheme.Themes.Any(
-                static (theme, themeId) => theme.Guid == themeId, themeId));
+                predicate: static (theme, themeId) => theme.Guid == themeId, arg: themeId));
     }
 
     public async Task<bool> IsThemeCustomizedAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/ExtractClass/VisualStudioExtractClassOptionsService.cs
+++ b/src/VisualStudio/Core/Def/ExtractClass/VisualStudioExtractClassOptionsService.cs
@@ -58,7 +58,7 @@ internal class VisualStudioExtractClassOptionsService : IExtractClassOptionsServ
                 new MemberSymbolViewModel(member, _glyphService)
                 {
                     // The member(s) user selected will be checked at the beginning.
-                    IsChecked = selectedMembers.Any(SymbolEquivalenceComparer.Instance.Equals, member),
+                    IsChecked = selectedMembers.Any(predicate: SymbolEquivalenceComparer.Instance.Equals, arg: member),
                     MakeAbstract = false,
                     IsMakeAbstractCheckable = !member.IsKind(SymbolKind.Field) && !member.IsAbstract,
                     IsCheckable = true

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -43,47 +43,47 @@ internal static class InheritanceMarginHelpers
     public static ImageMoniker GetMoniker(InheritanceRelationship inheritanceRelationship)
     {
         //  If there are multiple targets and we have the corresponding compound image, use it
-        if (s_relationships_Shown_As_I_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship)
-            && s_relationships_Shown_As_O_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
+        if (s_relationships_Shown_As_I_Up_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship)
+            && s_relationships_Shown_As_O_Down_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship))
         {
             return KnownMonikers.ImplementingOverridden;
         }
 
-        if (s_relationships_Shown_As_I_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship)
-            && s_relationships_Shown_As_O_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
+        if (s_relationships_Shown_As_I_Up_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship)
+            && s_relationships_Shown_As_O_Up_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship))
         {
             return KnownMonikers.ImplementingOverriding;
         }
 
-        if (s_relationships_Shown_As_I_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship)
-            && s_relationships_Shown_As_I_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
+        if (s_relationships_Shown_As_I_Up_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship)
+            && s_relationships_Shown_As_I_Down_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship))
         {
             return KnownMonikers.ImplementingImplemented;
         }
 
-        if (s_relationships_Shown_As_O_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship)
-            && s_relationships_Shown_As_O_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
+        if (s_relationships_Shown_As_O_Up_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship)
+            && s_relationships_Shown_As_O_Down_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship))
         {
             return KnownMonikers.OverridingOverridden;
         }
 
         // Otherwise, show the image based on this preference
-        if (s_relationships_Shown_As_I_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
+        if (s_relationships_Shown_As_I_Up_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship))
         {
             return KnownMonikers.Implementing;
         }
 
-        if (s_relationships_Shown_As_I_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
+        if (s_relationships_Shown_As_I_Down_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship))
         {
             return KnownMonikers.Implemented;
         }
 
-        if (s_relationships_Shown_As_O_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
+        if (s_relationships_Shown_As_O_Up_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship))
         {
             return KnownMonikers.Overriding;
         }
 
-        if (s_relationships_Shown_As_O_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
+        if (s_relationships_Shown_As_O_Down_Arrow.Any(predicate: static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), arg: inheritanceRelationship))
         {
             return KnownMonikers.Overridden;
         }

--- a/src/VisualStudio/Core/Def/MoveStaticMembers/VisualStudioMoveStaticMembersOptionsService.cs
+++ b/src/VisualStudio/Core/Def/MoveStaticMembers/VisualStudioMoveStaticMembersOptionsService.cs
@@ -106,7 +106,7 @@ internal class VisualStudioMoveStaticMembersOptionsService : IMoveStaticMembersO
                 new SymbolViewModel<ISymbol>(member, glyphService)
                 {
                     // The member(s) user selected will be checked at the beginning.
-                    IsChecked = selectedNodeSymbols.Any(SymbolEquivalenceComparer.Instance.Equals, member),
+                    IsChecked = selectedNodeSymbols.Any(predicate: SymbolEquivalenceComparer.Instance.Equals, arg: member),
                 });
 
         using var cancellationTokenSource = new CancellationTokenSource();

--- a/src/VisualStudio/Core/Def/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
@@ -45,7 +45,7 @@ internal class MoveToNamespaceDialogViewModel : AbstractNotifyPropertyChanged, I
 
     public void OnNamespaceUpdated()
     {
-        var isNewNamespace = !AvailableNamespaces.Any(static (i, self) => i.Namespace == self.NamespaceName, this);
+        var isNewNamespace = !AvailableNamespaces.Any(predicate: static (i, self) => i.Namespace == self.NamespaceName, arg: this);
         var isValidName = !isNewNamespace || IsValidNamespace(NamespaceName);
 
         if (isNewNamespace && isValidName)

--- a/src/VisualStudio/Core/Def/Progression/GraphNodeIdCreation.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphNodeIdCreation.cs
@@ -469,7 +469,7 @@ internal static class GraphNodeIdCreation
         if (containingSymbol is IMethodSymbol method && method.AssociatedSymbol != null && method.AssociatedSymbol.Kind == SymbolKind.Property)
         {
             var property = (IPropertySymbol)method.AssociatedSymbol;
-            if (property.Parameters.Any(static (p, symbol) => p.Name == symbol.Name, symbol))
+            if (property.Parameters.Any(predicate: static (p, symbol) => p.Name == symbol.Name, arg: symbol))
             {
                 containingSymbol = property;
             }

--- a/src/VisualStudio/Core/Def/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/FileChangeTracker.cs
@@ -108,7 +108,7 @@ internal sealed class FileChangeTracker : IVsFreeThreadedFileChangeEvents2, IDis
         Contract.ThrowIfTrue(_fileChangeCookie != s_none);
 
         _fileChangeCookie = AsyncLazy.Create(
-            static async (self, cancellationToken) =>
+            asynchronousComputeFunction: static async (self, cancellationToken) =>
             {
                 try
                 {
@@ -121,7 +121,7 @@ internal sealed class FileChangeTracker : IVsFreeThreadedFileChangeEvents2, IDis
                     return null;
                 }
             },
-            static (self, cancellationToken) =>
+            synchronousComputeFunction: static (self, cancellationToken) =>
             {
                 try
                 {

--- a/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -123,7 +123,7 @@ internal sealed partial class VisualStudioMetadataReferenceManager : IWorkspaceS
         => new VisualStudioPortableExecutableReference(this, properties, filePath, fileChangeTracker: null);
 
     private bool VsSmartScopeCandidate(string fullPath)
-        => _runtimeDirectories.Any(static (d, fullPath) => fullPath.StartsWith(d, StringComparison.OrdinalIgnoreCase), fullPath);
+        => _runtimeDirectories.Any(predicate: static (d, fullPath) => fullPath.StartsWith(d, StringComparison.OrdinalIgnoreCase), arg: fullPath);
 
     internal static IEnumerable<string> GetReferencePaths()
     {

--- a/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
@@ -32,7 +32,7 @@ internal sealed partial class VisualStudioRuleSetManager : IRuleSetManager
 
     public IReferenceCountedDisposable<ICacheEntry<string, IRuleSetFile>> GetOrCreateRuleSet(string ruleSetFileFullPath)
     {
-        var cacheEntry = _ruleSetFileMap.GetOrCreate(ruleSetFileFullPath, static (ruleSetFileFullPath, self) => new RuleSetFile(ruleSetFileFullPath, self), this);
+        var cacheEntry = _ruleSetFileMap.GetOrCreate(ruleSetFileFullPath, valueCreator: static (ruleSetFileFullPath, self) => new RuleSetFile(ruleSetFileFullPath, self), arg: this);
 
         // Call InitializeFileTracking outside the lock inside ReferenceCountedDisposableCache, so we don't have requests
         // for other files blocking behind the initialization of this one. RuleSetFile itself will ensure InitializeFileTracking is locked as appropriate.

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
@@ -200,7 +200,7 @@ internal partial class VisualStudioWorkspaceImpl
 
             void WatchHierarchy(IVsHierarchy hierarchyToWatch)
             {
-                _watchedHierarchiesForDocumentMoniker.Add(moniker, _hierarchyEventSinkCache.GetOrCreate(hierarchyToWatch, static (h, self) => new HierarchyEventSink(h, self), this));
+                _watchedHierarchiesForDocumentMoniker.Add(moniker, _hierarchyEventSinkCache.GetOrCreate(hierarchyToWatch, valueCreator: static (h, self) => new HierarchyEventSink(h, self), arg: this));
             }
 
             // Take a snapshot of the immutable data structure here to avoid mutation underneath us

--- a/src/VisualStudio/Core/Def/PullMemberUp/VisualStudioPullMemberUpService.cs
+++ b/src/VisualStudio/Core/Def/PullMemberUp/VisualStudioPullMemberUpService.cs
@@ -48,7 +48,7 @@ internal class VisualStudioPullMemberUpService : IPullMemberUpOptionsService
                 new MemberSymbolViewModel(member, _glyphService)
                 {
                     // The member user selected will be checked at the beginning.
-                    IsChecked = selectedMembers.Any(SymbolEquivalenceComparer.Instance.Equals, member),
+                    IsChecked = selectedMembers.Any(predicate: SymbolEquivalenceComparer.Instance.Equals, arg: member),
                     MakeAbstract = false,
                     IsMakeAbstractCheckable = !member.IsKind(SymbolKind.Field) && !member.IsAbstract,
                     IsCheckable = true

--- a/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
@@ -93,7 +93,7 @@ internal abstract class AbstractDelayStartedService
             return;
 
         // If feature isn't enabled for any registered language, do nothing.
-        var languageEnabled = _registeredLanguages.Any(lang => _perLanguageOptions.Any(static (option, arg) => arg.self._globalOptions.GetOption(option, arg.lang), (self: this, lang)));
+        var languageEnabled = _registeredLanguages.Any(lang => _perLanguageOptions.Any(predicate: static (option, arg) => arg.self._globalOptions.GetOption(option, arg.lang), arg: (self: this, lang)));
         if (!languageEnabled)
             return;
 

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
@@ -192,10 +192,10 @@ internal sealed class ValueTrackedTreeItemViewModel : TreeItemViewModel
         var valueTrackedItems = await _valueTrackingService.TrackValueSourceAsync(
             _solution, _trackedItem, cancellationToken).ConfigureAwait(false);
 
-        return await valueTrackedItems.SelectAsArrayAsync(static (item, self, cancellationToken) =>
+        return await valueTrackedItems.SelectAsArrayAsync(selector: static (item, self, cancellationToken) =>
             CreateAsync(
                 self._solution, item, children: ImmutableArray<TreeItemViewModel>.Empty,
                 self.TreeViewModel, self._glyphService, self._valueTrackingService, self._globalOptions,
-                self.ThreadingContext, self._listener, self._threadOperationExecutor, cancellationToken), this, cancellationToken).ConfigureAwait(false);
+                self.ThreadingContext, self._listener, self._threadOperationExecutor, cancellationToken), arg: this, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationViewModel.cs
@@ -189,21 +189,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
             {
                 _symbolKind = symbolKind;
                 Name = name;
-                IsChecked = specification.ApplicableSymbolKindList.Any(static (k, symbolKind) => k.SymbolKind == symbolKind, symbolKind);
+                IsChecked = specification.ApplicableSymbolKindList.Any(predicate: static (k, symbolKind) => k.SymbolKind == symbolKind, arg: symbolKind);
             }
 
             public SymbolKindViewModel(TypeKind typeKind, string name, SymbolSpecification specification)
             {
                 _typeKind = typeKind;
                 Name = name;
-                IsChecked = specification.ApplicableSymbolKindList.Any(static (k, typeKind) => k.TypeKind == typeKind, typeKind);
+                IsChecked = specification.ApplicableSymbolKindList.Any(predicate: static (k, typeKind) => k.TypeKind == typeKind, arg: typeKind);
             }
 
             public SymbolKindViewModel(MethodKind methodKind, string name, SymbolSpecification specification)
             {
                 _methodKind = methodKind;
                 Name = name;
-                IsChecked = specification.ApplicableSymbolKindList.Any(static (k, methodKind) => k.MethodKind == methodKind, methodKind);
+                IsChecked = specification.ApplicableSymbolKindList.Any(predicate: static (k, methodKind) => k.MethodKind == methodKind, arg: methodKind);
             }
 
             internal SymbolKindOrTypeKind CreateSymbolOrTypeOrMethodKind()
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
                 _accessibility = accessibility;
                 Name = name;
 
-                IsChecked = specification.ApplicableAccessibilityList.Any(static (a, accessibility) => a == accessibility, accessibility);
+                IsChecked = specification.ApplicableAccessibilityList.Any(predicate: static (a, accessibility) => a == accessibility, arg: accessibility);
             }
         }
 
@@ -256,7 +256,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
                 _modifier = modifier;
                 Name = name;
 
-                IsChecked = specification.RequiredModifierList.Any(static (m, modifier) => m.Modifier == modifier, modifier);
+                IsChecked = specification.RequiredModifierList.Any(predicate: static (m, modifier) => m.Modifier == modifier, arg: modifier);
             }
         }
     }

--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             public override async ValueTask<T> GetAssetAsync<T>(AssetPath assetPath, Checksum checksum, CancellationToken cancellationToken)
                 => await validator.GetValueAsync<T>(checksum).ConfigureAwait(false);
 
-            public override async Task GetAssetsAsync<T, TArg>(AssetPath assetPath, HashSet<Checksum> checksums, Action<Checksum, T, TArg>? callback, TArg? arg, CancellationToken cancellationToken) where TArg : default
+            public override async Task GetAssetsAsync<T, TArg>(AssetPath assetPath, HashSet<Checksum> checksums, TArg? arg, Action<Checksum, T, TArg>? callback, CancellationToken cancellationToken) where TArg : default
             {
                 foreach (var checksum in checksums)
                 {

--- a/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
@@ -195,8 +195,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 AssetPath assetPath,
                 ReadOnlyMemory<Checksum> checksums,
                 ISerializerService deserializerService,
-                Action<Checksum, T, TArg> callback,
                 TArg arg,
+                Action<Checksum, T, TArg> callback,
                 CancellationToken cancellationToken)
             {
                 foreach (var (checksum, asset) in map)

--- a/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
@@ -58,7 +58,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             Assert.Equal(data, stored);
 
             var stored2 = new List<(Checksum, object)>();
-            await provider.GetAssetsAsync<object, VoidResult>(AssetPath.FullLookupForTesting, new HashSet<Checksum> { checksum }, (checksum, asset, _) => stored2.Add((checksum, asset)), default, CancellationToken.None);
+            await provider.GetAssetsAsync<object, VoidResult>(AssetPath.FullLookupForTesting, new HashSet<Checksum> { checksum }, callback: (checksum, asset, _) => stored2.Add((checksum, asset)), arg: default, cancellationToken: CancellationToken.None);
             Assert.Equal(1, stored2.Count);
 
             Assert.Equal(checksum, stored2[0].Item1);

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -358,8 +358,8 @@ internal partial class CSharpRecommendationService
             var contextEnclosingNamedType = _context.SemanticModel.GetEnclosingNamedType(_context.Position, _cancellationToken);
 
             return symbols.WhereAsArray(
-                static (symbol, args) => !IsUndesirable(args._context, args.contextEnclosingNamedType, args.contextOuterTypes, args.filterOutOfScopeLocals, symbol, args._cancellationToken),
-                (_context, contextOuterTypes, contextEnclosingNamedType, filterOutOfScopeLocals, _cancellationToken));
+                predicate: static (symbol, args) => !IsUndesirable(args._context, args.contextEnclosingNamedType, args.contextOuterTypes, args.filterOutOfScopeLocals, symbol, args._cancellationToken),
+                arg: (_context, contextOuterTypes, contextEnclosingNamedType, filterOutOfScopeLocals, _cancellationToken));
 
             static bool IsUndesirable(
                 CSharpSyntaxContext context,
@@ -757,8 +757,8 @@ internal partial class CSharpRecommendationService
                 var symbols = GetMemberSymbols(containerSymbol, position: originalExpression.SpanStart, excludeInstance, useBaseReferenceAccessibility, unwrapNullable, isForDereference);
 
                 var namedSymbols = symbols.WhereAsArray(
-                    static (s, a) => !IsUndesirable(s, a.containerType, a.excludeStatic, a.excludeInstance, a.excludeBaseMethodsForRefStructs),
-                    (containerType, excludeStatic, excludeInstance, excludeBaseMethodsForRefStructs, 3));
+                    predicate: static (s, a) => !IsUndesirable(s, a.containerType, a.excludeStatic, a.excludeInstance, a.excludeBaseMethodsForRefStructs),
+                    arg: (containerType, excludeStatic, excludeInstance, excludeBaseMethodsForRefStructs, 3));
 
                 // if we're dotting off an instance, then add potential operators/indexers/conversions that may be
                 // applicable to it as well.

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
         private static bool IsInGAC(string filePath)
         {
-            return GlobalAssemblyCacheLocation.RootLocations.Any(static (gloc, filePath) => PathUtilities.IsChildPath(gloc, filePath), filePath);
+            return GlobalAssemblyCacheLocation.RootLocations.Any(predicate: static (gloc, filePath) => PathUtilities.IsChildPath(gloc, filePath), arg: filePath);
         }
 
         private static string? s_frameworkRoot;

--- a/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
@@ -491,7 +491,7 @@ internal abstract class AbstractCodeCleanerService : ICodeCleanerService
                     currentDocument = originalDocument;
                 }
 
-                using (Logger.LogBlock(FunctionId.CodeCleanup_IterateOneCodeCleanup, GetCodeCleanerTypeName, codeCleaner, cancellationToken))
+                using (Logger.LogBlock(FunctionId.CodeCleanup_IterateOneCodeCleanup, messageGetter: GetCodeCleanerTypeName, arg: codeCleaner, token: cancellationToken))
                 {
                     currentDocument = await codeCleaner.CleanupAsync(currentDocument, spans, options, cancellationToken).ConfigureAwait(false);
                 }
@@ -568,7 +568,7 @@ internal abstract class AbstractCodeCleanerService : ICodeCleanerService
                     currentRoot = originalRoot;
                 }
 
-                using (Logger.LogBlock(FunctionId.CodeCleanup_IterateOneCodeCleanup, GetCodeCleanerTypeName, codeCleaner, cancellationToken))
+                using (Logger.LogBlock(FunctionId.CodeCleanup_IterateOneCodeCleanup, messageGetter: GetCodeCleanerTypeName, arg: codeCleaner, token: cancellationToken))
                 {
                     currentRoot = await codeCleaner.CleanupAsync(currentRoot, spans, options, services, cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -282,7 +282,7 @@ public readonly struct CodeFixContext
             throw new ArgumentException(WorkspaceExtensionsResources.Supplied_diagnostic_cannot_be_null, nameof(diagnostics));
         }
 
-        if (diagnostics.Any((d, span) => d.Location.SourceSpan != span, span))
+        if (diagnostics.Any(predicate: (d, span) => d.Location.SourceSpan != span, arg: span))
         {
             throw new ArgumentException(string.Format(WorkspacesResources.Diagnostic_must_have_span_0, span.ToString()), nameof(diagnostics));
         }

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -33,7 +33,7 @@ internal static partial class Extensions
     }
 
     public static ValueTask<ImmutableArray<Location>> ConvertLocationsAsync(this IReadOnlyCollection<DiagnosticDataLocation> locations, Project project, CancellationToken cancellationToken)
-        => locations.SelectAsArrayAsync((location, project, cancellationToken) => location.ConvertLocationAsync(project, cancellationToken), project, cancellationToken);
+        => locations.SelectAsArrayAsync(selector: (location, project, cancellationToken) => location.ConvertLocationAsync(project, cancellationToken), arg: project, cancellationToken: cancellationToken);
 
     public static async ValueTask<Location> ConvertLocationAsync(
         this DiagnosticDataLocation dataLocation, Project project, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_AllDeclarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_AllDeclarations.cs
@@ -63,7 +63,7 @@ internal static partial class DeclarationFinder
 
         // Lazily produce the compilation.  We don't want to incur any costs (especially source generators) if there
         // are no results for this query in this project.
-        var lazyCompilation = AsyncLazy.Create(static (project, cancellationToken) =>
+        var lazyCompilation = AsyncLazy.Create(asynchronousComputeFunction: static (project, cancellationToken) =>
             project.GetRequiredCompilationAsync(cancellationToken),
             arg: project);
 
@@ -116,7 +116,7 @@ internal static partial class DeclarationFinder
             {
                 using var _ = ArrayBuilder<ISymbol>.GetInstance(out var buffer);
 
-                var lazyAssembly = AsyncLazy.Create(static async (arg, cancellationToken) =>
+                var lazyAssembly = AsyncLazy.Create(asynchronousComputeFunction: static async (arg, cancellationToken) =>
                     {
                         var compilation = await arg.lazyCompilation.GetValueAsync(cancellationToken).ConfigureAwait(false);
                         var assemblySymbol = compilation.GetAssemblyOrModuleSymbol(arg.peReference) as IAssemblySymbol;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
@@ -36,8 +36,8 @@ internal static partial class DependentTypeFinder
             {
                 lazyIndex = s_projectToIndex.GetValue(
                     project.State, p => AsyncLazy.Create(
-                        static (project, c) => CreateIndexAsync(project, c),
-                        project));
+                        asynchronousComputeFunction: static (project, c) => CreateIndexAsync(project, c),
+                        arg: project));
             }
 
             return lazyIndex.GetValueAsync(cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
@@ -27,7 +27,7 @@ internal sealed class FindReferenceCache
 
     public static async ValueTask<FindReferenceCache> GetCacheAsync(Document document, CancellationToken cancellationToken)
     {
-        var lazy = s_cache.GetValue(document, static document => AsyncLazy.Create(ComputeCacheAsync, document));
+        var lazy = s_cache.GetValue(document, static document => AsyncLazy.Create(asynchronousComputeFunction: ComputeCacheAsync, arg: document));
         return await lazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
         static async Task<FindReferenceCache> ComputeCacheAsync(Document document, CancellationToken cancellationToken)
@@ -90,7 +90,7 @@ internal sealed class FindReferenceCache
     }
 
     public SymbolInfo GetSymbolInfo(SyntaxNode node, CancellationToken cancellationToken)
-        => _symbolInfoCache.GetOrAdd(node, static (n, arg) => arg.SemanticModel.GetSymbolInfo(n, arg.cancellationToken), (SemanticModel, cancellationToken));
+        => _symbolInfoCache.GetOrAdd(node, valueFactory: static (n, arg) => arg.SemanticModel.GetSymbolInfo(n, arg.cancellationToken), factoryArgument: (SemanticModel, cancellationToken));
 
     public IAliasSymbol? GetAliasInfo(
         ISemanticFactsService semanticFacts, SyntaxToken token, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -493,7 +493,7 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
                 deconstructMethods = semanticFacts.GetDeconstructionForEachMethods(semanticModel, node);
             }
 
-            if (deconstructMethods.Any(static (m, symbol) => Matches(m, symbol), symbol))
+            if (deconstructMethods.Any(predicate: static (m, symbol) => Matches(m, symbol), arg: symbol))
             {
                 var location = state.SyntaxFacts.GetDeconstructionReferenceLocation(node);
                 var symbolUsageInfo = GetSymbolUsageInfo(node, state, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractTypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractTypeParameterSymbolReferenceFinder.cs
@@ -32,13 +32,13 @@ internal abstract class AbstractTypeParameterSymbolReferenceFinder : AbstractRef
 
         FindReferencesInTokens(
             symbol, state,
-            tokens.WhereAsArray(static (token, state) => !IsObjectCreationToken(token, state), state),
+            tokens.WhereAsArray(predicate: static (token, state) => !IsObjectCreationToken(token, state), arg: state),
             processResult,
             processResultData,
             cancellationToken);
 
         GetObjectCreationReferences(
-            tokens.WhereAsArray(static (token, state) => IsObjectCreationToken(token, state), state),
+            tokens.WhereAsArray(predicate: static (token, state) => IsObjectCreationToken(token, state), arg: state),
             processResult,
             processResultData);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
@@ -64,8 +64,8 @@ internal sealed class ConstructorInitializerSymbolReferenceFinder : AbstractRefe
             tokens = tokens.Concat(FindMatchingIdentifierTokens(state, "New", cancellationToken)).Distinct();
 
         var totalTokens = tokens.WhereAsArray(
-            static (token, tuple) => TokensMatch(tuple.state, token, tuple.methodSymbol.ContainingType.Name, tuple.cancellationToken),
-            (state, methodSymbol, cancellationToken));
+            predicate: static (token, tuple) => TokensMatch(tuple.state, token, tuple.methodSymbol.ContainingType.Name, tuple.cancellationToken),
+            arg: (state, methodSymbol, cancellationToken));
 
         FindReferencesInTokens(methodSymbol, state, totalTokens, processResult, processResultData, cancellationToken);
         return;

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Helpers.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Helpers.cs
@@ -55,8 +55,8 @@ public static partial class SymbolFinder
             var namespace2Count = namespace2.ConstituentNamespaces.Length;
             if (namespace1Count != namespace2Count)
             {
-                if ((namespace1Count > 1 && namespace1.ConstituentNamespaces.Any(static (n, arg) => OriginalSymbolsMatch(arg.solution, n, arg.namespace2), (solution, namespace2))) ||
-                    (namespace2Count > 1 && namespace2.ConstituentNamespaces.Any(static (n2, arg) => OriginalSymbolsMatch(arg.solution, arg.namespace1, n2), (solution, namespace1))))
+                if ((namespace1Count > 1 && namespace1.ConstituentNamespaces.Any(predicate: static (n, arg) => OriginalSymbolsMatch(arg.solution, n, arg.namespace2), arg: (solution, namespace2))) ||
+                    (namespace2Count > 1 && namespace2.ConstituentNamespaces.Any(predicate: static (n2, arg) => OriginalSymbolsMatch(arg.solution, arg.namespace1, n2), arg: (solution, namespace1))))
                 {
                     return true;
                 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -72,7 +72,7 @@ internal partial class SymbolTreeInfo
         var lazy = s_projectToSourceChecksum.GetValue(
             project.State,
             static p => AsyncLazy.Create(
-                static (p, c) => ComputeSourceSymbolsChecksumAsync(p, c),
+                asynchronousComputeFunction: static (p, c) => ComputeSourceSymbolsChecksumAsync(p, c),
                 arg: p));
 
         return lazy.GetValueAsync(cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.DeclarationInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.DeclarationInfo.cs
@@ -22,7 +22,7 @@ internal sealed partial class TopLevelSyntaxTreeIndex
         {
             try
             {
-                var infos = reader.ReadArray(static (r, stringTable) => DeclaredSymbolInfo.ReadFrom_ThrowsOnFailure(stringTable, r), stringTable);
+                var infos = reader.ReadArray(read: static (r, stringTable) => DeclaredSymbolInfo.ReadFrom_ThrowsOnFailure(stringTable, r), arg: stringTable);
                 return new DeclarationInfo(infos);
             }
             catch (Exception)

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -34,7 +34,7 @@ internal sealed class LinkedFileDiffMergingSession(Solution oldSolution, Solutio
                 var filePath = newDocument.FilePath;
                 Contract.ThrowIfNull(filePath);
 
-                var newDocumentsAndHashes = filePathToNewDocumentsAndHashes.GetOrAdd(filePath, static (_, capacity) => DocumentAndHashBuilder.GetInstance(capacity), relatedDocumentIds.Length);
+                var newDocumentsAndHashes = filePathToNewDocumentsAndHashes.GetOrAdd(filePath, function: static (_, capacity) => DocumentAndHashBuilder.GetInstance(capacity), arg: relatedDocumentIds.Length);
 
                 var newText = await newDocument.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
                 var newContentHash = newText.GetContentHash();

--- a/src/Workspaces/Core/Portable/Options/LegacyWorkspaceOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/LegacyWorkspaceOptionService.cs
@@ -121,8 +121,8 @@ internal sealed class LegacyGlobalOptionService(IGlobalOptionService globalOptio
             static (workspaces, workspace) =>
             {
                 return workspaces.WhereAsArray(
-                    static (weakWorkspace, workspaceToRemove) => weakWorkspace.TryGetTarget(out var workspace) && workspace != workspaceToRemove,
-                    workspace);
+                    predicate: static (weakWorkspace, workspaceToRemove) => weakWorkspace.TryGetTarget(out var workspace) && workspace != workspaceToRemove,
+                    arg: workspace);
             },
             workspace);
     }

--- a/src/Workspaces/Core/Portable/Options/OptionChangedEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionChangedEventArgs.cs
@@ -12,5 +12,5 @@ internal sealed class OptionChangedEventArgs(ImmutableArray<(OptionKey2 key, obj
     public ImmutableArray<(OptionKey2 key, object? newValue)> ChangedOptions => changedOptions;
 
     public bool HasOption(Func<IOption2, bool> predicate)
-        => changedOptions.Any(static (option, predicate) => predicate(option.key.Option), predicate);
+        => changedOptions.Any(predicate: static (option, predicate) => predicate(option.key.Option), arg: predicate);
 }

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -350,8 +350,8 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             //
             return recommendationSymbol.IsNamespace() &&
                    recommendationSymbol.Locations.Any(
-                       static (candidateLocation, declarationSyntax) => !(declarationSyntax.SyntaxTree == candidateLocation.SourceTree &&
-                                              declarationSyntax.Span.IntersectsWith(candidateLocation.SourceSpan)), declarationSyntax);
+                       predicate: static (candidateLocation, declarationSyntax) => !(declarationSyntax.SyntaxTree == candidateLocation.SourceTree &&
+                                              declarationSyntax.Span.IntersectsWith(candidateLocation.SourceSpan)), arg: declarationSyntax);
         }
 
         protected ImmutableArray<ISymbol> GetMemberSymbols(

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -123,13 +123,13 @@ internal partial class SymbolicRenameLocations
         Contract.ThrowIfNull(serializableLocations);
 
         var locations = await serializableLocations.Locations.SelectAsArrayAsync(
-            static (loc, solution, cancellationToken) => loc.RehydrateAsync(solution, cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+            selector: static (loc, solution, cancellationToken) => loc.RehydrateAsync(solution, cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var implicitLocations = await serializableLocations.ImplicitLocations.SelectAsArrayAsync(
-        static (loc, solution, cancellationToken) => loc.RehydrateAsync(solution, cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+        selector: static (loc, solution, cancellationToken) => loc.RehydrateAsync(solution, cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var referencedSymbols = await serializableLocations.ReferencedSymbols.SelectAsArrayAsync(
-            static (sym, solution, cancellationToken) => sym.TryRehydrateAsync(solution, cancellationToken), solution, cancellationToken).ConfigureAwait(false);
+            selector: static (sym, solution, cancellationToken) => sym.TryRehydrateAsync(solution, cancellationToken), arg: solution, cancellationToken: cancellationToken).ConfigureAwait(false);
         if (referencedSymbols.Any(s => s is null))
             return null;
 

--- a/src/Workspaces/Core/Portable/Rename/LightweightRenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/LightweightRenameLocations.cs
@@ -50,13 +50,13 @@ internal sealed partial class LightweightRenameLocations
     public async Task<SymbolicRenameLocations?> ToSymbolicLocationsAsync(ISymbol symbol, CancellationToken cancellationToken)
     {
         var referencedSymbols = await _referencedSymbols.SelectAsArrayAsync(
-            static (sym, solution, cancellationToken) => sym.TryRehydrateAsync(solution, cancellationToken), Solution, cancellationToken).ConfigureAwait(false);
+            selector: static (sym, solution, cancellationToken) => sym.TryRehydrateAsync(solution, cancellationToken), arg: Solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         if (referencedSymbols.Any(s => s is null))
             return null;
 
         var implicitLocations = await _implicitLocations.SelectAsArrayAsync(
-            static (loc, solution, cancellationToken) => loc.RehydrateAsync(solution, cancellationToken), Solution, cancellationToken).ConfigureAwait(false);
+            selector: static (loc, solution, cancellationToken) => loc.RehydrateAsync(solution, cancellationToken), arg: Solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return new SymbolicRenameLocations(
             symbol,

--- a/src/Workspaces/Core/Portable/Rename/Renamer.RenameDocumentActionSet.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.RenameDocumentActionSet.cs
@@ -77,7 +77,7 @@ public static partial class Renamer
                 throw new ArgumentNullException(nameof(solution));
             }
 
-            if (actions.Any(static (a, self) => !self.ApplicableActions.Contains(a), this))
+            if (actions.Any(predicate: static (a, self) => !self.ApplicableActions.Contains(a), arg: this))
             {
                 throw new ArgumentException(string.Format(WorkspacesResources.Cannot_apply_action_that_is_not_in_0, nameof(ApplicableActions)));
             }

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -105,7 +105,7 @@ internal sealed partial class SymbolicRenameLocations
             if (referencedSymbol.ContainingSymbol != null &&
                 referencedSymbol.ContainingSymbol.Kind == SymbolKind.NamedType &&
                 ((INamedTypeSymbol)referencedSymbol.ContainingSymbol).TypeKind == TypeKind.Interface &&
-                !originalSymbol.ExplicitInterfaceImplementations().Any(static (s, referencedSymbol) => s.Equals(referencedSymbol), referencedSymbol))
+                !originalSymbol.ExplicitInterfaceImplementations().Any(predicate: static (s, referencedSymbol) => s.Equals(referencedSymbol), arg: referencedSymbol))
             {
                 return true;
             }

--- a/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
@@ -132,10 +132,10 @@ internal sealed class SerializableSourceText
             // source text out of.
 
             return SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(
-                static (state, cancellationToken) => state.GetTextAsync(cancellationToken),
-                static (text, _) => new SerializableSourceText(text, text.GetContentHash()),
-                state,
-                cancellationToken);
+                func: static (state, cancellationToken) => state.GetTextAsync(cancellationToken),
+                transform: static (text, _) => new SerializableSourceText(text, text.GetContentHash()),
+                arg: state,
+                cancellationToken: cancellationToken);
         }
     }
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -69,7 +69,7 @@ internal partial class SerializerService : ISerializerService
     {
         var kind = value.GetWellKnownSynchronizationKind();
 
-        using (Logger.LogBlock(FunctionId.Serializer_CreateChecksum, s_logKind, kind, cancellationToken))
+        using (Logger.LogBlock(FunctionId.Serializer_CreateChecksum, messageGetter: s_logKind, arg: kind, token: cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -108,7 +108,7 @@ internal partial class SerializerService : ISerializerService
     {
         var kind = value.GetWellKnownSynchronizationKind();
 
-        using (Logger.LogBlock(FunctionId.Serializer_Serialize, s_logKind, kind, cancellationToken))
+        using (Logger.LogBlock(FunctionId.Serializer_Serialize, messageGetter: s_logKind, arg: kind, token: cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -257,7 +257,7 @@ internal partial class SerializerService : ISerializerService
 
     public object Deserialize(WellKnownSynchronizationKind kind, ObjectReader reader, CancellationToken cancellationToken)
     {
-        using (Logger.LogBlock(FunctionId.Serializer_Deserialize, s_logKind, kind, cancellationToken))
+        using (Logger.LogBlock(FunctionId.Serializer_Deserialize, messageGetter: s_logKind, arg: kind, token: cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -184,12 +184,12 @@ internal static partial class IMethodSymbolExtensions
         // Many static predicates use the same state argument in this method
         var arg = (removeAttributeTypes, accessibleWithin);
 
-        var methodHasAttribute = method.GetAttributes().Any(shouldRemoveAttribute, arg);
+        var methodHasAttribute = method.GetAttributes().Any(predicate: shouldRemoveAttribute, arg: arg);
 
         var someParameterHasAttribute = method.Parameters
-            .Any(static (m, arg) => m.GetAttributes().Any(shouldRemoveAttribute, arg), arg);
+            .Any(predicate: static (m, arg) => m.GetAttributes().Any(predicate: shouldRemoveAttribute, arg: arg), arg: arg);
 
-        var returnTypeHasAttribute = method.GetReturnTypeAttributes().Any(shouldRemoveAttribute, arg);
+        var returnTypeHasAttribute = method.GetReturnTypeAttributes().Any(predicate: shouldRemoveAttribute, arg: arg);
 
         if (!methodHasAttribute && !someParameterHasAttribute && !returnTypeHasAttribute)
         {
@@ -201,11 +201,11 @@ internal static partial class IMethodSymbolExtensions
             containingType: method.ContainingType,
             explicitInterfaceImplementations: method.ExplicitInterfaceImplementations,
             attributes: method.GetAttributes().WhereAsArray(static (a, arg) => !shouldRemoveAttribute(a, arg), arg),
-            parameters: method.Parameters.SelectAsArray(static (p, arg) =>
+            parameters: method.Parameters.SelectAsArray(map: static (p, arg) =>
                 CodeGenerationSymbolFactory.CreateParameterSymbol(
                     p.GetAttributes().WhereAsArray(static (a, arg) => !shouldRemoveAttribute(a, arg), arg),
                     p.RefKind, p.IsParams, p.Type, p.Name, p.IsOptional,
-                    p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null), arg),
+                    p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null), arg: arg),
             returnTypeAttributes: method.GetReturnTypeAttributes().WhereAsArray(static (a, arg) => !shouldRemoveAttribute(a, arg), arg));
 
         static bool shouldRemoveAttribute(AttributeData a, (INamedTypeSymbol[] removeAttributeTypes, ISymbol accessibleWithin) arg)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
@@ -44,7 +44,7 @@ internal static partial class IPropertySymbolExtensions
         var arg = (attributesToRemove, accessibleWithin);
 
         var someParameterHasAttribute = property.Parameters
-            .Any(static (p, arg) => p.GetAttributes().Any(ShouldRemoveAttribute, arg), arg);
+            .Any(predicate: static (p, arg) => p.GetAttributes().Any(predicate: ShouldRemoveAttribute, arg: arg), arg: arg);
         if (!someParameterHasAttribute)
             return property;
 
@@ -57,11 +57,11 @@ internal static partial class IPropertySymbolExtensions
             property.RefKind,
             property.ExplicitInterfaceImplementations,
             property.Name,
-            property.Parameters.SelectAsArray(static (p, arg) =>
+            property.Parameters.SelectAsArray(map: static (p, arg) =>
                 CodeGenerationSymbolFactory.CreateParameterSymbol(
                     p.GetAttributes().WhereAsArray(static (a, arg) => !ShouldRemoveAttribute(a, arg), arg),
                     p.RefKind, p.IsParams, p.Type, p.Name, p.IsOptional,
-                    p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null), arg),
+                    p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null), arg: arg),
             property.GetMethod,
             property.SetMethod,
             property.IsIndexer);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
@@ -288,7 +288,7 @@ internal static partial class SourceTextExtensions
             Contract.ThrowIfFalse(offset == length);
 
             var chunksArray = chunks.MoveToImmutable();
-            Contract.ThrowIfTrue(chunksArray.Any(static (c, s) => c.Length != s, CharArrayLength));
+            Contract.ThrowIfTrue(chunksArray.Any(predicate: static (c, s) => c.Length != s, arg: CharArrayLength));
 
             return new CharArrayChunkTextReader(chunksArray, length);
         }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
@@ -146,7 +146,7 @@ internal sealed class DocumentationComment
 
         private DocumentationComment ParseInternal(string xml)
         {
-            XmlFragmentParser.ParseFragment(xml, ParseCallback, this);
+            XmlFragmentParser.ParseFragment(xml, callback: ParseCallback, arg: this);
 
             if (_exceptionTextBuilders != null)
             {

--- a/src/Workspaces/Core/Portable/Shared/Utilities/XmlFragmentParser.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/XmlFragmentParser.cs
@@ -36,7 +36,7 @@ internal sealed class XmlFragmentParser
     /// It is important that the <paramref name="callback"/> action advances the <see cref="XmlReader"/>,
     /// otherwise parsing will never complete.
     /// </remarks>
-    public static void ParseFragment<TArg>(string xmlFragment, Action<XmlReader, TArg> callback, TArg arg)
+    public static void ParseFragment<TArg>(string xmlFragment, TArg arg, Action<XmlReader, TArg> callback)
     {
         var instance = s_pool.Allocate();
         try
@@ -54,7 +54,7 @@ internal sealed class XmlFragmentParser
         DtdProcessing = DtdProcessing.Prohibit,
     };
 
-    private void ParseInternal<TArg>(string text, Action<XmlReader, TArg> callback, TArg arg)
+    private void ParseInternal<TArg>(string text, TArg arg, Action<XmlReader, TArg> callback)
     {
         _textReader.SetText(text);
 

--- a/src/Workspaces/Core/Portable/Shared/Utilities/XmlFragmentParser.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/XmlFragmentParser.cs
@@ -41,7 +41,7 @@ internal sealed class XmlFragmentParser
         var instance = s_pool.Allocate();
         try
         {
-            instance.ParseInternal(xmlFragment, callback, arg);
+            instance.ParseInternal(xmlFragment, callback: callback, arg: arg);
         }
         finally
         {

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -119,8 +119,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             public Task<bool> ChecksumMatchesAsync(TKey key, string name, Checksum checksum, CancellationToken cancellationToken)
                 => Storage.PerformReadAsync(
-                    static t => t.self.ChecksumMatches(t.key, t.name, t.checksum, t.cancellationToken),
-                    (self: this, name, key, checksum, cancellationToken), cancellationToken);
+                    func: static t => t.self.ChecksumMatches(t.key, t.name, t.checksum, t.cancellationToken),
+                    arg: (self: this, name, key, checksum, cancellationToken), cancellationToken: cancellationToken);
 
             private bool ChecksumMatches(TKey key, string name, Checksum checksum, CancellationToken cancellationToken)
             {
@@ -136,8 +136,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             public Task<Stream?> ReadStreamAsync(TKey key, string name, Checksum? checksum, CancellationToken cancellationToken)
                 => Storage.PerformReadAsync(
-                    static t => t.self.ReadStream(t.key, t.name, t.checksum, t.cancellationToken),
-                    (self: this, key, name, checksum, cancellationToken), cancellationToken);
+                    func: static t => t.self.ReadStream(t.key, t.name, t.checksum, t.cancellationToken),
+                    arg: (self: this, key, name, checksum, cancellationToken), cancellationToken: cancellationToken);
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             private Stream? ReadStream(TKey key, string name, Checksum? checksum, CancellationToken cancellationToken)
@@ -216,8 +216,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
             public Task<bool> WriteStreamAsync(TKey key, string name, Stream stream, Checksum? checksum, CancellationToken cancellationToken)
                 => Storage.PerformWriteAsync(
-                    static t => t.self.WriteStream(t.key, t.name, t.stream, t.checksum, t.cancellationToken),
-                    (self: this, key, name, stream, checksum, cancellationToken), cancellationToken);
+                    func: static t => t.self.WriteStream(t.key, t.name, t.stream, t.checksum, t.cancellationToken),
+                    arg: (self: this, key, name, stream, checksum, cancellationToken), cancellationToken: cancellationToken);
 
             private bool WriteStream(TKey key, string dataName, Stream stream, Checksum? checksum, CancellationToken cancellationToken)
             {

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_Threading.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_Threading.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2;
 internal partial class SQLitePersistentStorage
 {
     private static async Task<TResult> PerformTaskAsync<TArg, TResult>(
-        Func<TArg, TResult> func, TArg arg,
+        TArg arg, Func<TArg, TResult> func,
         TaskScheduler scheduler, CancellationToken cancellationToken) where TArg : struct
     {
         // Get a pooled delegate that can be used to prevent having to alloc a new lambda that calls 'func' while
@@ -28,7 +28,7 @@ internal partial class SQLitePersistentStorage
 
     // Read tasks go to the concurrent-scheduler where they can run concurrently with other read
     // tasks.
-    private Task<TResult> PerformReadAsync<TArg, TResult>(Func<TArg, TResult> func, TArg arg, CancellationToken cancellationToken) where TArg : struct
+    private Task<TResult> PerformReadAsync<TArg, TResult>(TArg arg, Func<TArg, TResult> func, CancellationToken cancellationToken) where TArg : struct
     {
         // Suppress ExecutionContext flow for asynchronous operations that write to the database. In addition to
         // avoiding ExecutionContext allocations, this clears the LogicalCallContext and avoids the need to clone
@@ -43,7 +43,7 @@ internal partial class SQLitePersistentStorage
 
     // Write tasks go to the exclusive-scheduler so they run exclusively of all other threading
     // tasks we need to do.
-    public Task<TResult> PerformWriteAsync<TArg, TResult>(Func<TArg, TResult> func, TArg arg, CancellationToken cancellationToken) where TArg : struct
+    public Task<TResult> PerformWriteAsync<TArg, TResult>(TArg arg, Func<TArg, TResult> func, CancellationToken cancellationToken) where TArg : struct
     {
         // Suppress ExecutionContext flow for asynchronous operations that write to the database. In addition to
         // avoiding ExecutionContext allocations, this clears the LogicalCallContext and avoids the need to clone

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.MemoryMappedInfo.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.MemoryMappedInfo.cs
@@ -116,7 +116,7 @@ internal partial class TemporaryStorageService
         /// <param name="function">The function to execute.</param>
         /// <param name="argument">The argument to pass to the function.</param>
         /// <returns>The value returned by <paramref name="function"/>.</returns>
-        private static T RunWithCompactingGCFallback<TArg, T>(Func<TArg, T> function, TArg argument)
+        private static T RunWithCompactingGCFallback<TArg, T>(TArg argument, Func<TArg, T> function)
         {
             try
             {

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.MemoryMappedInfo.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.MemoryMappedInfo.cs
@@ -79,8 +79,8 @@ internal partial class TemporaryStorageService
             if (streamAccessor == null)
             {
                 var rawAccessor = RunWithCompactingGCFallback(
-                    static info => info.MemoryMappedFile.CreateViewAccessor(info.Offset, info.Size, MemoryMappedFileAccess.Read),
-                    this);
+                    function: static info => info.MemoryMappedFile.CreateViewAccessor(info.Offset, info.Size, MemoryMappedFileAccess.Read),
+                    argument: this);
                 streamAccessor = new ReferenceCountedDisposable<MemoryMappedViewAccessor>(rawAccessor);
                 _weakReadAccessor = new ReferenceCountedDisposable<MemoryMappedViewAccessor>.WeakReference(streamAccessor);
             }
@@ -96,8 +96,8 @@ internal partial class TemporaryStorageService
         public Stream CreateWritableStream()
         {
             return RunWithCompactingGCFallback(
-                static info => info.MemoryMappedFile.CreateViewStream(info.Offset, info.Size, MemoryMappedFileAccess.Write),
-                this);
+                function: static info => info.MemoryMappedFile.CreateViewStream(info.Offset, info.Size, MemoryMappedFileAccess.Write),
+                argument: this);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1056,7 +1056,7 @@ internal sealed partial class ProjectSystemProject
             if (!vsixRazorAnalyzers.IsEmpty)
             {
                 if (s_razorSourceGeneratorAssemblyRootedFileNames.Any(
-                    static (fileName, fullPath) => fullPath.EndsWith(fileName, StringComparison.OrdinalIgnoreCase), fullPath))
+                    predicate: static (fileName, fullPath) => fullPath.EndsWith(fileName, StringComparison.OrdinalIgnoreCase), arg: fullPath))
                 {
                     return OneOrMany.Create(vsixRazorAnalyzers);
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
@@ -57,8 +57,8 @@ internal readonly struct ChecksumCollection(ImmutableArray<Checksum> children) :
         AssetPath assetPath,
         TextDocumentStates<TState> documentStates,
         HashSet<Checksum> searchingChecksumsLeft,
-        Action<Checksum, object, TArg> onAssetFound,
         TArg arg,
+        Action<Checksum, object, TArg> onAssetFound,
         CancellationToken cancellationToken) where TState : TextDocumentState
     {
         var hintDocument = assetPath.DocumentId;
@@ -90,8 +90,8 @@ internal readonly struct ChecksumCollection(ImmutableArray<Checksum> children) :
         IReadOnlyList<T> values,
         ChecksumCollection checksums,
         HashSet<Checksum> searchingChecksumsLeft,
-        Action<Checksum, object, TArg> onAssetFound,
         TArg arg,
+        Action<Checksum, object, TArg> onAssetFound,
         CancellationToken cancellationToken) where T : class
     {
         Contract.ThrowIfFalse(values.Count == checksums.Children.Length);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
@@ -68,7 +68,7 @@ internal readonly struct ChecksumCollection(ImmutableArray<Checksum> children) :
             if (state != null)
             {
                 Contract.ThrowIfFalse(state.TryGetStateChecksums(out var stateChecksums));
-                await stateChecksums.FindAsync(assetPath, state, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+                await stateChecksums.FindAsync(assetPath, state, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
         else
@@ -81,7 +81,7 @@ internal readonly struct ChecksumCollection(ImmutableArray<Checksum> children) :
 
                 Contract.ThrowIfFalse(state.TryGetStateChecksums(out var stateChecksums));
 
-                await stateChecksums.FindAsync(assetPath, state, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+                await stateChecksums.FindAsync(assetPath, state, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -544,7 +544,7 @@ public class Document : TextDocument
 
     private void InitializeCachedOptions(OptionSet solutionOptions)
     {
-        var newAsyncLazy = AsyncLazy.Create(static async (arg, cancellationToken) =>
+        var newAsyncLazy = AsyncLazy.Create(asynchronousComputeFunction: static async (arg, cancellationToken) =>
         {
             var options = await arg.self.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
             return new DocumentOptionSet(options, arg.solutionOptions, arg.self.Project.Language);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -256,6 +256,6 @@ public sealed class DocumentInfo
         }
 
         public Checksum Checksum
-            => _lazyChecksum.Initialize(static @this => Checksum.Create(@this, static (@this, writer) => @this.WriteTo(writer)), this);
+            => _lazyChecksum.Initialize(valueFactory: static @this => Checksum.Create(@this, static (@this, writer) => @this.WriteTo(writer)), arg: this);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -120,8 +120,8 @@ internal partial class DocumentState : TextDocumentState
         PreservationMode mode = PreservationMode.PreserveValue)
     {
         return SimpleTreeAndVersionSource.Create(
-            static (arg, c) => FullyParseTreeAsync(arg.newTextSource, arg.loadTextOptions, arg.filePath, arg.options, arg.languageServices, arg.mode, c),
-            static (arg, c) => FullyParseTree(arg.newTextSource, arg.loadTextOptions, arg.filePath, arg.options, arg.languageServices, arg.mode, c),
+            asynchronousComputeFunction: static (arg, c) => FullyParseTreeAsync(arg.newTextSource, arg.loadTextOptions, arg.filePath, arg.options, arg.languageServices, arg.mode, c),
+            synchronousComputeFunction: static (arg, c) => FullyParseTree(arg.newTextSource, arg.loadTextOptions, arg.filePath, arg.options, arg.languageServices, arg.mode, c),
             arg: (newTextSource, loadTextOptions, filePath, options, languageServices, mode));
     }
 
@@ -183,8 +183,8 @@ internal partial class DocumentState : TextDocumentState
         LoadTextOptions loadTextOptions)
     {
         return SimpleTreeAndVersionSource.Create(
-            static (arg, c) => IncrementallyParseTreeAsync(arg.oldTreeSource, arg.newTextSource, arg.loadTextOptions, c),
-            static (arg, c) => IncrementallyParseTree(arg.oldTreeSource, arg.newTextSource, arg.loadTextOptions, c),
+            asynchronousComputeFunction: static (arg, c) => IncrementallyParseTreeAsync(arg.oldTreeSource, arg.newTextSource, arg.loadTextOptions, c),
+            synchronousComputeFunction: static (arg, c) => IncrementallyParseTree(arg.oldTreeSource, arg.newTextSource, arg.loadTextOptions, c),
             arg: (oldTreeSource, newTextSource, loadTextOptions));
     }
 
@@ -547,8 +547,8 @@ internal partial class DocumentState : TextDocumentState
             // its okay to use a strong cached AsyncLazy here because the compiler layer SyntaxTree will also keep the text alive once its built.
             var lazyTextAndVersion = new TreeTextSource(
                 AsyncLazy.Create(
-                    static (tree, c) => tree.GetTextAsync(c),
-                    static (tree, c) => tree.GetText(c),
+                    asynchronousComputeFunction: static (tree, c) => tree.GetTextAsync(c),
+                    synchronousComputeFunction: static (tree, c) => tree.GetText(c),
                     arg: tree),
                 textVersion);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
@@ -99,8 +99,8 @@ internal partial class DocumentState
         // provided source, gets the tree from it, and then wraps its root in a new tree for us.
 
         var lazyComputation = AsyncLazy.Create(
-            static (arg, cancellationToken) => TryReuseSiblingTreeAsync(arg.filePath, arg.languageServices, arg.loadTextOptions, arg.parseOptions, arg.originalTreeSource, arg.siblingTextSource, arg.siblingTreeSource, arg.forceEvenIfTreesWouldDiffer, cancellationToken),
-            static (arg, cancellationToken) => TryReuseSiblingTree(arg.filePath, arg.languageServices, arg.loadTextOptions, arg.parseOptions, arg.originalTreeSource, arg.siblingTextSource, arg.siblingTreeSource, arg.forceEvenIfTreesWouldDiffer, cancellationToken),
+            asynchronousComputeFunction: static (arg, cancellationToken) => TryReuseSiblingTreeAsync(arg.filePath, arg.languageServices, arg.loadTextOptions, arg.parseOptions, arg.originalTreeSource, arg.siblingTextSource, arg.siblingTreeSource, arg.forceEvenIfTreesWouldDiffer, cancellationToken),
+            synchronousComputeFunction: static (arg, cancellationToken) => TryReuseSiblingTree(arg.filePath, arg.languageServices, arg.loadTextOptions, arg.parseOptions, arg.originalTreeSource, arg.siblingTextSource, arg.siblingTreeSource, arg.forceEvenIfTreesWouldDiffer, cancellationToken),
             arg: (filePath: attributes.SyntaxTreeFilePath, languageServices, loadTextOptions, parseOptions, originalTreeSource, siblingTextSource, siblingTreeSource, forceEvenIfTreesWouldDiffer));
 
         var newTreeSource = new LinkedFileReuseTreeAndVersionSource(originalTreeSource, lazyComputation);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/FileTextLoader.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/FileTextLoader.cs
@@ -172,7 +172,7 @@ public class FileTextLoader : TextLoader
         // we do not lock this file.
 
         var textAndVersion = await FileUtilities.RethrowExceptionsAsIOExceptionAsync(
-            async static t =>
+            operation: async static t =>
             {
                 using var stream = t.self.OpenFile(bufferSize: 1, useAsync: true);
                 var version = VersionStamp.Create(t.prevLastWriteTime);
@@ -182,7 +182,7 @@ public class FileTextLoader : TextLoader
                 using var readStream = await SerializableBytes.CreateReadableStreamAsync(stream, cancellationToken: t.cancellationToken).ConfigureAwait(false);
                 var text = t.self.CreateText(readStream, t.options, t.cancellationToken);
                 return TextAndVersion.Create(text, version, t.self.Path);
-            }, (self: this, prevLastWriteTime, options, cancellationToken)).ConfigureAwait(false);
+            }, arg: (self: this, prevLastWriteTime, options, cancellationToken)).ConfigureAwait(false);
 
         return CheckForConcurrentFileWrites(prevLastWriteTime, textAndVersion);
     }
@@ -199,14 +199,14 @@ public class FileTextLoader : TextLoader
         ValidateFileLength(Path, fileLength);
 
         var textAndVersion = FileUtilities.RethrowExceptionsAsIOException(
-            static t =>
+            operation: static t =>
             {
                 // Open file for reading with FileShare mode read/write/delete so that we do not lock this file.
                 using var stream = t.self.OpenFile(bufferSize: 4096, useAsync: false);
                 var version = VersionStamp.Create(t.prevLastWriteTime);
                 var text = t.self.CreateText(stream, t.options, t.cancellationToken);
                 return TextAndVersion.Create(text, version, t.self.Path);
-            }, (self: this, prevLastWriteTime, options, cancellationToken));
+            }, arg: (self: this, prevLastWriteTime, options, cancellationToken));
 
         return CheckForConcurrentFileWrites(prevLastWriteTime, textAndVersion);
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -105,7 +105,7 @@ public sealed class ProjectId : IEquatable<ProjectId>, IComparable<ProjectId>
     }
 
     internal Checksum Checksum
-        => _lazyChecksum.Initialize(static @this => Checksum.Create(@this,
+        => _lazyChecksum.Initialize(valueFactory: static @this => Checksum.Create(@this,
             static (@this, writer) =>
             {
                 // Combine "ProjectId" string and guid.  That way in the off chance that something in the stack uses
@@ -113,7 +113,7 @@ public sealed class ProjectId : IEquatable<ProjectId>, IComparable<ProjectId>
                 // different.
                 writer.WriteString(nameof(ProjectId));
                 writer.WriteGuid(@this.Id);
-            }), this);
+            }), arg: this);
 
     int IComparable<ProjectId>.CompareTo(ProjectId? other)
     {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -504,11 +504,11 @@ public sealed class ProjectInfo
         /// langword="null"/> if the name does not contain a flavor.
         /// </summary>
         public (string? name, string? flavor) NameAndFlavor
-            => _lazyNameAndFlavor.Initialize(static @this =>
+            => _lazyNameAndFlavor.Initialize(valueFactory: static @this =>
             {
                 var match = s_projectNameAndFlavor.Match(@this.Name);
                 return match.Success ? (match.Groups["name"].Value, match.Groups["flavor"].Value) : default;
-            }, this);
+            }, arg: this);
 
         public ProjectAttributes With(
             VersionStamp? version = null,
@@ -637,6 +637,6 @@ public sealed class ProjectInfo
         }
 
         public Checksum Checksum
-            => _lazyChecksum.Initialize(static @this => Checksum.Create(@this, static (@this, writer) => @this.WriteTo(writer)), this);
+            => _lazyChecksum.Initialize(valueFactory: static @this => Checksum.Create(@this, static (@this, writer) => @this.WriteTo(writer)), arg: this);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -52,7 +52,7 @@ public partial class Solution
         _cachedFrozenSolution = cachedFrozenSolution ??
             AsyncLazy.Create(synchronousComputeFunction: static (self, c) =>
                 self.ComputeFrozenSolution(c),
-                this);
+                arg: this);
     }
 
     internal Solution(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs
@@ -234,8 +234,8 @@ internal partial class SolutionCompilationState
             }
 
             public RootedSymbolSet RootedSymbolSet => _rootedSymbolSet.Initialize(
-                static finalCompilationWithGeneratedDocuments => RootedSymbolSet.Create(finalCompilationWithGeneratedDocuments),
-                this.FinalCompilationWithGeneratedDocuments);
+                valueFactory: static finalCompilationWithGeneratedDocuments => RootedSymbolSet.Create(finalCompilationWithGeneratedDocuments),
+                arg: this.FinalCompilationWithGeneratedDocuments);
 
             public FinalCompilationTrackerState WithCreationPolicy(CreationPolicy creationPolicy)
                 => creationPolicy == this.CreationPolicy

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis
                 try
                 {
                     using (Logger.LogBlock(FunctionId.Workspace_Project_CompilationTracker_BuildCompilationAsync,
-                                           s_logBuildCompilationAsync, ProjectState, cancellationToken))
+                                           messageGetter: s_logBuildCompilationAsync, arg: ProjectState, token: cancellationToken))
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
@@ -1045,7 +1045,7 @@ namespace Microsoft.CodeAnalysis
                     // note: solution is captured here, but it will go away once GetValueAsync executes.
                     Interlocked.CompareExchange(
                         ref _lazyDependentVersion,
-                        AsyncLazy.Create(static (arg, c) =>
+                        AsyncLazy.Create(asynchronousComputeFunction: static (arg, c) =>
                             arg.self.ComputeDependentVersionAsync(arg.compilationState, c),
                             arg: (self: this, compilationState)),
                         null);
@@ -1084,7 +1084,7 @@ namespace Microsoft.CodeAnalysis
                     // note: solution is captured here, but it will go away once GetValueAsync executes.
                     Interlocked.CompareExchange(
                         ref _lazyDependentSemanticVersion,
-                        AsyncLazy.Create(static (arg, c) =>
+                        AsyncLazy.Create(asynchronousComputeFunction: static (arg, c) =>
                             arg.self.ComputeDependentSemanticVersionAsync(arg.compilationState, c),
                             arg: (self: this, compilationState))
                         , null);
@@ -1122,7 +1122,7 @@ namespace Microsoft.CodeAnalysis
                     // note: solution is captured here, but it will go away once GetValueAsync executes.
                     Interlocked.CompareExchange(
                         ref _lazyDependentChecksum,
-                        AsyncLazy.Create(static (arg, c) =>
+                        AsyncLazy.Create(asynchronousComputeFunction: static (arg, c) =>
                             arg.self.ComputeDependentChecksumAsync(arg.SolutionState, c),
                             arg: (self: this, compilationState.SolutionState)),
                         null);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.SkeletonReferenceCache.cs
@@ -208,7 +208,7 @@ internal partial class SolutionCompilationState
             // concurrent requests asynchronously wait for that work to be done.
 
             var lazy = s_compilationToSkeletonSet.GetValue(compilation,
-                compilation => AsyncLazy.Create(static (arg, cancellationToken) =>
+                compilation => AsyncLazy.Create(asynchronousComputeFunction: static (arg, cancellationToken) =>
                     Task.FromResult(CreateSkeletonSet(arg.services, arg.compilation, cancellationToken)),
                     arg: (services, compilation)));
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.WithFrozenSourceGeneratedDocumentsCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.WithFrozenSourceGeneratedDocumentsCompilationTracker.cs
@@ -154,7 +154,7 @@ internal partial class SolutionCompilationState
                 // note: solution is captured here, but it will go away once GetValueAsync executes.
                 Interlocked.CompareExchange(
                     ref _lazyDependentChecksum,
-                    AsyncLazy.Create(static (arg, c) =>
+                    AsyncLazy.Create(asynchronousComputeFunction: static (arg, c) =>
                         arg.self.ComputeDependentChecksumAsync(arg.tmp, c),
                         arg: (self: this, tmp)),
                     null);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -171,9 +171,9 @@ internal sealed partial class SolutionCompilationState
     /// <inheritdoc cref="SolutionState.ForkProject"/>
     private SolutionCompilationState ForkProject<TArg>(
         StateChange stateChange,
+        TArg arg,
         Func<StateChange, TArg, TranslationAction?> translate,
-        bool forkTracker,
-        TArg arg)
+        bool forkTracker)
     {
         // If the solution didn't actually change, there's no need to change us.
         if (stateChange.NewSolutionState == this.SolutionState)
@@ -229,8 +229,8 @@ internal sealed partial class SolutionCompilationState
     private ImmutableSegmentedDictionary<ProjectId, ICompilationTracker> CreateCompilationTrackerMap<TArg>(
         ProjectId changedProjectId,
         ProjectDependencyGraph dependencyGraph,
-        Action<ImmutableSegmentedDictionary<ProjectId, ICompilationTracker>.Builder, TArg> modifyNewTrackerInfo,
         TArg arg,
+        Action<ImmutableSegmentedDictionary<ProjectId, ICompilationTracker>.Builder, TArg> modifyNewTrackerInfo,
         bool skipEmptyCallback)
     {
         return CreateCompilationTrackerMap(CanReuse, (changedProjectId, dependencyGraph), modifyNewTrackerInfo, arg, skipEmptyCallback);
@@ -257,8 +257,8 @@ internal sealed partial class SolutionCompilationState
     private ImmutableSegmentedDictionary<ProjectId, ICompilationTracker> CreateCompilationTrackerMap<TArg>(
         ImmutableArray<ProjectId> changedProjectIds,
         ProjectDependencyGraph dependencyGraph,
-        Action<ImmutableSegmentedDictionary<ProjectId, ICompilationTracker>.Builder, TArg> modifyNewTrackerInfo,
         TArg arg,
+        Action<ImmutableSegmentedDictionary<ProjectId, ICompilationTracker>.Builder, TArg> modifyNewTrackerInfo,
         bool skipEmptyCallback)
     {
         return CreateCompilationTrackerMap(CanReuse, (changedProjectIds, dependencyGraph), modifyNewTrackerInfo, arg, skipEmptyCallback);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState_Checksum.cs
@@ -80,7 +80,7 @@ internal partial class SolutionCompilationState
         {
             if (!_lazyProjectChecksums.TryGetValue(projectId, out checksums))
             {
-                checksums = AsyncLazy.Create(static async (arg, cancellationToken) =>
+                checksums = AsyncLazy.Create(asynchronousComputeFunction: static async (arg, cancellationToken) =>
                 {
                     var (checksum, projectCone) = await arg.self.ComputeChecksumsAsync(arg.projectId, cancellationToken).ConfigureAwait(false);
                     Contract.ThrowIfNull(projectCone);
@@ -133,7 +133,7 @@ internal partial class SolutionCompilationState
                 {
                     var serializer = this.SolutionState.Services.GetRequiredService<ISerializerService>();
                     var identityChecksums = FrozenSourceGeneratedDocumentStates.SelectAsArray(
-                        static (s, arg) => arg.serializer.CreateChecksum(s.Identity, cancellationToken: arg.cancellationToken), (serializer, cancellationToken));
+                        selector: static (s, arg) => arg.serializer.CreateChecksum(s.Identity, cancellationToken: arg.cancellationToken), arg: (serializer, cancellationToken));
 
                     frozenSourceGeneratedDocumentTexts = await FrozenSourceGeneratedDocumentStates.GetDocumentChecksumsAndIdsAsync(cancellationToken).ConfigureAwait(false);
                     frozenSourceGeneratedDocumentIdentities = new ChecksumCollection(identityChecksums);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -181,6 +181,6 @@ public sealed class SolutionInfo
         }
 
         public Checksum Checksum
-            => _lazyChecksum.Initialize(static @this => Checksum.Create(@this, static (@this, writer) => @this.WriteTo(writer)), this);
+            => _lazyChecksum.Initialize(valueFactory: static @this => Checksum.Create(@this, static (@this, writer) => @this.WriteTo(writer)), arg: this);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -90,7 +90,7 @@ internal sealed partial class SolutionState
         _lazyAnalyzers = lazyAnalyzers ?? CreateLazyHostDiagnosticAnalyzers(analyzerReferences);
 
         // when solution state is changed, we recalculate its checksum
-        _lazyChecksums = AsyncLazy.Create(static (self, c) =>
+        _lazyChecksums = AsyncLazy.Create(asynchronousComputeFunction: static (self, c) =>
             self.ComputeChecksumsAsync(projectConeId: null, c),
             arg: this);
 
@@ -469,7 +469,7 @@ internal sealed partial class SolutionState
     {
         Contract.ThrowIfFalse(amount is -1 or +1);
 
-        var index = languageCountDeltas.IndexOf(static (c, language) => c.language == language, language);
+        var index = languageCountDeltas.IndexOf(predicate: static (c, language) => c.language == language, arg: language);
         if (index < 0)
         {
             languageCountDeltas.Add((language, amount));
@@ -1360,7 +1360,7 @@ internal sealed partial class SolutionState
 
         var documentIds = GetDocumentIdsWithFilePath(filePath);
         return documentIds.WhereAsArray(
-            static (documentId, args) =>
+            predicate: static (documentId, args) =>
             {
                 var projectState = args.solution.GetProjectState(documentId.ProjectId);
                 if (projectState == null)
@@ -1378,7 +1378,7 @@ internal sealed partial class SolutionState
                 // GetDocumentIdsWithFilePath may return DocumentIds for other types of documents (like additional files), so filter to normal documents
                 return projectState.DocumentStates.Contains(documentId);
             },
-            (solution: this, projectState.Language));
+            arg: (solution: this, projectState.Language));
     }
 
     /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -80,7 +80,7 @@ internal partial class SolutionState
             if (!_lazyProjectChecksums.TryGetValue(projectId, out checksums))
             {
                 checksums = AsyncLazy.Create(
-                    static (arg, cancellationToken) => arg.self.ComputeChecksumsAsync(arg.projectId, cancellationToken),
+                    asynchronousComputeFunction: static (arg, cancellationToken) => arg.self.ComputeChecksumsAsync(arg.projectId, cancellationToken),
                     arg: (self: this, projectId));
                 _lazyProjectChecksums.Add(projectId, checksums);
             }
@@ -139,7 +139,7 @@ internal partial class SolutionState
 
                 var fallbackAnalyzerOptionsChecksum = ChecksumCache.GetOrCreate(
                     FallbackAnalyzerOptions,
-                    static (value, args) => args.serializer.CreateChecksum(value, args.cancellationToken),
+                    checksumCreator: static (value, args) => args.serializer.CreateChecksum(value, args.cancellationToken),
                     arg: (serializer, cancellationToken));
 
                 var stateChecksums = new SolutionStateChecksums(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -117,8 +117,8 @@ internal sealed class SolutionCompilationStateChecksums
         ProjectCone? projectCone,
         AssetPath assetPath,
         HashSet<Checksum> searchingChecksumsLeft,
-        Action<Checksum, object, TArg> onAssetFound,
         TArg arg,
+        Action<Checksum, object, TArg> onAssetFound,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -279,8 +279,8 @@ internal sealed class SolutionStateChecksums(
         ProjectCone? projectCone,
         AssetPath assetPath,
         HashSet<Checksum> searchingChecksumsLeft,
-        Action<Checksum, object, TArg> onAssetFound,
         TArg arg,
+        Action<Checksum, object, TArg> onAssetFound,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -449,8 +449,8 @@ internal sealed class ProjectStateChecksums(
         ProjectState state,
         AssetPath assetPath,
         HashSet<Checksum> searchingChecksumsLeft,
-        Action<Checksum, object, TArg> onAssetFound,
         TArg arg,
+        Action<Checksum, object, TArg> onAssetFound,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -535,8 +535,8 @@ internal sealed class DocumentStateChecksums(
         AssetPath assetPath,
         TextDocumentState state,
         HashSet<Checksum> searchingChecksumsLeft,
-        Action<Checksum, object, TArg> onAssetFound,
         TArg arg,
+        Action<Checksum, object, TArg> onAssetFound,
         CancellationToken cancellationToken)
     {
         Debug.Assert(state.TryGetStateChecksums(out var stateChecksum) && this == stateChecksum);
@@ -562,7 +562,7 @@ internal sealed class DocumentStateChecksums(
 /// </summary>
 internal static class ChecksumCache
 {
-    public static Checksum GetOrCreate<TValue, TArg>(TValue value, Func<TValue, TArg, Checksum> checksumCreator, TArg arg)
+    public static Checksum GetOrCreate<TValue, TArg>(TValue value, TArg arg, Func<TValue, TArg, Checksum> checksumCreator)
         where TValue : class
     {
         return StronglyTypedChecksumCache<TValue, Checksum>.GetOrCreate(value, checksumCreator: checksumCreator, arg: arg);
@@ -590,7 +590,7 @@ internal static class ChecksumCache
     {
         private static readonly ConditionalWeakTable<TValue, StrongBox<TResult>> s_objectToChecksumCollectionCache = new();
 
-        public static TResult GetOrCreate<TArg>(TValue value, Func<TValue, TArg, TResult> checksumCreator, TArg arg)
+        public static TResult GetOrCreate<TArg>(TValue value, TArg arg, Func<TValue, TArg, TResult> checksumCreator)
         {
             if (s_objectToChecksumCollectionCache.TryGetValue(value, out var checksumCollection))
                 return checksumCollection.Value;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -147,7 +147,7 @@ internal sealed class SolutionCompilationStateChecksums
                 {
                     await ChecksumCollection.FindAsync(
                         new AssetPath(AssetPathKind.DocumentText, assetPath.ProjectId, assetPath.DocumentId),
-                        compilationState.FrozenSourceGeneratedDocumentStates, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+                        compilationState.FrozenSourceGeneratedDocumentStates, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
 
                 // ... or one of the identities. In this case, we'll use the fact that there's a 1:1 correspondence between the
@@ -193,13 +193,13 @@ internal sealed class SolutionCompilationStateChecksums
             // If we're not in a project cone, start the search at the top most state-checksum corresponding to the
             // entire solution.
             Contract.ThrowIfFalse(solutionState.TryGetStateChecksums(out var solutionChecksums));
-            await solutionChecksums.FindAsync(solutionState, projectCone, assetPath, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+            await solutionChecksums.FindAsync(solutionState, projectCone, assetPath, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         else
         {
             // Otherwise, grab the top-most state checksum for this cone and search within that.
             Contract.ThrowIfFalse(solutionState.TryGetStateChecksums(projectCone.RootProjectId, out var solutionChecksums));
-            await solutionChecksums.FindAsync(solutionState, projectCone, assetPath, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+            await solutionChecksums.FindAsync(solutionState, projectCone, assetPath, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 }
@@ -296,7 +296,7 @@ internal sealed class SolutionStateChecksums(
                 onAssetFound(Attributes, solution.SolutionAttributes, arg);
 
             if (assetPath.IncludeSolutionAnalyzerReferences)
-                ChecksumCollection.Find(solution.AnalyzerReferences, AnalyzerReferences, searchingChecksumsLeft, onAssetFound, arg, cancellationToken);
+                ChecksumCollection.Find(solution.AnalyzerReferences, AnalyzerReferences, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken);
 
             if (assetPath.IncludeSolutionFallbackAnalyzerOptions && searchingChecksumsLeft.Remove(FallbackAnalyzerOptions))
                 onAssetFound(FallbackAnalyzerOptions, solution.FallbackAnalyzerOptions, arg);
@@ -318,7 +318,7 @@ internal sealed class SolutionStateChecksums(
                 if (projectState != null &&
                     projectState.TryGetStateChecksums(out var projectStateChecksums))
                 {
-                    await projectStateChecksums.FindAsync(projectState, assetPath, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+                    await projectStateChecksums.FindAsync(projectState, assetPath, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
             }
             else
@@ -341,7 +341,7 @@ internal sealed class SolutionStateChecksums(
                     if (!projectState.TryGetStateChecksums(out var projectStateChecksums))
                         continue;
 
-                    await projectStateChecksums.FindAsync(projectState, assetPath, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+                    await projectStateChecksums.FindAsync(projectState, assetPath, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -482,20 +482,20 @@ internal sealed class ProjectStateChecksums(
             }
 
             if (assetPath.IncludeProjectProjectReferences)
-                ChecksumCollection.Find(state.ProjectReferences, ProjectReferences, searchingChecksumsLeft, onAssetFound, arg, cancellationToken);
+                ChecksumCollection.Find(state.ProjectReferences, ProjectReferences, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken);
 
             if (assetPath.IncludeProjectMetadataReferences)
-                ChecksumCollection.Find(state.MetadataReferences, MetadataReferences, searchingChecksumsLeft, onAssetFound, arg, cancellationToken);
+                ChecksumCollection.Find(state.MetadataReferences, MetadataReferences, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken);
 
             if (assetPath.IncludeProjectAnalyzerReferences)
-                ChecksumCollection.Find(state.AnalyzerReferences, AnalyzerReferences, searchingChecksumsLeft, onAssetFound, arg, cancellationToken);
+                ChecksumCollection.Find(state.AnalyzerReferences, AnalyzerReferences, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken);
         }
 
         if (assetPath.IncludeDocuments)
         {
-            await ChecksumCollection.FindAsync(assetPath, state.DocumentStates, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
-            await ChecksumCollection.FindAsync(assetPath, state.AdditionalDocumentStates, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
-            await ChecksumCollection.FindAsync(assetPath, state.AnalyzerConfigDocumentStates, searchingChecksumsLeft, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+            await ChecksumCollection.FindAsync(assetPath, state.DocumentStates, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await ChecksumCollection.FindAsync(assetPath, state.AdditionalDocumentStates, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await ChecksumCollection.FindAsync(assetPath, state.AnalyzerConfigDocumentStates, searchingChecksumsLeft, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -565,7 +565,7 @@ internal static class ChecksumCache
     public static Checksum GetOrCreate<TValue, TArg>(TValue value, Func<TValue, TArg, Checksum> checksumCreator, TArg arg)
         where TValue : class
     {
-        return StronglyTypedChecksumCache<TValue, Checksum>.GetOrCreate(value, checksumCreator, arg);
+        return StronglyTypedChecksumCache<TValue, Checksum>.GetOrCreate(value, checksumCreator: checksumCreator, arg: arg);
     }
 
     public static ChecksumCollection GetOrCreateChecksumCollection<TReference>(
@@ -573,7 +573,7 @@ internal static class ChecksumCache
     {
         return StronglyTypedChecksumCache<IReadOnlyList<TReference>, ChecksumCollection>.GetOrCreate(
             references,
-            static (references, tuple) =>
+            checksumCreator: static (references, tuple) =>
             {
                 var checksums = new FixedSizeArrayBuilder<Checksum>(references.Count);
                 foreach (var reference in references)
@@ -581,7 +581,7 @@ internal static class ChecksumCache
 
                 return new ChecksumCollection(checksums.MoveToImmutable());
             },
-            (serializer, cancellationToken));
+            arg: (serializer, cancellationToken));
     }
 
     private static class StronglyTypedChecksumCache<TValue, TResult>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -50,7 +50,7 @@ internal partial class TextDocumentState
         // a new AsyncLazy to compute the checksum though, and that's because there's no practical way for
         // the newly created TextDocumentState to have the same checksum as a previous TextDocumentState:
         // if we're creating a new state, it's because something changed, and we'll have to create a new checksum.
-        _lazyChecksums = AsyncLazy.Create(static (self, cancellationToken) => self.ComputeChecksumsAsync(cancellationToken), arg: this);
+        _lazyChecksums = AsyncLazy.Create(asynchronousComputeFunction: static (self, cancellationToken) => self.ComputeChecksumsAsync(cancellationToken), arg: this);
     }
 
     public TextDocumentState(SolutionServices solutionServices, DocumentInfo info, LoadTextOptions loadTextOptions)
@@ -106,10 +106,10 @@ internal partial class TextDocumentState
         }
 
         return SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(
-            static (self, cancellationToken) => self.GetTextAndVersionAsync(cancellationToken),
-            static (textAndVersion, _) => textAndVersion.Text,
-            this,
-            cancellationToken);
+            func: static (self, cancellationToken) => self.GetTextAndVersionAsync(cancellationToken),
+            transform: static (textAndVersion, _) => textAndVersion.Text,
+            arg: this,
+            cancellationToken: cancellationToken);
     }
 
     public SourceText GetTextSynchronously(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState_Checksum.cs
@@ -24,10 +24,10 @@ internal partial class TextDocumentState
     public Task<Checksum> GetChecksumAsync(CancellationToken cancellationToken)
     {
         return SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(
-            static (lazyChecksums, cancellationToken) => new ValueTask<DocumentStateChecksums>(lazyChecksums.GetValueAsync(cancellationToken)),
-            static (documentStateChecksums, _) => documentStateChecksums.Checksum,
-            _lazyChecksums,
-            cancellationToken).AsTask();
+            func: static (lazyChecksums, cancellationToken) => new ValueTask<DocumentStateChecksums>(lazyChecksums.GetValueAsync(cancellationToken)),
+            transform: static (documentStateChecksums, _) => documentStateChecksums.Checksum,
+            arg: _lazyChecksums,
+            cancellationToken: cancellationToken).AsTask();
     }
 
     private async Task<DocumentStateChecksums> ComputeChecksumsAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -132,7 +132,7 @@ internal sealed class TextDocumentStates<TState>
             selector: static (state, selector) => selector(state),
             arg: selector);
 
-    public ImmutableArray<TValue> SelectAsArray<TValue, TArg>(Func<TState, TArg, TValue> selector, TArg arg)
+    public ImmutableArray<TValue> SelectAsArray<TValue, TArg>(TArg arg, Func<TState, TArg, TValue> selector)
     {
         var result = new FixedSizeArrayBuilder<TValue>(_map.Count);
         foreach (var (_, state) in _map)
@@ -190,7 +190,7 @@ internal sealed class TextDocumentStates<TState>
         return new(_ids, builder.ToImmutable(), filePathToDocumentIds);
     }
 
-    public TextDocumentStates<TState> UpdateStates<TArg>(Func<TState, TArg, TState> transformation, TArg arg)
+    public TextDocumentStates<TState> UpdateStates<TArg>(TArg arg, Func<TState, TArg, TState> transformation)
     {
         var builder = _map.ToBuilder();
         var filePathsChanged = false;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -129,8 +129,8 @@ internal sealed class TextDocumentStates<TState>
 
     public ImmutableArray<TValue> SelectAsArray<TValue>(Func<TState, TValue> selector)
         => SelectAsArray(
-            static (state, selector) => selector(state),
-            selector);
+            selector: static (state, selector) => selector(state),
+            arg: selector);
 
     public ImmutableArray<TValue> SelectAsArray<TValue, TArg>(Func<TState, TArg, TValue> selector, TArg arg)
     {
@@ -159,7 +159,7 @@ internal sealed class TextDocumentStates<TState>
             foreach (var documentId in _ids)
                 set.Add(documentId);
 
-            if (ids.All(static (id, set) => set.Contains(id), set))
+            if (ids.All(predicate: static (id, set) => set.Contains(id), arg: set))
                 return Empty;
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/VersionSource/SimpleTreeAndVersionSource.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/VersionSource/SimpleTreeAndVersionSource.cs
@@ -33,8 +33,9 @@ internal sealed class SimpleTreeAndVersionSource : ITreeAndVersionSource
         => _source.TryGetValue(out value);
 
     public static SimpleTreeAndVersionSource Create<TArg>(
+        TArg arg,
         Func<TArg, CancellationToken, Task<TreeAndVersion>> asynchronousComputeFunction,
-        Func<TArg, CancellationToken, TreeAndVersion>? synchronousComputeFunction, TArg arg)
+        Func<TArg, CancellationToken, TreeAndVersion>? synchronousComputeFunction)
     {
         return new(AsyncLazy<TreeAndVersion>.Create(asynchronousComputeFunction, synchronousComputeFunction, arg));
     }

--- a/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
@@ -36,7 +36,7 @@ internal static class TextExtensions
 
             var relatedIds = solution.GetRelatedDocumentIds(documentId);
             solution = solution.WithDocumentText(relatedIds, text, PreservationMode.PreserveIdentity);
-            return relatedIds.SelectAsArray((id, solution) => solution.GetRequiredDocument(id), solution);
+            return relatedIds.SelectAsArray(map: (id, solution) => solution.GetRequiredDocument(id), arg: solution);
         }
 
         return [];
@@ -112,7 +112,7 @@ internal static class TextExtensions
             if (documentId != null)
             {
                 var relatedIds = solution.GetRelatedDocumentIds(documentId);
-                return relatedIds.SelectAsArray((id, solution) => solution.GetRequiredDocument(id), solution);
+                return relatedIds.SelectAsArray(map: (id, solution) => solution.GetRequiredDocument(id), arg: solution);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -67,7 +67,7 @@ public abstract partial class Workspace
                 using (Logger.LogBlock(FunctionId.Workspace_Events, (s, p, d, k) => $"{s.Id} - {p} - {d} {kind.ToString()}", newSolution, projectId, documentId, kind, CancellationToken.None))
                 {
                     var args = new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId);
-                    ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
+                    ev.RaiseEvent(invoker: static (handler, arg) => handler(arg.self, arg.args), arg: (self: this, args));
                 }
             }, WorkspaceChangeEventName);
         }
@@ -100,7 +100,7 @@ public abstract partial class Workspace
         if (ev.HasHandlers)
         {
             var args = new WorkspaceDiagnosticEventArgs(diagnostic);
-            ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
+            ev.RaiseEvent(invoker: static (handler, arg) => handler(arg.self, arg.args), arg: (self: this, args));
         }
     }
 
@@ -154,7 +154,7 @@ public abstract partial class Workspace
         {
             return this.ScheduleTask(() =>
             {
-                ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
+                ev.RaiseEvent(invoker: static (handler, arg) => handler(arg.self, arg.args), arg: (self: this, args));
             }, eventName);
         }
         else
@@ -233,7 +233,7 @@ public abstract partial class Workspace
             return this.ScheduleTask(() =>
             {
                 var args = new DocumentActiveContextChangedEventArgs(currentSolution, sourceTextContainer, oldActiveContextDocumentId, newActiveContextDocumentId);
-                ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
+                ev.RaiseEvent(invoker: static (handler, arg) => handler(arg.self, arg.args), arg: (self: this, args));
             }, "Workspace.WorkspaceChanged");
         }
         else

--- a/src/Workspaces/CoreTest/UtilityTest/AsyncLazyTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/AsyncLazyTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
 
             lazy = AsyncLazy.Create(
-                static (computeFunctionRunning, c) =>
+                asynchronousComputeFunction: static (computeFunctionRunning, c) =>
                 {
                     computeFunctionRunning.Set();
                     while (true)
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var cancellationTokenSource = new CancellationTokenSource();
 
-            var lazy = AsyncLazy.Create(static (cancellationTokenSource, c) => Task.Run((Func<object>)(() =>
+            var lazy = AsyncLazy.Create(asynchronousComputeFunction: static (cancellationTokenSource, c) => Task.Run((Func<object>)(() =>
             {
                 cancellationTokenSource.Cancel();
                 while (true)
@@ -241,8 +241,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
 
             var lazy = AsyncLazy.Create(
-                static (synchronousComputation, c) => Task.FromResult(synchronousComputation(c)),
-                includeSynchronousComputation ? static (synchronousComputation, c) => synchronousComputation(c) : null!,
+                asynchronousComputeFunction: static (synchronousComputation, c) => Task.FromResult(synchronousComputation(c)),
+                synchronousComputeFunction: includeSynchronousComputation ? static (synchronousComputation, c) => synchronousComputation(c) : null!,
                 arg: synchronousComputation);
 
             var thrownException = Assert.Throws<OperationCanceledException>(() =>

--- a/src/Workspaces/CoreTest/UtilityTest/SpecializedTasksTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SpecializedTasksTests.cs
@@ -78,8 +78,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var cancellationToken = new CancellationToken(canceled: false);
 
 #pragma warning disable CA2012 // Use ValueTasks correctly (the instance is never created)
-            Assert.Throws<ArgumentNullException>("func", () => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(null!, transform, arg, cancellationToken));
-            Assert.Throws<ArgumentNullException>("transform", () => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync<StateType, IntermediateType, ResultType>(func, null!, arg, cancellationToken));
+            Assert.Throws<ArgumentNullException>("func", () => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: null!, transform: transform, arg: arg, cancellationToken: cancellationToken));
+            Assert.Throws<ArgumentNullException>("transform", () => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync<StateType, IntermediateType, ResultType>(func: func, transform: null!, arg: arg, cancellationToken: cancellationToken));
 #pragma warning restore CA2012 // Use ValueTasks correctly
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var arg = new StateType();
             var cancellationToken = new CancellationToken(canceled: false);
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.True(task.IsCompletedSuccessfully);
             Assert.NotNull(task.Result);
         }
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.True(task.IsCanceled);
             var exception = Assert.Throws<TaskCanceledException>(() => task.Result);
             Assert.Equal(cancellationToken, exception.CancellationToken);
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var arg = new StateType();
             var cancellationToken = new CancellationToken(canceled: false);
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.False(task.IsCompleted);
 
             gate.Set();
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.False(task.IsCompleted);
 
             gate.Set();
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.True(task.IsCanceled);
             var exception = Assert.Throws<TaskCanceledException>(() => task.Result);
             Assert.Equal(cancellationToken, exception.CancellationToken);
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.False(task.IsCompleted);
 
             gate.Set();
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.True(task.IsCanceled);
             var exception = Assert.Throws<TaskCanceledException>(() => task.Result);
 
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.False(task.IsCompleted);
 
             gate.Set();
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.True(task.IsCanceled);
             var exception = Assert.Throws<TaskCanceledException>(() => task.Result);
             Assert.Equal(cancellationToken, exception.CancellationToken);
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.False(task.IsCompleted);
 
             gate.Set();
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var arg = new StateType();
 
 #pragma warning disable CA2012 // Use ValueTasks correctly (the instance is never created)
-            var exception = Assert.Throws<InvalidOperationException>(() => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken));
+            var exception = Assert.Throws<InvalidOperationException>(() => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken));
 #pragma warning restore CA2012 // Use ValueTasks correctly
             Assert.Same(fault, exception);
             Assert.False(executedTransform);
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.True(task.IsFaulted);
             var exception = Assert.Throws<InvalidOperationException>(() => task.Result);
             Assert.Same(fault, exception);
@@ -423,7 +423,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.False(task.IsCompleted);
 
             gate.Set();
@@ -451,7 +451,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var arg = new StateType();
 
 #pragma warning disable CA2012 // Use ValueTasks correctly (the instance is never created)
-            var exception = Assert.Throws<InvalidOperationException>(() => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken));
+            var exception = Assert.Throws<InvalidOperationException>(() => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken));
 #pragma warning restore CA2012 // Use ValueTasks correctly
             Assert.Same(fault, exception);
             Assert.False(executedTransform);
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.True(task.IsCanceled);
             var exception = Assert.Throws<TaskCanceledException>(() => task.Result);
             Assert.Equal(cancellationToken, exception.CancellationToken);
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             };
             var arg = new StateType();
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.False(task.IsCompleted);
 
             gate.Set();
@@ -526,7 +526,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var cancellationToken = new CancellationToken(canceled: false);
 
 #pragma warning disable CA2012 // Use ValueTasks correctly (the instance is never created)
-            var exception = Assert.Throws<InvalidOperationException>(() => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken));
+            var exception = Assert.Throws<InvalidOperationException>(() => SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken));
 #pragma warning restore CA2012 // Use ValueTasks correctly
             Assert.Same(fault, exception);
         }
@@ -546,7 +546,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var arg = new StateType();
             var cancellationToken = new CancellationToken(canceled: false);
 
-            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func, transform, arg, cancellationToken).Preserve();
+            var task = SpecializedTasks.TransformWithoutIntermediateCancellationExceptionAsync(func: func, transform: transform, arg: arg, cancellationToken: cancellationToken).Preserve();
             Assert.False(task.IsCompleted);
 
             gate.Set();

--- a/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing;
 internal sealed class SimpleAssetSource(ISerializerService serializerService, IReadOnlyDictionary<Checksum, object> map) : IAssetSource
 {
     public ValueTask GetAssetsAsync<T, TArg>(
-        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, Action<Checksum, T, TArg> callback, TArg arg, CancellationToken cancellationToken)
+        Checksum solutionChecksum, AssetPath assetPath, ReadOnlyMemory<Checksum> checksums, ISerializerService deserializerService, TArg arg, Action<Checksum, T, TArg> callback, CancellationToken cancellationToken)
     {
         foreach (var checksum in checksums.Span)
         {

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -24,7 +24,7 @@ internal abstract class AbstractAssetProvider
     /// return data of type T whose checksum is the given checksum
     /// </summary>
     public abstract ValueTask<T> GetAssetAsync<T>(AssetPath assetPath, Checksum checksum, CancellationToken cancellationToken);
-    public abstract Task GetAssetsAsync<T, TArg>(AssetPath assetPath, HashSet<Checksum> checksums, Action<Checksum, T, TArg>? callback, TArg? arg, CancellationToken cancellationToken);
+    public abstract Task GetAssetsAsync<T, TArg>(AssetPath assetPath, HashSet<Checksum> checksums, TArg? arg, Action<Checksum, T, TArg>? callback, CancellationToken cancellationToken);
 
     public async Task<SolutionInfo> CreateSolutionInfoAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
     {
@@ -180,7 +180,7 @@ internal static class AbstractAssetProviderExtensions
     }
 
     public static async Task GetAssetsAsync<T, TArg>(
-        this AbstractAssetProvider assetProvider, AssetPath assetPath, ChecksumCollection checksums, Action<Checksum, T, TArg>? callback, TArg? arg, CancellationToken cancellationToken)
+        this AbstractAssetProvider assetProvider, AssetPath assetPath, ChecksumCollection checksums, TArg? arg, Action<Checksum, T, TArg>? callback, CancellationToken cancellationToken)
     {
         using var _1 = PooledHashSet<Checksum>.GetInstance(out var checksumSet);
 #if NET

--- a/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/AbstractAssetProvider.cs
@@ -156,10 +156,10 @@ internal abstract class AbstractAssetProvider
     public readonly struct AssetHelper<T>(AbstractAssetProvider assetProvider)
     {
         public Task GetAssetsAsync<TArg>(AssetPath assetPath, HashSet<Checksum> checksums, Action<Checksum, T, TArg>? callback, TArg? arg, CancellationToken cancellationToken)
-            => assetProvider.GetAssetsAsync(assetPath, checksums, callback, arg, cancellationToken);
+            => assetProvider.GetAssetsAsync(assetPath, checksums, callback: callback, arg: arg, cancellationToken: cancellationToken);
 
         public Task GetAssetsAsync<TArg>(AssetPath assetPath, ChecksumCollection checksums, Action<Checksum, T, TArg>? callback, TArg? arg, CancellationToken cancellationToken)
-            => assetProvider.GetAssetsAsync(assetPath, checksums, callback, arg, cancellationToken);
+            => assetProvider.GetAssetsAsync(assetPath, checksums, callback: callback, arg: arg, cancellationToken: cancellationToken);
     }
 }
 
@@ -169,14 +169,14 @@ internal static class AbstractAssetProviderExtensions
         this AbstractAssetProvider assetProvider, AssetPath assetPath, HashSet<Checksum> checksums, CancellationToken cancellationToken)
     {
         return assetProvider.GetAssetsAsync<TAsset, VoidResult>(
-            assetPath, checksums, callback: null, arg: default, cancellationToken);
+            assetPath, checksums, callback: null, arg: default, cancellationToken: cancellationToken);
     }
 
     public static Task GetAssetsAsync<T>(
         this AbstractAssetProvider assetProvider, AssetPath assetPath, ChecksumCollection checksums, CancellationToken cancellationToken)
     {
         return assetProvider.GetAssetsAsync<T, VoidResult>(
-            assetPath, checksums, callback: null, arg: default, cancellationToken);
+            assetPath, checksums, callback: null, arg: default, cancellationToken: cancellationToken);
     }
 
     public static async Task GetAssetsAsync<T, TArg>(
@@ -188,7 +188,7 @@ internal static class AbstractAssetProviderExtensions
 #endif
         checksumSet.AddAll(checksums.Children);
 
-        await assetProvider.GetAssetsAsync(assetPath, checksumSet, callback, arg, cancellationToken).ConfigureAwait(false);
+        await assetProvider.GetAssetsAsync(assetPath, checksumSet, callback: callback, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Workspaces/Remote/Core/RemoteHostAssetWriter.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetWriter.cs
@@ -79,8 +79,8 @@ internal readonly struct RemoteHostAssetWriter(
     private Task FindAssetsAsync(Action<ChecksumAndAsset> onItemFound, CancellationToken cancellationToken)
         => _scope.FindAssetsAsync(
             _assetPath, _checksums,
-            static (checksum, asset, onItemFound) => onItemFound((checksum, asset)),
-            onItemFound, cancellationToken);
+            onAssetFound: static (checksum, asset, onItemFound) => onItemFound((checksum, asset)),
+            arg: onItemFound, cancellationToken: cancellationToken);
 
     private async Task WriteBatchToPipeAsync(
         IAsyncEnumerable<ChecksumAndAsset> checksumsAndAssets, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -52,7 +52,7 @@ internal partial class SolutionAssetStorage
             var numberOfChecksumsToSearch = checksumsToFind.Count;
             Contract.ThrowIfTrue(checksumsToFind.Contains(Checksum.Null));
 
-            await FindAssetsAsync(assetPath, checksumsToFind, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+            await FindAssetsAsync(assetPath, checksumsToFind, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             Contract.ThrowIfTrue(checksumsToFind.Count > 0);
 
@@ -75,13 +75,13 @@ internal partial class SolutionAssetStorage
                 // If we're not in a project cone, start the search at the top most state-checksum corresponding to the
                 // entire solution.
                 Contract.ThrowIfFalse(solutionState.TryGetStateChecksums(out var stateChecksums));
-                await stateChecksums.FindAsync(solutionState, this.ProjectCone, assetPath, remainingChecksumsToFind, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+                await stateChecksums.FindAsync(solutionState, this.ProjectCone, assetPath, remainingChecksumsToFind, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 // Otherwise, grab the top-most state checksum for this cone and search within that.
                 Contract.ThrowIfFalse(solutionState.TryGetStateChecksums(this.ProjectCone.RootProjectId, out var stateChecksums));
-                await stateChecksums.FindAsync(solutionState, this.ProjectCone, assetPath, remainingChecksumsToFind, onAssetFound, arg, cancellationToken).ConfigureAwait(false);
+                await stateChecksums.FindAsync(solutionState, this.ProjectCone, assetPath, remainingChecksumsToFind, onAssetFound: onAssetFound, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -101,13 +101,13 @@ internal partial class SolutionAssetStorage
                 var checksums = new ReadOnlyMemory<Checksum>([checksum]);
 
                 object? asset = null;
-                await scope.FindAssetsAsync(AssetPath.FullLookupForTesting, checksums, (foundChecksum, foundAsset, _) =>
+                await scope.FindAssetsAsync(AssetPath.FullLookupForTesting, checksums, onAssetFound: (foundChecksum, foundAsset, _) =>
                 {
                     Contract.ThrowIfNull(foundAsset);
                     Contract.ThrowIfTrue(asset != null); // We should only find one asset
                     Contract.ThrowIfTrue(checksum != foundChecksum);
                     asset = foundAsset;
-                }, default(VoidResult), cancellationToken).ConfigureAwait(false);
+                }, arg: default(VoidResult), cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 Contract.ThrowIfNull(asset);
 

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -40,8 +40,8 @@ internal partial class SolutionAssetStorage
         public async Task FindAssetsAsync<TArg>(
             AssetPath assetPath,
             ReadOnlyMemory<Checksum> checksums,
-            Action<Checksum, object, TArg> onAssetFound,
             TArg arg,
+            Action<Checksum, object, TArg> onAssetFound,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -66,7 +66,7 @@ internal partial class SolutionAssetStorage
         }
 
         private async Task FindAssetsAsync<TArg>(
-            AssetPath assetPath, HashSet<Checksum> remainingChecksumsToFind, Action<Checksum, object, TArg> onAssetFound, TArg arg, CancellationToken cancellationToken)
+            AssetPath assetPath, HashSet<Checksum> remainingChecksumsToFind, TArg arg, Action<Checksum, object, TArg> onAssetFound, CancellationToken cancellationToken)
         {
             var solutionState = this.CompilationState;
 

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -51,7 +51,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     }
 
     public override async Task GetAssetsAsync<T, TArg>(
-        AssetPath assetPath, HashSet<Checksum> checksums, Action<Checksum, T, TArg>? callback, TArg? arg, CancellationToken cancellationToken) where TArg : default
+        AssetPath assetPath, HashSet<Checksum> checksums, TArg? arg, Action<Checksum, T, TArg>? callback, CancellationToken cancellationToken) where TArg : default
     {
         await this.SynchronizeAssetsAsync(assetPath, checksums, callback: callback, arg: arg, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
@@ -233,7 +233,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
     }
 
     private async ValueTask SynchronizeAssetsAsync<T, TArg>(
-        AssetPath assetPath, HashSet<Checksum> checksums, Action<Checksum, T, TArg>? callback, TArg? arg, CancellationToken cancellationToken)
+        AssetPath assetPath, HashSet<Checksum> checksums, TArg? arg, Action<Checksum, T, TArg>? callback, CancellationToken cancellationToken)
     {
         Contract.ThrowIfTrue(checksums.Contains(Checksum.Null));
         if (checksums.Count == 0)

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -20,7 +20,7 @@ internal interface IAssetSource
         AssetPath assetPath,
         ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
-        Action<Checksum, T, TArg> callback,
         TArg arg,
+        Action<Checksum, T, TArg> callback,
         CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
@@ -75,7 +75,7 @@ internal sealed class SolutionAssetCache
 
     public bool TryGetAsset<T>(Checksum checksum, [MaybeNullWhen(false)] out T value)
     {
-        using (Logger.LogBlock(FunctionId.AssetStorage_TryGetAsset, Checksum.GetChecksumLogInfo, checksum, CancellationToken.None))
+        using (Logger.LogBlock(FunctionId.AssetStorage_TryGetAsset, messageGetter: Checksum.GetChecksumLogInfo, arg: checksum, token: CancellationToken.None))
         {
             if (!_assets.TryGetValue(checksum, out var entry))
             {

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -20,8 +20,8 @@ internal sealed class SolutionAssetSource(ServiceBrokerClient client) : IAssetSo
         AssetPath assetPath,
         ReadOnlyMemory<Checksum> checksums,
         ISerializerService serializerService,
-        Action<Checksum, T, TArg> assetCallback,
         TArg arg,
+        Action<Checksum, T, TArg> assetCallback,
         CancellationToken cancellationToken)
     {
         // Make sure we are on the thread pool to avoid UI thread dependencies if external code uses ConfigureAwait(true)

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -190,17 +190,17 @@ namespace Microsoft.CodeAnalysis.Remote
             if (projectId == null)
             {
                 var compilationChecksums = await solution.CompilationState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-                await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, AssetPath.FullLookupForTesting, Flatten(compilationChecksums), callback, map, cancellationToken).ConfigureAwait(false);
+                await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, AssetPath.FullLookupForTesting, Flatten(compilationChecksums), onAssetFound: callback, arg: map, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 foreach (var frozenSourceGeneratedDocumentState in solution.CompilationState.FrozenSourceGeneratedDocumentStates?.States.Values ?? [])
                 {
                     var documentChecksums = await frozenSourceGeneratedDocumentState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-                    await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, AssetPath.FullLookupForTesting, Flatten(documentChecksums), callback, map, cancellationToken).ConfigureAwait(false);
+                    await compilationChecksums.FindAsync(solution.CompilationState, projectCone: null, AssetPath.FullLookupForTesting, Flatten(documentChecksums), onAssetFound: callback, arg: map, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
 
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfTrue(solutionChecksums.ProjectCone != null);
-                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone: null, AssetPath.FullLookupForTesting, Flatten(solutionChecksums), callback, map, cancellationToken).ConfigureAwait(false);
+                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone: null, AssetPath.FullLookupForTesting, Flatten(solutionChecksums), onAssetFound: callback, arg: map, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 foreach (var project in solution.Projects)
                     await project.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);
@@ -208,11 +208,11 @@ namespace Microsoft.CodeAnalysis.Remote
             else
             {
                 var (compilationChecksums, projectCone) = await solution.CompilationState.GetStateChecksumsAsync(projectId, cancellationToken).ConfigureAwait(false);
-                await compilationChecksums.FindAsync(solution.CompilationState, projectCone, AssetPath.SolutionAndProjectForTesting(projectId), Flatten(compilationChecksums), callback, map, cancellationToken).ConfigureAwait(false);
+                await compilationChecksums.FindAsync(solution.CompilationState, projectCone, AssetPath.SolutionAndProjectForTesting(projectId), Flatten(compilationChecksums), onAssetFound: callback, arg: map, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 var solutionChecksums = await solution.CompilationState.SolutionState.GetStateChecksumsAsync(projectId, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfFalse(projectCone.Equals(solutionChecksums.ProjectCone));
-                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, AssetPath.SolutionAndProjectForTesting(projectId), Flatten(solutionChecksums), callback, map, cancellationToken).ConfigureAwait(false);
+                await solutionChecksums.FindAsync(solution.CompilationState.SolutionState, projectCone, AssetPath.SolutionAndProjectForTesting(projectId), Flatten(solutionChecksums), onAssetFound: callback, arg: map, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 var project = solution.GetRequiredProject(projectId);
                 await project.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);
@@ -231,12 +231,12 @@ namespace Microsoft.CodeAnalysis.Remote
             var callback = static (Checksum checksum, object asset, Dictionary<Checksum, object> map) => { map[checksum] = asset; };
 
             var projectChecksums = await project.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-            await projectChecksums.FindAsync(project.State, AssetPath.FullLookupForTesting, Flatten(projectChecksums), callback, map, cancellationToken).ConfigureAwait(false);
+            await projectChecksums.FindAsync(project.State, AssetPath.FullLookupForTesting, Flatten(projectChecksums), onAssetFound: callback, arg: map, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             foreach (var document in project.Documents.Concat(project.AdditionalDocuments).Concat(project.AnalyzerConfigDocuments))
             {
                 var documentChecksums = await document.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
-                await documentChecksums.FindAsync(AssetPathKind.Documents, document.State, Flatten(documentChecksums), callback, map, cancellationToken).ConfigureAwait(false);
+                await documentChecksums.FindAsync(AssetPathKind.Documents, document.State, Flatten(documentChecksums), onAssetFound: callback, arg: map, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/AssetSynchronization/RemoteAssetSynchronizationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/AssetSynchronization/RemoteAssetSynchronizationService.cs
@@ -32,7 +32,7 @@ internal sealed class RemoteAssetSynchronizationService(in BrokeredServiceBase.S
     {
         return RunServiceAsync(async cancellationToken =>
         {
-            using (RoslynLogger.LogBlock(FunctionId.RemoteHostService_SynchronizePrimaryWorkspaceAsync, Checksum.GetChecksumLogInfo, solutionChecksum, cancellationToken))
+            using (RoslynLogger.LogBlock(FunctionId.RemoteHostService_SynchronizePrimaryWorkspaceAsync, messageGetter: Checksum.GetChecksumLogInfo, arg: solutionChecksum, token: cancellationToken))
             {
                 var workspace = GetWorkspace();
                 var assetProvider = workspace.CreateAssetProvider(solutionChecksum, WorkspaceManager.SolutionAssetCache, SolutionAssetSource);
@@ -54,7 +54,7 @@ internal sealed class RemoteAssetSynchronizationService(in BrokeredServiceBase.S
         {
             var workspace = GetWorkspace();
 
-            using (RoslynLogger.LogBlock(FunctionId.RemoteHostService_SynchronizeTextAsync, Checksum.GetChecksumLogInfo, baseTextChecksum, cancellationToken))
+            using (RoslynLogger.LogBlock(FunctionId.RemoteHostService_SynchronizeTextAsync, messageGetter: Checksum.GetChecksumLogInfo, arg: baseTextChecksum, token: cancellationToken))
             {
                 // Try to get the text associated with baseTextChecksum
                 var text = await TryGetSourceTextAsync(WorkspaceManager, workspace, documentId, baseTextChecksum, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/ClientOptionsProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ClientOptionsProvider.cs
@@ -19,7 +19,7 @@ internal sealed class ClientOptionsProvider<TOptions, TCallback>(RemoteCallback<
     public async ValueTask<TOptions> GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
     {
         var lazyOptions = ImmutableInterlocked.GetOrAdd(ref _cache, languageServices.Language, _ => AsyncLazy.Create(
-            static (arg, cancellationToken) => arg.self.GetRemoteOptionsAsync(arg.languageServices, cancellationToken), arg: (self: this, languageServices)));
+            asynchronousComputeFunction: static (arg, cancellationToken) => arg.self.GetRemoteOptionsAsync(arg.languageServices, cancellationToken), arg: (self: this, languageServices)));
         return await lazyOptions.GetValueAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
@@ -231,11 +231,11 @@ namespace Microsoft.CodeAnalysis.Remote
                 CancellationToken cancellationToken)
             {
                 var dehydrated = references.SelectAsArray(
-                    static (reference, tuple) => (
+                    map: static (reference, tuple) => (
                         SerializableSymbolGroup.Dehydrate(tuple.solution, reference.group, tuple.cancellationToken),
                         SerializableSymbolAndProjectId.Dehydrate(tuple.solution, reference.symbol, tuple.cancellationToken),
                         SerializableReferenceLocation.Dehydrate(reference.location, tuple.cancellationToken)),
-                    (solution: _solution, cancellationToken));
+                    arg: (solution: _solution, cancellationToken));
 
                 await _callback.InvokeAsync(
                     (callback, cancellationToken) => callback.OnReferencesFoundAsync(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/WrappingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/WrappingFormattingRule.cs
@@ -187,13 +187,13 @@ internal sealed class WrappingFormattingRule : BaseFormattingRule
 
         var span = TextSpan.FromBounds(startToken.SpanStart, endToken.Span.End);
         list.RemoveOrTransformAll(
-            (operation, span) =>
+            transform: (operation, span) =>
             {
                 if (operation.TextSpan.Start >= span.Start && operation.TextSpan.End <= span.End && operation.Option.HasFlag(SuppressOption.NoWrappingIfOnSingleLine))
                     return null;
 
                 return operation;
             },
-            span);
+            arg: span);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SemanticFacts/CSharpSemanticFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SemanticFacts/CSharpSemanticFacts.cs
@@ -68,7 +68,7 @@ internal sealed partial class CSharpSemanticFacts : ISemanticFacts
                 {
                     // The token may be part of a larger name (for example, `int` in `public static operator int[](Goo g);`.
                     // So check if the symbol's location encompasses the span of the token we're asking about.
-                    if (symbol.Locations.Any(static (loc, location) => loc.SourceTree == location.SourceTree && loc.SourceSpan.Contains(location.SourceSpan), location))
+                    if (symbol.Locations.Any(predicate: static (loc, location) => loc.SourceTree == location.SourceTree && loc.SourceSpan.Contains(location.SourceSpan), arg: location))
                         return symbol;
                 }
                 else

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
@@ -231,7 +231,7 @@ internal static partial class INamedTypeSymbolExtensions
                 // interface I<T> where T : I<T> { static abstract int operator -(T x); }
 
                 // See https://github.com/dotnet/csharplang/blob/main/spec/classes.md#unary-operators.
-                return method.Parameters.Any(static (p, within) => p.Type.Equals(within, SymbolEqualityComparer.Default), within);
+                return method.Parameters.Any(predicate: static (p, within) => p.Type.Equals(within, SymbolEqualityComparer.Default), arg: within);
             }
 
             return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/IParameterSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/IParameterSymbolExtensions.cs
@@ -36,7 +36,7 @@ internal static partial class IParameterSymbolExtensions
             // ok, we have a record constructor.  This might be the primary constructor or not.
             var parameterSyntax = parameter.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
             var constructorSyntax = constructor.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
-            if (containingType.DeclaringSyntaxReferences.Any(static (r, arg) => r.GetSyntax(arg.cancellationToken) == arg.constructorSyntax, (constructorSyntax, cancellationToken)))
+            if (containingType.DeclaringSyntaxReferences.Any(predicate: static (r, arg) => r.GetSyntax(arg.cancellationToken) == arg.constructorSyntax, arg: (constructorSyntax, cancellationToken)))
             {
                 // this was a primary constructor. see if we can map this parameter to a corresponding synthesized property 
                 foreach (var member in containingType.GetMembers(parameter.Name))
@@ -66,7 +66,7 @@ internal static partial class IParameterSymbolExtensions
             })
         {
             var constructorSyntax = constructorReference.GetSyntax(cancellationToken);
-            return containingType.DeclaringSyntaxReferences.Any(static (r, arg) => r.GetSyntax(arg.cancellationToken) == arg.constructorSyntax, (constructorSyntax, cancellationToken));
+            return containingType.DeclaringSyntaxReferences.Any(predicate: static (r, arg) => r.GetSyntax(arg.cancellationToken) == arg.constructorSyntax, arg: (constructorSyntax, cancellationToken));
         }
 
         return false;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.RequiresUnsafeModifierVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.RequiresUnsafeModifierVisitor.cs
@@ -90,7 +90,7 @@ internal partial class ISymbolExtensions
 
             return
                 symbol.Type.Accept(this) ||
-                symbol.Parameters.Any(static (p, self) => p.Accept(self), this);
+                symbol.Parameters.Any(predicate: static (p, self) => p.Accept(self), arg: this);
         }
 
         public override bool VisitTypeParameter(ITypeParameterSymbol symbol)
@@ -100,7 +100,7 @@ internal partial class ISymbolExtensions
                 return false;
             }
 
-            return symbol.ConstraintTypes.Any(static (ts, self) => ts.Accept(self), this);
+            return symbol.ConstraintTypes.Any(predicate: static (ts, self) => ts.Accept(self), arg: this);
         }
 
         public override bool VisitMethod(IMethodSymbol symbol)
@@ -112,8 +112,8 @@ internal partial class ISymbolExtensions
 
             return
                 symbol.ReturnType.Accept(this) ||
-                symbol.Parameters.Any(static (p, self) => p.Accept(self), this) ||
-                symbol.TypeParameters.Any(static (tp, self) => tp.Accept(self), this);
+                symbol.Parameters.Any(predicate: static (p, self) => p.Accept(self), arg: this) ||
+                symbol.TypeParameters.Any(predicate: static (tp, self) => tp.Accept(self), arg: this);
         }
 
         public override bool VisitParameter(IParameterSymbol symbol)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -217,7 +217,7 @@ internal static partial class ITypeSymbolExtensions
         this ITypeSymbol type, ITypeSymbol interfaceType)
     {
         var originalInterfaceType = interfaceType.OriginalDefinition;
-        return type.AllInterfaces.Any(static (t, originalInterfaceType) => SymbolEquivalenceComparer.Instance.Equals(t.OriginalDefinition, originalInterfaceType), originalInterfaceType);
+        return type.AllInterfaces.Any(predicate: static (t, originalInterfaceType) => SymbolEquivalenceComparer.Instance.Equals(t.OriginalDefinition, originalInterfaceType), arg: originalInterfaceType);
     }
 
     public static bool Implements(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ListExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ListExtensions.cs
@@ -21,7 +21,7 @@ internal static class ListExtensions
     /// <param name="transform">A function which transforms each element. The function returns the transformed list
     /// element, or <see langword="null"/> to remove the current item from the list.</param>
     /// <param name="arg">The state argument to pass to the transformation callback.</param>
-    public static void RemoveOrTransformAll<T, TArg>(this List<T> list, Func<T, TArg, T?> transform, TArg arg)
+    public static void RemoveOrTransformAll<T, TArg>(this List<T> list, TArg arg, Func<T, TArg, T?> transform)
         where T : class
     {
         RoslynDebug.AssertNotNull(list);
@@ -40,7 +40,7 @@ internal static class ListExtensions
         list.RemoveRange(targetIndex, list.Count - targetIndex);
     }
 
-    public static void RemoveOrTransformAll<T, TArg>(this List<T> list, Func<T, TArg, T?> transform, TArg arg)
+    public static void RemoveOrTransformAll<T, TArg>(this List<T> list, TArg arg, Func<T, TArg, T?> transform)
         where T : struct
     {
         RoslynDebug.AssertNotNull(list);
@@ -59,7 +59,7 @@ internal static class ListExtensions
         list.RemoveRange(targetIndex, list.Count - targetIndex);
     }
 
-    public static void RemoveOrTransformAll<T, TArg>(this ArrayBuilder<T> list, Func<T, TArg, T?> transform, TArg arg)
+    public static void RemoveOrTransformAll<T, TArg>(this ArrayBuilder<T> list, TArg arg, Func<T, TArg, T?> transform)
         where T : struct
     {
         RoslynDebug.AssertNotNull(list);
@@ -84,7 +84,7 @@ internal static class ListExtensions
     /// <returns>
     /// True if any item has been removed.
     /// </returns>
-    public static bool TryRemoveFirst<T, TArg>(this IList<T> list, Func<T, TArg, bool> selector, TArg arg, [NotNullWhen(true)] out T? removedItem)
+    public static bool TryRemoveFirst<T, TArg>(this IList<T> list, TArg arg, Func<T, TArg, bool> selector, [NotNullWhen(true)] out T? removedItem)
         where T : notnull
     {
         for (var i = 0; i < list.Count; i++)
@@ -115,7 +115,7 @@ internal static class ListExtensions
         return -1;
     }
 
-    public static int IndexOf<T, TArg>(this IList<T> list, Func<T, TArg, bool> predicate, TArg arg)
+    public static int IndexOf<T, TArg>(this IList<T> list, TArg arg, Func<T, TArg, bool> predicate)
     {
         for (var i = 0; i < list.Count; i++)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ObjectWriterExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ObjectWriterExtensions.cs
@@ -22,7 +22,7 @@ internal static class ObjectWriterExtensions
 internal static class ObjectReaderExtensions
 {
     public static ImmutableArray<T> ReadArray<T>(this ObjectReader reader, Func<ObjectReader, T> read)
-        => ReadArray(reader, static (reader, read) => read(reader), read);
+        => ReadArray(reader, read: static (reader, read) => read(reader), arg: read);
 
     public static ImmutableArray<T> ReadArray<T, TArg>(this ObjectReader reader, Func<ObjectReader, TArg, T> read, TArg arg)
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ObjectWriterExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ObjectWriterExtensions.cs
@@ -24,7 +24,7 @@ internal static class ObjectReaderExtensions
     public static ImmutableArray<T> ReadArray<T>(this ObjectReader reader, Func<ObjectReader, T> read)
         => ReadArray(reader, read: static (reader, read) => read(reader), arg: read);
 
-    public static ImmutableArray<T> ReadArray<T, TArg>(this ObjectReader reader, Func<ObjectReader, TArg, T> read, TArg arg)
+    public static ImmutableArray<T> ReadArray<T, TArg>(this ObjectReader reader, TArg arg, Func<ObjectReader, TArg, T> read)
     {
         var length = reader.ReadInt32();
         var builder = new FixedSizeArrayBuilder<T>(length);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SemanticModelExtensions.cs
@@ -188,7 +188,7 @@ internal static partial class SemanticModelExtensions
             return false;
 
         var enumerableType = semanticModel.Compilation.IEnumerableOfTType();
-        return type.AllInterfaces.Any(static (i, enumerableType) => i.OriginalDefinition.Equals(enumerableType), enumerableType);
+        return type.AllInterfaces.Any(predicate: static (i, enumerableType) => i.OriginalDefinition.Equals(enumerableType), arg: enumerableType);
     }
 
     private static bool TryGeneratePluralizedNameFromTypeArgument(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.AnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.AnalysisData.cs
@@ -187,11 +187,11 @@ internal static partial class SymbolUsageAnalysis
             {
                 CurrentBlockAnalysisData.ForEachCurrentWrite(
                     symbol,
-                    static (write, arg) =>
+                    action: static (write, arg) =>
                     {
                         arg.self.SymbolsWriteBuilder[(arg.symbol, write)] = true;
                     },
-                    (symbol, self: this));
+                    arg: (symbol, self: this));
             }
 
             // Mark the current symbol as read.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -73,7 +73,7 @@ internal static partial class SymbolUsageAnalysis
         /// <summary>
         /// Gets the currently reachable writes for the given symbol.
         /// </summary>
-        public void ForEachCurrentWrite<TArg>(ISymbol symbol, Action<IOperation, TArg> action, TArg arg)
+        public void ForEachCurrentWrite<TArg>(ISymbol symbol, TArg arg, Action<IOperation, TArg> action)
         {
             ForEachCurrentWrite(
                 symbol,
@@ -85,7 +85,7 @@ internal static partial class SymbolUsageAnalysis
                 arg: (action, arg));
         }
 
-        public bool ForEachCurrentWrite<TArg>(ISymbol symbol, Func<IOperation, TArg, bool> action, TArg arg)
+        public bool ForEachCurrentWrite<TArg>(ISymbol symbol, TArg arg, Func<IOperation, TArg, bool> action)
         {
             if (_reachingWrites.TryGetValue(symbol, out var values))
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -77,12 +77,12 @@ internal static partial class SymbolUsageAnalysis
         {
             ForEachCurrentWrite(
                 symbol,
-                static (write, arg) =>
+                action: static (write, arg) =>
                 {
                     arg.action(write, arg.arg);
                     return true;
                 },
-                (action, arg));
+                arg: (action, arg));
         }
 
         public bool ForEachCurrentWrite<TArg>(ISymbol symbol, Func<IOperation, TArg, bool> action, TArg arg)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.FlowGraphAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.FlowGraphAnalysisData.cs
@@ -442,14 +442,14 @@ internal static partial class SymbolUsageAnalysis
                     {
                         CurrentBlockAnalysisData.ForEachCurrentWrite(
                             parameter,
-                            static (write, arg) =>
+                            action: static (write, arg) =>
                             {
                                 if (write != null)
                                 {
                                     arg.self.SymbolsWriteBuilder[(arg.parameter, write)] = true;
                                 }
                             },
-                            (parameter, self: this));
+                            arg: (parameter, self: this));
                     }
                 }
             }
@@ -523,7 +523,7 @@ internal static partial class SymbolUsageAnalysis
                 var targetsBuilder = PooledHashSet<IOperation>.GetInstance();
                 var completedVisit = CurrentBlockAnalysisData.ForEachCurrentWrite(
                     symbol,
-                    static (symbolWrite, arg) =>
+                    action: static (symbolWrite, arg) =>
                     {
                         if (symbolWrite == null)
                         {
@@ -551,7 +551,7 @@ internal static partial class SymbolUsageAnalysis
                         // Continue with the iteration
                         return true;
                     },
-                    (targetsBuilder, self: this));
+                    arg: (targetsBuilder, self: this));
 
                 if (!completedVisit)
                     return;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.IndentationData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.IndentationData.cs
@@ -95,11 +95,11 @@ internal partial class FormattingContext
             return InterlockedOperations.Initialize(
                 ref _lazyIndentationDelta,
                 UninitializedIndentationDelta,
-                static self => self._indentationDeltaGetter(
+                valueFactory: static self => self._indentationDeltaGetter(
                     self._formattingContext,
                     self.Operation,
                     self._effectiveBaseTokenGetter(self._formattingContext, self.Operation)),
-                this);
+                arg: this);
         }
 
         public override int Indentation => GetOrComputeIndentationDelta() + _baseIndentationGetter(_formattingContext, _effectiveBaseTokenGetter(_formattingContext, Operation));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.InitialContextFinder.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.InitialContextFinder.cs
@@ -154,7 +154,7 @@ internal partial class FormattingContext
             {
                 _formattingRules.AddSuppressOperations(buffer, currentIndentationNode);
 
-                buffer.RemoveAll(Predicate, (startPosition, _tokenStream, mask));
+                buffer.RemoveAll(match: Predicate, arg: (startPosition, _tokenStream, mask));
                 if (buffer.Count > 0)
                 {
                     result.AddRange(buffer);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/BaseIndentationFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/BaseIndentationFormattingRule.cs
@@ -65,7 +65,7 @@ internal class BaseIndentationFormattingRule : AbstractFormattingRule
     private void AdjustIndentBlockOperation(List<IndentBlockOperation> list)
     {
         list.RemoveOrTransformAll(
-            (operation, self) =>
+            transform: (operation, self) =>
             {
                 // already filtered out operation
                 if (operation == null)
@@ -101,7 +101,7 @@ internal class BaseIndentationFormattingRule : AbstractFormattingRule
 
                 return operation;
             },
-            this);
+            arg: this);
     }
 
     private bool Myself(IndentBlockOperation operation)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/LogMessage.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/LogMessage.cs
@@ -20,7 +20,7 @@ internal abstract class LogMessage
     public static LogMessage Create(Func<string> messageGetter, LogLevel logLevel)
         => LazyLogMessage.Construct(messageGetter, logLevel);
 
-    public static LogMessage Create<TArg>(Func<TArg, string> messageGetter, TArg arg, LogLevel logLevel)
+    public static LogMessage Create<TArg>(TArg arg, Func<TArg, string> messageGetter, LogLevel logLevel)
         => LazyLogMessage<TArg>.Construct(messageGetter, arg, logLevel);
 
     public static LogMessage Create<TArg0, TArg1>(Func<TArg0, TArg1, string> messageGetter, TArg0 arg0, TArg1 arg1, LogLevel logLevel)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/Logger.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/Logger.cs
@@ -83,7 +83,7 @@ internal static partial class Logger
     /// log a specific event with a context message that requires some arguments to be created when requested.
     /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
     /// </summary>
-    public static void Log<TArg>(FunctionId functionId, Func<TArg, string> messageGetter, TArg arg, LogLevel logLevel = LogLevel.Debug)
+    public static void Log<TArg>(FunctionId functionId, TArg arg, Func<TArg, string> messageGetter, LogLevel logLevel = LogLevel.Debug)
     {
         if (TryGetActiveLogger(functionId, out var logger))
         {
@@ -180,7 +180,7 @@ internal static partial class Logger
     /// log a start and end pair with a context message that requires some arguments to be created when requested.
     /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
     /// </summary>
-    public static IDisposable LogBlock<TArg>(FunctionId functionId, Func<TArg, string> messageGetter, TArg arg, CancellationToken token, LogLevel logLevel = LogLevel.Trace)
+    public static IDisposable LogBlock<TArg>(FunctionId functionId, TArg arg, Func<TArg, string> messageGetter, CancellationToken token, LogLevel logLevel = LogLevel.Trace)
         => TryGetActiveLogger(functionId, out _)
             ? CreateLogBlock(functionId, LogMessage.Create(messageGetter: messageGetter, arg: arg, logLevel: logLevel), GetNextUniqueBlockId(), token)
             : EmptyLogBlock.Instance;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/Logger.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/Logger.cs
@@ -87,7 +87,7 @@ internal static partial class Logger
     {
         if (TryGetActiveLogger(functionId, out var logger))
         {
-            var logMessage = LogMessage.Create(messageGetter, arg, logLevel);
+            var logMessage = LogMessage.Create(messageGetter: messageGetter, arg: arg, logLevel: logLevel);
             logger.Log(functionId, logMessage);
             logMessage.Free();
         }
@@ -182,7 +182,7 @@ internal static partial class Logger
     /// </summary>
     public static IDisposable LogBlock<TArg>(FunctionId functionId, Func<TArg, string> messageGetter, TArg arg, CancellationToken token, LogLevel logLevel = LogLevel.Trace)
         => TryGetActiveLogger(functionId, out _)
-            ? CreateLogBlock(functionId, LogMessage.Create(messageGetter, arg, logLevel), GetNextUniqueBlockId(), token)
+            ? CreateLogBlock(functionId, LogMessage.Create(messageGetter: messageGetter, arg: arg, logLevel: logLevel), GetNextUniqueBlockId(), token)
             : EmptyLogBlock.Instance;
 
     /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
@@ -94,8 +94,8 @@ internal sealed class SymbolSpecification(
     }
 
     public bool AppliesTo(ISymbol symbol)
-        => ApplicableSymbolKindList.Any(static (kind, symbol) => kind.MatchesSymbol(symbol), symbol) &&
-           RequiredModifierList.All(static (modifier, symbol) => modifier.MatchesSymbol(symbol), symbol) &&
+        => ApplicableSymbolKindList.Any(predicate: static (kind, symbol) => kind.MatchesSymbol(symbol), arg: symbol) &&
+           RequiredModifierList.All(predicate: static (modifier, symbol) => modifier.MatchesSymbol(symbol), arg: symbol) &&
            ApplicableAccessibilityList.Contains(GetAccessibility(symbol));
 
     public bool AppliesTo(SymbolKind symbolKind, Accessibility accessibility)
@@ -103,7 +103,7 @@ internal sealed class SymbolSpecification(
 
     public bool AppliesTo(SymbolKindOrTypeKind kind, DeclarationModifiers modifiers, Accessibility? accessibility)
     {
-        if (!ApplicableSymbolKindList.Any(static (k, kind) => k.Equals(kind), kind))
+        if (!ApplicableSymbolKindList.Any(predicate: static (k, kind) => k.Equals(kind), arg: kind))
         {
             return false;
         }
@@ -114,7 +114,7 @@ internal sealed class SymbolSpecification(
             return false;
         }
 
-        if (accessibility.HasValue && !ApplicableAccessibilityList.Any(static (k, accessibility) => k == accessibility, accessibility))
+        if (accessibility.HasValue && !ApplicableAccessibilityList.Any(predicate: static (k, accessibility) => k == accessibility, arg: accessibility))
         {
             return false;
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/HeaderFacts/AbstractHeaderFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/HeaderFacts/AbstractHeaderFacts.cs
@@ -56,7 +56,7 @@ internal abstract class AbstractHeaderFacts : IHeaderFacts
         // Holes are exclusive: 
         // To be consistent with other 'being on the edge' of Tokens/Nodes a position is 
         // in a hole (not in a header) only if it's inside _inside_ a hole, not only on the edge.
-        if (holes.Any(static (h, position) => h.Span.Contains(position) && position > h.Span.Start, position))
+        if (holes.Any(predicate: static (h, position) => h.Span.Contains(position) && position > h.Span.Start, arg: position))
         {
             return false;
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,16 +10,16 @@ namespace Roslyn.Utilities;
 
 internal static class AsyncLazy
 {
-    public static AsyncLazy<T> Create<T, TArg>(Func<TArg, CancellationToken, Task<T>> asynchronousComputeFunction, Func<TArg, CancellationToken, T>? synchronousComputeFunction, TArg arg)
+    public static AsyncLazy<T> Create<T, TArg>(TArg arg, Func<TArg, CancellationToken, Task<T>> asynchronousComputeFunction, Func<TArg, CancellationToken, T>? synchronousComputeFunction)
         => AsyncLazy<T>.Create(asynchronousComputeFunction, synchronousComputeFunction, arg);
 
-    public static AsyncLazy<T> Create<T, TArg>(Func<TArg, CancellationToken, Task<T>> asynchronousComputeFunction, TArg arg)
+    public static AsyncLazy<T> Create<T, TArg>(TArg arg, Func<TArg, CancellationToken, Task<T>> asynchronousComputeFunction)
         => Create(
             asynchronousComputeFunction: asynchronousComputeFunction,
             synchronousComputeFunction: null,
             arg: arg);
 
-    public static AsyncLazy<T> Create<T, TArg>(Func<TArg, CancellationToken, T> synchronousComputeFunction, TArg arg)
+    public static AsyncLazy<T> Create<T, TArg>(TArg arg, Func<TArg, CancellationToken, T> synchronousComputeFunction)
         => Create(
             asynchronousComputeFunction: static (outerArg, cancellationToken) => Task.FromResult(outerArg.synchronousComputeFunction(outerArg.arg, cancellationToken)),
             synchronousComputeFunction: static (outerArg, cancellationToken) => outerArg.synchronousComputeFunction(outerArg.arg, cancellationToken),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,15 +15,15 @@ internal static class AsyncLazy
 
     public static AsyncLazy<T> Create<T, TArg>(Func<TArg, CancellationToken, Task<T>> asynchronousComputeFunction, TArg arg)
         => Create(
-            asynchronousComputeFunction,
+            asynchronousComputeFunction: asynchronousComputeFunction,
             synchronousComputeFunction: null,
-            arg);
+            arg: arg);
 
     public static AsyncLazy<T> Create<T, TArg>(Func<TArg, CancellationToken, T> synchronousComputeFunction, TArg arg)
         => Create(
             asynchronousComputeFunction: static (outerArg, cancellationToken) => Task.FromResult(outerArg.synchronousComputeFunction(outerArg.arg, cancellationToken)),
             synchronousComputeFunction: static (outerArg, cancellationToken) => outerArg.synchronousComputeFunction(outerArg.arg, cancellationToken),
-            (synchronousComputeFunction, arg));
+            arg: (synchronousComputeFunction, arg));
 
     public static AsyncLazy<T> Create<T>(Func<CancellationToken, Task<T>> asynchronousComputeFunction)
         => Create(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
@@ -101,7 +101,7 @@ internal class EventMap
         public void Unregister()
             => _handler = null;
 
-        public void Invoke<TArg>(Action<TEventHandler, TArg> invoker, TArg arg)
+        public void Invoke<TArg>(TArg arg, Action<TEventHandler, TArg> invoker)
         {
             var handler = _handler;
             if (handler != null)
@@ -153,7 +153,7 @@ internal class EventMap
             get { return _registries != null && _registries.Length > 0; }
         }
 
-        public readonly void RaiseEvent<TArg>(Action<TEventHandler, TArg> invoker, TArg arg)
+        public readonly void RaiseEvent<TArg>(TArg arg, Action<TEventHandler, TArg> invoker)
         {
             // The try/catch here is to find additional telemetry for https://devdiv.visualstudio.com/DevDiv/_queries/query/71ee8553-7220-4b2a-98cf-20edab701fd1/.
             // We've realized there's a problem with our eventing, where if an exception is encountered while calling into subscribers to Workspace events,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
@@ -167,7 +167,7 @@ internal class EventMap
                 {
                     foreach (var registry in _registries)
                     {
-                        registry.Invoke(invoker, arg);
+                        registry.Invoke(invoker: invoker, arg: arg);
                     }
                 }
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
@@ -25,7 +25,7 @@ internal static class IDictionaryExtensions
         return value;
     }
 
-    public static V GetOrAdd<K, V, TArg>(this IDictionary<K, V> dictionary, K key, Func<K, TArg, V> function, TArg arg)
+    public static V GetOrAdd<K, V, TArg>(this IDictionary<K, V> dictionary, K key, TArg arg, Func<K, TArg, V> function)
         where K : notnull
     {
         if (!dictionary.TryGetValue(key, out var value))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposable.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposable.cs
@@ -256,7 +256,7 @@ internal sealed class ReferenceCountedDisposable<T> : IReferenceCountedDisposabl
 
             // We only need to allocate a new WeakReference<T> for this reference if one has not already been
             // created for it.
-            InterlockedOperations.Initialize(ref referenceCount._weakInstance, static instance => new WeakReference<T>(instance), instance);
+            InterlockedOperations.Initialize(ref referenceCount._weakInstance, valueFactory: static instance => new WeakReference<T>(instance), arg: instance);
 
             _boxedReferenceCount = referenceCount;
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposableCache.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposableCache.cs
@@ -19,7 +19,7 @@ internal sealed class ReferenceCountedDisposableCache<TKey, TValue> where TValue
     private readonly Dictionary<TKey, ReferenceCountedDisposable<Entry>.WeakReference> _cache = [];
     private readonly object _gate = new();
 
-    public IReferenceCountedDisposable<ICacheEntry<TKey, TValue>> GetOrCreate<TArg>(TKey key, Func<TKey, TArg, TValue> valueCreator, TArg arg)
+    public IReferenceCountedDisposable<ICacheEntry<TKey, TValue>> GetOrCreate<TArg>(TKey key, TArg arg, Func<TKey, TArg, TValue> valueCreator)
     {
         lock (_gate)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SpecializedTasks.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SpecializedTasks.cs
@@ -121,9 +121,9 @@ internal static class SpecializedTasks
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the operation will observe.</param>
     /// <returns></returns>
     public static ValueTask<TResult> TransformWithoutIntermediateCancellationExceptionAsync<TArg, TIntermediate, TResult>(
+        TArg arg,
         Func<TArg, CancellationToken, ValueTask<TIntermediate>> func,
         Func<TIntermediate, TArg, TResult> transform,
-        TArg arg,
         CancellationToken cancellationToken)
     {
         if (func is null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/NamedTypeGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/NamedTypeGenerator.cs
@@ -119,7 +119,7 @@ internal static class NamedTypeGenerator
             members = members.Remove(primaryConstructor);
 
             // remove any fields/properties that were created by the primary constructor
-            members = members.WhereAsArray(m => m is not IPropertySymbol and not IFieldSymbol || !primaryConstructor.Parameters.Any(static (p, m) => p.Name == m.Name, m));
+            members = members.WhereAsArray(m => m is not IPropertySymbol and not IFieldSymbol || !primaryConstructor.Parameters.Any(predicate: static (p, m) => p.Name == m.Name, arg: m));
         }
 
         // remove any implicit overrides to generate.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/NullableHelpers/NullableHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/NullableHelpers/NullableHelpers.cs
@@ -101,7 +101,7 @@ internal static class NullableHelpers
             ILocalReferenceOperation localReference => localReference.Local.Equals(symbol),
             IParameterReferenceOperation parameterReference => parameterReference.Parameter.Equals(symbol),
             IAssignmentOperation assignment => IsSymbolReferencedByOperation(assignment.Target, symbol),
-            ITupleOperation tupleOperation => tupleOperation.Elements.Any(static (element, symbol) => IsSymbolReferencedByOperation(element, symbol), symbol),
+            ITupleOperation tupleOperation => tupleOperation.Elements.Any(predicate: static (element, symbol) => IsSymbolReferencedByOperation(element, symbol), arg: symbol),
             IForEachLoopOperation { LoopControlVariable: IVariableDeclaratorOperation variableDeclarator } => variableDeclarator.Symbol.Equals(symbol),
 
             // A variable initializer is required for this to be a meaningful operation for determining possible null assignment

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
@@ -24,7 +24,7 @@ internal abstract partial class AbstractCodeGenerationService<TCodeGenerationCon
     public bool CanAddTo(ISymbol destination, Solution solution, CancellationToken cancellationToken)
     {
         var declarations = _symbolDeclarationService.GetDeclarations(destination);
-        return declarations.Any(static (r, arg) => arg.self.CanAddTo(r.GetSyntax(arg.cancellationToken), arg.solution, arg.cancellationToken), (self: this, solution, cancellationToken));
+        return declarations.Any(predicate: static (r, arg) => arg.self.CanAddTo(r.GetSyntax(arg.cancellationToken), arg.solution, arg.cancellationToken), arg: (self: this, solution, cancellationToken));
     }
 
     protected static SyntaxToken GetEndToken(SyntaxNode node)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
@@ -33,7 +33,7 @@ internal static class AddImportHelpers
             // already in the file (like a class) and we don't want it to move to
             // the using.
             var firstToken = root.GetFirstToken();
-            var endOfLine = root.DescendantTrivia().FirstOrNull((trivia, syntaxFacts) => syntaxFacts.IsEndOfLineTrivia(trivia), syntaxFacts) ?? syntaxFacts.ElasticCarriageReturnLineFeed;
+            var endOfLine = root.DescendantTrivia().FirstOrNull(predicate: (trivia, syntaxFacts) => syntaxFacts.IsEndOfLineTrivia(trivia), arg: syntaxFacts) ?? syntaxFacts.ElasticCarriageReturnLineFeed;
 
             // Remove the leading directives from the first token.
             var newFirstToken = firstToken.WithLeadingTrivia(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/LayeredServiceUtilities.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/LayeredServiceUtilities.cs
@@ -51,7 +51,7 @@ internal static class LayeredServiceUtilities
         // If a service is exported for specific workspace kinds and the current workspace kind is among them, use it.
         if (workspaceKind != null)
         {
-            service = servicesOfMatchingType.SingleOrDefault(static (lz, workspaceKind) => lz.Metadata.WorkspaceKinds.Contains(workspaceKind), workspaceKind);
+            service = servicesOfMatchingType.SingleOrDefault(predicate: static (lz, workspaceKind) => lz.Metadata.WorkspaceKinds.Contains(workspaceKind), arg: workspaceKind);
             if (service != null)
             {
                 return service;
@@ -79,6 +79,6 @@ internal static class LayeredServiceUtilities
         return null;
 
         Lazy<TServiceInterface, TMetadata>? TryGetServiceByLayer(string layer)
-            => servicesOfMatchingType.SingleOrDefault(static (lz, layer) => lz.Metadata.WorkspaceKinds is [] && lz.Metadata.Layer == layer, layer);
+            => servicesOfMatchingType.SingleOrDefault(predicate: static (lz, layer) => lz.Metadata.WorkspaceKinds is [] && lz.Metadata.Layer == layer, arg: layer);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ContextQuery/VisualBasicSyntaxContextExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ContextQuery/VisualBasicSyntaxContextExtensions.vb
@@ -71,12 +71,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension()>
         Friend Function IsInStatementBlockOfKind(context As VisualBasicSyntaxContext, kind As SyntaxKind) As Boolean
-            Return IsInStatementBlockHelper(context, Function(n, k) n.IsKind(k), kind)
+            Return IsInStatementBlockHelper(context, predicate:=Function(n, k) n.IsKind(k), arg:=kind)
         End Function
 
         <Extension()>
         Friend Function IsInStatementBlockOfKind(context As VisualBasicSyntaxContext, ParamArray kinds As SyntaxKind()) As Boolean
-            Return IsInStatementBlockHelper(context, Function(n, k) n.IsKind(k), kinds)
+            Return IsInStatementBlockHelper(context, predicate:=Function(n, k) n.IsKind(k), arg:=kinds)
         End Function
 
         Private Function IsInStatementBlockHelper(Of TArg)(context As VisualBasicSyntaxContext, predicate As Func(Of SyntaxNode, TArg, Boolean), arg As TArg) As Boolean


### PR DESCRIPTION
Throughout roslyn, we have a lot of callback-based code that uses a `TArg` parameter for context, to avoid costly repeat lambda allocations. Unfortunately, they uniformly put `TArg` _after_ the delegate type. This is not great for IDE usability, as the compiler can't make any type inferences on the callback parameter until the `TArg` argument is actually specified. This results in an awkward pattern of just typing an empty lambda, filling out the `TArg` parameter, and then going back to the body of the lambda to fill it out. I've previously asked that new overloads of these types of methods put `TArg` _before_ the callback, to avoid this pitfall. The pushback on this has always been "let's address that uniformly across the project, rather than making this one callback different." Well, I got tired of people telling me that, so I did just that.

In order to avoid any potential for ordering differences and to make the code easier to review, I opted to leave existing callsites essentially untouched: I just explicitly specified parameter names for calls, so that the current execution orders are unchanged. To construct this PR, I wrote a small tool that went through all of our non-public, callback-taking methods (namely, generic methods with a type parameter named `TArg`, a parameter of that argument, and a parameter of a delegate type that is generic and takes a `TArg` parameter). For each call of these methods, it found the first callback parameter, and the first `TArg` parameter. If they were out of order (ie, callback before `TArg`) then it did:

* For every method invocation, it adjusted the code to explicitly name every argument from the callback to the end of the invocation. This ensures that we won't have compilation errors when we reorder parameters.
* For every method definition, it pulled the `TArg` parameter to just before the first callback.

I then went through, fixed up formatting errors, and verified that nothing was getting unexpectedly reordered. To make this process easier to review, I have split this into 4 commits. The first commit is just parameter names. The second commit is just parameter reordering. Commit 3 is a few VB formatting updates that needed to happen after parameter names shifted lambda locations, and a baseline change that was asserting a method signature. Commit 4 is a fix to the IOperation generator for the new format. I would definitely suggest reviewing commit-by-commit here.