### PR TITLE
Add source.dot.net stage 1 asset publication

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -346,7 +346,7 @@ extends:
       - ${{ if eq(variables.enableSourceIndex, 'true') }}:
         - template: /eng/common/templates-official/job/source-index-stage1.yml@self
           parameters:
-            sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng\build.ps1 -configuration Release -prepareMachine -ci -build -binaryLogName Build.binlog -skipDocumentation -msbuildEngine dotnet /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false"
+            sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng\build.ps1 -configuration Release -prepareMachine -ci -restore -build -binaryLogName Build.binlog -skipDocumentation -msbuildEngine dotnet /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false"
             binlogPath: Build.binlog
             pool:
               name: $(DncEngInternalBuildPool)

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -78,9 +78,9 @@ variables:
   - name: Insertion.TitleSuffix
     value: ''
 
-  #- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-  - name: enableSourceIndex
-    value: true
+  - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+    - name: enableSourceIndex
+      value: true
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -347,7 +347,7 @@ extends:
         - template: /eng/common/templates-official/job/source-index-stage1.yml@self
           parameters:
             sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng\build.ps1 -configuration Release -prepareMachine -ci -restore -build -binaryLogName Build.binlog -skipDocumentation -msbuildEngine dotnet /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false"
-            binlogPath: Build.binlog
+            binlogPath: artifacts/log/$(BuildConfiguration)/Build.binlog
             pool:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals 1es-windows-2022

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -346,7 +346,7 @@ extends:
       - ${{ if eq(variables.enableSourceIndex, 'true') }}:
         - template: /eng/common/templates-official/job/source-index-stage1.yml@self
           parameters:
-            sourceIndexBuildCommand: owershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng\build.ps1 -configuration Release -prepareMachine -ci -build -binaryLogName Build.binlog -skipDocumentation -msbuildEngine dotnet /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false"
+            sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng\build.ps1 -configuration Release -prepareMachine -ci -build -binaryLogName Build.binlog -skipDocumentation -msbuildEngine dotnet /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false"
             binlogPath: Build.binlog
             pool:
               name: $(DncEngInternalBuildPool)

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -78,6 +78,10 @@ variables:
   - name: Insertion.TitleSuffix
     value: ''
 
+  #- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+  - name: enableSourceIndex
+    value: true
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
@@ -338,6 +342,15 @@ extends:
           pool:
             name: NetCore1ESPool-Svc-Internal
             demands: ImageOverride -equals windows.vs2022.amd64
+
+      - ${{ if eq(variables.enableSourceIndex, 'true') }}:
+        - template: /eng/common/templates-official/job/source-index-stage1.yml@self
+          parameters:
+            sourceIndexBuildCommand: owershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng\build.ps1 -configuration Release -prepareMachine -ci -build -binaryLogName Build.binlog -skipDocumentation -msbuildEngine dotnet /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false"
+            binlogPath: Build.binlog
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022
 
     - stage: insert
       dependsOn:


### PR DESCRIPTION
This is a prerequisite for inclusion on source.dot.net.

Roslyn has its own source-indexer instance on sourceroslyn.io, based on an obsolete code snapshot. This PR opts Roslyn in for the main source.dot.net instance, which is regenerated daily from the most recent CI build of all contributing repositories.

Putting asset publication inside individual repositories allows the repo owners who know their code best to fine-tune their build flags and environment.

Please note that there is [an issue under active investigation](https://github.com/dotnet/dnceng/issues/2974) where V2 repository publishing can occasionally fail due to obscure permissions errors from Azure since we switched uploads from SAS to Managed Identity (currently about 6 failures per day total across all repositories)