### PR TITLE
Update asserts to improve diagnosability of dartlab test failure

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpBuild.cs
@@ -66,10 +66,10 @@ class Program
         var commandLine = $"\"{pathToSolution}\" /Rebuild Debug /Out \"{logFileName}\" /rootsuffix RoslynDev /log";
 
         var process = Process.Start(pathToDevenv, commandLine);
-        Assert.Equal(0, await process.WaitForExitAsync(HangMitigatingCancellationToken));
+        var exitCode = await process.WaitForExitAsync(HangMitigatingCancellationToken);
 
         Assert.Contains("Rebuild All: 1 succeeded, 0 failed, 0 skipped", File.ReadAllText(logFileName));
-
+        Assert.Equal(0, exitCode);
         Assert.Equal(0, process.ExitCode);
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicEditAndContinue.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicEditAndContinue.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.VisualStudio.IntegrationTests;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Roslyn.VisualStudio.NewIntegrationTests.VisualBasic;
@@ -247,7 +248,7 @@ End Module
             ],
             HangMitigatingCancellationToken);
 
-        Assert.Empty(await TestServices.ErrorList.GetErrorsAsync(HangMitigatingCancellationToken));
+        AssertEx.Empty(await TestServices.ErrorList.GetErrorsAsync(HangMitigatingCancellationToken));
     }
 
     [IdeFact]


### PR DESCRIPTION
Teams thread: https://teams.microsoft.com/l/message/19:ed7a508bf00c4b088a7760359f0d0308@thread.skype/1720564915113?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4ba7372f-2799-4677-89f0-7a1aaea3706c&parentMessageId=1720564915113&teamName=.NET%20Developer%20Experience&channelName=InfraSwat&createdTime=1720564915113

We are trying to learn more about recent [dartlab test failures](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9854018&view=logs&j=bf62c3a4-1004-564b-6dcc-6dcb68a53174&t=a22d3ce4-072b-576a-e4bd-9c2188caedc2):

```log
  Failed Roslyn.VisualStudio.NewIntegrationTests.CSharp.CSharpBuild.BuildWithCommandLine (VS2022) [16 s]
  Error Message:
   Assert.Equal() Failure
Expected: 0
Actual:   1
  Stack Trace:
     at Roslyn.VisualStudio.NewIntegrationTests.CSharp.CSharpBuild.<BuildWithCommandLine>d__2.MoveNext() in /_/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpBuild.cs:line 69
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  Failed Roslyn.VisualStudio.NewIntegrationTests.VisualBasic.BasicEditAndContinue+CommonProjectSystem.EditLambdaExpression (VS2022) [18 s]
  Error Message:
   Assert.Empty() Failure
Collection: ["TestProj.vbproj(1, 1): warning NU1604: Project dep"...]
  Stack Trace:
     at Roslyn.VisualStudio.NewIntegrationTests.VisualBasic.BasicEditAndContinue.<EditLambdaExpression>d__10.MoveNext() in /_/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicEditAndContinue.cs:line 144
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  Failed Roslyn.VisualStudio.NewIntegrationTests.VisualBasic.BasicEditAndContinue+CommonProjectSystem.MultiProjectDebuggingWhereNotAllModulesAreLoaded (VS2022) [11 s]
  Error Message:
   Assert.Empty() Failure
Collection: ["TestProj.vbproj(1, 1): warning NU1604: Project dep"...]
  Stack Trace:
     at Roslyn.VisualStudio.NewIntegrationTests.VisualBasic.BasicEditAndContinue.<MultiProjectDebuggingWhereNotAllModulesAreLoaded>d__13.MoveNext() in /_/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicEditAndContinue.cs:line 250
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
```
