### PR TITLE
Avoid BuildHost crash in Mono due to missing types

### DIFF
--- a/src/Workspaces/Core/MSBuild.BuildHost/BuildHost.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/BuildHost.cs
@@ -161,9 +161,18 @@ internal sealed class BuildHost : IBuildHost
     /// <summary>
     /// Returns the target ID of the <see cref="ProjectFile"/> object created for this.
     /// </summary>
-    public async Task<int> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken)
+    public Task<int> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken)
     {
         EnsureMSBuildLoaded(projectFilePath);
+        return LoadProjectFileCoreAsync(projectFilePath, languageName, cancellationToken);
+    }
+
+    // When using the Mono runtime, the MSBuild types used in this method must be available
+    // to the JIT during compilation of the method, so they have to be loaded by the caller;
+    // therefore this method must not be inlined.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private async Task<int> LoadProjectFileCoreAsync(string projectFilePath, string languageName, CancellationToken cancellationToken)
+    {
         CreateBuildManager();
 
         ProjectFileLoader projectLoader = languageName switch


### PR DESCRIPTION
The LoadProjectFileAsync routine calls EnsureMSBuildLoaded to make sure the Microsoft.Build.dll is accessible, but requires types from that assembly within the routine itself.  This may not always work with Mono, as the JIT may look up the types during compilation.

Fixed by splitting out a LoadProjectFileCoreAsync routine, similarly to what is already done for GetProjectsInSolution.

Fixes https://github.com/dotnet/runtime/issues/101121.