### PR TITLE
Add the ResolveKeySource workround back

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -66,6 +66,9 @@
       Related to https://github.com/dotnet/sdk/issues/41791.
     -->
     <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
+
+    <!-- https://github.com/dotnet/msbuild/issues/10306 -->
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);ResolveKeySource</CoreCompileDependsOn> 
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)TargetFrameworks.props" />


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/74205 this PR adds the trick.
It was merged in 7/9.

Later this PR https://github.com/dotnet/roslyn/pull/74320, it was based on an old main, so Cyrus temp added that line, then created a commit removing that line.
Then PR was merged on 7/11.


From this point, Git removed the workaround.