### PR TITLE
Also checking line end when block structure is filtered

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/InvalidIdentifierStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/InvalidIdentifierStructureTests.cs
@@ -72,6 +72,7 @@ public class InvalidIdentifierStructureTests : AbstractSyntaxStructureProviderTe
 
         await VerifyBlockSpansAsync(code,
             Region("textspan3", "/* now everything is commented (); ...", autoCollapse: true),
+            Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: false),
             Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
     }
 }

--- a/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
+++ b/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Implementation.Structure;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Structure;
@@ -323,6 +324,39 @@ End Module";
         var hints = tags.Select(x => x.GetCollapsedHintForm()).Cast<ViewHostingControl>().ToArray();
         Assert.Equal("Sub Main(args As String())\r\nEnd Sub", hints[1].GetText_TestOnly()); // method
         hints.Do(v => v.TextView_TestOnly.Close());
+    }
+
+    [WpfFact]
+    [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2094051")]
+    public async Task IfShouldBeCollapsed()
+    {
+        var code = @"
+Module Program
+    Sub Main(args As String())
+        Dim str = """"
+        If str.Contains(""foo"") Then
+
+        End If
+    End Sub
+End Module";
+
+        using var workspace = EditorTestWorkspace.CreateVisualBasic(code, composition: EditorTestCompositions.EditorFeaturesWpf);
+        var tags = await GetTagsFromWorkspaceAsync(workspace);
+        Assert.Collection(tags, programTag =>
+        {
+            Assert.Equal("Module Program", GetHeaderText(programTag));
+            Assert.Equal(8, GetCollapsedHintLineCount(programTag));
+        },
+        mainTag =>
+        {
+            Assert.Equal("Sub Main(args As String())", GetHeaderText(mainTag));
+            Assert.Equal(6, GetCollapsedHintLineCount(mainTag));
+        },
+        IfTag =>
+        {
+            Assert.Equal("If str.Contains(\"foo\") Then", GetHeaderText(IfTag));
+            Assert.Equal(3, GetCollapsedHintLineCount(IfTag));
+        });
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
@@ -50,16 +50,19 @@ internal abstract class AbstractBlockStructureProvider : BlockStructureProvider
             // We only collapse the "inner" span which has larger start.
             spans.Sort(static (x, y) => y.TextSpan.Start.CompareTo(x.TextSpan.Start));
 
-            var lastAddedLine = -1;
+            var lastAddedLineStart = -1;
+            var lastAddedLineEnd = -1;
             var text = context.SyntaxTree.GetText(context.CancellationToken);
 
             foreach (var span in spans)
             {
-                var line = text.Lines.GetLinePosition(span.TextSpan.Start).Line;
-                if (line == lastAddedLine)
+                var lineStart = text.Lines.GetLinePosition(span.TextSpan.Start).Line;
+                var lineEnd = text.Lines.GetLinePosition(span.TextSpan.End).Line;
+                if (lineStart == lastAddedLineStart && lastAddedLineEnd == lineEnd)
                     continue;
 
-                lastAddedLine = line;
+                lastAddedLineStart = lineStart;
+                lastAddedLineEnd = lineEnd;
                 context.Spans.Add(span);
             }
         }


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2094051

Reason:
In PR https://github.com/dotnet/roslyn/pull/71064, it introduced a trick to only fold the inner method2 in this case:
```
Method1(Method2(
))
```
`Method1`'s block is skipped because it has the same start line as `Method2`

However this introduce problem because in this case
```
        If str.Contains("foo") Then

        End If
```
In VB, we first provide the block structure of `If`, also we provide the block structure for `foo` because it is a string literal https://github.com/dotnet/roslyn/blob/release/dev17.10/src/Features/CSharp/Portable/Structure/Providers/StringLiteralExpressionStructureProvider.cs

Because `foo` and If statement both have the same start line, `If` statement is removed from the block structure span.

Later, because `foo`'s structure is removed because its start line and end line are same. https://github.com/dotnet/roslyn/blob/fa643d6e3ccb036d1b8ba936b5622f448b2f0abe/src/EditorFeatures/Core/Structure/AbstractStructureTaggerProvider.cs#L263

Fix:
Instead of only checking for the start line, also check the end line when trying to remove the block. It should still work for case 
```
Method1(Method2(
))
```
the block structure of `Method1` would still be removed.  and it's safer when dealing with other cases.

Before:
![image](https://github.com/user-attachments/assets/81bdd80d-8c34-47ae-b360-b2b77380227a)


After:
![image](https://github.com/user-attachments/assets/312f7e1c-9129-4a4e-9a84-6df752528183)
