### PR TITLE
Adjust overload resolution priority from LDM

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1712,10 +1712,15 @@ outerDefault:
             return currentBestIndex;
         }
 
-        private static void RemoveLowerPriorityMembers<TMemberResolution, TMember>(ArrayBuilder<TMemberResolution> results)
+        private void RemoveLowerPriorityMembers<TMemberResolution, TMember>(ArrayBuilder<TMemberResolution> results)
             where TMemberResolution : IMemberResolutionResultWithPriority<TMember>
             where TMember : Symbol
         {
+            if (!Compilation.IsFeatureEnabled(MessageID.IDS_OverloadResolutionPriority))
+            {
+                return;
+            }
+
             // - Then, the reduced set of candidate members is grouped by declaring type. Within each group:
             //     - Candidate function members are ordered by *overload_resolution_priority*.
             //     - All members that have a lower *overload_resolution_priority* than the highest found within its declaring type group are removed.

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1201,7 +1201,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                        or MethodKind.Constructor
                        or MethodKind.UserDefinedOperator
                        or MethodKind.ReducedExtension
-                       or MethodKind.LocalFunction
             && !IsOverride;
 
         #region IMethodSymbolInternal


### PR DESCRIPTION
LDM today decided that on older language versions, we shouldn't influence overload resolution from OverloadResolutionPriority. It also decided that we should disallow the attribute on local functions.
