### PR TITLE
Increase driver cache size

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -10070,6 +10070,7 @@ class C
                 ctx.RegisterSourceOutput(ctx.ParseOptionsProvider, (spc, po) =>
                 {
                     sourceCallbackCount++;
+                    spc.AddSource("output.cs", "");
                 });
             });
 
@@ -10175,6 +10176,7 @@ class C
                 ctx.RegisterSourceOutput(ctx.ParseOptionsProvider, (spc, po) =>
                 {
                     sourceCallbackCount++;
+                    spc.AddSource("output.cs", "");
                 });
             });
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -10120,6 +10120,7 @@ class C
                 ctx.RegisterSourceOutput(ctx.ParseOptionsProvider, (spc, po) =>
                 {
                     sourceCallbackCount++;
+                    spc.AddSource("output.cs", "");
                 });
             });
 
@@ -10245,6 +10246,7 @@ class C
                 ctx.RegisterSourceOutput(ctx.ParseOptionsProvider, (spc, po) =>
                 {
                     sourceCallbackCount++;
+                    spc.AddSource("output.cs", "");
                 });
             });
 
@@ -10253,6 +10255,7 @@ class C
                 ctx.RegisterSourceOutput(ctx.ParseOptionsProvider, (spc, po) =>
                 {
                     sourceCallbackCount2++;
+                    spc.AddSource("output.cs", "");
                 });
             });
 
@@ -10358,6 +10361,7 @@ a = globalA");
                 ctx.RegisterSourceOutput(ctx.ParseOptionsProvider, (spc, po) =>
                 {
                     sourceCallbackCount++;
+                    spc.AddSource("output.cs", "");
                 });
 
                 ctx.RegisterSourceOutput(ctx.AnalyzerConfigOptionsProvider, (spc, po) =>
@@ -10443,6 +10447,7 @@ class C
                 ctx.RegisterSourceOutput(ctx.CompilationProvider, (spc, po) =>
                 {
                     sourceCallbackCount++;
+                    spc.AddSource("output.cs", "");
                 });
             });
 

--- a/src/Compilers/CSharp/Test/CommandLine/GeneratorDriverCacheTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/GeneratorDriverCacheTests.cs
@@ -54,11 +54,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         [Fact]
         public void DriverCache_Evicts_Least_Recently_Used()
         {
-            var drivers = GetDrivers(GeneratorDriverCache.MaxCacheSize + 2);
-            var driverCache = new GeneratorDriverCache();
+            var maxCacheSize = 10;
+
+            var drivers = GetDrivers(maxCacheSize + 2);
+            var driverCache = new GeneratorDriverCache(maxCacheSize);
 
             // put n+1 drivers into the cache
-            for (int i = 0; i < GeneratorDriverCache.MaxCacheSize + 1; i++)
+            for (int i = 0; i < maxCacheSize + 1; i++)
             {
                 driverCache.CacheGenerator(i.ToString(), drivers[i]);
             }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -838,7 +838,11 @@ namespace Microsoft.CodeAnalysis
             driver = driver.RunGeneratorsAndUpdateCompilation(input, out var compilationOut, out var diagnostics);
             generatorDiagnostics.AddRange(diagnostics);
 
-            if (!disableCache)
+            // We only cache the generator driver if it produced any generated files. While its possible that it was expensive
+            // to calculate that nothing needed to be generated, real world usage has found that generators are generally only
+            // expensive when actually producing source. By only caching those with results, we help to keep memory usage down
+            // when it probably wouldn't improve the performance anyway.
+            if (!disableCache && driver.GetRunResult().GeneratedTrees.Any())
             {
                 this.GeneratorDriverCache?.CacheGenerator(cacheKey, driver);
             }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -838,7 +838,7 @@ namespace Microsoft.CodeAnalysis
             driver = driver.RunGeneratorsAndUpdateCompilation(input, out var compilationOut, out var diagnostics);
             generatorDiagnostics.AddRange(diagnostics);
 
-            // We only cache the generator driver if it produced any generated files. While its possible that it was expensive
+            // We only cache the generator driver if it produced any generated files. While it's possible that it was expensive
             // to calculate that nothing needed to be generated, real world usage has found that generators are generally only
             // expensive when actually producing source. By only caching those with results, we help to keep memory usage down
             // when it probably wouldn't improve the performance anyway.

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverCache.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverCache.cs
@@ -10,11 +10,11 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal sealed class GeneratorDriverCache
+    internal sealed class GeneratorDriverCache(int maxCacheSize = 100)
     {
-        internal const int MaxCacheSize = 100;
+        internal readonly int MaxCacheSize = maxCacheSize;
 
-        private readonly (string cacheKey, GeneratorDriver driver)[] _cachedDrivers = new (string, GeneratorDriver)[MaxCacheSize];
+        private readonly (string cacheKey, GeneratorDriver driver)[] _cachedDrivers = new (string, GeneratorDriver)[maxCacheSize];
 
         private readonly object _cacheLock = new object();
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverCache.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverCache.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class GeneratorDriverCache
     {
-        internal const int MaxCacheSize = 10;
+        internal const int MaxCacheSize = 100;
 
         private readonly (string cacheKey, GeneratorDriver driver)[] _cachedDrivers = new (string, GeneratorDriver)[MaxCacheSize];
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverCache.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverCache.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class GeneratorDriverCache(int maxCacheSize = 100)
     {
-        internal readonly int MaxCacheSize = maxCacheSize;
+        private readonly int MaxCacheSize = maxCacheSize;
 
         private readonly (string cacheKey, GeneratorDriver driver)[] _cachedDrivers = new (string, GeneratorDriver)[maxCacheSize];
 

--- a/src/Tools/Replay/Replay.cs
+++ b/src/Tools/Replay/Replay.cs
@@ -62,13 +62,13 @@ static ReplayOptions ParseOptions(string[] args)
     }
 
     return new ReplayOptions(
-        PipeName: Guid.NewGuid().ToString(),
-        ClientDirectory: AppDomain.CurrentDomain.BaseDirectory!,
-        OutputDirectory: outputDirectory,
-        BinlogPath: binlogPath,
-        MaxParallel: maxParallel,
-        Wait: wait,
-        Iterations: iterations);
+        pipeName: Guid.NewGuid().ToString(),
+        clientDirectory: AppDomain.CurrentDomain.BaseDirectory!,
+        outputDirectory: outputDirectory,
+        binlogPath: binlogPath,
+        maxParallel: maxParallel,
+        wait: wait,
+        iterations: iterations);
 }
 
 static async Task<int> RunAsync(ReplayOptions options)
@@ -272,9 +272,27 @@ static void RewriteOutputPaths(string outputDirectory, string[] args)
     }
 }
 
-internal sealed record ReplayOptions(string PipeName, string ClientDirectory, string OutputDirectory, string BinlogPath, int MaxParallel, bool Wait, int Iterations)
+internal sealed class ReplayOptions(
+    string pipeName,
+    string clientDirectory,
+    string outputDirectory,
+    string binlogPath,
+    int maxParallel,
+    bool wait,
+    int iterations)
 {
-    internal string TempDirectory { get; } = Path.Combine(OutputDirectory, "temp");
+    internal string PipeName { get; } = pipeName;
+    internal string ClientDirectory { get; } = clientDirectory;
+    internal string OutputDirectory { get; } = outputDirectory;
+    internal string BinlogPath { get; } = binlogPath;
+    internal int MaxParallel { get; } = maxParallel;
+    internal string TempDirectory { get; } = Path.Combine(outputDirectory, "temp");
+    internal bool Wait { get; } = wait;
+    internal int Iterations { get; } = iterations;
 }
 
-internal readonly record struct BuildData(CompilerCall CompilerCall, BuildResponse BuildResponse);
+internal readonly struct BuildData(CompilerCall compilerCall, BuildResponse response)
+{
+    internal CompilerCall CompilerCall { get; } = compilerCall;
+    internal BuildResponse BuildResponse { get; } = response;
+}

--- a/src/Tools/Replay/Replay.csproj
+++ b/src/Tools/Replay/Replay.csproj
@@ -11,6 +11,7 @@
     <Compile Include="..\..\Compilers\Core\CommandLine\CompilerServerLogger.cs" />
     <Compile Include="..\..\Compilers\Core\CommandLine\NativeMethods.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\CommitHashAttribute.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\Debug.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\NullableAttributes.cs" />


### PR DESCRIPTION
This ups the size of the generator cache based on observed 'big' projects in the wild. We also only cache a generator driver if it actually produced any results, based on observations that its generally fast to produce nothing. 

Also updates the replay tool to support multiple iterations for testing scenarios like this (second commit)