### PR TITLE
Support VS System theme

### DIFF
--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -127,7 +127,7 @@ internal sealed partial class ColorSchemeApplier
     private async ValueTask QueueColorSchemeUpdateAsync(CancellationToken cancellationToken)
     {
         // Wait until things have settled down from the theme change, since we will potentially be changing theme colors.
-        await VsTaskLibraryHelper.StartOnIdle(_threadingContext.JoinableTaskFactory, () => UpdateColorSchemeAsync(token));
+        await VsTaskLibraryHelper.StartOnIdle(_threadingContext.JoinableTaskFactory, () => UpdateColorSchemeAsync(cancellationToken));
     }
 
     /// <summary>

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -124,7 +124,7 @@ internal sealed partial class ColorSchemeApplier
         return Task.CompletedTask;
     }
 
-    private async ValueTask QueueColorSchemeUpdateAsync(CancellationToken token)
+    private async ValueTask QueueColorSchemeUpdateAsync(CancellationToken cancellationToken)
     {
         // Wait until things have settled down from the theme change, since we will potentially be changing theme colors.
         await VsTaskLibraryHelper.StartOnIdle(_threadingContext.JoinableTaskFactory, () => UpdateColorSchemeAsync(token));

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
@@ -16,6 +16,7 @@ internal static class FeatureAttribute
     public const string CodeDefinitionWindow = nameof(CodeDefinitionWindow);
     public const string CodeLens = nameof(CodeLens);
     public const string CodeModel = nameof(CodeModel);
+    public const string ColorScheme = nameof(ColorScheme);
     public const string CompletionSet = nameof(CompletionSet);
     public const string CopilotSuggestions = nameof(CopilotSuggestions);
     public const string DesignerAttributes = nameof(DesignerAttributes);


### PR DESCRIPTION
The System theme has a unique ThemeId but reuses the editor colors from the Light and Dark themes. When the System theme is selected we will now check the registry to see whether Apps should be using the light theme and then apply the appropriate color scheme.

I also noticed while testing that VSColorTheme_ThemeChanged fires multiple times in a row when the Windows theme is changed.  We only need to apply the color scheme colors once in response. I have added a field to track whether we have an update pending.

Resolves #74416 