### PR TITLE
Skip TestCode classification type when computing tokens.

### DIFF
--- a/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             using var _1 = Classifier.GetPooledList(out var classifiedSpans);
             using var _2 = Classifier.GetPooledList(out var updatedClassifiedSpans);
 
-            // We either calculate the tokens for the full document span, or the user 
+            // We either calculate the tokens for the full document span, or the user
             // can pass in a range from the full document if they wish.
             ImmutableArray<TextSpan> textSpans;
             if (spans.Length == 0)
@@ -337,6 +337,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 {
                     // 6. Token modifiers - each set bit will be looked up in SemanticTokensLegend.tokenModifiers
                     modifierBits |= TokenModifiers.Deprecated;
+                }
+                else if (classificationType == ClassificationTypeNames.TestCode)
+                {
+                    // Skip additive types that are not being converted to token modifiers.
                 }
                 else
                 {


### PR DESCRIPTION
When the AdditiveClassification TestCode is encountered the SemanticTokenHelper throws a "missing token index" exception. Which is presented as a failed range request.
<img width="495" alt="image" src="https://github.com/user-attachments/assets/9daebaf7-fdeb-4081-9710-76fab93f704f">

Skipping this classification when calculating tokens allows the request to complete.
<img width="420" alt="image" src="https://github.com/user-attachments/assets/9e263626-631c-40bc-9f0e-4e62fd36a97c">
