### PR TITLE
Add monthly smoke test to release branch official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -36,6 +36,18 @@ parameters:
   type: boolean
   default: true
 
+schedules:
+  - cron: "0 8 23-29 * 0"
+    displayName: "Monthly smoke test"
+    branches:
+      include: 
+        - main
+        - release/*
+      exclude: 
+        - ""
+    always: true # Run even if there have been no source code changes since the last successful scheduled run
+    batch: false # Do not run the pipeline if the previously scheduled run is in-progress
+
 # The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
   - name: _DotNetArtifactsCategory


### PR DESCRIPTION
Run official builds each month on all active servicing branches starting with 17.6. This helps us catch if these infrequently run builds have been broken by infrastructure changes, and avoid scrambling when we need to build a servicing fix before a deadline.

Copied schedule from dotnet/roslyn-analyzers#7316. We are expecting if merged the job will run this Sunday so we can verify that everything is working as we expect.

@arkalyanms @phil-allen-msft 