### PR TITLE
Ignore MSBuild_Logs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .packages/
 .nuget/
 .complog/
+/MSBuild_Logs/
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/


### PR DESCRIPTION
This folder is used for build logs produced when environment variable MSBuildDebugEngine=1.