### PR TITLE
Flesh out capturing of `this` into a closure in an instance extension member.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
@@ -144,6 +144,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                if (_containingMethod is not null &&
+                    ContainingType.OriginalDefinition.TryGetCorrespondingStaticMetadataExtensionMember(_containingMethod.OriginalDefinition) is MethodSymbol staticMetadataSymbol)
+                {
+                    // PROTOTYPE(roles): It looks like SemanticModel and probably some other consumers might create this symbol without a method.
+                    //                   Figure out what the scenarios and what RefKind will be appropriate for extension types extending
+                    //                   types not known to be a reference type.
+                    return staticMetadataSymbol.Parameters[0].RefKind;
+                }
+
                 if (ContainingType?.TypeKind != TypeKind.Struct)
                 {
                     return RefKind.None;

--- a/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/ExtensionTypeTests.cs
@@ -41118,6 +41118,156 @@ class Program
     }
 
     [Fact]
+    public void InstanceMethod_Metadata_22_LambdaCapturing()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public void Method()
+    {
+        var d1 = () => this.Increment();
+        d1();
+        var d2 = () => this.EIncrement();
+        d2();
+    }
+
+    public void EIncrement()
+    {
+        this.Increment();
+    }
+}
+
+public class C
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var src2 = """
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var c = new C();
+        c.Method();
+        System.Console.WriteLine(c.F);
+    }
+}
+""";
+        var comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+
+        verifier.VerifyIL("E.Method(C)",
+"""
+{
+  // Code size       46 (0x2e)
+  .maxstack  3
+  IL_0000:  newobj     "E.<>c__DisplayClass0_0..ctor()"
+  IL_0005:  dup
+  IL_0006:  ldarg.0
+  IL_0007:  stfld      "C E.<>c__DisplayClass0_0.<>4__this"
+  IL_000c:  dup
+  IL_000d:  ldftn      "void E.<>c__DisplayClass0_0.<Method>b__0()"
+  IL_0013:  newobj     "System.Action..ctor(object, nint)"
+  IL_0018:  callvirt   "void System.Action.Invoke()"
+  IL_001d:  ldftn      "void E.<>c__DisplayClass0_0.<Method>b__1()"
+  IL_0023:  newobj     "System.Action..ctor(object, nint)"
+  IL_0028:  callvirt   "void System.Action.Invoke()"
+  IL_002d:  ret
+}
+""");
+
+        comp = CreateCompilation(src1 + src2, targetFramework: TargetFramework.Net80, options: TestOptions.DebugExe);
+        CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("2"), verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_23_LambdaCapturing()
+    {
+        var src1 = """
+public implicit extension E for C
+{
+    public void Method()
+    {
+        var d1 = () => this.Increment();
+        d1();
+        var d2 = () => this.EIncrement();
+        d2();
+    }
+
+    public void EIncrement()
+    {
+        this.Increment();
+    }
+}
+
+public struct C
+{
+    public int F;
+
+    public void Increment()
+    {
+        F++;
+    }
+}
+""";
+        var comp = CreateCompilation(src1, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
+        comp.VerifyDiagnostics(
+            // (5,24): error CS1673: Anonymous methods, lambda expressions, query expressions, and local functions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression, query expression, or local function and using the local instead.
+            //         var d1 = () => this.Increment();
+            Diagnostic(ErrorCode.ERR_ThisStructNotInAnonMeth, "this").WithLocation(5, 24),
+            // (7,24): error CS1673: Anonymous methods, lambda expressions, query expressions, and local functions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression, query expression, or local function and using the local instead.
+            //         var d2 = () => this.EIncrement();
+            Diagnostic(ErrorCode.ERR_ThisStructNotInAnonMeth, "this").WithLocation(7, 24)
+            );
+    }
+
+    [Fact]
+    public void InstanceMethod_Metadata_24_LambdaCapturing()
+    {
+        var src1 = """
+public implicit extension E<T> for T where T : I1
+{
+    public void Method()
+    {
+        var d1 = () => this.Increment();
+        d1();
+        var d2 = () => this.EIncrement();
+        d2();
+    }
+
+    public void EIncrement()
+    {
+        this.Increment();
+    }
+}
+
+public interface I1
+{
+    public void Increment();
+}
+""";
+        var comp = CreateCompilation(src1, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDll);
+        comp.VerifyDiagnostics(
+            // (5,24): error CS1673: Anonymous methods, lambda expressions, query expressions, and local functions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression, query expression, or local function and using the local instead.
+            //         var d1 = () => this.Increment();
+            Diagnostic(ErrorCode.ERR_ThisStructNotInAnonMeth, "this").WithLocation(5, 24),
+            // (7,24): error CS1673: Anonymous methods, lambda expressions, query expressions, and local functions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression, query expression, or local function and using the local instead.
+            //         var d2 = () => this.EIncrement();
+            Diagnostic(ErrorCode.ERR_ThisStructNotInAnonMeth, "this").WithLocation(7, 24)
+            );
+    }
+
+    [Fact]
     public void InstanceProperty_Metadata_01()
     {
         var src1 = """
@@ -42081,9 +42231,6 @@ class Program
     }
 
     // PROTOTYPE(roles): Add flavors of "_Metadata" tests for an underlying type a type parameter known/unknown to be a reference type
-
-    // PROTOTYPE(roles): Test capturing of struct underlying type into a closure in an instance extension member.  
-    //                   Probably should be an error.
 
     // PROTOTYPE(roles): Test expression trees with instance members.
 


### PR DESCRIPTION
Relates to test plan https://github.com/dotnet/roslyn/issues/66722