### PR TITLE
Address issues with VSIX item publishing projects and FUTDC

### DIFF
--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -151,12 +151,12 @@
     Workaround for missing dependency publishing feature in the VS SDK.
     
     Relies on the following convention: When a project reference publish outputs (i.e. more than standard build outputs) need to be packaged into a VSIX,
-    the project should define VsixItemsOutputGroup target and include it in ProjectRefrence.IncludeOutputGroupsInVSIX.
+    the project should define PublishedProjectOutputGroup target and include it in ProjectRefrence.IncludeOutputGroupsInVSIX.
 
-    VsixItemsOutputGroup target may gather all the publishing items to be packaged into the VSIX using PublishItemsOutputGroup target,
-    but should not depend on Publish target (i.e. invoking VsixItemsOutputGroup target should not trigger actual publishing).
+    PublishedProjectOutputGroup target may gather all the publishing items to be packaged into the VSIX using PublishItemsOutputGroup target,
+    but should not depend on Publish target (i.e. invoking PublishedProjectOutputGroup target should not trigger actual publishing).
 
-    Target PublishProjectReferencesForVsixCreation will take care of publishing for all ProjectReferences with VsixItemsOutputGroup.
+    Target PublishProjectReferencesForVsixCreation will take care of publishing for all ProjectReferences with PublishedProjectOutputGroup.
   -->
   
   <PropertyGroup>
@@ -165,7 +165,7 @@
 
   <Target Name="PublishProjectReferencesForVsixCreation">
     <ItemGroup>
-      <_ProjectsToPublish Include="@(ProjectReference)" Condition="$([MSBuild]::ValueOrDefault('%(ProjectReference.IncludeOutputGroupsInVSIX)', '').Contains('VsixItemsOutputGroup'))"/>
+      <_ProjectsToPublish Include="@(ProjectReference)" Condition="$([MSBuild]::ValueOrDefault('%(ProjectReference.IncludeOutputGroupsInVSIX)', '').Contains('PublishedProjectOutputGroup'))"/>
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectsToPublish)"

--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -144,6 +144,33 @@
 
   <Import Project="GeneratePkgDef.targets" Condition="'$(MSBuildRuntimeType)' != 'Core' and '$(GeneratePkgDefFile)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true'" />
 
-    <!-- Workaround to fix https://github.com/dotnet/msbuild/issues/10306 -->
+  <!-- Workaround to fix https://github.com/dotnet/msbuild/issues/10306 -->
   <Target Name="ExtensionJsonOutputGroupFixed" Returns="@(ExtensionJsonOutputGroupOutput)" DependsOnTargets="PrepareResources;ExtensionJsonOutputGroup" />
+
+  <!--
+    Workaround for missing dependency publishing feature in the VS SDK.
+    
+    When a project reference publishing outputs need to be packaged into a VSIX,
+    the project should define VsixItemsOutputGroup target and include it in ProjectRefrence.IncludeOutputGroupsInVSIX.
+    
+    VsixItemsOutputGroup target should gather all the publishing items to be packaged into the VSIX using PublishVsixItems target,
+    but should not depend on Publish targets (i.e. invoking VsixItemsOutputGroup target should not trigger actual publishing).
+    PublishProjectReferencesForVsixCreation below will take care of publishing for all ProjectReferences with VsixItemsOutputGroup.
+  -->
+  
+  <PropertyGroup>
+    <CreateVsixContainerDependsOn>$(CreateVsixContainerDependsOn);PublishProjectReferencesForVsixCreation</CreateVsixContainerDependsOn>
+  </PropertyGroup>
+
+  <Target Name="PublishProjectReferencesForVsixCreation">
+    <ItemGroup>
+      <_ProjectsToPublish Include="@(ProjectReference)" Condition="$([MSBuild]::ValueOrDefault('%(IncludeOutputGroupsInVSIX)', '').Contains('VsixItemsOutputGroup'))"/>
+    </ItemGroup>
+
+    <MSBuild Projects="@(_ProjectsToPublish)"
+             BuildInParallel="$(BuildInParallel)"
+             Properties="%(_ProjectsToPublish.SetConfiguration);%(_ProjectsToPublish.SetPlatform);%(_ProjectsToPublish.SetTargetFramework)"
+             Targets="PublishVsixItems"
+             RebaseOutputs="true" />
+  </Target>
 </Project>

--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -165,7 +165,7 @@
 
   <Target Name="PublishProjectReferencesForVsixCreation">
     <ItemGroup>
-      <_ProjectsToPublish Include="@(ProjectReference)" Condition="$([MSBuild]::ValueOrDefault('%(IncludeOutputGroupsInVSIX)', '').Contains('VsixItemsOutputGroup'))"/>
+      <_ProjectsToPublish Include="@(ProjectReference)" Condition="$([MSBuild]::ValueOrDefault('%(ProjectReference.IncludeOutputGroupsInVSIX)', '').Contains('VsixItemsOutputGroup'))"/>
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectsToPublish)"

--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -150,12 +150,13 @@
   <!--
     Workaround for missing dependency publishing feature in the VS SDK.
     
-    When a project reference publishing outputs need to be packaged into a VSIX,
+    Relies on the following convention: When a project reference publish outputs (i.e. more than standard build outputs) need to be packaged into a VSIX,
     the project should define VsixItemsOutputGroup target and include it in ProjectRefrence.IncludeOutputGroupsInVSIX.
-    
-    VsixItemsOutputGroup target should gather all the publishing items to be packaged into the VSIX using PublishVsixItems target,
-    but should not depend on Publish targets (i.e. invoking VsixItemsOutputGroup target should not trigger actual publishing).
-    PublishProjectReferencesForVsixCreation below will take care of publishing for all ProjectReferences with VsixItemsOutputGroup.
+
+    VsixItemsOutputGroup target may gather all the publishing items to be packaged into the VSIX using PublishItemsOutputGroup target,
+    but should not depend on Publish target (i.e. invoking VsixItemsOutputGroup target should not trigger actual publishing).
+
+    Target PublishProjectReferencesForVsixCreation will take care of publishing for all ProjectReferences with VsixItemsOutputGroup.
   -->
   
   <PropertyGroup>

--- a/src/Features/CSharpTest/Microsoft.CodeAnalysis.CSharp.Features.UnitTests.csproj
+++ b/src/Features/CSharpTest/Microsoft.CodeAnalysis.CSharp.Features.UnitTests.csproj
@@ -31,7 +31,7 @@
 
   <Target Name="_DeploySemanticSearchRefAssemblies" AfterTargets="ResolveProjectReferences" Condition="'$(DesignTimeBuild)' != 'true'">
 
-    <MSBuild Projects="@(CopyPublishedOutputProjectReference)" Targets="PublishProjectOutputGroup" BuildInParallel="$(BuildInParallel)" Properties="%(CopyPublishedOutputProjectReference.SetTargetFramework)">
+    <MSBuild Projects="@(CopyPublishedOutputProjectReference)" Targets="PublishVsixItems" BuildInParallel="$(BuildInParallel)" Properties="%(CopyPublishedOutputProjectReference.SetTargetFramework)">
       <Output TaskParameter="TargetOutputs" ItemName="%(CopyPublishedOutputProjectReference.OutputItemType)" />
     </MSBuild>
 

--- a/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
+++ b/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
@@ -26,31 +26,40 @@
     <Content Include="..\App.config" />
     <Compile Include="..\InteractiveHostEntryPoint.cs" />
   </ItemGroup>
+  
+  <Target Name="VsixItemsOutputGroup" DependsOnTargets="PublishItemsOutputGroup" Returns="@(_VsixItem)">
+    <!-- Workaround for https://github.com/dotnet/sdk/issues/42255 -->
+    <PropertyGroup>
+      <!-- IntermediateDepsFilePath is the location where the deps.json file is originally created -->
+      <_IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' != ''">$(PublishDepsFilePath)</_IntermediateDepsFilePath >
+      <_IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' == ''">$(IntermediateOutputPath)$(ProjectDepsFileName)</_IntermediateDepsFilePath >
+    </PropertyGroup>
 
-  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Publish" Returns="@(_PublishedFiles)">
     <ItemGroup>
       <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->
-      <_PublishedFiles Include="$(PublishDir)**\*.*" />
-      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Extension)' == '.pdb'" />
-
+      <_VsixItem Include="@(PublishItemsOutputGroupOutputs->'%(OutputPath)')" />
+      <_VsixItem Remove="@(_VsixItem)" Condition="'%(Extension)' == '.pdb'" />
+      
+      <!-- Include .deps.json file (see https://github.com/dotnet/sdk/issues/42255) -->
+      <_VsixItem Include="$(_IntermediateDepsFilePath)" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
+        
       <!-- Include .rsp file -->
-      <_PublishedFiles Include="$(MSBuildProjectDirectory)\Desktop\CSharpInteractive.rsp" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
-      <_PublishedFiles Include="$(MSBuildProjectDirectory)\Core\CSharpInteractive.rsp" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
+      <_VsixItem Include="$(MSBuildProjectDirectory)\Desktop\CSharpInteractive.rsp" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+      <_VsixItem Include="$(MSBuildProjectDirectory)\Core\CSharpInteractive.rsp" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
 
       <!-- Include the specified .editorconfig file to pickup the correct interactive settings. -->
-      <_PublishedFiles Include="$(MSBuildProjectDirectory)\.editorconfig"/>
-
-      <!-- Set TargetPath -->
-      <_PublishedFiles Update="@(_PublishedFiles)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
+      <_VsixItem Include="$(MSBuildProjectDirectory)\.editorconfig" />
 
       <!-- Set NGEN metadata -->
-      <_PublishedFiles Update="@(_PublishedFiles)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and ('%(Extension)' == '.dll' or '%(Extension)' == '.exe')">
+      <_VsixItem Update="@(_VsixItem)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and ('%(Extension)' == '.dll' or '%(Extension)' == '.exe')">
         <Ngen>true</Ngen>
         <NgenPriority>3</NgenPriority>
         <NgenArchitecture Condition="'%(Filename)' != 'InteractiveHost64'">All</NgenArchitecture>
         <NgenArchitecture Condition="'%(Filename)' == 'InteractiveHost64'">X64</NgenArchitecture>
         <NgenApplication>[installDir]\Common7\IDE\$(CommonExtensionInstallationRoot)\$(LanguageServicesExtensionInstallationFolder)\InteractiveHost\Desktop\InteractiveHost64.exe</NgenApplication>
-      </_PublishedFiles>
+      </_VsixItem>
     </ItemGroup>
   </Target>
+
+  <Target Name="PublishVsixItems" DependsOnTargets="Publish;VsixItemsOutputGroup" Returns="@(_VsixItem)" />
 </Project>

--- a/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
+++ b/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
@@ -27,7 +27,7 @@
     <Compile Include="..\InteractiveHostEntryPoint.cs" />
   </ItemGroup>
   
-  <Target Name="VsixItemsOutputGroup" DependsOnTargets="PublishItemsOutputGroup" Returns="@(_VsixItem)">
+  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="PublishItemsOutputGroup" Returns="@(_VsixItem)">
     <!-- Workaround for https://github.com/dotnet/sdk/issues/42255 -->
     <PropertyGroup>
       <!-- IntermediateDepsFilePath is the location where the deps.json file is originally created -->
@@ -64,5 +64,5 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PublishVsixItems" DependsOnTargets="Publish;VsixItemsOutputGroup" Returns="@(_VsixItem)" />
+  <Target Name="PublishVsixItems" DependsOnTargets="Publish;PublishedProjectOutputGroup" Returns="@(_VsixItem)" />
 </Project>

--- a/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
+++ b/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
@@ -51,7 +51,8 @@
       <_VsixItem Include="$(MSBuildProjectDirectory)\.editorconfig" />
 
       <!-- Set TargetPath -->
-      <_PublishedFiles Update="@(_PublishedFiles)" TargetPath="%(Filename)%(Extension)" Condition="'%(TargetPath)' == ''" />
+      <_VsixItem Update="@(_VsixItem)" TargetPath="%(Filename)%(Extension)" Condition="'%(_VsixItem.TargetPath)' == ''" />
+
       <!-- Set NGEN metadata -->
       <_VsixItem Update="@(_VsixItem)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and ('%(Extension)' == '.dll' or '%(Extension)' == '.exe')">
         <Ngen>true</Ngen>

--- a/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
+++ b/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
@@ -39,10 +39,10 @@
       <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->
       <_VsixItem Include="@(PublishItemsOutputGroupOutputs->'%(OutputPath)')" />
       <_VsixItem Remove="@(_VsixItem)" Condition="'%(Extension)' == '.pdb'" />
-      
+
       <!-- Include .deps.json file (see https://github.com/dotnet/sdk/issues/42255) -->
       <_VsixItem Include="$(_IntermediateDepsFilePath)" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
-        
+
       <!-- Include .rsp file -->
       <_VsixItem Include="$(MSBuildProjectDirectory)\Desktop\CSharpInteractive.rsp" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
       <_VsixItem Include="$(MSBuildProjectDirectory)\Core\CSharpInteractive.rsp" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
@@ -50,6 +50,8 @@
       <!-- Include the specified .editorconfig file to pickup the correct interactive settings. -->
       <_VsixItem Include="$(MSBuildProjectDirectory)\.editorconfig" />
 
+      <!-- Set TargetPath -->
+      <_PublishedFiles Update="@(_PublishedFiles)" TargetPath="%(Filename)%(Extension)" Condition="'%(TargetPath)' == ''" />
       <!-- Set NGEN metadata -->
       <_VsixItem Update="@(_VsixItem)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and ('%(Extension)' == '.dll' or '%(Extension)' == '.exe')">
         <Ngen>true</Ngen>

--- a/src/Interactive/HostProcess/x86/InteractiveHost32.csproj
+++ b/src/Interactive/HostProcess/x86/InteractiveHost32.csproj
@@ -22,22 +22,25 @@
 
   <!--
     InteractiveHost32 is deployed to the same directory as InteractiveHost64 as it shares the same dependencies.
-    
-    Ideally this would just return @(BuiltProjectOutputGroupOutput) but that does not reliably include the generated App.config file.
-    See https://github.com/microsoft/msbuild/issues/5433.
-
-    Use BuiltProjectOutputGroup as the dependend target to ensure the targets has all dependencies that BuiltProjectOutputGroupOutput would have.
   -->
-  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Build;BuiltProjectOutputGroup" Returns="@(_PublishProjectOutputGroup)">
+  <Target Name="VsixItemsOutputGroup" Returns="@(_VsixItem)">
     <ItemGroup>
-      <_PublishProjectOutputGroup Include="$(TargetPath)">
+      <_VsixItem Include="$(TargetPath)">
         <TargetPath>$(TargetFileName)</TargetPath>
         <Ngen>true</Ngen>
         <NgenPriority>3</NgenPriority>
         <NgenArchitecture>X86</NgenArchitecture>
         <NgenApplication>[installDir]\Common7\IDE\$(CommonExtensionInstallationRoot)\$(LanguageServicesExtensionInstallationFolder)\InteractiveHost\Desktop\InteractiveHost32.exe</NgenApplication>
-      </_PublishProjectOutputGroup>
-      <_PublishProjectOutputGroup Include="$(TargetPath).config" TargetPath="$(TargetFileName).config"/>
+      </_VsixItem>
+      <_VsixItem Include="$(TargetPath).config" TargetPath="$(TargetFileName).config"/>
     </ItemGroup>
   </Target>
+
+  <!--
+    Ideally this would just return @(BuiltProjectOutputGroupOutput) but that does not reliably include the generated App.config file.
+    See https://github.com/microsoft/msbuild/issues/5433.
+
+    Use BuiltProjectOutputGroup as the dependend target to ensure the targets has all dependencies that BuiltProjectOutputGroupOutput would have.
+  -->
+  <Target Name="PublishVsixItems" DependsOnTargets="Build;BuiltProjectOutputGroup;VsixItemsOutputGroup" Returns="@(_VsixItem)" />
 </Project>

--- a/src/Interactive/HostProcess/x86/InteractiveHost32.csproj
+++ b/src/Interactive/HostProcess/x86/InteractiveHost32.csproj
@@ -23,7 +23,7 @@
   <!--
     InteractiveHost32 is deployed to the same directory as InteractiveHost64 as it shares the same dependencies.
   -->
-  <Target Name="VsixItemsOutputGroup" Returns="@(_VsixItem)">
+  <Target Name="PublishedProjectOutputGroup" Returns="@(_VsixItem)">
     <ItemGroup>
       <_VsixItem Include="$(TargetPath)">
         <TargetPath>$(TargetFileName)</TargetPath>
@@ -42,5 +42,5 @@
 
     Use BuiltProjectOutputGroup as the dependend target to ensure the targets has all dependencies that BuiltProjectOutputGroupOutput would have.
   -->
-  <Target Name="PublishVsixItems" DependsOnTargets="Build;BuiltProjectOutputGroup;VsixItemsOutputGroup" Returns="@(_VsixItem)" />
+  <Target Name="PublishVsixItems" DependsOnTargets="Build;BuiltProjectOutputGroup;PublishedProjectOutputGroup" Returns="@(_VsixItem)" />
 </Project>

--- a/src/Interactive/HostTest/InteractiveHost.UnitTests.csproj
+++ b/src/Interactive/HostTest/InteractiveHost.UnitTests.csproj
@@ -50,8 +50,7 @@
   -->
   <Target Name="_DeployInteractiveHosts" AfterTargets="ResolveProjectReferences" Condition="'$(DesignTimeBuild)' != 'true'">
 
-    <MSBuild Projects="@(CopyPublishedOutputProjectReference)" Targets="PublishProjectOutputGroup" BuildInParallel="$(BuildInParallel)" Properties="%(CopyPublishedOutputProjectReference.SetTargetFramework)">
-
+    <MSBuild Projects="@(CopyPublishedOutputProjectReference)" Targets="PublishVsixItems" BuildInParallel="$(BuildInParallel)" Properties="%(CopyPublishedOutputProjectReference.SetTargetFramework)">
       <Output TaskParameter="TargetOutputs" ItemName="%(CopyPublishedOutputProjectReference.OutputItemType)" />
     </MSBuild>
 

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
@@ -61,8 +61,8 @@
   </Target>
 
   <!-- Used from Setup and test projects to fetch the list of generated ref assemblies -->
-  <Target Name="VsixItemsOutputGroup" DependsOnTargets="_CalculateFilteredReferenceAssembliesInputsAndOutputs" Returns="@(_OutputFile)"  />
+  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="_CalculateFilteredReferenceAssembliesInputsAndOutputs" Returns="@(_OutputFile)"  />
 
   <!-- Generates ref assemblies -->
-  <Target Name="PublishVsixItems" DependsOnTargets="VsixItemsOutputGroup;GenerateFilteredReferenceAssemblies" Returns="@(_OutputFile)" />
+  <Target Name="PublishVsixItems" DependsOnTargets="PublishedProjectOutputGroup;GenerateFilteredReferenceAssemblies" Returns="@(_OutputFile)" />
 </Project>

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
@@ -61,10 +61,8 @@
   </Target>
 
   <!-- Used from Setup and test projects to fetch the list of generated ref assemblies -->
-  <Target Name="PublishProjectOutputGroup" Returns="@(_PublishProjectOutputGroupOutput)" DependsOnTargets="GenerateFilteredReferenceAssemblies">
+  <Target Name="VsixItemsOutputGroup" DependsOnTargets="_CalculateFilteredReferenceAssembliesInputsAndOutputs" Returns="@(_OutputFile)"  />
 
-    <ItemGroup>
-      <_PublishProjectOutputGroupOutput Include="@(_OutputFile)" />
-    </ItemGroup>
-  </Target>
+  <!-- Generates ref assemblies -->
+  <Target Name="PublishVsixItems" DependsOnTargets="VsixItemsOutputGroup;GenerateFilteredReferenceAssemblies" Returns="@(_OutputFile)" />
 </Project>

--- a/src/VisualStudio/Setup.ServiceHub/arm64/Roslyn.VisualStudio.ServiceHub.Setup.arm64.csproj
+++ b/src/VisualStudio/Setup.ServiceHub/arm64/Roslyn.VisualStudio.ServiceHub.Setup.arm64.csproj
@@ -20,7 +20,7 @@
       <!-- This project targets netcoreapp -->
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>PublishedProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
       <Private>false</Private>
       <!-- Disable NGEN. Core assemblies are crossgened. -->

--- a/src/VisualStudio/Setup.ServiceHub/arm64/Roslyn.VisualStudio.ServiceHub.Setup.arm64.csproj
+++ b/src/VisualStudio/Setup.ServiceHub/arm64/Roslyn.VisualStudio.ServiceHub.Setup.arm64.csproj
@@ -20,7 +20,7 @@
       <!-- This project targets netcoreapp -->
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>PublishProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
       <Private>false</Private>
       <!-- Disable NGEN. Core assemblies are crossgened. -->

--- a/src/VisualStudio/Setup.ServiceHub/x64/Roslyn.VisualStudio.ServiceHub.Setup.x64.csproj
+++ b/src/VisualStudio/Setup.ServiceHub/x64/Roslyn.VisualStudio.ServiceHub.Setup.x64.csproj
@@ -12,7 +12,7 @@
       <!-- This project targets netcoreapp -->
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>PublishedProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
       <Private>false</Private>
       <!-- Disable NGEN. Core assemblies are crossgened. -->

--- a/src/VisualStudio/Setup.ServiceHub/x64/Roslyn.VisualStudio.ServiceHub.Setup.x64.csproj
+++ b/src/VisualStudio/Setup.ServiceHub/x64/Roslyn.VisualStudio.ServiceHub.Setup.x64.csproj
@@ -12,7 +12,7 @@
       <!-- This project targets netcoreapp -->
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>PublishProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
       <Private>false</Private>
       <!-- Disable NGEN. Core assemblies are crossgened. -->

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -278,7 +278,7 @@
 
       <Private>false</Private>
       <VSIXSubPath>InteractiveHost\Core</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>PublishedProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
 
       <!-- Disable NGEN. Core assemblies are crossgened. -->
@@ -293,7 +293,7 @@
 
       <Private>false</Private>
       <VSIXSubPath>InteractiveHost\Desktop</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>PublishedProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\..\Interactive\HostProcess\x86\InteractiveHost32.csproj">
@@ -308,7 +308,7 @@
 
       <Private>false</Private>
       <VSIXSubPath>InteractiveHost\Desktop</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>PublishedProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\..\Tools\SemanticSearch\ReferenceAssemblies\SemanticSearch.ReferenceAssemblies.csproj">
@@ -317,7 +317,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>false</Private>
       <VSIXSubPath>SemanticSearchRefs</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>PublishedProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>false</Ngen>
     </ProjectReference>

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -278,7 +278,7 @@
 
       <Private>false</Private>
       <VSIXSubPath>InteractiveHost\Core</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>PublishProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
 
       <!-- Disable NGEN. Core assemblies are crossgened. -->
@@ -293,7 +293,7 @@
 
       <Private>false</Private>
       <VSIXSubPath>InteractiveHost\Desktop</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>PublishProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\..\Interactive\HostProcess\x86\InteractiveHost32.csproj">
@@ -308,7 +308,7 @@
 
       <Private>false</Private>
       <VSIXSubPath>InteractiveHost\Desktop</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>PublishProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\..\Tools\SemanticSearch\ReferenceAssemblies\SemanticSearch.ReferenceAssemblies.csproj">
@@ -317,7 +317,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>false</Private>
       <VSIXSubPath>SemanticSearchRefs</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>PublishProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>VsixItemsOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>false</Ngen>
     </ProjectReference>

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -105,7 +105,7 @@
   </Target>
 
   <Target Name="CompileReadyToRun"
-          DependsOnTargets="PrepareCrossgenTargets"
+          DependsOnTargets="Publish;PrepareCrossgenTargets"
           Condition="'$(GenerateReadyToRun)' == 'true'"
           Inputs="%(_CrossgenTargetPaths.FullPath)"
           Outputs="%(_CrossgenTargetPaths.OutputPath)">    

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -35,9 +35,12 @@
     -->    
     <PackageReference Include="Microsoft.NETCore.App.crossgen2.win-x64" Condition="'$(GenerateReadyToRun)' == 'true'" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />    
   </ItemGroup>
-
-  <Target Name="LocateCrossgenTargets" DependsOnTargets="Publish">
+  
+  <Target Name="CalculateCrossgenInputs" DependsOnTargets="PublishItemsOutputGroup">
     <ItemGroup>
+      <_PublishPaths Include="@(PublishItemsOutputGroupOutputs->'%(OutputPath)')" />
+      <_PublishDllPaths Include="@(_PublishPaths)" Condition="'%(Extension)' == '.dll'" />
+
       <!-- Find all Roslyn assemblies that we want to crossgen -->
       <_R2RAssemblies Include="@(ReferencePath->'%(FileName)%(Extension)')" Condition="'%(ReferenceSourceTarget)' == 'ProjectReference'" />
 
@@ -58,7 +61,7 @@
       <_R2RAssemblies Include="Microsoft.NET.StringTools.dll" />
 
       <!-- Find all assemblies (including Roslyn and all dependencies) from the actual published location -->
-      <_AllPublishedAssemblyPaths Include="$(PublishDir)**\*.dll" Exclude="$(PublishDir)**\*.resources.dll" />
+      <_AllPublishedAssemblyPaths Include="@(_PublishDllPaths)" Exclude="%(FileName).EndsWith('.resources')" />
       <_AllPublishedAssemblies Include="@(_AllPublishedAssemblyPaths->'%(FileName)%(Extension)')" >
         <_FullFilePath>%(FullPath)</_FullFilePath>
       </_AllPublishedAssemblies>
@@ -71,6 +74,15 @@
 
       <!-- Now we get all Roslyn assemblies in the publish folder -->
       <_R2RAssemblyPaths Include="@(_AllPublishedAssemblyPaths)" Exclude="@(_NoR2RAssemblyPaths)" />
+
+      <!-- Dependencies -->
+      <_RuntimeLibraries Include="$(_RuntimeLibrariesPath)**\*.dll" />
+      <_WinRuntimeLibraries Include="$(_WinRuntimeLibrariesPath)**\*.dll" />
+
+      <_RuntimeLibrariesInPublishDir Include="@(_RuntimeLibraries->'$(PublishDir)%(FileName)%(Extension)')" />
+      <_RuntimeLibrariesInPublishDir Include="@(_WinRuntimeLibraries->'$(PublishDir)%(FileName)%(Extension)')" />
+
+      <_NonRuntimeAssembliesInPublishDir Include="@(_PublishDllPaths)" Exclude="@(_RuntimeLibrariesInPublishDir)" />
     </ItemGroup>
     
     <PropertyGroup>
@@ -79,7 +91,7 @@
     </PropertyGroup>   
   </Target>
 
-  <Target Name="PrepareCrossgenTargets" DependsOnTargets="LocateCrossgenTargets" Condition="'$(GenerateReadyToRun)' == 'true'">
+  <Target Name="PrepareCrossgenTargets" DependsOnTargets="CalculateCrossgenInputs" Condition="'$(GenerateReadyToRun)' == 'true'">
     <Move SourceFiles="@(_R2RAssemblyPaths)" DestinationFolder="$(OriginalAssemblyDir)">
       <Output TaskParameter="DestinationFiles" ItemName="_FilesWritten" />
     </Move>
@@ -93,7 +105,7 @@
   </Target>
 
   <Target Name="CompileReadyToRun"
-          DependsOnTargets="LocateDependencies;PrepareCrossgenTargets"
+          DependsOnTargets="PrepareCrossgenTargets"
           Condition="'$(GenerateReadyToRun)' == 'true'"
           Inputs="%(_CrossgenTargetPaths.FullPath)"
           Outputs="%(_CrossgenTargetPaths.OutputPath)">    
@@ -125,21 +137,7 @@
     <Error Text="Crossgen2 failed with exit code $(_Crossgen2ErrorCode)." Condition="'$(_Crossgen2ErrorCode)' != '0'" />
   </Target>
 
-  <Target Name="LocateDependencies" DependsOnTargets="Publish">
-    <ItemGroup>
-      <_RuntimeLibraries Include="$(_RuntimeLibrariesPath)**\*.dll" />
-      <_WinRuntimeLibraries Include="$(_WinRuntimeLibrariesPath)**\*.dll" />
-
-      <_RuntimeLibrariesInPublishDir Include="@(_RuntimeLibraries->'$(PublishDir)%(FileName)%(Extension)')" />
-      <_RuntimeLibrariesInPublishDir Include="@(_WinRuntimeLibraries->'$(PublishDir)%(FileName)%(Extension)')" />
-
-      <_NonRuntimeAssembliesInPublishDir Include="$(PublishDir)*.dll" Exclude="@(_RuntimeLibrariesInPublishDir)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="BeforePublishProjectOutputGroup" DependsOnTargets="LocateDependencies;LocateCrossgenTargets" />
-
-  <Target Name="PublishProjectOutputGroup" DependsOnTargets="BeforePublishProjectOutputGroup;CompileReadyToRun" Returns="@(_PublishedFiles)">
+  <Target Name="VsixItemsOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)">
     <PropertyGroup>
       <!-- 
         For BCL, we want to use the version provided by the runtime in VS, not the ones from the NuGet packages. 
@@ -153,20 +151,21 @@
       -->
       <_ExcludeRuntimeLibraries Condition="'$(OfficialBuild)' == 'true'">true</_ExcludeRuntimeLibraries>
     </PropertyGroup>
-    <ItemGroup>
-      <_ExcludedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*" />
-      <_ExcludedFiles Include="$(PublishDir)**\*.pdb" />
-      <_ExcludedFiles Include="$(CrossgenWorkDir)**\*" />
 
-      <!-- the only assembly we need under runtime folder (runtimes\win-x64\native\e_sqlite3.dll) is handled by the vsix project directly -->
-      <_ExcludedFiles Include="$(PublishDir)runtimes\**\*.*" />
-      <_ExcludedFiles Condition="'$(_ExcludeRuntimeLibraries)' == 'true'" Include="@(_RuntimeLibrariesInPublishDir)" />
-    </ItemGroup>
     <ItemGroup>
       <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->
-      <_PublishedFiles Include="$(PublishDir)**\*.*" Exclude="@(_ExcludedFiles)"/>
-      <!-- Set TargetPath -->
-      <_PublishedFiles Update="@(_PublishedFiles)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
-  </ItemGroup>
+      <_VsixItem Include="@(_PublishPaths)" />
+      <_VsixItem Remove="@(_VsixItem)" Condition="'%(Extension)' == '.pdb'" />
+
+      <!-- Exclude dummy build outputs compiled for this setup project -->
+      <_VsixItem Remove="@(_VsixItem)" Condition="$([MSBuild]::ValueOrDefault('%(FileName)', '').StartsWith('$(TargetName)'))" />
+      
+      <!-- the only assembly we need under runtime folder (runtimes\win-x64\native\e_sqlite3.dll) is handled by the vsix project directly -->
+      <_VsixItem Remove="@(_VsixItem)" Condition="$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith('$(PublishDir)runtimes'))" />
+
+      <_VsixItem Remove="@(_RuntimeLibrariesInPublishDir)" Condition="'$(_ExcludeRuntimeLibraries)' == 'true'" />
+    </ItemGroup>
   </Target>
+
+  <Target Name="PublishVsixItems" DependsOnTargets="VsixItemsOutputGroup;CompileReadyToRun" Returns="@(_VsixItem)" />
 </Project>

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -137,7 +137,7 @@
     <Error Text="Crossgen2 failed with exit code $(_Crossgen2ErrorCode)." Condition="'$(_Crossgen2ErrorCode)' != '0'" />
   </Target>
 
-  <Target Name="VsixItemsOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)">
+  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)">
     <PropertyGroup>
       <!-- 
         For BCL, we want to use the version provided by the runtime in VS, not the ones from the NuGet packages. 
@@ -167,5 +167,5 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PublishVsixItems" DependsOnTargets="VsixItemsOutputGroup;CompileReadyToRun" Returns="@(_VsixItem)" />
+  <Target Name="PublishVsixItems" DependsOnTargets="PublishedProjectOutputGroup;CompileReadyToRun" Returns="@(_VsixItem)" />
 </Project>

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -137,7 +137,7 @@
     <Error Text="Crossgen2 failed with exit code $(_Crossgen2ErrorCode)." Condition="'$(_Crossgen2ErrorCode)' != '0'" />
   </Target>
 
-  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)">
+  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)" Condition="'$(GenerateReadyToRun)' == 'true'">
     <PropertyGroup>
       <!-- 
         For BCL, we want to use the version provided by the runtime in VS, not the ones from the NuGet packages. 

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -97,7 +97,7 @@
     </Move>
     <ItemGroup>
       <_CrossgenTargetsAsDependencies Include="$(OriginalAssemblyDir)*.dll" />
-      <_NonCrossgenTargetsAsDependencies Include="@(_NonRuntimeAssembliesInPublishDir)" Exclude="@(_R2RAssemblyPaths)" />      
+      <_NonCrossgenTargetsAsDependencies Include="@(_NonRuntimeAssembliesInPublishDir)" Exclude="@(_R2RAssemblyPaths)" />
       <_CrossgenTargetPaths Include="@(_CrossgenTargetsAsDependencies)">      
         <OutputPath>$(PublishDir)%(_CrossgenTargetsAsDependencies.Filename)%(_CrossgenTargetsAsDependencies.Extension)</OutputPath>
       </_CrossgenTargetPaths>
@@ -105,14 +105,14 @@
   </Target>
 
   <Target Name="CompileReadyToRun"
-          DependsOnTargets="Publish;PrepareCrossgenTargets"
+          DependsOnTargets="PrepareCrossgenTargets"
           Condition="'$(GenerateReadyToRun)' == 'true'"
           Inputs="%(_CrossgenTargetPaths.FullPath)"
-          Outputs="%(_CrossgenTargetPaths.OutputPath)">    
+          Outputs="%(_CrossgenTargetPaths.OutputPath)">
     <PropertyGroup>
       <_Crossgen2ExePath>$(PkgMicrosoft_NETCore_App_crossgen2_win-x64)\tools\crossgen2.exe</_Crossgen2ExePath>
       <_R2ROptimizeAssemblyPath>%(_CrossgenTargetPaths.FullPath)</_R2ROptimizeAssemblyPath>
-      <_R2ROptimizeAssemblyOutputPath>$(PublishDir)%(_CrossgenTargetPaths.Filename)%(_CrossgenTargetPaths.Extension)</_R2ROptimizeAssemblyOutputPath>      
+      <_R2ROptimizeAssemblyOutputPath>$(PublishDir)%(_CrossgenTargetPaths.Filename)%(_CrossgenTargetPaths.Extension)</_R2ROptimizeAssemblyOutputPath>
       <_RspFilePath>$(CrossgenWorkDir)%(_CrossgenTargetPaths.Filename).CrossgenArgs.rsp</_RspFilePath>
     </PropertyGroup>
     <ItemGroup>
@@ -133,11 +133,11 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="_Crossgen2Output" />
       <Output TaskParameter="ExitCode" PropertyName="_Crossgen2ErrorCode" />
     </Exec>
-    <Message Text="$(_Crossgen2Output)" />             
+    <Message Text="$(_Crossgen2Output)" />
     <Error Text="Crossgen2 failed with exit code $(_Crossgen2ErrorCode)." Condition="'$(_Crossgen2ErrorCode)' != '0'" />
   </Target>
 
-  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)" Condition="'$(GenerateReadyToRun)' == 'true'">
+  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)">
     <PropertyGroup>
       <!-- 
         For BCL, we want to use the version provided by the runtime in VS, not the ones from the NuGet packages. 
@@ -159,7 +159,7 @@
 
       <!-- Exclude dummy build outputs compiled for this setup project -->
       <_VsixItem Remove="@(_VsixItem)" Condition="$([MSBuild]::ValueOrDefault('%(FileName)', '').StartsWith('$(TargetName)'))" />
-      
+
       <!-- the only assembly we need under runtime folder (runtimes\win-x64\native\e_sqlite3.dll) is handled by the vsix project directly -->
       <_VsixItem Remove="@(_VsixItem)" Condition="$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith('$(PublishDir)runtimes'))" />
 
@@ -167,5 +167,5 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PublishVsixItems" DependsOnTargets="PublishedProjectOutputGroup;CompileReadyToRun" Returns="@(_VsixItem)" />
+  <Target Name="PublishVsixItems" DependsOnTargets="Publish;PublishedProjectOutputGroup;CompileReadyToRun" Returns="@(_VsixItem)" />
 </Project>


### PR DESCRIPTION
Workaround missing dependency publishing feature in the VS SDK.

Introduces the following convention: When a project reference publish outputs (i.e. more than standard build outputs) need to be packaged into a VSIX,
the project should define `VsixItemsOutputGroup` target and include it in `ProjectRefrence.IncludeOutputGroupsInVSIX`.

`VsixItemsOutputGroup` target may gather all the publishing items to be packaged into the VSIX using `PublishItemsOutputGroup` target,
but should not depend on `Publish` target (i.e. invoking `VsixItemsOutputGroup` target should not trigger actual publishing).

A custom target run before `CreateVsixContainer` will take care of publishing for all `ProjectReferences` with `VsixItemsOutputGroup`.