### PR TITLE
Add explicit cast to UseCoalesceExpressionForIfNullStatementCheckCodeFixProvider

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
+++ b/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
@@ -77,6 +77,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UnsealClass\CSharpUnsealClassCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UpdateProjectToAllowUnsafe\CSharpUpdateProjectToAllowUnsafeCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UpgradeProject\CSharpUpgradeProjectCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpCollectionExpressionRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForBuilderCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForFluentCodeFixProvider.cs" />

--- a/src/Analyzers/CSharp/CodeFixes/UseCoalesceExpression/CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCoalesceExpression/CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.UseCoalesceExpression;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseCoalesceExpression;
+
+[ExtensionOrder(Before = PredefinedCodeFixProviderNames.AddBraces)]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.UseCoalesceExpressionForIfNullStatementCheck), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider()
+    : AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider
+{
+    protected override bool ShouldAddExplicitCast(
+        ISyntaxFactsService syntaxFacts, SemanticModel semanticModel,
+        SyntaxNode expressionToCoalesce, SyntaxNode whenTrueStatement,
+        [NotNullWhen(true)] out ITypeSymbol? castTo,
+        CancellationToken cancellationToken)
+    {
+        castTo = null;
+
+        if (!syntaxFacts.IsSimpleAssignmentStatement(whenTrueStatement))
+            return false;
+
+        syntaxFacts.GetPartsOfAssignmentStatement(whenTrueStatement, out var left, out var right);
+
+        var leftPartTypeSymbol = semanticModel.GetTypeInfo(expressionToCoalesce, cancellationToken).Type;
+        var rightPartTypeSymbol = semanticModel.GetTypeInfo(right, cancellationToken).Type;
+        var finalDestinationTypeSymbol = semanticModel.GetTypeInfo(left, cancellationToken).Type;
+
+        if (leftPartTypeSymbol == null || rightPartTypeSymbol == null || finalDestinationTypeSymbol == null)
+            return false;
+
+        if (leftPartTypeSymbol.Equals(rightPartTypeSymbol))
+            return false;
+
+        if (semanticModel.Compilation.HasImplicitConversion(leftPartTypeSymbol, rightPartTypeSymbol) ||
+            semanticModel.Compilation.HasImplicitConversion(rightPartTypeSymbol, leftPartTypeSymbol))
+        {
+            return false;
+        }
+
+        castTo = finalDestinationTypeSymbol;
+        return true;
+    }
+}

--- a/src/Analyzers/CSharp/CodeFixes/UseCoalesceExpression/CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCoalesceExpression/CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
@@ -20,18 +20,13 @@ internal sealed class CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixP
     : AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider
 {
     protected override ITypeSymbol? TryGetExplicitCast(
-        ISyntaxFactsService syntaxFacts, SemanticModel semanticModel,
-        SyntaxNode expressionToCoalesce, SyntaxNode whenTrueStatement,
+        SemanticModel semanticModel, SyntaxNode expressionToCoalesce,
+        SyntaxNode leftAssignmentPart, SyntaxNode rightAssignmentPart,
         CancellationToken cancellationToken)
     {
-        if (!syntaxFacts.IsSimpleAssignmentStatement(whenTrueStatement))
-            return null;
-
-        syntaxFacts.GetPartsOfAssignmentStatement(whenTrueStatement, out var left, out var right);
-
         var leftPartTypeSymbol = semanticModel.GetTypeInfo(expressionToCoalesce, cancellationToken).Type;
-        var rightPartTypeSymbol = semanticModel.GetTypeInfo(right, cancellationToken).Type;
-        var finalDestinationTypeSymbol = semanticModel.GetTypeInfo(left, cancellationToken).Type;
+        var rightPartTypeSymbol = semanticModel.GetTypeInfo(rightAssignmentPart, cancellationToken).Type;
+        var finalDestinationTypeSymbol = semanticModel.GetTypeInfo(leftAssignmentPart, cancellationToken).Type;
 
         if (leftPartTypeSymbol == null || rightPartTypeSymbol == null || finalDestinationTypeSymbol == null)
             return null;

--- a/src/Analyzers/CSharp/Tests/UseCoalesceExpression/UseCoalesceExpressionForIfNullStatementCheckTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCoalesceExpression/UseCoalesceExpressionForIfNullStatementCheckTests.cs
@@ -4,16 +4,17 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.UseCoalesceExpression;
+using Microsoft.CodeAnalysis.CSharp.UseCoalesceExpression;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.UseCoalesceExpression;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.UseCoalesceExpression;
 
 using VerifyCS = CSharpCodeFixVerifier<
     CSharpUseCoalesceExpressionForIfNullStatementCheckDiagnosticAnalyzer,
-    UseCoalesceExpressionForIfNullStatementCheckCodeFixProvider>;
+    CSharpUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider>;
 
 [Trait(Traits.Feature, Traits.Features.CodeActionsUseCoalesceExpression)]
 public class UseCoalesceExpressionForIfNullStatementCheckTests
@@ -456,6 +457,238 @@ public class UseCoalesceExpressionForIfNullStatementCheckTests
             TestCode = text,
             FixedCode = text,
             LanguageVersion = LanguageVersion.CSharp9,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74460")]
+    public async Task TestLocalDeclaration_CastWithParenthesizedExpression()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode =
+            """
+            interface I
+            {
+            }
+
+            class C : I
+            {
+                void M(object o)
+                {
+                    I item = o as C;
+                    [|if|] (item == null)
+                    {
+                        item = o as D;
+                    }
+                }
+            }
+
+            class D : I
+            {
+            }
+            """,
+            FixedCode =
+            """
+            interface I
+            {
+            }
+
+            class C : I
+            {
+                void M(object o)
+                {
+                    I item = (I)(o as C) ?? o as D;
+                }
+            }
+
+            class D : I
+            {
+            }
+            """
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74460")]
+    public async Task TestLocalDeclaration_CastWithoutParenthesizedExpression()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode =
+            """
+            interface I
+            {
+            }
+
+            class C : I
+            {
+                void M(C c, D d)
+                {
+                    I item = c;
+                    [|if|] (item == null)
+                    {
+                        item = d;
+                    }
+                }
+            }
+
+            class D : I
+            {
+            }
+            """,
+            FixedCode =
+            """
+            interface I
+            {
+            }
+
+            class C : I
+            {
+                void M(C c, D d)
+                {
+                    I item = (I)c ?? d;
+                }
+            }
+
+            class D : I
+            {
+            }
+            """
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74460")]
+    public async Task TestLocalDeclaration_NoCastWhenEqualSymbol()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode =
+            """
+            interface I
+            {
+            }
+
+            class C : I
+            {
+                void M(C c1, C c2)
+                {
+                    I item = c1;
+                    [|if|] (item == null)
+                    {
+                        item = c2;
+                    }
+                }
+            }
+            """,
+            FixedCode =
+            """
+            interface I
+            {
+            }
+
+            class C : I
+            {
+                void M(C c1, C c2)
+                {
+                    I item = c1 ?? c2;
+                }
+            }
+            """
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74460")]
+    public async Task TestLocalDeclaration_NoCastWhenDerivedClass()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode =
+            """
+            interface I
+            {
+            }
+
+            class C : I
+            {
+                void M(C c, D d)
+                {
+                    I item = c;
+                    [|if|] (item == null)
+                    {
+                        item = d;
+                    }
+                }
+            }
+
+            class D : C
+            {
+            }
+            """,
+            FixedCode =
+            """
+            interface I
+            {
+            }
+
+            class C : I
+            {
+                void M(C c, D d)
+                {
+                    I item = c ?? d;
+                }
+            }
+
+            class D : C
+            {
+            }
+            """
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74460")]
+    public async Task TestLocalDeclaration_NoCastWhenDerivedClassReversed()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode =
+            """
+            interface I
+            {
+            }
+
+            class C : D
+            {
+                void M(C c, D d)
+                {
+                    I item = c;
+                    [|if|] (item == null)
+                    {
+                        item = d;
+                    }
+                }
+            }
+
+            class D : I
+            {
+            }
+            """,
+            FixedCode =
+            """
+            interface I
+            {
+            }
+
+            class C : D
+            {
+                void M(C c, D d)
+                {
+                    I item = c ?? d;
+                }
+            }
+
+            class D : I
+            {
+            }
+            """
         }.RunAsync();
     }
 }

--- a/src/Analyzers/Core/CodeFixes/CodeFixes.projitems
+++ b/src/Analyzers/Core/CodeFixes/CodeFixes.projitems
@@ -70,7 +70,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SimplifyInterpolation\AbstractSimplifyInterpolationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SimplifyLinqExpression\AbstractSimplifyLinqExpressionCodeFixProvider`3.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UpgradeProject\AbstractUpgradeProjectCodeFixProvider.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\UseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\UseCoalesceExpressionForTernaryConditionalCheckCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\UseCoalesceExpressionForNullableTernaryConditionalCheckCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\AbstractUseCollectionExpressionCodeFixProvider.cs" />

--- a/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
@@ -58,7 +58,12 @@ internal abstract class AbstractUseCoalesceExpressionForIfNullStatementCheckCode
         SyntaxNode TryAddExplicitCast(SyntaxNode expressionToCoalesce, SyntaxNode whenTrueStatement)
         {
             // This can be either SimpleAssignmentStatement or ThrowStatement
-            // We only care about casting in the former case.
+            // We only care about casting in the former case since the two
+            // types being coalesce-d might not be the same and might result in broken
+            // code without the cast.
+            // In the latter case something like
+            // _ = myParameter ?? throw new ArgumentNullException(nameof(myParameter));
+            // will be always valid.
             if (!syntaxFacts.IsSimpleAssignmentStatement(whenTrueStatement))
                 return expressionToCoalesce;
 

--- a/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
@@ -26,11 +26,10 @@ internal abstract class AbstractUseCoalesceExpressionForIfNullStatementCheckCode
         return Task.CompletedTask;
     }
 
-    protected abstract bool ShouldAddExplicitCast(
+    protected virtual ITypeSymbol? TryGetExplicitCast(
         ISyntaxFactsService syntaxFacts, SemanticModel semanticModel,
         SyntaxNode expressionToCoalesce, SyntaxNode whenTrueStatement,
-        [NotNullWhen(true)] out ITypeSymbol? castTo,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken) => null;
 
     protected override async Task FixAllAsync(
         Document document, ImmutableArray<Diagnostic> diagnostics,
@@ -48,8 +47,8 @@ internal abstract class AbstractUseCoalesceExpressionForIfNullStatementCheckCode
 
             var left = expressionToCoalesce.WithoutTrivia();
 
-            if (ShouldAddExplicitCast(syntaxFacts, semanticModel, expressionToCoalesce,
-                whenTrueStatement, out var castTo, cancellationToken))
+            if (TryGetExplicitCast(syntaxFacts, semanticModel, expressionToCoalesce,
+                whenTrueStatement, cancellationToken) is { } castTo)
             {
                 left = generator.CastExpression(castTo, left);
             }

--- a/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.cs
@@ -57,6 +57,8 @@ internal abstract class AbstractUseCoalesceExpressionForIfNullStatementCheckCode
 
         SyntaxNode TryAddExplicitCast(SyntaxNode expressionToCoalesce, SyntaxNode whenTrueStatement)
         {
+            // This can be either SimpleAssignmentStatement or ThrowStatement
+            // We only care about casting in the former case.
             if (!syntaxFacts.IsSimpleAssignmentStatement(whenTrueStatement))
                 return expressionToCoalesce;
 

--- a/src/Analyzers/VisualBasic/CodeFixes/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb
@@ -2,7 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-
 Imports System.Composition
 Imports System.Diagnostics.CodeAnalysis
 Imports System.Threading

--- a/src/Analyzers/VisualBasic/CodeFixes/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb
@@ -20,9 +20,5 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCoalesceExpression
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
         End Sub
-
-        Protected Overrides Function ShouldAddExplicitCast(syntaxFacts As ISyntaxFactsService, semanticModel As SemanticModel, expressionToCoalesce As SyntaxNode, whenTrueStatement As SyntaxNode, <NotNullWhen(True)> ByRef castTo As ITypeSymbol, cancellationToken As CancellationToken) As Boolean
-            Return False
-        End Function
     End Class
 End Namespace

--- a/src/Analyzers/VisualBasic/CodeFixes/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb
@@ -1,0 +1,29 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+
+Imports System.Composition
+Imports System.Diagnostics.CodeAnalysis
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.LanguageService
+Imports Microsoft.CodeAnalysis.UseCoalesceExpression
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseCoalesceExpression
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.UseCoalesceExpressionForIfNullStatementCheck), [Shared]>
+    <ExtensionOrder(Before:=PredefinedCodeFixProviderNames.AddBraces)>
+    Friend Class VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider
+        Inherits AbstractUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+
+        Protected Overrides Function ShouldAddExplicitCast(syntaxFacts As ISyntaxFactsService, semanticModel As SemanticModel, expressionToCoalesce As SyntaxNode, whenTrueStatement As SyntaxNode, <NotNullWhen(True)> ByRef castTo As ITypeSymbol, cancellationToken As CancellationToken) As Boolean
+            Return False
+        End Function
+    End Class
+End Namespace

--- a/src/Analyzers/VisualBasic/CodeFixes/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseCoalesceExpression/VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb
@@ -3,11 +3,8 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Composition
-Imports System.Diagnostics.CodeAnalysis
-Imports System.Threading
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Host.Mef
-Imports Microsoft.CodeAnalysis.LanguageService
 Imports Microsoft.CodeAnalysis.UseCoalesceExpression
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseCoalesceExpression

--- a/src/Analyzers/VisualBasic/CodeFixes/VisualBasicCodeFixes.projitems
+++ b/src/Analyzers/VisualBasic/CodeFixes/VisualBasicCodeFixes.projitems
@@ -50,6 +50,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SimplifyLinqExpression\VisualBasicSimplifyLinqExpressionCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)SimplifyObjectCreation\VisualBasicSimplifyObjectCreationCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UnsealClass\VisualBasicUnsealClassCodeFixProvider.vb" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\VisualBasicUseCoalesceExpressionForIfNullStatementCheckCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\VisualBasicUseCollectionInitializerCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\VisualBasicUseCompoundAssignmentCodeFixProvider.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseConditionalExpression\MultiLineConditionalExpressionFormattingRule.vb" />


### PR DESCRIPTION
This adds an explicit cast to `UseCoalesceExpressionForIfNullStatementCheckCodeFixProvider` (if necessary) to make sure the code fix does not produce broken code.

Whether or not the cast is added depends on the types that are being coalesce-d
1. Two equal types - no cast
2. Two types that are implicitly convertible from one to another - no cast
3. Two different types - explicit cast to final type

As for VisualBasic from what I can tell this cast is completely unnecessary, due to the coalesce expression behaving differently, however I am not an expert so please check if the tests I added are correct.

Closes #74460 