### PR TITLE
Do not parse methods with accessibility modifiers as local functions

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -2485,43 +2485,29 @@ class C
         [Fact]
         public void ForgotSemicolonLocalFunctionsMistake()
         {
-            var src = @"
-class C
-{
-    public void M1()
-    {
-    // forget closing brace
+            var src = """
+                class C
+                {
+                    public void M1()
+                    {
+                    // forget closing brace
 
-    public void BadLocal1()
-    {
-        this.BadLocal2();
-    }
+                    public void BadLocal1()
+                    {
+                        this.BadLocal2();
+                    }
 
-    public void BadLocal2()
-    {
-    }
+                    public void BadLocal2()
+                    {
+                    }
 
-    public int P => 0;
-}";
+                    public int P => 0;
+                }
+                """;
             VerifyDiagnostics(src,
-                // (8,5): error CS0106: The modifier 'public' is not valid for this item
-                //     public void BadLocal1()
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "public").WithArguments("public").WithLocation(8, 5),
-                // (13,5): error CS0106: The modifier 'public' is not valid for this item
-                //     public void BadLocal2()
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "public").WithArguments("public").WithLocation(13, 5),
-                // (15,6): error CS1513: } expected
-                //     }
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(15, 6),
-                // (10,14): error CS1061: 'C' does not contain a definition for 'BadLocal2' and no extension method 'BadLocal2' accepting a first argument of type 'C' could be found (are you missing a using directive or an assembly reference?)
-                //         this.BadLocal2();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "BadLocal2").WithArguments("C", "BadLocal2").WithLocation(10, 14),
-                // (8,17): warning CS8321: The local function 'BadLocal1' is declared but never used
-                //     public void BadLocal1()
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "BadLocal1").WithArguments("BadLocal1").WithLocation(8, 17),
-                // (13,17): warning CS8321: The local function 'BadLocal2' is declared but never used
-                //     public void BadLocal2()
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "BadLocal2").WithArguments("BadLocal2").WithLocation(13, 17));
+                // (5,6): error CS1513: } expected
+                //     {
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(4, 6));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("internal")]
         [InlineData("protected")]
         [InlineData("private")]
+        [WorkItem("https://github.com/dotnet/roslyn/pull/74484")]
         public void AccessibilityModifierErrorRecovery(string accessibility)
         {
             var file = ParseTree($$"""

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -29,45 +29,62 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("private")]
         public void AccessibilityModifierErrorRecovery(string accessibility)
         {
-            var file = ParseTree($@"
-class C
-{{
-    void M()
-    {{
-        // bad visibility modifier
-        {accessibility} void localFunc() {{}}
-    }}
-    void M2()
-    {{
-        typing
-        {accessibility} void localFunc() {{}}
-    }}
-    void M3()
-    {{
-    // Ambiguous between local func with bad modifier and missing closing
-    // brace on previous method. Parsing currently assumes the former,
-    // assuming the tokens are parseable as a local func.
-    {accessibility} void M4() {{}}
-}}");
+            var file = ParseTree($$"""
+                class C
+                {
+                    void M()
+                    {
+                        // bad visibility modifier
+                        {{accessibility}} void localFunc() {}
+                    }
+                    void M2()
+                    {
+                        typing
+                        {{accessibility}} void localFunc() {}
+                    }
+                    void M3()
+                    {
+                    // Ambiguous between local func with bad modifier and missing closing
+                    // brace on previous method. Parsing currently assumes the former,
+                    // assuming the tokens are parseable as a local func.
+                    {{accessibility}} void M4() {}
+                }
+                """);
 
             Assert.NotNull(file);
             file.GetDiagnostics().Verify(
-                // (7,9): error CS0106: The modifier '{accessibility}' is not valid for this item
-                //         {accessibility} void localFunc() {}
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, accessibility).WithArguments(accessibility).WithLocation(7, 9),
-                // (11,15): error CS1002: ; expected
+                // (4,6): error CS1513: } expected
+                //     {
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(4, 6),
+                // (8,5): error CS8803: Top-level statements must precede namespace and type declarations.
+                //     void M2()
+                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, """
+                void M2()
+                    {
+                        typing
+
+                """).WithLocation(8, 5),
+                // (10,15): error CS1002: ; expected
                 //         typing
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(11, 15),
-                // (12,9): error CS0106: The modifier '{accessibility}' is not valid for this item
-                //         {accessibility} void localFunc() {}
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, accessibility).WithArguments(accessibility).WithLocation(12, 9),
-                // (19,5): error CS0106: The modifier '{accessibility}' is not valid for this item
-                //     {accessibility} void M4() {}
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, accessibility).WithArguments(accessibility).WithLocation(19, 5),
-                // (20,2): error CS1513: } expected
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(10, 15),
+                // (10,15): error CS1513: } expected
+                //         typing
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(10, 15),
+                // (11,9): error CS0106: The modifier 'internal' is not valid for this item
+                //         internal void localFunc() {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, $"{accessibility}").WithArguments($"{accessibility}").WithLocation(11, 9),
+                // (12,5): error CS1022: Type or namespace definition, or end-of-file expected
+                //     }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(12, 5),
+                // (14,6): error CS1513: } expected
+                //     {
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(14, 6),
+                // (18,5): error CS0106: The modifier 'internal' is not valid for this item
+                //     internal void M4() {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, $"{accessibility}").WithArguments($"{accessibility}").WithLocation(18, 5),
+                // (19,1): error CS1022: Type or namespace definition, or end-of-file expected
                 // }
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(20, 2)
-                );
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(19, 1));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -3556,21 +3556,19 @@ System.Console.WriteLine(true)";
             Assert.Equal((int)ErrorCode.ERR_SemicolonExpected, statement.Errors()[0].Code);
         }
 
-        [WorkItem(266237, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=266237")]
-        [Fact]
+        [Fact, WorkItem("https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=266237")]
         public void NullExceptionInLabeledStatement()
         {
             UsingStatement(@"{ label: public",
-                // (1,1): error CS1073: Unexpected token 'public'
-                // { label: public
-                Diagnostic(ErrorCode.ERR_UnexpectedToken, "{ label: ").WithArguments("public").WithLocation(1, 1),
                 // (1,10): error CS1002: ; expected
                 // { label: public
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "public").WithLocation(1, 10),
                 // (1,10): error CS1513: } expected
                 // { label: public
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "public").WithLocation(1, 10)
-                );
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "public").WithLocation(1, 10),
+                // (1,16): error CS1513: } expected
+                // { label: public
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 16));
 
             N(SyntaxKind.Block);
             {
@@ -3586,6 +3584,7 @@ System.Console.WriteLine(true)";
                 }
                 M(SyntaxKind.CloseBraceToken);
             }
+            EOF();
             EOF();
         }
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -12598,7 +12598,7 @@ $$
         End Function
 
         <WpfTheory, CombinatorialData>
-        <WorkItem("https://github.com/dotnet/roslyn/issues/72392")>
+        <WorkItem("https://github.com/dotnet/roslyn/pull/74484")>
         Public Async Function ReferenceToMethodThatFollow(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document>

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -12596,5 +12596,29 @@ $$
                 Await state.AssertCompletionItemsContain("System", displayTextSuffix:="")
             End Using
         End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/72392")>
+        Public Async Function ReferenceToMethodThatFollow(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+                class C
+                {
+                    void M()
+                    {
+                        if (true)
+                        {
+                            this.Sw$$
+
+                    private void SwitchColor() { }
+                }
+                </Document>,
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.CSharp12)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertCompletionItemsContain("SwitchColor", displayTextSuffix:="")
+            End Using
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74482