### PR TITLE
Adds support for metadata LSP language features in VSCode

### DIFF
--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/NullResultMetadataAsSourceFileProvider.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/NullResultMetadataAsSourceFileProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
@@ -47,8 +48,9 @@ internal class NullResultMetadataAsSourceFileProvider : IMetadataAsSourceFilePro
         return null;
     }
 
-    public bool TryAddDocumentToWorkspace(MetadataAsSourceWorkspace workspace, string filePath, Text.SourceTextContainer sourceTextContainer)
+    public bool TryAddDocumentToWorkspace(MetadataAsSourceWorkspace workspace, string filePath, Text.SourceTextContainer sourceTextContainer, [NotNullWhen(true)] out DocumentId? documentId)
     {
+        documentId = null!;
         return true;
     }
 

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
@@ -300,7 +300,7 @@ public abstract partial class AbstractMetadataAsSourceTests
             using var reader = File.OpenRead(file.FilePath);
             var stringText = EncodedStringText.Create(reader);
 
-            Assert.True(_metadataAsSourceService.TryAddDocumentToWorkspace(file.FilePath, stringText.Container));
+            Assert.True(_metadataAsSourceService.TryAddDocumentToWorkspace(file.FilePath, stringText.Container, out var _));
 
             return stringText.Container.GetRelatedDocuments().Single();
         }

--- a/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileProvider.cs
@@ -36,16 +36,12 @@ internal interface IMetadataAsSourceFileProvider
     /// <summary>
     /// Called when the file returned from <see cref="GetGeneratedFileAsync"/> needs to be added to the workspace,
     /// to be opened.  Will be called on the main thread of the workspace host.
-    /// 
-    /// Callers of this must guarantee serial access.
     /// </summary>
     bool TryAddDocumentToWorkspace(MetadataAsSourceWorkspace workspace, string filePath, SourceTextContainer sourceTextContainer, [NotNullWhen(true)] out DocumentId? documentId);
 
     /// <summary>
     /// Called when the file is being closed, and so needs to be removed from the workspace.  Will be called on the
     /// main thread of the workspace host.
-    /// 
-    /// Callers of this must guarantee serial access.
     /// </summary>
     bool TryRemoveDocumentFromWorkspace(MetadataAsSourceWorkspace workspace, string filePath);
 

--- a/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
@@ -35,12 +36,16 @@ internal interface IMetadataAsSourceFileProvider
     /// <summary>
     /// Called when the file returned from <see cref="GetGeneratedFileAsync"/> needs to be added to the workspace,
     /// to be opened.  Will be called on the main thread of the workspace host.
+    /// 
+    /// Callers of this must guarantee serial access.
     /// </summary>
-    bool TryAddDocumentToWorkspace(MetadataAsSourceWorkspace workspace, string filePath, SourceTextContainer sourceTextContainer);
+    bool TryAddDocumentToWorkspace(MetadataAsSourceWorkspace workspace, string filePath, SourceTextContainer sourceTextContainer, [NotNullWhen(true)] out DocumentId? documentId);
 
     /// <summary>
     /// Called when the file is being closed, and so needs to be removed from the workspace.  Will be called on the
     /// main thread of the workspace host.
+    /// 
+    /// Callers of this must guarantee serial access.
     /// </summary>
     bool TryRemoveDocumentFromWorkspace(MetadataAsSourceWorkspace workspace, string filePath);
 

--- a/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
@@ -31,8 +32,16 @@ internal interface IMetadataAsSourceFileService
         MetadataAsSourceOptions options,
         CancellationToken cancellationToken);
 
-    bool TryAddDocumentToWorkspace(string filePath, SourceTextContainer buffer);
+    /// <summary>
+    /// Checks if the given file path is a metadata as source file and adds to the metadata workspace if it is.
+    /// Callers must ensure this is only called serially.
+    /// </summary>
+    bool TryAddDocumentToWorkspace(string filePath, SourceTextContainer sourceTextContainer, [NotNullWhen(true)] out DocumentId? documentId);
 
+    /// <summary>
+    /// Checks if the given file path is a metadata as source file and removes from the metadata workspace if it is.
+    /// Callers must ensure this is only called serially.
+    /// </summary>
     bool TryRemoveDocumentFromWorkspace(string filePath);
 
     bool IsNavigableMetadataSymbol(ISymbol symbol);

--- a/src/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             // those cases, we do not need to add an additional workspace to manage new files we hear about.  So only
             // add the LspMiscellaneousFilesWorkspace for hosts that have not already brought their own.
             if (serverKind == WellKnownLspServerKinds.CSharpVisualBasicLspServer)
-                AddLazyService<LspMiscellaneousFilesWorkspace>(lspServices => new LspMiscellaneousFilesWorkspace(lspServices, hostServices));
+                AddLazyService<LspMiscellaneousFilesWorkspace>(lspServices => lspServices.GetRequiredService<LspMiscellaneousFilesWorkspaceProvider>().CreateLspMiscellaneousFilesWorkspace(lspServices, hostServices));
 
             return baseServiceMap.ToFrozenDictionary(
                 keySelector: kvp => kvp.Key,

--- a/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspace.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspace.cs
@@ -74,10 +74,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// Calls to this method and <see cref="AddMiscellaneousDocument(Uri, SourceText, string, ILspLogger)"/> are made
         /// from LSP text sync request handling which do not run concurrently.
         /// </summary>
-        public void TryRemoveMiscellaneousDocument(Uri uri, bool removeFromMetadata)
+        public void TryRemoveMiscellaneousDocument(Uri uri, bool removeFromMetadataWorkspace)
         {
             var documentFilePath = ProtocolConversions.GetDocumentFilePathFromUri(uri);
-            if (removeFromMetadata && metadataAsSourceFileService.TryRemoveDocumentFromWorkspace(documentFilePath))
+            if (removeFromMetadataWorkspace && metadataAsSourceFileService.TryRemoveDocumentFromWorkspace(documentFilePath))
             {
                 return;
             }

--- a/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer;
 [ExportCSharpVisualBasicStatelessLspService(typeof(LspMiscellaneousFilesWorkspaceProvider)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal class LspMiscellaneousFilesWorkspaceProvider(IMetadataAsSourceFileService metadataAsSourceFileService) : ILspService
+internal sealed class LspMiscellaneousFilesWorkspaceProvider(IMetadataAsSourceFileService metadataAsSourceFileService) : ILspService
 {
     public LspMiscellaneousFilesWorkspace CreateLspMiscellaneousFilesWorkspace(ILspServices lspServices, HostServices hostServices)
     {

--- a/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspaceProvider.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.MetadataAsSource;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+
+namespace Microsoft.CodeAnalysis.LanguageServer;
+
+/// <summary>
+/// Service to create <see cref="LspWorkspaceManager"/> instances.
+/// This is not exported as a <see cref="ILspServiceFactory"/> as it requires
+/// special base language server dependencies such as the <see cref="HostServices"/>
+/// </summary>
+[ExportCSharpVisualBasicStatelessLspService(typeof(LspMiscellaneousFilesWorkspaceProvider)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class LspMiscellaneousFilesWorkspaceProvider(IMetadataAsSourceFileService metadataAsSourceFileService) : ILspService
+{
+    public LspMiscellaneousFilesWorkspace CreateLspMiscellaneousFilesWorkspace(ILspServices lspServices, HostServices hostServices)
+    {
+        return new LspMiscellaneousFilesWorkspace(lspServices, metadataAsSourceFileService, hostServices);
+    }
+}

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -146,7 +146,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         _cachedLspSolutions.Clear();
 
         // Also remove it from our loose files or metadata workspace if it is still there.
-        _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri, removeFromMetadata: true);
+        _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri, removeFromMetadataWorkspace: true);
 
         LspTextChanged?.Invoke(this, EventArgs.Empty);
 
@@ -238,8 +238,10 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 // As we found the document in a non-misc workspace, also attempt to remove it from the misc workspace
                 // if it happens to be in there as well.
                 if (workspace != _lspMiscellaneousFilesWorkspace)
+                {
                     // Do not attempt to remove the file from the metadata workspace (the document is still open).
-                    _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri, removeFromMetadata: false);
+                    _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri, removeFromMetadataWorkspace: false);
+                }
 
                 return (workspace, document.Project.Solution, document);
             }

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -256,7 +256,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         {
             var miscDocument = _lspMiscellaneousFilesWorkspace?.AddMiscellaneousDocument(uri, trackedDocument.Text, trackedDocument.LanguageId, _logger);
             if (miscDocument is not null)
-                return (_lspMiscellaneousFilesWorkspace, miscDocument.Project.Solution, miscDocument);
+                return (miscDocument.Project.Solution.Workspace, miscDocument.Project.Solution, miscDocument);
         }
 
         return default;

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -145,8 +145,8 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         // If LSP changed, we need to compare against the workspace again to get the updated solution.
         _cachedLspSolutions.Clear();
 
-        // Also remove it from our loose files workspace if it is still there.
-        _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri);
+        // Also remove it from our loose files or metadata workspace if it is still there.
+        _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri, removeFromMetadata: true);
 
         LspTextChanged?.Invoke(this, EventArgs.Empty);
 
@@ -238,7 +238,8 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 // As we found the document in a non-misc workspace, also attempt to remove it from the misc workspace
                 // if it happens to be in there as well.
                 if (workspace != _lspMiscellaneousFilesWorkspace)
-                    _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri);
+                    // Do not attempt to remove the file from the metadata workspace (the document is still open).
+                    _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri, removeFromMetadata: false);
 
                 return (workspace, document.Project.Solution, document);
             }

--- a/src/LanguageServer/ProtocolUnitTests/Metadata/LspMetadataAsSourceWorkspaceTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Metadata/LspMetadataAsSourceWorkspaceTests.cs
@@ -15,7 +15,7 @@ using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Metadata;
 
-public class LspMetadataAsSourceWorkspaceTests : AbstractLanguageServerProtocolTests
+public sealed class LspMetadataAsSourceWorkspaceTests : AbstractLanguageServerProtocolTests
 {
     public LspMetadataAsSourceWorkspaceTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {

--- a/src/LanguageServer/ProtocolUnitTests/Metadata/LspMetadataAsSourceWorkspaceTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Metadata/LspMetadataAsSourceWorkspaceTests.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.MetadataAsSource;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Metadata;
+
+public class LspMetadataAsSourceWorkspaceTests : AbstractLanguageServerProtocolTests
+{
+    public LspMetadataAsSourceWorkspaceTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestMetadataFile_OpenClosed(bool mutatingLspWorkspace)
+    {
+        var source =
+            """
+            using System;
+            class A
+            {
+                void M()
+                {
+                    Console.{|definition:WriteLine|}("Hello, World!");
+                }
+            }
+            """;
+
+        // Create a server with LSP misc file workspace and metadata service.
+        await using var testLspServer = await CreateTestLspServerAsync(source, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+        // Get the metadata definition.
+        var location = testLspServer.GetLocations("definition").Single();
+        var definition = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Location[]>(LSP.Methods.TextDocumentDefinitionName,
+                           CreateTextDocumentPositionParams(location), CancellationToken.None);
+
+        // Open the metadata file and verify it gets added to the metadata workspace.
+        await testLspServer.OpenDocumentAsync(definition.Single().Uri, text: string.Empty).ConfigureAwait(false);
+
+        Assert.Equal(WorkspaceKind.MetadataAsSource, (await GetWorkspaceForDocument(testLspServer, definition.Single().Uri)).Kind);
+        AssertMiscFileWorkspaceEmpty(testLspServer);
+
+        // Close the metadata file and verify it gets removed from the metadata workspace.
+        await testLspServer.CloseDocumentAsync(definition.Single().Uri).ConfigureAwait(false);
+
+        AssertMetadataFileWorkspaceEmpty(testLspServer);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestMetadataFile_LanguageFeatures(bool mutatingLspWorkspace)
+    {
+        var source =
+            """
+            using System;
+            class A
+            {
+                void M()
+                {
+                    Console.{|definition:WriteLine|}("Hello, World!");
+                }
+            }
+            """;
+
+        var metadataSource =
+            """
+            namespace System
+            {
+                public class Console
+                {
+                    public static void WriteLine(string value) {}
+                }
+            }
+            """;
+
+        // Create a server with LSP misc file workspace and metadata service.
+        await using var testLspServer = await CreateTestLspServerAsync(source, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+        // Get the metadata definition.
+        var location = testLspServer.GetLocations("definition").Single();
+        var definition = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Location[]>(LSP.Methods.TextDocumentDefinitionName,
+                           CreateTextDocumentPositionParams(location), CancellationToken.None);
+
+        // Open the metadata file and verify it gets added to the metadata workspace.
+        // We don't have the real metadata source, so just populate it with our fake metadata source.
+        await testLspServer.OpenDocumentAsync(definition.Single().Uri, text: metadataSource).ConfigureAwait(false);
+        var workspaceForDocument = await GetWorkspaceForDocument(testLspServer, definition.Single().Uri);
+        Assert.Equal(WorkspaceKind.MetadataAsSource, workspaceForDocument.Kind);
+        AssertMiscFileWorkspaceEmpty(testLspServer);
+
+        // Manually register the workspace for followup requests - the workspace event listener that
+        //  normally registers it on creation is not running in test code.
+        testLspServer.TestWorkspace.ExportProvider.GetExportedValue<LspWorkspaceRegistrationService>().Register(workspaceForDocument);
+
+        var locationOfStringKeyword = new LSP.Location
+        {
+            Uri = definition.Single().Uri,
+            Range = new LSP.Range
+            {
+                Start = new LSP.Position { Line = 4, Character = 40 },
+                End = new LSP.Position { Line = 4, Character = 40 }
+            }
+        };
+
+        var definitionFromMetadata = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Location[]>(LSP.Methods.TextDocumentDefinitionName,
+                           CreateTextDocumentPositionParams(locationOfStringKeyword), CancellationToken.None);
+
+        Assert.NotEmpty(definitionFromMetadata);
+        Assert.Contains("String.cs", definitionFromMetadata.Single().Uri.LocalPath);
+    }
+
+    private static async Task<Workspace> GetWorkspaceForDocument(TestLspServer testLspServer, Uri fileUri)
+    {
+        var (lspWorkspace, _, _) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = fileUri }, CancellationToken.None);
+        return lspWorkspace!;
+    }
+
+    private static void AssertMiscFileWorkspaceEmpty(TestLspServer testLspServer)
+    {
+        var doc = testLspServer.GetManagerAccessor().GetLspMiscellaneousFilesWorkspace()!.CurrentSolution.Projects.SingleOrDefault()?.Documents.SingleOrDefault();
+        Assert.Null(doc);
+    }
+
+    private static void AssertMetadataFileWorkspaceEmpty(TestLspServer testLspServer)
+    {
+        var provider = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IMetadataAsSourceFileService>();
+        var metadataDocument = provider.TryGetWorkspace()?.CurrentSolution.Projects.SingleOrDefault()?.Documents.SingleOrDefault();
+        Assert.Null(metadataDocument);
+    }
+}

--- a/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -259,7 +259,7 @@ internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IOpenText
     {
         _threadingContext.ThrowIfNotOnUIThread();
 
-        if (_fileTrackingMetadataAsSourceService.TryAddDocumentToWorkspace(moniker, textBuffer.AsTextContainer()))
+        if (_fileTrackingMetadataAsSourceService.TryAddDocumentToWorkspace(moniker, textBuffer.AsTextContainer(), out var _))
         {
             // We already added it, so we will keep it excluded from the misc files workspace
             return;


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/5787

In VS, the VS misc workspace delegates to the MetadataAsSource workspace to open the file if it recognizes a metadata file.  This was not happening in VSCode because we do not use the VS misc workspace.  So files would get generated, but never added to the MetadataAsSource workspace.

Instead, I added similar functionality to the LSP misc files workspace (to add/remove from MetadataAsSource if a metadata file is opened/closed).

![metadata_lang_features](https://github.com/user-attachments/assets/bbb089a0-fb46-4337-9040-1300ceacdf32)
