### PR TITLE
Fix nested nullability of collection expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -69,6 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             HashSet<TypeSymbol> candidateTypes = new HashSet<TypeSymbol>(comparer);
             foreach (BoundExpression expr in exprs)
             {
+                Debug.Assert(!NullableWalker.IsTargetTypedExpression(expr));
                 TypeSymbol? type = expr.GetTypeOrFunctionType();
 
                 if (type is { })
@@ -132,9 +133,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             try
             {
                 var conversionsWithoutNullability = conversions.WithNullability(false);
-                TypeSymbol? type1 = expr1.Type;
 
-                if (type1 is { })
+                Debug.Assert(!NullableWalker.IsTargetTypedExpression(expr1));
+                if (expr1.Type is { } type1)
                 {
                     if (type1.IsErrorType())
                     {
@@ -148,9 +149,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                TypeSymbol? type2 = expr2.Type;
-
-                if (type2 is { })
+                Debug.Assert(!NullableWalker.IsTargetTypedExpression(expr1));
+                if (expr2.Type is { } type2)
                 {
                     if (type2.IsErrorType())
                     {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9317,10 +9317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             while (conversionOpt != null && conversionOpt != convertedNode)
             {
                 Debug.Assert(conversionOpt.ConversionGroupOpt == conversionGroup);
-                if (!visitResult.LValueType.Type.Equals(conversionOpt.Type, TypeCompareKind.AllNullableIgnoreOptions))
-                {
-                    // visitResult = withType(visitResult, conversionOpt.Type);
-                }
+                Debug.Assert(resultType.Type.Equals.Equals(conversionOpt.Type, TypeCompareKind.AllNullableIgnoreOptions));
                 SetAnalyzedNullability(conversionOpt, visitResult);
                 conversionOpt = conversionOpt.Operand as BoundConversion;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9317,7 +9317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             while (conversionOpt != null && conversionOpt != convertedNode)
             {
                 Debug.Assert(conversionOpt.ConversionGroupOpt == conversionGroup);
-                Debug.Assert(resultType.Type.Equals.Equals(conversionOpt.Type, TypeCompareKind.AllNullableIgnoreOptions));
+                Debug.Assert(resultType.Type.Equals(conversionOpt.Type, TypeCompareKind.AllNullableIgnoreOptions));
                 SetAnalyzedNullability(conversionOpt, visitResult);
                 conversionOpt = conversionOpt.Operand as BoundConversion;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9317,7 +9317,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             while (conversionOpt != null && conversionOpt != convertedNode)
             {
                 Debug.Assert(conversionOpt.ConversionGroupOpt == conversionGroup);
-                // TODO2: what does it mean for these types to differ? Why is it correct to copy over the top-level nullability when the types have differences beyond nullability?
                 if (!visitResult.LValueType.Type.Equals(conversionOpt.Type, TypeCompareKind.AllNullableIgnoreOptions))
                 {
                     visitResult = withType(visitResult, conversionOpt.Type);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9319,15 +9319,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(conversionOpt.ConversionGroupOpt == conversionGroup);
                 if (!visitResult.LValueType.Type.Equals(conversionOpt.Type, TypeCompareKind.AllNullableIgnoreOptions))
                 {
-                    visitResult = withType(visitResult, conversionOpt.Type);
+                    // visitResult = withType(visitResult, conversionOpt.Type);
                 }
                 SetAnalyzedNullability(conversionOpt, visitResult);
                 conversionOpt = conversionOpt.Operand as BoundConversion;
             }
 
-            static VisitResult withType(VisitResult visitResult, TypeSymbol newType) =>
-                new VisitResult(TypeWithState.Create(newType, visitResult.RValueType.State),
-                                TypeWithAnnotations.Create(newType, visitResult.LValueType.NullableAnnotation));
+            // static VisitResult withType(VisitResult visitResult, TypeSymbol newType) =>
+            //     new VisitResult(TypeWithState.Create(newType, visitResult.RValueType.State),
+            //                     TypeWithAnnotations.Create(newType, visitResult.LValueType.NullableAnnotation));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9317,7 +9317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             while (conversionOpt != null && conversionOpt != convertedNode)
             {
                 Debug.Assert(conversionOpt.ConversionGroupOpt == conversionGroup);
-                Debug.Assert(resultType.Type.Equals(conversionOpt.Type, TypeCompareKind.AllNullableIgnoreOptions));
+                Debug.Assert(conversionOpt.Type.Equals(resultType.Type, TypeCompareKind.AllNullableIgnoreOptions));
                 SetAnalyzedNullability(conversionOpt, visitResult);
                 conversionOpt = conversionOpt.Operand as BoundConversion;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4613,11 +4613,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var (returnExpr, resultType, _) = returns[i];
                 resultTypes.Add(resultType);
-
-                if (!IsTargetTypedExpression(returnExpr))
-                {
-                    placeholdersBuilder.Add(CreatePlaceholderIfNecessary(returnExpr, resultType));
-                }
+                placeholdersBuilder.Add(CreatePlaceholderIfNecessary(returnExpr, resultType));
             }
 
             var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9317,14 +9317,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             while (conversionOpt != null && conversionOpt != convertedNode)
             {
                 Debug.Assert(conversionOpt.ConversionGroupOpt == conversionGroup);
-                Debug.Assert(conversionOpt.Type.Equals(resultType.Type, TypeCompareKind.AllNullableIgnoreOptions));
+
+                // https://github.com/dotnet/roslyn/issues/35046
+                // SetAnalyzedNullability will drop the type if the visitResult.RValueType.Type differs from conversionOpt.Type.
+                // (It will use the top-level nullability from visitResult, though.)
+                //
+                // Here, the visitResult represents the result of visiting the operand.
+                // Ideally, we would use the visitResult to reinfer the types of the containing conversions, and store those results here.
                 SetAnalyzedNullability(conversionOpt, visitResult);
+
                 conversionOpt = conversionOpt.Operand as BoundConversion;
             }
-
-            // static VisitResult withType(VisitResult visitResult, TypeSymbol newType) =>
-            //     new VisitResult(TypeWithState.Create(newType, visitResult.RValueType.State),
-            //                     TypeWithAnnotations.Create(newType, visitResult.LValueType.NullableAnnotation));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -898,8 +898,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 resultTypes.Add(armType);
                 Join(ref endState, ref this.State);
 
-                // Build placeholders for inference in order to preserve annotations.
-                placeholderBuilder.Add(CreatePlaceholderIfNecessary(expression, armType.ToTypeWithAnnotations(compilation)));
+                if (!IsTargetTypedExpression(expression))
+                {
+                    // Build placeholders for inference in order to preserve annotations.
+                    placeholderBuilder.Add(CreatePlaceholderIfNecessary(expression, armType.ToTypeWithAnnotations(compilation)));
+                }
             }
 
             SetState(endState);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -5501,7 +5501,22 @@ class C
                 """;
 
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics();
+            comp.VerifyEmitDiagnostics(
+                // (9,16): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         x[0] = null; // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 16),
+                // (21,16): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         x[0] = null; // 3
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(21, 16),
+                // (27,16): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         x[0] = null; // 4
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(27, 16),
+                // (35,16): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         x[0] = null; // 5
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(35, 16),
+                // (41,16): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         x[0] = null; // 6
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(41, 16));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -5261,6 +5261,29 @@ class C
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71522")]
+        public void CollectionExpression_NestedNullability_01_RhsTargetTyped()
+        {
+            var source = """
+                #nullable enable
+
+                var b = false;
+                var arr = b ? new[] { "1" } : ["2"];
+                """;
+
+            var comp = CreateCompilation(source);
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var root = tree.GetRoot();
+            var collectionExpr = root.DescendantNodes().OfType<CollectionExpressionSyntax>().Single();
+            var typeInfo = model.GetTypeInfo(collectionExpr);
+            var type = (IArrayTypeSymbol)typeInfo.ConvertedType;
+            Assert.Equal("System.String[]", type.ToTestDisplayString());
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, type.NullableAnnotation);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, type.ElementNullableAnnotation);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71522")]
         public void CollectionExpression_NestedNullability_02()
         {
             var source = """


### PR DESCRIPTION
Closes #71522

Adjust NullableWalker to stop passing target-typed expressions to BestTypeInferrer. This was causing the converted collection-expr's type from initial binding to sneak into the nullable best type analysis, causing some NotAnnotated annotations to get replaced with Oblivious in the array element case.

Also adjust BestTypeInferrer to expect that target-typed expressions are not passed to it. It doesn't make sense for a target-typed expression to participate in best-type. Target-typed expressions should only be converted to the resulting best-type, not have their type used as input to best-type analysis.
