### PR TITLE
Reduce Roslyn packages impact on UI thread

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -69,8 +69,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 this.RegisterService<ICSharpTempPECompilerService>(async ct =>
                 {
                     var workspace = this.ComponentModel.GetService<VisualStudioWorkspace>();
+                    var metadataService = workspace.Services.GetService<IMetadataService>();
+
                     await JoinableTaskFactory.SwitchToMainThreadAsync(ct);
-                    return new TempPECompilerService(workspace.Services.GetService<IMetadataService>());
+                    return new TempPECompilerService(metadataService);
                 });
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, ErrorSeverity.General))

--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -65,7 +65,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             try
             {
                 await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
-                await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
                 this.RegisterService<ICSharpTempPECompilerService>(async ct =>
                 {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -27,8 +27,6 @@ internal abstract class AbstractPackage : AsyncPackage
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
-        await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
-
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         _componentModel_doNotAccessDirectly = (IComponentModel)await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(true);

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -27,8 +27,6 @@ internal abstract class AbstractPackage : AsyncPackage
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
-        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
         _componentModel_doNotAccessDirectly = (IComponentModel)await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(true);
         Assumes.Present(_componentModel_doNotAccessDirectly);
     }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -147,8 +147,6 @@ internal sealed class RoslynPackage : AbstractPackage
 
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-        cancellationToken.ThrowIfCancellationRequested();
-
         // Ensure the options persisters are loaded since we have to fetch options from the shell
         LoadOptionPersistersAsync(this.ComponentModel, cancellationToken).Forget();
 

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -68,7 +68,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         Protected Overrides Async Function InitializeAsync(cancellationToken As CancellationToken, progress As IProgress(Of ServiceProgressData)) As Task
             Try
                 Await MyBase.InitializeAsync(cancellationToken, progress).ConfigureAwait(True)
-                Await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken)
 
                 RegisterLanguageService(GetType(IVbCompilerService), Function() Task.FromResult(_comAggregate))
 


### PR DESCRIPTION
Based on our UI and hang data, Roslyn's packages are one the most expensive packages during solution load. This is an attempt at moving as much as posssible of the Roslyn packages to a background thread, removing unnecessarily UI thread dependencies. This is entirely untested - and I expect to run this through a full insertion before merge.