### PR TITLE
Don't try and add the result diagnostics if they are default or empty

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.RegularCompilationTracker.cs
@@ -872,7 +872,7 @@ namespace Microsoft.CodeAnalysis
 
                 foreach (var result in driverRunResult.Results)
                 {
-                    if (!IsGeneratorRunResultToIgnore(result))
+                    if (!result.Diagnostics.IsDefaultOrEmpty && !IsGeneratorRunResultToIgnore(result))
                     {
                         builder.AddRange(result.Diagnostics);
                     }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2152389 
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2170891

This is a trivial fix and follow up from https://github.com/dotnet/roslyn/pull/74034

Don't know the IDE code well enough to craft a test to cover this though