### PR TITLE
Avoid assert in emit layer when intercepted call implicitly captures receiver to temp

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -138,6 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref BoundExpression? receiverOpt,
             ref ImmutableArray<BoundExpression> arguments,
             ref ImmutableArray<RefKind> argumentRefKindsOpt,
+            ref ArrayBuilder<LocalSymbol> temps,
             bool invokedAsExtensionMethod,
             Syntax.SimpleNameSyntax? nameSyntax)
         {
@@ -281,11 +282,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                     || (!receiverOpt.Type.IsReferenceType && interceptor.Parameters[0].Type.IsReferenceType));
                 receiverOpt = MakeConversionNode(receiverOpt, interceptor.Parameters[0].Type, @checked: false, markAsChecked: true);
 
+                var thisRefKind = methodThisParameter.RefKind;
+                // Instance call receivers can be implicitly captured to temps in the emit layer, but not static call arguments
+                // Therefore we may need to explicitly store the receiver to temp here.
+                if (thisRefKind != RefKind.None
+                    && !Binder.HasHome(
+                        receiverOpt,
+                        thisRefKind == RefKind.Ref ? Binder.AddressKind.Writeable : Binder.AddressKind.ReadOnlyStrict,
+                        _factory.CurrentFunction,
+                        peVerifyCompatEnabled: false,
+                        stackLocalsOpt: null))
+                {
+                    var receiverTemp = _factory.StoreToTemp(receiverOpt, out var assignmentToTemp);
+                    temps.Add(receiverTemp.LocalSymbol);
+                    receiverOpt = _factory.Sequence(locals: [], sideEffects: [assignmentToTemp], receiverTemp);
+                }
+
                 arguments = arguments.Insert(0, receiverOpt);
                 receiverOpt = null;
 
                 // CodeGenerator.EmitArguments requires that we have a fully-filled-out argumentRefKindsOpt for any ref/in/out arguments.
-                var thisRefKind = methodThisParameter.RefKind;
                 if (argumentRefKindsOpt.IsDefault && thisRefKind != RefKind.None)
                 {
                     argumentRefKindsOpt = method.Parameters.SelectAsArray(static param => param.RefKind);
@@ -401,7 +417,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ref temps,
                     invokedAsExtensionMethod);
 
-                InterceptCallAndAdjustArguments(ref method, ref rewrittenReceiver, ref rewrittenArguments, ref argRefKindsOpt, invokedAsExtensionMethod, node.InterceptableNameSyntax);
+                InterceptCallAndAdjustArguments(ref method, ref rewrittenReceiver, ref rewrittenArguments, ref argRefKindsOpt, ref temps, invokedAsExtensionMethod, node.InterceptableNameSyntax);
 
                 if (Instrument)
                 {


### PR DESCRIPTION
Closes #71657

Extracted from #74363. This part of the change I feel confident is one we should be making. The other part I want to revisit and PR separately.

This PR is preserving an already-shipped behavior without changing it. It is just changing the exact way we get that behavior by adding the temp in lowering, when we know we are in the specific situation we want to permit, rather than in the more general code path in emit, which was tripping a debug assertion.
