### PR TITLE
Include InterpolatedString conversions in standard implicit conversion from expression assert

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -671,9 +671,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 }
 
-                // See comment in ClassifyStandardImplicitConversion(BoundExpression, ...)
-                // where the set of standard implicit conversions is extended from the spec
-                // to include conversions from expression.
                 switch (kind)
                 {
                     case ConversionKind.NullLiteral:
@@ -686,6 +683,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case ConversionKind.StackAllocToPointerType:
                     case ConversionKind.StackAllocToSpanType:
                     case ConversionKind.InlineArray:
+                    case ConversionKind.InterpolatedString:
                         return true;
                     default:
                         return false;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -580,34 +580,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Conversion.NoConversion;
         }
 
-        private static bool IsStandardImplicitConversionFromExpression(ConversionKind kind)
-        {
-            if (IsStandardImplicitConversionFromType(kind))
-            {
-                return true;
-            }
-
-            // See comment in ClassifyStandardImplicitConversion(BoundExpression, ...)
-            // where the set of standard implicit conversions is extended from the spec
-            // to include conversions from expression.
-            switch (kind)
-            {
-                case ConversionKind.NullLiteral:
-                case ConversionKind.AnonymousFunction:
-                case ConversionKind.MethodGroup:
-                case ConversionKind.ImplicitEnumeration:
-                case ConversionKind.ImplicitDynamic:
-                case ConversionKind.ImplicitNullToPointer:
-                case ConversionKind.ImplicitTupleLiteral:
-                case ConversionKind.StackAllocToPointerType:
-                case ConversionKind.StackAllocToSpanType:
-                case ConversionKind.InlineArray:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
         // See https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/conversions.md#1042-standard-implicit-conversions:
         // "The standard conversions are those pre-defined conversions that can occur as part of a user-defined conversion."
         private static bool IsStandardImplicitConversionFromType(ConversionKind kind)
@@ -671,7 +643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 !conversion.IsInterpolatedStringHandler &&
                 !isImplicitCollectionExpressionConversion(conversion))
             {
-                Debug.Assert(IsStandardImplicitConversionFromExpression(conversion.Kind));
+                Debug.Assert(isStandardImplicitConversionFromExpression(conversion.Kind));
                 return conversion;
             }
 
@@ -690,6 +662,34 @@ namespace Microsoft.CodeAnalysis.CSharp
                     { Kind: ConversionKind.ImplicitNullable, UnderlyingConversions: [{ Kind: ConversionKind.CollectionExpression }] } => true,
                     _ => false,
                 };
+            }
+
+            static bool isStandardImplicitConversionFromExpression(ConversionKind kind)
+            {
+                if (IsStandardImplicitConversionFromType(kind))
+                {
+                    return true;
+                }
+
+                // See comment in ClassifyStandardImplicitConversion(BoundExpression, ...)
+                // where the set of standard implicit conversions is extended from the spec
+                // to include conversions from expression.
+                switch (kind)
+                {
+                    case ConversionKind.NullLiteral:
+                    case ConversionKind.AnonymousFunction:
+                    case ConversionKind.MethodGroup:
+                    case ConversionKind.ImplicitEnumeration:
+                    case ConversionKind.ImplicitDynamic:
+                    case ConversionKind.ImplicitNullToPointer:
+                    case ConversionKind.ImplicitTupleLiteral:
+                    case ConversionKind.StackAllocToPointerType:
+                    case ConversionKind.StackAllocToSpanType:
+                    case ConversionKind.InlineArray:
+                        return true;
+                    default:
+                        return false;
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -18917,7 +18917,7 @@ literal:literal
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74427")]
         public void InterpolatedStringAsInputToUserDefinedConversion_01()
         {
-            var source = $$"""
+            var source = """
                 class C
                 {
                     static void Main()
@@ -18950,12 +18950,12 @@ literal:literal
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74427")]
         public void InterpolatedStringAsInputToUserDefinedConversion_02()
         {
-            var source = $$"""
+            var source = """
                 class C
                 {
                     static void Main()
                     {
-                        var y = (C1)$"dog"; // works
+                        var y = (C1)$"dog";
                         System.Console.WriteLine(y);
                     }
                 }


### PR DESCRIPTION
We extend the spec to replicate native compiler bugs for implicit conversions from expression; FormattableString is one that we've long included, but haven't actually tested, apparently. Commit 1 is a copy/paste to move a regular function to a local function. Commit 2 is the actual change. Fixes https://github.com/dotnet/roslyn/issues/74427. 