### PR TITLE
Fix URI handling when comparing encoded and unencoded URIs

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -42,7 +42,7 @@ namespace Roslyn.Test.Utilities
     [UseExportProvider]
     public abstract partial class AbstractLanguageServerProtocolTests
     {
-        private static readonly SystemTextJsonFormatter s_messageFormatter = RoslynLanguageServer.CreateJsonMessageFormatter();
+        protected static readonly JsonSerializerOptions JsonSerializerOptions = RoslynLanguageServer.CreateJsonMessageFormatter().JsonSerializerOptions;
 
         private protected readonly AbstractLspLogger TestOutputLspLogger;
         protected AbstractLanguageServerProtocolTests(ITestOutputHelper? testOutputHelper)
@@ -124,8 +124,8 @@ namespace Roslyn.Test.Utilities
         /// <param name="actual">the actual object to be converted to JSON.</param>
         public static void AssertJsonEquals<T1, T2>(T1 expected, T2 actual)
         {
-            var expectedStr = JsonSerializer.Serialize(expected, s_messageFormatter.JsonSerializerOptions);
-            var actualStr = JsonSerializer.Serialize(actual, s_messageFormatter.JsonSerializerOptions);
+            var expectedStr = JsonSerializer.Serialize(expected, JsonSerializerOptions);
+            var actualStr = JsonSerializer.Serialize(actual, JsonSerializerOptions);
             AssertEqualIgnoringWhitespace(expectedStr, actualStr);
         }
 
@@ -269,7 +269,7 @@ namespace Roslyn.Test.Utilities
                 SortText = sortText,
                 InsertTextFormat = LSP.InsertTextFormat.Plaintext,
                 Kind = kind,
-                Data = JsonSerializer.SerializeToElement(new CompletionResolveData(resultId, ProtocolConversions.DocumentToTextDocumentIdentifier(document)), s_messageFormatter.JsonSerializerOptions),
+                Data = JsonSerializer.SerializeToElement(new CompletionResolveData(resultId, ProtocolConversions.DocumentToTextDocumentIdentifier(document)), JsonSerializerOptions),
                 Preselect = preselect,
                 VsResolveTextEditOnCommit = vsResolveTextEditOnCommit,
                 LabelDetails = labelDetails
@@ -640,6 +640,11 @@ namespace Roslyn.Test.Utilities
             public Task ExecuteNotification0Async(string methodName)
             {
                 return _clientRpc.NotifyWithParameterObjectAsync(methodName);
+            }
+
+            public Task ExecutePreSerializedRequestAsync(string methodName, JsonDocument serializedRequest)
+            {
+                return _clientRpc.InvokeWithParameterObjectAsync(methodName, serializedRequest);
             }
 
             public async Task OpenDocumentAsync(Uri documentUri, string? text = null, string languageId = "")

--- a/src/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -3,9 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Composition;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,6 +24,8 @@ public class UriTests : AbstractLanguageServerProtocolTests
     public UriTests(ITestOutputHelper? testOutputHelper) : base(testOutputHelper)
     {
     }
+
+    protected override TestComposition Composition => base.Composition.AddParts(typeof(CustomResolveHandler));
 
     [Theory, CombinatorialData]
     [WorkItem("https://github.com/dotnet/runtime/issues/89538")]
@@ -149,5 +158,75 @@ public class UriTests : AbstractLanguageServerProtocolTests
         var gitText = await gitDocument.GetTextAsync();
         Assert.Equal(gitDocumentUri, gitDocument.GetURI());
         Assert.Equal(gitDocumentText, gitText.ToString());
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestFindsExistingDocumentWhenUriHasDifferentEncodingAsync(bool mutatingLspWorkspace)
+    {
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+        // Execute the request as JSON directly to avoid the test client serializing System.Uri using the encoded Uri to send to the server.
+        var requestJson = """
+            {
+                "textDocument": {
+                    "uri": "git:/c:/Users/dabarbet/source/repos/ConsoleApp10/ConsoleApp10/Program.cs?{{\"path\":\"c:\\\\Users\\\\dabarbet\\\\source\\\\repos\\\\ConsoleApp10\\\\ConsoleApp10\\\\Program.cs\",\"ref\":\"~\"}}",
+                    "languageId": "csharp",
+                    "text": "LSP text"
+                }
+            }
+            """;
+        var jsonDocument = JsonDocument.Parse(requestJson);
+        await testLspServer.ExecutePreSerializedRequestAsync(LSP.Methods.TextDocumentDidOpenName, jsonDocument);
+
+        // Retrieve the URI from the json - this is the unencoded (and not JSON escaped) version of the URI.
+        var unencodedUri = JsonSerializer.Deserialize<LSP.DidOpenTextDocumentParams>(jsonDocument, JsonSerializerOptions)!.TextDocument.Uri;
+
+        // Access the document using the unencoded URI to make sure we find it in the C# misc files.
+        var (workspace, _, lspDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = unencodedUri }, CancellationToken.None).ConfigureAwait(false);
+        AssertEx.NotNull(lspDocument);
+        Assert.Equal(WorkspaceKind.MiscellaneousFiles, workspace?.Kind);
+        Assert.Equal(LanguageNames.CSharp, lspDocument.Project.Language);
+        var originalText = await lspDocument.GetTextAsync(CancellationToken.None);
+        Assert.Equal("LSP text", originalText.ToString());
+
+        // Now make a request using the encoded document to ensure the server is able to find the document in misc C# files.
+        var encodedUriString = @"git:/c:/Users/dabarbet/source/repos/ConsoleApp10/ConsoleApp10/Program.cs?%7B%7B%22path%22:%22c:%5C%5CUsers%5C%5Cdabarbet%5C%5Csource%5C%5Crepos%5C%5CConsoleApp10%5C%5CConsoleApp10%5C%5CProgram.cs%22,%22ref%22:%22~%22%7D%7D";
+#pragma warning disable RS0030 // Do not use banned APIs
+        var encodedUri = new Uri(encodedUriString, UriKind.Absolute);
+#pragma warning restore RS0030 // Do not use banned APIs
+        var info = await testLspServer.ExecuteRequestAsync<CustomResolveParams, ResolvedDocumentInfo>(CustomResolveHandler.MethodName,
+                new CustomResolveParams(new LSP.TextDocumentIdentifier { Uri = encodedUri }), CancellationToken.None);
+        Assert.Equal(WorkspaceKind.MiscellaneousFiles, workspace?.Kind);
+        Assert.Equal(LanguageNames.CSharp, lspDocument.Project.Language);
+
+        var (encodedWorkspace, _, encodedDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = encodedUri }, CancellationToken.None).ConfigureAwait(false);
+        Assert.Same(workspace, encodedWorkspace);
+        AssertEx.NotNull(encodedDocument);
+        Assert.Equal(LanguageNames.CSharp, encodedDocument.Project.Language);
+        var encodedText = await encodedDocument.GetTextAsync(CancellationToken.None);
+        Assert.Equal("LSP text", encodedText.ToString());
+
+        // The text we get back should be the exact same instance that was originally saved by the unencoded request.
+        Assert.Same(originalText, encodedText);
+    }
+
+    private record class ResolvedDocumentInfo(string WorkspaceKind, string ProjectLanguage);
+    private record class CustomResolveParams([property: JsonPropertyName("textDocument")] LSP.TextDocumentIdentifier TextDocument);
+
+    [ExportCSharpVisualBasicStatelessLspService(typeof(CustomResolveHandler)), PartNotDiscoverable, Shared]
+    [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    private class CustomResolveHandler() : ILspServiceDocumentRequestHandler<CustomResolveParams, ResolvedDocumentInfo>
+    {
+        public const string MethodName = nameof(CustomResolveHandler);
+
+        public bool MutatesSolutionState => false;
+        public bool RequiresLSPSolution => true;
+        public LSP.TextDocumentIdentifier GetTextDocumentIdentifier(CustomResolveParams request) => request.TextDocument;
+        public Task<ResolvedDocumentInfo> HandleRequestAsync(CustomResolveParams request, RequestContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new ResolvedDocumentInfo(context.Workspace!.Kind!, context.GetRequiredDocument().Project.Language));
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/5843

This is a 'fun' one.

Essentially the issue happened when the original didOpen for a document was received with an unencoded URI, but a followup request (for a xxx/resolve) passed in the encoded URI.

Unencoded URI: 
```
git:/c:/Users/dabarbet/source/repos/ConsoleApp10/ConsoleApp10/Program.cs?{\"path\":\"c:\\\\Users\\\\dabarbet\\\\source\\\\repos\\\\ConsoleApp10\\\\ConsoleApp10\\\\Program.cs\",\"ref\":\"~\"}
```
Encoded URI: 
```
git:/c:/Users/dabarbet/source/repos/ConsoleApp10/ConsoleApp10/Program.cs?%7B%22path%22:%22c:%5C%5CUsers%5C%5Cdabarbet%5C%5Csource%5C%5Crepos%5C%5CConsoleApp10%5C%5CConsoleApp10%5C%5CProgram.cs%22,%22ref%22:%22~%22%7D
```



Generally, clients are expected to be consistent when passing URIs to the server (always give the same encoded or unencoded version), see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri
This is still true.

However, the issue came when roundtripping URIs sent by the server.  Consider the following scenario
1.  Client sends `textDocument/didOpen` with unencoded URI
2.  Server saves associated information against the URI
3.  Client asks for `textDocument/codelens` for the unencoded URI
4.  Server responds with codelenses.  The codelenses store the document URI in the code lens resolve data so when resolved we can find the document again
5.  When the codelens items are serialized back to the client, the server serializes the URI using `System.Uri.AbsoluteUri`. 
 The AbsoluteUri is always the **encoded** URI, so the codelens data contains the **encoded** URI.
https://github.com/dotnet/roslyn/blob/91773064bdc85ab3f64d8118d7b1f562f70dccc6/src/LanguageServer/Protocol/Protocol/Converters/DocumentUriConverter.cs#L20
7.  The client sends us a `codelens/resolve` request without touching the data (expected, its opaque to the client).
8.  The server uses the URI from the codelens resolve data (the encoded version) to try to find the document associated with the `codelens/resolve` request - but `System.Uri.Equals` does not consider the encoded and unencoded URIs to be equal.  This fails the request because we can't find the information from the prior `textDocument/didOpen` associated with it.

To fix this issue where the server cannot match the request for the encoded Uri to the unencoded version I considered a couple of paths
1.  When we store info for the URI, we consider the unescaped and escaped version to be equal using a custom comparer
2.  When serializing URIs, serialize the `OriginalString` property instead of the `AbsoluteUri` property

In this PR I chose 1.  I don't believe 2 is the correct solution - the `OriginalString` is **not always a valid URI** depending on how the URI is created.  For the generic LSP library converter, it cannot assume that the `Uri` object has a valid uri-formatted value in `OriginalString` (note that this change was attempted before back when we used the VS LSP libraries, and had to be reverted).