### PR TITLE
Set FlagNetStandard1XDependencies=true

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -84,6 +84,6 @@
     <UsingToolMicrosoftNetCompilers Condition="'$(BootstrapBuildPath)' == ''">true</UsingToolMicrosoftNetCompilers>
     <UseVSTestRunner>true</UseVSTestRunner>
     <!-- Prohibit the usage of .NET Standard 1.x dependencies. -->
-    <FlagNetStandard1XDependencies>true</FlagNetStandard1XDependencies>
+    <FlagNetStandard1XDependencies Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</FlagNetStandard1XDependencies>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -83,5 +83,7 @@
     -->
     <UsingToolMicrosoftNetCompilers Condition="'$(BootstrapBuildPath)' == ''">true</UsingToolMicrosoftNetCompilers>
     <UseVSTestRunner>true</UseVSTestRunner>
+    <!-- Prohibit the usage of .NET Standard 1.x dependencies. -->
+    <FlagNetStandard1XDependencies>true</FlagNetStandard1XDependencies>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Set `FlagNetStandard1XDependencies` opt-in Arcade switch to validate that netstandard1.x packages aren't directly or transitively brought in when building from source.

Thanks to https://github.com/dotnet/roslyn/commit/59981258f6d92b8c07bbccb8e789e2a59ec7e1ea, this is now possible.