### PR TITLE
DocumentState constructors refactoring

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -276,7 +276,7 @@ internal sealed class CommittedSolution
                         filePath: document.FilePath,
                         isGenerated: document.State.Attributes.IsGenerated)
                         .WithDesignTimeOnly(document.State.Attributes.DesignTimeOnly)
-                        .WithDocumentServiceProvider(document.State.Services));
+                        .WithDocumentServiceProvider(document.State.DocumentServiceProvider));
                 }
 
                 var matchingSourceText = maybeMatchingSourceText.Value;

--- a/src/VisualStudio/Core/Test/Venus/DocumentServiceTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/DocumentServiceTests.vb
@@ -114,7 +114,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Venus
                 Dim openDocument = subjectDocument.GetOpenTextContainer()
                 Dim sourceGeneratedDocumentId = workspace.GetDocumentIdInCurrentContext(openDocument)
                 Dim document = Assert.IsType(Of SourceGeneratedDocument)(Await workspace.CurrentSolution.GetDocumentAsync(sourceGeneratedDocumentId, includeSourceGenerated:=True))
-                Dim documentServices = document.State.Services
+                Dim documentServices = document.State.DocumentServiceProvider
                 Dim documentOperations = documentServices.GetService(Of IDocumentOperationService)()
 
                 Assert.False(documentOperations.CanApplyChange)

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
@@ -14,17 +14,17 @@ internal static class Extensions
         => document?.State.CanApplyChange() ?? false;
 
     public static bool CanApplyChange([NotNullWhen(returnValue: true)] this TextDocumentState? document)
-        => document?.Services.GetService<IDocumentOperationService>()?.CanApplyChange ?? false;
+        => document?.DocumentServiceProvider.GetService<IDocumentOperationService>()?.CanApplyChange ?? false;
 
     public static bool SupportsDiagnostics([NotNullWhen(returnValue: true)] this TextDocument? document)
         => document?.State.SupportsDiagnostics() ?? false;
 
     public static bool SupportsDiagnostics([NotNullWhen(returnValue: true)] this TextDocumentState? document)
-        => document?.Services.GetService<IDocumentOperationService>()?.SupportDiagnostics ?? false;
+        => document?.DocumentServiceProvider.GetService<IDocumentOperationService>()?.SupportDiagnostics ?? false;
 
     public static bool IsRazorDocument(this TextDocument document)
         => IsRazorDocument(document.State);
 
     public static bool IsRazorDocument(this TextDocumentState documentState)
-        => documentState.Services.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName == RazorCSharpLspClientName;
+        => documentState.DocumentServiceProvider.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName == RazorCSharpLspClientName;
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocumentState.cs
@@ -10,29 +10,34 @@ namespace Microsoft.CodeAnalysis;
 
 internal sealed class AdditionalDocumentState : TextDocumentState
 {
-    private readonly AdditionalText _additionalText;
+    public readonly AdditionalText AdditionalText;
 
     private AdditionalDocumentState(
         SolutionServices solutionServices,
-        IDocumentServiceProvider documentServiceProvider,
+        IDocumentServiceProvider? documentServiceProvider,
         DocumentInfo.DocumentAttributes attributes,
         ITextAndVersionSource textAndVersionSource,
         LoadTextOptions loadTextOptions)
         : base(solutionServices, documentServiceProvider, attributes, textAndVersionSource, loadTextOptions)
     {
-        _additionalText = new AdditionalTextWithState(this);
+        AdditionalText = new AdditionalTextWithState(this);
     }
 
     public AdditionalDocumentState(
         SolutionServices solutionServices,
         DocumentInfo documentInfo,
         LoadTextOptions loadTextOptions)
-        : base(solutionServices, documentInfo, loadTextOptions)
+        : this(solutionServices, documentInfo.DocumentServiceProvider, documentInfo.Attributes, CreateTextAndVersionSource(solutionServices, documentInfo, loadTextOptions), loadTextOptions)
     {
-        _additionalText = new AdditionalTextWithState(this);
     }
 
-    public AdditionalText AdditionalText => _additionalText;
+    protected override TextDocumentState UpdateAttributes(DocumentInfo.DocumentAttributes newAttributes)
+        => new AdditionalDocumentState(
+            SolutionServices,
+            DocumentServiceProvider,
+            newAttributes,
+            TextAndVersionSource,
+            LoadTextOptions);
 
     public new AdditionalDocumentState UpdateText(TextLoader loader, PreservationMode mode)
         => (AdditionalDocumentState)base.UpdateText(loader, mode);
@@ -46,8 +51,8 @@ internal sealed class AdditionalDocumentState : TextDocumentState
     protected override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
     {
         return new AdditionalDocumentState(
-            this.solutionServices,
-            this.Services,
+            this.SolutionServices,
+            this.DocumentServiceProvider,
             this.Attributes,
             newTextSource,
             this.LoadTextOptions);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -14,38 +12,40 @@ namespace Microsoft.CodeAnalysis;
 
 internal sealed class AnalyzerConfigDocumentState : TextDocumentState
 {
-    private readonly AsyncLazy<AnalyzerConfig> _analyzerConfigValueSource;
+    private readonly AsyncLazy<AnalyzerConfig> _lazyAnalyzerConfig;
 
     private AnalyzerConfigDocumentState(
         SolutionServices solutionServices,
-        IDocumentServiceProvider documentServiceProvider,
+        IDocumentServiceProvider? documentServiceProvider,
         DocumentInfo.DocumentAttributes attributes,
         ITextAndVersionSource textAndVersionSource,
-        LoadTextOptions loadTextOptions)
+        LoadTextOptions loadTextOptions,
+        AsyncLazy<AnalyzerConfig>? lazyAnalyzerConfig = null)
         : base(solutionServices, documentServiceProvider, attributes, textAndVersionSource, loadTextOptions)
     {
-        _analyzerConfigValueSource = CreateAnalyzerConfigValueSource();
+        _lazyAnalyzerConfig = lazyAnalyzerConfig ?? AsyncLazy.Create(
+            asynchronousComputeFunction: static async (self, cancellationToken) => AnalyzerConfig.Parse(await self.GetTextAsync(cancellationToken).ConfigureAwait(false), self.FilePath),
+            synchronousComputeFunction: static (self, cancellationToken) => AnalyzerConfig.Parse(self.GetTextSynchronously(cancellationToken), self.FilePath),
+            arg: this);
     }
 
     public AnalyzerConfigDocumentState(
         SolutionServices solutionServices,
         DocumentInfo documentInfo,
         LoadTextOptions loadTextOptions)
-        : base(solutionServices, documentInfo, loadTextOptions)
+        : this(solutionServices, documentInfo.DocumentServiceProvider, documentInfo.Attributes, CreateTextAndVersionSource(solutionServices, documentInfo, loadTextOptions), loadTextOptions)
     {
-        _analyzerConfigValueSource = CreateAnalyzerConfigValueSource();
     }
 
-    private AsyncLazy<AnalyzerConfig> CreateAnalyzerConfigValueSource()
-    {
-        return AsyncLazy.Create(
-            asynchronousComputeFunction: static async (self, cancellationToken) => AnalyzerConfig.Parse(await self.GetTextAsync(cancellationToken).ConfigureAwait(false), self.FilePath),
-            synchronousComputeFunction: static (self, cancellationToken) => AnalyzerConfig.Parse(self.GetTextSynchronously(cancellationToken), self.FilePath),
-            arg: this);
-    }
-
-    public AnalyzerConfig GetAnalyzerConfig(CancellationToken cancellationToken) => _analyzerConfigValueSource.GetValue(cancellationToken);
-    public Task<AnalyzerConfig> GetAnalyzerConfigAsync(CancellationToken cancellationToken) => _analyzerConfigValueSource.GetValueAsync(cancellationToken);
+    protected override TextDocumentState UpdateAttributes(DocumentInfo.DocumentAttributes newAttributes)
+        => new AnalyzerConfigDocumentState(
+            SolutionServices,
+            DocumentServiceProvider,
+            newAttributes,
+            TextAndVersionSource,
+            LoadTextOptions,
+            // Reuse parsed config unless the path changed:
+            Attributes.FilePath == newAttributes.FilePath ? _lazyAnalyzerConfig : null);
 
     public new AnalyzerConfigDocumentState UpdateText(TextLoader loader, PreservationMode mode)
         => (AnalyzerConfigDocumentState)base.UpdateText(loader, mode);
@@ -59,10 +59,16 @@ internal sealed class AnalyzerConfigDocumentState : TextDocumentState
     protected override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
     {
         return new AnalyzerConfigDocumentState(
-            this.solutionServices,
-            this.Services,
+            this.SolutionServices,
+            this.DocumentServiceProvider,
             this.Attributes,
             newTextSource,
             this.LoadTextOptions);
     }
+
+    public AnalyzerConfig GetAnalyzerConfig(CancellationToken cancellationToken)
+        => _lazyAnalyzerConfig.GetValue(cancellationToken);
+
+    public Task<AnalyzerConfig> GetAnalyzerConfigAsync(CancellationToken cancellationToken)
+        => _lazyAnalyzerConfig.GetValueAsync(cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -40,9 +40,9 @@ internal partial class DocumentState : TextDocumentState
         LanguageServices languageServices,
         IDocumentServiceProvider? documentServiceProvider,
         DocumentInfo.DocumentAttributes attributes,
-        ParseOptions? options,
         ITextAndVersionSource textSource,
         LoadTextOptions loadTextOptions,
+        ParseOptions? options,
         ITreeAndVersionSource? treeSource)
         : base(languageServices.SolutionServices, documentServiceProvider, attributes, textSource, loadTextOptions)
     {
@@ -53,33 +53,41 @@ internal partial class DocumentState : TextDocumentState
         TreeSource = treeSource;
     }
 
-    public DocumentState(
+    public static DocumentState Create(
         LanguageServices languageServices,
         DocumentInfo info,
         ParseOptions? options,
         LoadTextOptions loadTextOptions)
-        : base(languageServices.SolutionServices, info, loadTextOptions)
     {
-        LanguageServices = languageServices;
-        ParseOptions = options;
+        var textSource = CreateTextAndVersionSource(languageServices.SolutionServices, info, loadTextOptions);
 
         // If this is document that doesn't support syntax, then don't even bother holding
         // onto any tree source.  It will never be used to get a tree, and can only hurt us
         // by possibly holding onto data that might cause a slow memory leak.
+        ITreeAndVersionSource? treeSource;
         if (languageServices.GetService<ISyntaxTreeFactoryService>() == null)
         {
-            TreeSource = null;
+            treeSource = null;
         }
         else
         {
             Contract.ThrowIfNull(options);
-            TreeSource = CreateLazyFullyParsedTree(
-                TextAndVersionSource,
-                LoadTextOptions,
+            treeSource = CreateLazyFullyParsedTree(
+                textSource,
+                loadTextOptions,
                 info.Attributes.SyntaxTreeFilePath,
                 options,
                 languageServices);
         }
+
+        return new DocumentState(
+            languageServices,
+            info.DocumentServiceProvider,
+            info.Attributes,
+            textSource,
+            loadTextOptions,
+            options,
+            treeSource);
     }
 
     [MemberNotNullWhen(true, nameof(TreeSource))]
@@ -320,11 +328,11 @@ internal partial class DocumentState : TextDocumentState
 
         return new DocumentState(
             LanguageServices,
-            Services,
+            DocumentServiceProvider,
             Attributes,
-            ParseOptions,
             TextAndVersionSource,
             newLoadTextOptions,
+            ParseOptions,
             newTreeSource);
     }
 
@@ -367,11 +375,11 @@ internal partial class DocumentState : TextDocumentState
 
         return new DocumentState(
             LanguageServices,
-            Services,
+            DocumentServiceProvider,
             Attributes.With(sourceCodeKind: options.Kind),
-            options,
             TextAndVersionSource,
             LoadTextOptions,
+            options,
             newTreeSource);
     }
 
@@ -390,13 +398,9 @@ internal partial class DocumentState : TextDocumentState
         return WithAttributes(Attributes.With(sourceCodeKind: kind));
     }
 
-    public DocumentState WithAttributes(DocumentInfo.DocumentAttributes newAttributes)
+    protected override TextDocumentState UpdateAttributes(DocumentInfo.DocumentAttributes newAttributes)
     {
-        if (ReferenceEquals(newAttributes, Attributes))
-        {
-            return this;
-        }
-
+        Debug.Assert(!ReferenceEquals(newAttributes, Attributes));
         ITreeAndVersionSource? newTreeSource;
 
         if (newAttributes.SyntaxTreeFilePath != Attributes.SyntaxTreeFilePath)
@@ -418,13 +422,16 @@ internal partial class DocumentState : TextDocumentState
 
         return new DocumentState(
             LanguageServices,
-            Services,
+            DocumentServiceProvider,
             newAttributes,
-            ParseOptions,
             TextAndVersionSource,
             LoadTextOptions,
+            ParseOptions,
             newTreeSource);
     }
+
+    public new DocumentState WithAttributes(DocumentInfo.DocumentAttributes newAttributes)
+        => (DocumentState)base.WithAttributes(newAttributes);
 
     public new DocumentState UpdateText(SourceText newText, PreservationMode mode)
         => (DocumentState)base.UpdateText(newText, mode);
@@ -460,11 +467,11 @@ internal partial class DocumentState : TextDocumentState
 
         return new DocumentState(
             LanguageServices,
-            Services,
+            DocumentServiceProvider,
             Attributes,
-            ParseOptions,
             textSource: newTextSource,
             LoadTextOptions,
+            ParseOptions,
             treeSource: newTreeSource);
     }
 
@@ -503,11 +510,11 @@ internal partial class DocumentState : TextDocumentState
 
         return new DocumentState(
             LanguageServices,
-            Services,
+            DocumentServiceProvider,
             Attributes,
-            ParseOptions,
             textSource: text,
             LoadTextOptions,
+            ParseOptions,
             treeSource: SimpleTreeAndVersionSource.Create(treeAndVersion));
 
         // use static method so we don't capture references to this

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -400,7 +400,7 @@ internal partial class DocumentState : TextDocumentState
 
     protected override TextDocumentState UpdateAttributes(DocumentInfo.DocumentAttributes newAttributes)
     {
-        Debug.Assert(!ReferenceEquals(newAttributes, Attributes));
+        Contract.ThrowIfTrue(ReferenceEquals(newAttributes, Attributes));
         ITreeAndVersionSource? newTreeSource;
 
         if (newAttributes.SyntaxTreeFilePath != Attributes.SyntaxTreeFilePath)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
@@ -51,11 +51,11 @@ internal partial class DocumentState
         {
             return new DocumentState(
                 LanguageServices,
-                Services,
+                DocumentServiceProvider,
                 Attributes,
-                ParseOptions,
                 siblingTextSource,
                 LoadTextOptions,
+                ParseOptions,
                 treeSource: null);
         }
 
@@ -77,7 +77,7 @@ internal partial class DocumentState
         // Defer to static helper to make sure we don't accidentally capture anything else we don't want off of 'this'
         // (like "this.TreeSource").
         return UpdateTextAndTreeContentsWorker(
-            this.Attributes, this.LanguageServices, this.Services, this.LoadTextOptions, this.ParseOptions,
+            this.Attributes, this.LanguageServices, this.DocumentServiceProvider, this.LoadTextOptions, this.ParseOptions,
             originalTreeSource, siblingTextSource, siblingTreeSource, forceEvenIfTreesWouldDiffer);
     }
 
@@ -106,7 +106,7 @@ internal partial class DocumentState
         var newTreeSource = new LinkedFileReuseTreeAndVersionSource(originalTreeSource, lazyComputation);
 
         return new DocumentState(
-            languageServices, services, attributes, parseOptions, siblingTextSource, loadTextOptions, newTreeSource);
+            languageServices, services, attributes, siblingTextSource, loadTextOptions, parseOptions, newTreeSource);
 
         static bool TryReuseSiblingRoot(
             string filePath,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -274,7 +274,7 @@ internal partial class ProjectState
 
     internal DocumentState CreateDocument(DocumentInfo documentInfo, ParseOptions? parseOptions, LoadTextOptions loadTextOptions)
     {
-        var doc = new DocumentState(LanguageServices, documentInfo, parseOptions, loadTextOptions);
+        var doc = DocumentState.Create(LanguageServices, documentInfo, parseOptions, loadTextOptions);
 
         if (doc.SourceCodeKind != documentInfo.SourceCodeKind)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.Contracts;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.SourceGeneration;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
 
@@ -107,7 +109,7 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         ITreeAndVersionSource treeSource,
         Lazy<Checksum> lazyContentHash,
         DateTime generationDateTime)
-        : base(languageServices, documentServiceProvider, attributes, options, textSource, loadTextOptions, treeSource)
+        : base(languageServices, documentServiceProvider, attributes, textSource, loadTextOptions, options, treeSource)
     {
         Identity = documentIdentity;
 
@@ -115,6 +117,9 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         _lazyContentHash = lazyContentHash;
         GenerationDateTime = generationDateTime;
     }
+
+    protected override TextDocumentState UpdateAttributes(DocumentInfo.DocumentAttributes newAttributes)
+        => throw ExceptionUtilities.Unreachable();
 
     private static Checksum ComputeContentHash(SourceText text)
         => Checksum.From(text.GetContentHash());
@@ -172,7 +177,7 @@ internal sealed class SourceGeneratedDocumentState : DocumentState
         return new(
             this.Identity,
             this.LanguageServices,
-            this.Services,
+            this.DocumentServiceProvider,
             this.Attributes,
             this.ParseOptions,
             this.TextAndVersionSource,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
@@ -56,7 +56,7 @@ public class TextDocument
     /// <summary>
     /// A <see cref="IDocumentServiceProvider"/> associated with this document
     /// </summary>
-    internal IDocumentServiceProvider Services => State.Services;
+    internal IDocumentServiceProvider Services => State.DocumentServiceProvider;
 
     /// <summary>
     /// Get the current text for the document if it is already loaded and available.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState_Checksum.cs
@@ -13,7 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis;
 
-internal partial class TextDocumentState
+internal abstract partial class TextDocumentState
 {
     public bool TryGetStateChecksums([NotNullWhen(returnValue: true)] out DocumentStateChecksums? stateChecksums)
         => _lazyChecksums.TryGetValue(out stateChecksums);

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1606,7 +1606,7 @@ public abstract partial class Workspace : IDisposable
         {
             // ApplyDocumentInfoChanged ignores the loader information, so we can pass null for it
             ApplyDocumentInfoChanged(newDoc.Id,
-                new DocumentInfo(newDoc.DocumentState.Attributes, loader: null, documentServiceProvider: newDoc.State.Services));
+                new DocumentInfo(newDoc.DocumentState.Attributes, loader: null, documentServiceProvider: newDoc.State.DocumentServiceProvider));
         }
     }
 


### PR DESCRIPTION
Make `TextDocumentState` abstract type with a single constructor. This avoids duplicating constructor code in derived types.
Clean up properties, add `TextDocumentState.WithAttributes` that updates attributes of any `TextDocumentState` subtype.

