### PR TITLE
Eliminate contentChanged parameter

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -843,10 +843,10 @@ internal partial class ProjectState
             analyzerConfigOptionsCache: new AnalyzerConfigOptionsCache(AnalyzerConfigDocumentStates, _analyzerConfigOptionsCache.FallbackOptions));
     }
 
-    public ProjectState UpdateDocument(DocumentState newDocument, bool contentChanged)
-        => UpdateDocuments([DocumentStates.GetRequiredState(newDocument.Id)], [newDocument], contentChanged);
+    public ProjectState UpdateDocument(DocumentState newDocument)
+        => UpdateDocuments([DocumentStates.GetRequiredState(newDocument.Id)], [newDocument]);
 
-    public ProjectState UpdateDocuments(ImmutableArray<DocumentState> oldDocuments, ImmutableArray<DocumentState> newDocuments, bool contentChanged)
+    public ProjectState UpdateDocuments(ImmutableArray<DocumentState> oldDocuments, ImmutableArray<DocumentState> newDocuments)
     {
         Contract.ThrowIfTrue(oldDocuments.IsEmpty);
         Contract.ThrowIfFalse(oldDocuments.Length == newDocuments.Length);
@@ -860,7 +860,6 @@ internal partial class ProjectState
             AdditionalDocumentStates,
             oldDocuments.CastArray<TextDocumentState>(),
             newDocuments.CastArray<TextDocumentState>(),
-            contentChanged,
             out var dependentDocumentVersion,
             out var dependentSemanticVersion);
 
@@ -870,10 +869,10 @@ internal partial class ProjectState
             latestDocumentTopLevelChangeVersion: dependentSemanticVersion);
     }
 
-    public ProjectState UpdateAdditionalDocument(AdditionalDocumentState newDocument, bool contentChanged)
-        => UpdateAdditionalDocuments([AdditionalDocumentStates.GetRequiredState(newDocument.Id)], [newDocument], contentChanged);
+    public ProjectState UpdateAdditionalDocument(AdditionalDocumentState newDocument)
+        => UpdateAdditionalDocuments([AdditionalDocumentStates.GetRequiredState(newDocument.Id)], [newDocument]);
 
-    public ProjectState UpdateAdditionalDocuments(ImmutableArray<AdditionalDocumentState> oldDocuments, ImmutableArray<AdditionalDocumentState> newDocuments, bool contentChanged)
+    public ProjectState UpdateAdditionalDocuments(ImmutableArray<AdditionalDocumentState> oldDocuments, ImmutableArray<AdditionalDocumentState> newDocuments)
     {
         Contract.ThrowIfTrue(oldDocuments.IsEmpty);
         Contract.ThrowIfFalse(oldDocuments.Length == newDocuments.Length);
@@ -886,7 +885,6 @@ internal partial class ProjectState
             newDocumentStates,
             oldDocuments.CastArray<TextDocumentState>(),
             newDocuments.CastArray<TextDocumentState>(),
-            contentChanged,
             out var dependentDocumentVersion,
             out var dependentSemanticVersion);
 
@@ -923,12 +921,15 @@ internal partial class ProjectState
         TextDocumentStates<AdditionalDocumentState> newAdditionalDocumentStates,
         ImmutableArray<TextDocumentState> oldDocuments,
         ImmutableArray<TextDocumentState> newDocuments,
-        bool contentChanged,
         out AsyncLazy<VersionStamp> dependentDocumentVersion,
         out AsyncLazy<VersionStamp> dependentSemanticVersion)
     {
         var recalculateDocumentVersion = false;
         var recalculateSemanticVersion = false;
+
+        var contentChanged = !oldDocuments.SequenceEqual(
+            newDocuments,
+            static (oldDocument, newDocument) => oldDocument.TextAndVersionSource == newDocument.TextAndVersionSource);
 
         if (contentChanged)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -960,7 +960,7 @@ internal sealed partial class SolutionState
             return new(this, oldProject, oldProject);
         }
 
-        return UpdateDocumentState(newDocument, contentChanged: false);
+        return UpdateDocumentState(newDocument);
     }
 
     /// <summary>
@@ -976,7 +976,7 @@ internal sealed partial class SolutionState
             return new(this, oldProject, oldProject);
         }
 
-        return UpdateDocumentState(oldDocument.UpdateText(text, mode), contentChanged: true);
+        return UpdateDocumentState(oldDocument.UpdateText(text, mode));
     }
 
     public StateChange WithDocumentState(DocumentState newDocument)
@@ -988,7 +988,7 @@ internal sealed partial class SolutionState
             return new(this, oldProject, oldProject);
         }
 
-        return UpdateDocumentState(newDocument, contentChanged: true);
+        return UpdateDocumentState(newDocument);
     }
 
     /// <summary>
@@ -1004,7 +1004,7 @@ internal sealed partial class SolutionState
             return new(this, oldProject, oldProject);
         }
 
-        return UpdateAdditionalDocumentState(oldDocument.UpdateText(text, mode), contentChanged: true);
+        return UpdateAdditionalDocumentState(oldDocument.UpdateText(text, mode));
     }
 
     /// <summary>
@@ -1036,7 +1036,7 @@ internal sealed partial class SolutionState
             return new(this, oldProject, oldProject);
         }
 
-        return UpdateDocumentState(oldDocument.UpdateText(textAndVersion, mode), contentChanged: true);
+        return UpdateDocumentState(oldDocument.UpdateText(textAndVersion, mode));
     }
 
     /// <summary>
@@ -1052,7 +1052,7 @@ internal sealed partial class SolutionState
             return new(this, oldProject, oldProject);
         }
 
-        return UpdateAdditionalDocumentState(oldDocument.UpdateText(textAndVersion, mode), contentChanged: true);
+        return UpdateAdditionalDocumentState(oldDocument.UpdateText(textAndVersion, mode));
     }
 
     /// <summary>
@@ -1084,7 +1084,7 @@ internal sealed partial class SolutionState
             return new(this, oldProject, oldProject);
         }
 
-        return UpdateDocumentState(oldDocument.UpdateSourceCodeKind(sourceCodeKind), contentChanged: true);
+        return UpdateDocumentState(oldDocument.UpdateSourceCodeKind(sourceCodeKind));
     }
 
     public StateChange UpdateDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
@@ -1093,7 +1093,7 @@ internal sealed partial class SolutionState
 
         // Assumes that content has changed. User could have closed a doc without saving and we are loading text
         // from closed file with old content.
-        return UpdateDocumentState(oldDocument.UpdateText(loader, mode), contentChanged: true);
+        return UpdateDocumentState(oldDocument.UpdateText(loader, mode));
     }
 
     /// <summary>
@@ -1106,7 +1106,7 @@ internal sealed partial class SolutionState
 
         // Assumes that content has changed. User could have closed a doc without saving and we are loading text
         // from closed file with old content.
-        return UpdateAdditionalDocumentState(oldDocument.UpdateText(loader, mode), contentChanged: true);
+        return UpdateAdditionalDocumentState(oldDocument.UpdateText(loader, mode));
     }
 
     /// <summary>
@@ -1122,10 +1122,10 @@ internal sealed partial class SolutionState
         return UpdateAnalyzerConfigDocumentState(oldDocument.UpdateText(loader, mode));
     }
 
-    private StateChange UpdateDocumentState(DocumentState newDocument, bool contentChanged)
+    private StateChange UpdateDocumentState(DocumentState newDocument)
     {
         var oldProject = GetProjectState(newDocument.Id.ProjectId)!;
-        var newProject = oldProject.UpdateDocument(newDocument, contentChanged);
+        var newProject = oldProject.UpdateDocument(newDocument);
 
         // This method shouldn't have been called if the document has not changed.
         Debug.Assert(oldProject != newProject);
@@ -1135,10 +1135,10 @@ internal sealed partial class SolutionState
             newProject);
     }
 
-    private StateChange UpdateAdditionalDocumentState(AdditionalDocumentState newDocument, bool contentChanged)
+    private StateChange UpdateAdditionalDocumentState(AdditionalDocumentState newDocument)
     {
         var oldProject = GetRequiredProjectState(newDocument.Id.ProjectId);
-        var newProject = oldProject.UpdateAdditionalDocument(newDocument, contentChanged);
+        var newProject = oldProject.UpdateAdditionalDocument(newDocument);
 
         // This method shouldn't have been called if the document has not changed.
         Debug.Assert(oldProject != newProject);


### PR DESCRIPTION
Calculating the value is simple and more reliable. It will also allow us to call the APIs when we do not know what exact changes were made.