### PR TITLE
Remove a closure allocation from WrappedNavigationBarItem.ctor

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/WrappedNavigationBarItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/WrappedNavigationBarItem.cs
@@ -26,7 +26,7 @@ internal sealed class WrappedNavigationBarItem : NavigationBarItem, IEquatable<W
               underlyingItem.Text,
               underlyingItem.Glyph,
               GetSpans(underlyingItem),
-              underlyingItem.ChildItems.SelectAsArray(v => (NavigationBarItem)new WrappedNavigationBarItem(textVersion, v)),
+              underlyingItem.ChildItems.SelectAsArray(static (v, textVersion) => (NavigationBarItem)new WrappedNavigationBarItem(textVersion, v), textVersion),
               underlyingItem.Indent,
               underlyingItem.Bolded,
               underlyingItem.Grayed)


### PR DESCRIPTION
This shows up in the scrolling speedometer test as 0.4% of VS allocations.

![image](https://github.com/user-attachments/assets/ff14084a-95e1-4492-86b3-5f51483c18c9)