### PR TITLE
Rename Suggestions: Fix getting of the context string, gracefully handle errors

### DIFF
--- a/src/EditorFeatures/CSharp/InlineRename/CSharpEditorInlineRenameService.cs
+++ b/src/EditorFeatures/CSharp/InlineRename/CSharpEditorInlineRenameService.cs
@@ -148,7 +148,7 @@ internal sealed class CSharpEditorInlineRenameService([ImportMany] IEnumerable<I
             // expand to select the corresponding lines completely.
             startPosition = documentText.Lines[startLine].Start;
             endPosition = documentText.Lines[endLine].End;
-            var length = endPosition - startPosition + 1;
+            var length = endPosition - startPosition;
 
             surroundingSpanOfInterest = new TextSpan(startPosition, length);
 

--- a/src/EditorFeatures/CSharp/InlineRename/CSharpEditorInlineRenameService.cs
+++ b/src/EditorFeatures/CSharp/InlineRename/CSharpEditorInlineRenameService.cs
@@ -9,7 +9,6 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
 using Microsoft.CodeAnalysis.GoToDefinition;
@@ -17,7 +16,6 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.InlineRename;
 

--- a/src/EditorFeatures/CSharpTest/Rename/CSharpInlineRenameServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Rename/CSharpInlineRenameServiceTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Rename
                 if (x is null || y is null)
                     return false;
 
-                if (x.Count != y.Count())
+                if (x.Count != y.Count)
                     return false;
 
                 foreach (var (elementFromX, elementFromY) in x.Zip(y, (elementFromX, elementFromY) => (elementFromX, elementFromY)))

--- a/src/EditorFeatures/CSharpTest/Rename/CSharpInlineRenameServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Rename/CSharpInlineRenameServiceTests.cs
@@ -22,6 +22,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Rename
 {
     [UseExportProvider]
+    [Trait(Traits.Feature, Traits.Features.Rename)]
     public class CSharpInlineRenameServiceTests
     {
         private class ContextDictionaryComparer : IEqualityComparer<ImmutableDictionary<string, ImmutableArray<string>>?>
@@ -71,7 +72,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Rename
         }
 
         [Fact]
-        public async Task Test()
+        [WorkItem("https://github.com/dotnet/roslyn/issues/74545")]
+        public async Task VerifyContextReachEndOfFile()
         {
             var markup = @"
 public class Sampl$$eClass()

--- a/src/EditorFeatures/CSharpTest/Rename/CSharpInlineRenameServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Rename/CSharpInlineRenameServiceTests.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO.Hashing;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Rename
+{
+    [UseExportProvider]
+    public class CSharpInlineRenameServiceTests
+    {
+        private class ContextDictionaryComparer : IEqualityComparer<ImmutableDictionary<string, ImmutableArray<string>>?>
+        {
+            public static ContextDictionaryComparer Instance = new();
+
+            public bool Equals(ImmutableDictionary<string, ImmutableArray<string>>? x, ImmutableDictionary<string, ImmutableArray<string>>? y)
+            {
+                if (x == y)
+                    return true;
+
+                if (x is null || y is null)
+                    return false;
+
+                if (x.Count != y.Count())
+                    return false;
+
+                foreach (var (elementFromX, elementFromY) in x.Zip(y, (elementFromX, elementFromY) => (elementFromX, elementFromY)))
+                {
+                    var (keyFromX, valueFromX) = elementFromX;
+                    var (keyFromY, valueFromY) = elementFromY;
+
+                    if (keyFromX != keyFromY || !valueFromX.SequenceEqual(valueFromY))
+                        return false;
+                }
+
+                return true;
+            }
+
+            public int GetHashCode(ImmutableDictionary<string, ImmutableArray<string>>? obj)
+                => EqualityComparer<ImmutableDictionary<string, ImmutableArray<string>>?>.Default.GetHashCode(obj);
+        }
+
+        private static async Task VerifyGetRenameContextAsync(
+            string markup, string expectedContextJson, SymbolRenameOptions options, CancellationToken cancellationToken)
+        {
+            using var workspace = TestWorkspace.CreateCSharp(markup, composition: EditorTestCompositions.EditorFeatures);
+            var documentId = workspace.Documents.Single().Id;
+            var document = workspace.CurrentSolution.GetRequiredDocument(documentId);
+            var inlineRenameService = document.GetRequiredLanguageService<IEditorInlineRenameService>();
+            MarkupTestFile.GetPosition(markup, out _, out int cursorPosition);
+            var inlineRenameInfo = await inlineRenameService.GetRenameInfoAsync(document, cursorPosition, cancellationToken).ConfigureAwait(false);
+            var inlineRenameLocationSet = await inlineRenameInfo.FindRenameLocationsAsync(options, cancellationToken).ConfigureAwait(false);
+            var context = await inlineRenameService.GetRenameContextAsync(inlineRenameInfo, inlineRenameLocationSet, cancellationToken).ConfigureAwait(false);
+            var expectedContext = JsonSerializer.Deserialize<ImmutableDictionary<string, ImmutableArray<string>>>(expectedContextJson);
+            AssertEx.AreEqual(expectedContext, context, comparer: ContextDictionaryComparer.Instance);
+        }
+
+        [Fact]
+        public async Task Test()
+        {
+            var markup = @"
+public class Sampl$$eClass()
+{
+}";
+            await VerifyGetRenameContextAsync(
+                markup,
+                @"
+{
+    ""definition"" : [ ""public class SampleClass()\r\n{\r\n}"" ]
+}",
+                new SymbolRenameOptions(),
+                CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
There was an edge case in code that gets context (references, definitions) for copilot rename suggestions.
When a reference/definition touched the end of file (because there was no empty line at the end of file), `ArgumentOutOfRangeException` was thrown from within `GetRenameContextAsync`, and Roslyn ended up not making the rename request at all.

The solution is twofold:
1. Gracefully handle errors. If context cannot be obtained, make a request without context
2. Fix the code that gets context span. It was incorrectly attempting to get an extra trailing character, which was typically `\r` on Windows machines (and therefore not visible in logs).

Fixes #74545 and DevDiv 2173894