### PR TITLE
Fix race condition in LSP FindAllReferences when linked files were involved.

### DIFF
--- a/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -132,6 +132,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public override async ValueTask OnReferencesFoundAsync(IAsyncEnumerable<SourceReferenceItem> references, CancellationToken cancellationToken)
         {
             await foreach (var reference in references)
+                await OnSingleReferenceFoundAsync(reference, cancellationToken).ConfigureAwait(false);
+
+            async ValueTask OnSingleReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
             {
                 using (await _semaphore.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
                 {

--- a/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -132,16 +132,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public override async ValueTask OnReferencesFoundAsync(IAsyncEnumerable<SourceReferenceItem> references, CancellationToken cancellationToken)
         {
             await foreach (var reference in references)
-                await OnSingleReferenceFoundAsync(reference, cancellationToken).ConfigureAwait(false);
-
-            async ValueTask OnSingleReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
             {
                 using (await _semaphore.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
                 {
                     // Each reference should be associated with a definition. If this somehow isn't the
                     // case, we bail out early.
                     if (!_definitionToId.TryGetValue(reference.Definition, out var definitionId))
-                        return;
+                        continue;
 
                     var documentSpan = reference.SourceSpan;
                     var document = documentSpan.Document;
@@ -149,7 +146,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     // If this is reference to the same physical location we've already reported, just
                     // filter this out.  it will clutter the UI to show the same places.
                     if (!_referenceLocations.Add((document.FilePath, reference.SourceSpan.SourceSpan)))
-                        return;
+                        continue;
 
                     // If the definition hasn't been reported yet, add it to our list of references to report.
                     if (_definitionsWithoutReference.TryGetValue(definitionId, out var definition))

--- a/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerFeaturesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerFeaturesTests.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
-using System.ServiceModel.Syndication;
 using System.Threading.Tasks;
-using EnvDTE;
 using Microsoft.CodeAnalysis.Editor.Test;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -14,12 +12,9 @@ using Xunit.Abstractions;
 using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.References;
-public class FindAllReferencesHandlerFeaturesTests : AbstractLanguageServerProtocolTests
+public sealed class FindAllReferencesHandlerFeaturesTests(ITestOutputHelper? testOutputHelper)
+    : AbstractLanguageServerProtocolTests(testOutputHelper)
 {
-    public FindAllReferencesHandlerFeaturesTests(ITestOutputHelper? testOutputHelper) : base(testOutputHelper)
-    {
-    }
-
     protected override TestComposition Composition => LspTestCompositions.LanguageServerProtocol
         .AddParts(typeof(TestDocumentTrackingService))
         .AddParts(typeof(TestWorkspaceRegistrationService));
@@ -28,22 +23,24 @@ public class FindAllReferencesHandlerFeaturesTests : AbstractLanguageServerProto
     public async Task TestFindAllReferencesAsync_DoesNotUseVSTypes(bool mutatingLspWorkspace)
     {
         var markup =
-@"class A
-{
-    public int {|reference:someInt|} = 1;
-    void M()
-    {
-        var i = {|reference:someInt|} + 1;
-    }
-}
-class B
-{
-    int someInt = A.{|reference:someInt|} + 1;
-    void M2()
-    {
-        var j = someInt + A.{|caret:|}{|reference:someInt|};
-    }
-}";
+            """
+            class A
+            {
+                public int {|reference:someInt|} = 1;
+                void M()
+                {
+                    var i = {|reference:someInt|} + 1;
+                }
+            }
+            class B
+            {
+                int someInt = A.{|reference:someInt|} + 1;
+                void M2()
+                {
+                    var j = someInt + A.{|caret:|}{|reference:someInt|};
+                }
+            }
+            """;
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, new LSP.ClientCapabilities());
 
         var results = await FindAllReferencesHandlerTests.RunFindAllReferencesNonVSAsync(testLspServer, testLspServer.GetLocations("caret").First());
@@ -54,11 +51,13 @@ class B
     public async Task TestFindAllReferencesAsync_LargeNumberOfReferences(bool mutatingLspWorkspace)
     {
         var markup =
-@"using System.Threading.Tasks
-class A
-{
-    private {|caret:Task|} someTask = Task.CompletedTask;
-}";
+            """
+            using System.Threading.Tasks
+            class A
+            {
+                private {|caret:Task|} someTask = Task.CompletedTask;
+            }
+            """;
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, new LSP.ClientCapabilities());
 
         for (var i = 0; i < 100; i++)
@@ -86,68 +85,72 @@ class A
     {
         _ = iteration;
         var markup =
-@"using System.Threading.Tasks
-class A
-{
-    private void SomeMethod()
-    {
-        Do({|caret:Task|}.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-        Do(Task.CompletedTask);
-    }
-}";
+            """
+            using System.Threading.Tasks
+            class A
+            {
+                private void SomeMethod()
+                {
+                    Do({|caret:Task|}.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                    Do(Task.CompletedTask);
+                }
+            }
+            """;
 
         var workspaceXml =
-$@"<Workspace>
-    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"">
-        <Document FilePath=""C:\C.cs"">{markup}</Document>
-    </Project>
-    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj2"">
-        <Document IsLinkFile=""true"" LinkFilePath=""C:\C.cs"" LinkAssemblyName=""CSProj1""></Document>
-    </Project>
-</Workspace>";
+            $"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj1">
+                    <Document FilePath="C:\C.cs">{markup}</Document>
+                </Project>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj2">
+                    <Document IsLinkFile="true" LinkFilePath="C:\C.cs" LinkAssemblyName="CSProj1"></Document>
+                </Project>
+            </Workspace>
+            """;
 
         await using var testLspServer = await CreateXmlTestLspServerAsync(workspaceXml, mutatingLspWorkspace, initializationOptions: new InitializationOptions
         {

--- a/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerFeaturesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerFeaturesTests.cs
@@ -51,9 +51,8 @@ class B
     }
 
     [Theory, CombinatorialData]
-    public async Task TestFindAllReferencesAsync_LargeNumberOfReferences(bool mutatingLspWorkspace, [CombinatorialRange(0, 50)] int iteration)
+    public async Task TestFindAllReferencesAsync_LargeNumberOfReferences(bool mutatingLspWorkspace)
     {
-        _ = iteration;
         var markup =
 @"using System.Threading.Tasks
 class A
@@ -80,5 +79,84 @@ class A
 
         var results = await FindAllReferencesHandlerTests.RunFindAllReferencesNonVSAsync(testLspServer, testLspServer.GetLocations("caret").First());
         Assert.Equal(103, results.Length);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestFindAllReferencesAsync_LinkedFile(bool mutatingLspWorkspace, [CombinatorialRange(0, 10)] int iteration)
+    {
+        _ = iteration;
+        var markup =
+@"using System.Threading.Tasks
+class A
+{
+    private void SomeMethod()
+    {
+        Do({|caret:Task|}.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+        Do(Task.CompletedTask);
+    }
+}";
+
+        var workspaceXml =
+$@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"">
+        <Document FilePath=""C:\C.cs"">{markup}</Document>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj2"">
+        <Document IsLinkFile=""true"" LinkFilePath=""C:\C.cs"" LinkAssemblyName=""CSProj1""></Document>
+    </Project>
+</Workspace>";
+
+        await using var testLspServer = await CreateXmlTestLspServerAsync(workspaceXml, mutatingLspWorkspace, initializationOptions: new InitializationOptions
+        {
+            ClientCapabilities = new LSP.ClientCapabilities()
+        });
+
+        await WaitForWorkspaceOperationsAsync(testLspServer.TestWorkspace);
+
+        var results = await FindAllReferencesHandlerTests.RunFindAllReferencesNonVSAsync(testLspServer, testLspServer.GetLocations("caret").First());
+        Assert.Equal(46, results.Length);
     }
 }

--- a/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerFeaturesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerFeaturesTests.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.ServiceModel.Syndication;
 using System.Threading.Tasks;
+using EnvDTE;
 using Microsoft.CodeAnalysis.Editor.Test;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -46,5 +48,37 @@ class B
 
         var results = await FindAllReferencesHandlerTests.RunFindAllReferencesNonVSAsync(testLspServer, testLspServer.GetLocations("caret").First());
         AssertLocationsEqual(testLspServer.GetLocations("reference"), results.Select(result => result));
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestFindAllReferencesAsync_LargeNumberOfReferences(bool mutatingLspWorkspace, [CombinatorialRange(0, 50)] int iteration)
+    {
+        _ = iteration;
+        var markup =
+@"using System.Threading.Tasks
+class A
+{
+    private {|caret:Task|} someTask = Task.CompletedTask;
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, new LSP.ClientCapabilities());
+
+        for (var i = 0; i < 100; i++)
+        {
+            var source = $$"""
+            using System.Threading.Tasks
+            class SomeClass{{i}}
+            {
+                private Task someTask;
+            }
+            """;
+
+            var testDocument = new EditorTestHostDocument(text: source, displayName: @$"C:\SomeFile{i}.cs", exportProvider: testLspServer.TestWorkspace.ExportProvider, filePath: @$"C:\SomeFile{i}.cs");
+            testLspServer.TestWorkspace.AddTestProject(new EditorTestHostProject(testLspServer.TestWorkspace, documents: new[] { testDocument }));
+        }
+
+        await WaitForWorkspaceOperationsAsync(testLspServer.TestWorkspace);
+
+        var results = await FindAllReferencesHandlerTests.RunFindAllReferencesNonVSAsync(testLspServer, testLspServer.GetLocations("caret").First());
+        Assert.Equal(103, results.Length);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-csharp/issues/7391

TestFindAllReferencesAsync_LinkedFile should fail a few times (other passes)