### PR TITLE
Erase extension types eagerly during translation of type symbols to Cci entities.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ImportChain.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ImportChain.cs
@@ -131,7 +131,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static Cci.ITypeReference GetTypeReference(TypeSymbol type, SyntaxNode syntaxNode, Emit.PEModuleBuilder moduleBuilder, DiagnosticBag diagnostics)
         {
-            return moduleBuilder.Translate(type, syntaxNode, diagnostics);
+            // PROTOTYPE(roles): Does this go to PDB only? Do we care about constraint violations there?
+            //                   If so, we might need an alternative way to encode extension references.
+            return moduleBuilder.Translate(type, syntaxNode, diagnostics, eraseExtensions: false);
         }
 
         private static Cci.IAssemblyReference TryGetAssemblyScope(NamespaceSymbol @namespace, Emit.PEModuleBuilder moduleBuilder, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         var localSymbol = new SynthesizedLocal(_method, _method.ReturnTypeWithAnnotations, SynthesizedLocalKind.FunctionReturnValue, bodySyntax);
 
                         result = _builder.LocalSlotManager.DeclareLocal(
-                            type: _module.Translate(localSymbol.Type, bodySyntax, _diagnostics.DiagnosticBag),
+                            type: _module.Translate(localSymbol.Type, bodySyntax, _diagnostics.DiagnosticBag, eraseExtensions: true),
                             symbol: localSymbol,
                             name: null,
                             kind: localSymbol.SynthesizedKind,
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitSymbolToken(TypeSymbol symbol, SyntaxNode syntaxNode)
         {
-            EmitTypeReferenceToken(_module.Translate(symbol, syntaxNode, _diagnostics.DiagnosticBag), syntaxNode);
+            EmitTypeReferenceToken(_module.Translate(symbol, syntaxNode, _diagnostics.DiagnosticBag, eraseExtensions: true), syntaxNode);
         }
 
         private void EmitSymbolToken(MethodSymbol method, SyntaxNode syntaxNode, BoundArgListOperator optArgList, bool encodeAsRawDefinitionToken = false)
@@ -359,7 +359,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitSignatureToken(FunctionPointerTypeSymbol symbol, SyntaxNode syntaxNode)
         {
-            _builder.EmitToken(_module.Translate(symbol).Signature, syntaxNode, _diagnostics.DiagnosticBag);
+            _builder.EmitToken(_module.Translate(symbol, eraseExtensions: true).Signature, syntaxNode, _diagnostics.DiagnosticBag);
         }
 
         private void EmitSequencePointStatement(BoundSequencePoint node)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                _builder.EmitArrayElementAddress(_module.Translate((ArrayTypeSymbol)arrayAccess.Expression.Type),
+                _builder.EmitArrayElementAddress(_module.Translate((ArrayTypeSymbol)arrayAccess.Expression.Type, eraseExtensions: true),
                                                 arrayAccess.Syntax, _diagnostics.DiagnosticBag);
             }
         }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
@@ -648,7 +648,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // ensure deterministic behavior.
                 arrayType = arrayType.WithElementType(TypeWithAnnotations.Create(elementType.EnumUnderlyingTypeOrSelf()));
 
-                var cachingField = _builder.module.GetArrayCachingFieldForData(data, _module.Translate(arrayType), wrappedExpression.Syntax, _diagnostics.DiagnosticBag);
+                var cachingField = _builder.module.GetArrayCachingFieldForData(data, _module.Translate(arrayType, eraseExtensions: true), wrappedExpression.Syntax, _diagnostics.DiagnosticBag);
                 var arrayNotNullLabel = new object();
 
                 // T[]? array = PrivateImplementationDetails.cachingField;
@@ -706,7 +706,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
 
                 ImmutableArray<ConstantValue> constants = initializers.SelectAsArray(static init => init.ConstantValueOpt!);
-                Cci.IFieldReference cachingField = _builder.module.GetArrayCachingFieldForConstants(constants, _module.Translate(arrayType),
+                Cci.IFieldReference cachingField = _builder.module.GetArrayCachingFieldForConstants(constants, _module.Translate(arrayType, eraseExtensions: true),
                     arrayCreation.Syntax, _diagnostics.DiagnosticBag);
 
                 var arrayNotNullLabel = new object();

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1093,7 +1093,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                _builder.EmitArrayElementLoad(_module.Translate((ArrayTypeSymbol)arrayAccess.Expression.Type), arrayAccess.Expression.Syntax, _diagnostics.DiagnosticBag);
+                _builder.EmitArrayElementLoad(_module.Translate((ArrayTypeSymbol)arrayAccess.Expression.Type, eraseExtensions: true), arrayAccess.Expression.Syntax, _diagnostics.DiagnosticBag);
             }
 
             EmitPopIfUnused(used);
@@ -2366,7 +2366,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                _builder.EmitArrayCreation(_module.Translate(arrayType), expression.Syntax, _diagnostics.DiagnosticBag);
+                _builder.EmitArrayCreation(_module.Translate(arrayType, eraseExtensions: true), expression.Syntax, _diagnostics.DiagnosticBag);
             }
 
             if (expression.InitializerOpt != null)
@@ -3184,7 +3184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                _builder.EmitArrayElementStore(_module.Translate(arrayType), syntaxNode, _diagnostics.DiagnosticBag);
+                _builder.EmitArrayElementStore(_module.Translate(arrayType, eraseExtensions: true), syntaxNode, _diagnostics.DiagnosticBag);
             }
         }
 
@@ -3585,18 +3585,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private void EmitModuleVersionIdToken(BoundModuleVersionId node)
         {
             _builder.EmitToken(
-                _module.GetModuleVersionId(_module.Translate(node.Type, node.Syntax, _diagnostics.DiagnosticBag), node.Syntax, _diagnostics.DiagnosticBag),
+                _module.GetModuleVersionId(_module.Translate(node.Type, node.Syntax, _diagnostics.DiagnosticBag, eraseExtensions: true), node.Syntax, _diagnostics.DiagnosticBag),
                 node.Syntax,
                 _diagnostics.DiagnosticBag);
         }
 
         private void EmitThrowIfModuleCancellationRequested(SyntaxNode syntax)
         {
-            var cancellationTokenType = _module.CommonCompilation.CommonGetWellKnownType(WellKnownType.System_Threading_CancellationToken);
+            var cancellationTokenType = _module.Compilation.GetWellKnownType(WellKnownType.System_Threading_CancellationToken);
 
             _builder.EmitOpCode(ILOpCode.Ldsflda);
             _builder.EmitToken(
-                _module.GetModuleCancellationToken(_module.Translate(cancellationTokenType, syntax, _diagnostics.DiagnosticBag), syntax, _diagnostics.DiagnosticBag),
+                _module.GetModuleCancellationToken(_module.Translate(cancellationTokenType, syntax, _diagnostics.DiagnosticBag, Emit.ExtensionsEraseMode.None), syntax, _diagnostics.DiagnosticBag),
                 syntax,
                 _diagnostics.DiagnosticBag);
 
@@ -3614,11 +3614,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitModuleCancellationTokenLoad(SyntaxNode syntax)
         {
-            var cancellationTokenType = _module.CommonCompilation.CommonGetWellKnownType(WellKnownType.System_Threading_CancellationToken);
+            var cancellationTokenType = _module.Compilation.GetWellKnownType(WellKnownType.System_Threading_CancellationToken);
 
             _builder.EmitOpCode(ILOpCode.Ldsfld);
             _builder.EmitToken(
-                _module.GetModuleCancellationToken(_module.Translate(cancellationTokenType, syntax, _diagnostics.DiagnosticBag), syntax, _diagnostics.DiagnosticBag),
+                _module.GetModuleCancellationToken(_module.Translate(cancellationTokenType, syntax, _diagnostics.DiagnosticBag, Emit.ExtensionsEraseMode.None), syntax, _diagnostics.DiagnosticBag),
                 syntax,
                 _diagnostics.DiagnosticBag);
         }
@@ -3643,7 +3643,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitInstrumentationPayloadRootToken(BoundInstrumentationPayloadRoot node)
         {
-            _builder.EmitToken(_module.GetInstrumentationPayloadRoot(node.AnalysisKind, _module.Translate(node.Type, node.Syntax, _diagnostics.DiagnosticBag), node.Syntax, _diagnostics.DiagnosticBag), node.Syntax, _diagnostics.DiagnosticBag);
+            _builder.EmitToken(_module.GetInstrumentationPayloadRoot(node.AnalysisKind, _module.Translate(node.Type, node.Syntax, _diagnostics.DiagnosticBag, eraseExtensions: true), node.Syntax, _diagnostics.DiagnosticBag), node.Syntax, _diagnostics.DiagnosticBag);
         }
 
         private void EmitSourceDocumentIndex(BoundSourceDocumentIndex node)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -912,7 +912,7 @@ oneMoreTime:
                     {
                         // Ensure the return type has been translated. (Necessary
                         // for cases of untranslated anonymous types.)
-                        _module.Translate(expressionOpt.Type, boundReturnStatement.Syntax, _diagnostics.DiagnosticBag);
+                        _module.Translate(expressionOpt.Type, boundReturnStatement.Syntax, _diagnostics.DiagnosticBag, eraseExtensions: true);
                     }
                     _builder.EmitRet(expressionOpt == null);
                 }
@@ -1046,7 +1046,7 @@ oneMoreTime:
             if (catchBlock.ExceptionFilterOpt == null)
             {
                 var exceptionType = ((object)catchBlock.ExceptionTypeOpt != null) ?
-                    _module.Translate(catchBlock.ExceptionTypeOpt, catchBlock.Syntax, _diagnostics.DiagnosticBag) :
+                    _module.Translate(catchBlock.ExceptionTypeOpt, catchBlock.Syntax, _diagnostics.DiagnosticBag, eraseExtensions: true) :
                     _module.GetSpecialType(SpecialType.System_Object, catchBlock.Syntax, _diagnostics.DiagnosticBag);
 
                 _builder.OpenLocalScope(ScopeType.Catch, exceptionType);
@@ -1093,7 +1093,7 @@ oneMoreTime:
 
                 if ((object)catchBlock.ExceptionTypeOpt != null)
                 {
-                    var exceptionType = _module.Translate(catchBlock.ExceptionTypeOpt, catchBlock.Syntax, _diagnostics.DiagnosticBag);
+                    var exceptionType = _module.Translate(catchBlock.ExceptionTypeOpt, catchBlock.Syntax, _diagnostics.DiagnosticBag, eraseExtensions: true);
 
                     _builder.EmitOpCode(ILOpCode.Isinst);
                     _builder.EmitToken(exceptionType, catchBlock.Syntax, _diagnostics.DiagnosticBag);
@@ -1797,13 +1797,13 @@ oneMoreTime:
                 // (represented here by IntPtr) instead.
                 translatedType = pointedAtType.IsVoidType()
                     ? _module.GetSpecialType(SpecialType.System_IntPtr, syntaxNode, _diagnostics.DiagnosticBag)
-                    : _module.Translate(pointedAtType, syntaxNode, _diagnostics.DiagnosticBag);
+                    : _module.Translate(pointedAtType, syntaxNode, _diagnostics.DiagnosticBag, eraseExtensions: true);
             }
             else
             {
                 constraints = (local.IsPinned ? LocalSlotConstraints.Pinned : LocalSlotConstraints.None) |
                     (local.RefKind != RefKind.None ? LocalSlotConstraints.ByRef : LocalSlotConstraints.None);
-                translatedType = _module.Translate(local.Type, syntaxNode, _diagnostics.DiagnosticBag);
+                translatedType = _module.Translate(local.Type, syntaxNode, _diagnostics.DiagnosticBag, eraseExtensions: true);
             }
 
             // Even though we don't need the token immediately, we will need it later when signature for the local is emitted.
@@ -1900,7 +1900,7 @@ oneMoreTime:
         private LocalDefinition AllocateTemp(TypeSymbol type, SyntaxNode syntaxNode, LocalSlotConstraints slotConstraints = LocalSlotConstraints.None)
         {
             return _builder.LocalSlotManager.AllocateSlot(
-                _module.Translate(type, syntaxNode, _diagnostics.DiagnosticBag),
+                _module.Translate(type, syntaxNode, _diagnostics.DiagnosticBag, eraseExtensions: true),
                 slotConstraints);
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             var visited = (TypeSymbol)_deepTranslator.Visit(type);
             Debug.Assert((object)visited != null);
             //Debug.Assert(visited != null || type is LambdaFrame || ((NamedTypeSymbol)type).ConstructedFrom is LambdaFrame);
-            return Translate(visited ?? type, null, diagnostics);
+            return Translate(visited ?? type, null, diagnostics, eraseExtensions: true);
         }
 
         private static EmitBaseline.MetadataSymbols GetOrCreateMetadataSymbols(EmitBaseline initialBaseline, CSharpCompilation compilation)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/ArrayTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/ArrayTypeSymbolAdapter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
 
             TypeWithAnnotations elementType = AdaptedArrayTypeSymbol.ElementTypeWithAnnotations;
-            var type = moduleBeingBuilt.Translate(elementType.Type, syntaxNodeOpt: (CSharpSyntaxNode?)context.SyntaxNode, diagnostics: context.Diagnostics, keepExtension: context.KeepExtensions);
+            var type = moduleBeingBuilt.Translate(elementType.Type, syntaxNodeOpt: (CSharpSyntaxNode?)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: false);
 
             if (elementType.CustomModifiers.Length == 0)
             {

--- a/src/Compilers/CSharp/Portable/Emitter/Model/AttributeDataAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/AttributeDataAdapter.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
             // PROTOTYPE validate once extension types are all allowed in attributes
-            return moduleBeingBuilt.Translate(this.AttributeClass, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, keepExtension: false);
+            return moduleBeingBuilt.Translate(this.AttributeClass, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, ExtensionsEraseMode.ExcludeSelf);
         }
 
         bool Cci.ICustomAttribute.AllowMultiple
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(!argument.Values.IsDefault);
             var values = argument.Values;
-            var arrayType = ((PEModuleBuilder)context.Module).Translate((ArrayTypeSymbol)argument.TypeInternal);
+            var arrayType = ((PEModuleBuilder)context.Module).Translate((ArrayTypeSymbol)argument.TypeInternal, eraseExtensions: true);
 
             if (values.Length == 0)
             {
@@ -150,8 +150,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var moduleBeingBuilt = (PEModuleBuilder)context.Module;
             var syntaxNodeOpt = (CSharpSyntaxNode)context.SyntaxNode;
             var diagnostics = context.Diagnostics;
-            return new MetadataTypeOf(moduleBeingBuilt.Translate((TypeSymbol)argument.ValueInternal, syntaxNodeOpt, diagnostics),
-                                      moduleBeingBuilt.Translate((TypeSymbol)argument.TypeInternal, syntaxNodeOpt, diagnostics));
+            return new MetadataTypeOf(moduleBeingBuilt.Translate((TypeSymbol)argument.ValueInternal, syntaxNodeOpt, diagnostics, eraseExtensions: true),
+                                      moduleBeingBuilt.Translate((TypeSymbol)argument.TypeInternal, syntaxNodeOpt, diagnostics, eraseExtensions: true));
         }
 
         private static MetadataSerializedType CreateSerializedType(TypedConstant argument, EmitContext context)
@@ -164,8 +164,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var diagnostics = context.Diagnostics;
 
             return new MetadataSerializedType(
-                moduleBeingBuilt.Translate((TypeSymbol)argument.ValueInternal, syntaxNodeOpt, diagnostics, keepExtension: true),
-                moduleBeingBuilt.Translate((TypeSymbol)argument.TypeInternal, syntaxNodeOpt, diagnostics));
+                moduleBeingBuilt.Translate((TypeSymbol)argument.ValueInternal, syntaxNodeOpt, diagnostics, eraseExtensions: false),
+                moduleBeingBuilt.Translate((NamedTypeSymbol)argument.TypeInternal, syntaxNodeOpt, diagnostics, ExtensionsEraseMode.None));
         }
 
         private static MetadataConstant CreateMetadataConstant(ITypeSymbolInternal type, object value, EmitContext context)
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
-            return new MetadataNamedArgument(symbol, moduleBeingBuilt.Translate(type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics), value);
+            return new MetadataNamedArgument(symbol, moduleBeingBuilt.Translate(type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: true), value);
         }
 
         private Symbol LookupName(string name)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/CustomModifierAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/CustomModifierAdapter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         Cci.ITypeReference Cci.ICustomModifier.GetModifier(EmitContext context)
         {
-            return ((PEModuleBuilder)context.Module).Translate(this.ModifierSymbol, (CSharpSyntaxNode)context.SyntaxNode, context.Diagnostics, keepExtension: true);
+            return ((PEModuleBuilder)context.Module).Translate(this.ModifierSymbol, (CSharpSyntaxNode)context.SyntaxNode, context.Diagnostics, ExtensionsEraseMode.None);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/EventSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/EventSymbolAdapter.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         Cci.ITypeReference Cci.IEventDefinition.GetType(EmitContext context)
         {
-            return ((PEModuleBuilder)context.Module).Translate(AdaptedEventSymbol.Type, syntaxNodeOpt: (CSharpSyntaxNode?)context.SyntaxNode, diagnostics: context.Diagnostics);
+            return ((PEModuleBuilder)context.Module).Translate(AdaptedEventSymbol.Type, syntaxNodeOpt: (CSharpSyntaxNode?)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: true);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Emitter/Model/FieldSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/FieldSymbolAdapter.cs
@@ -38,7 +38,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var implType = isFixed ? AdaptedFieldSymbol.FixedImplementationType(moduleBeingBuilt) : fieldTypeWithAnnotations.Type;
             var type = moduleBeingBuilt.Translate(implType,
                                                   syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
-                                                  diagnostics: context.Diagnostics);
+                                                  diagnostics: context.Diagnostics,
+                                                  eraseExtensions: true);
 
             if (isFixed || customModifiers.Length == 0)
             {
@@ -97,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return moduleBeingBuilt.Translate(AdaptedFieldSymbol.ContainingType,
                                               syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
                                               diagnostics: context.Diagnostics,
-                                              keepExtension: true,
+                                              AdaptedFieldSymbol.IsDefinition ? ExtensionsEraseMode.None : ExtensionsEraseMode.ExcludeSelf,
                                               needDeclaration: AdaptedFieldSymbol.IsDefinition);
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/GenericMethodInstanceReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/GenericMethodInstanceReference.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             foreach (var arg in UnderlyingMethod.TypeArgumentsWithAnnotations)
             {
                 Debug.Assert(arg.CustomModifiers.IsEmpty);
-                yield return moduleBeingBuilt.Translate(arg.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics);
+                yield return moduleBeingBuilt.Translate(arg.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: true);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/GenericNestedTypeInstanceReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/GenericNestedTypeInstanceReference.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         Cci.ITypeReference Cci.ITypeMemberReference.GetContainingType(EmitContext context)
         {
             return ((PEModuleBuilder)context.Module).Translate(UnderlyingNamedType.ContainingType, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics,
-                keepExtension: true);
+                ExtensionsEraseMode.None);
         }
 
         public override Cci.IGenericTypeInstanceReference AsGenericTypeInstanceReference

--- a/src/Compilers/CSharp/Portable/Emitter/Model/GenericTypeInstanceReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/GenericTypeInstanceReference.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             var builder = ArrayBuilder<Cci.ITypeReference>.GetInstance();
             foreach (TypeWithAnnotations type in UnderlyingNamedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics)
             {
-                builder.Add(moduleBeingBuilt.Translate(type.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics));
+                builder.Add(moduleBeingBuilt.Translate(type.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: false));
             }
 
             return builder.ToImmutableAndFree();
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             return (Cci.INamedTypeReference)moduleBeingBuilt.Translate(
                 UnderlyingNamedType.OriginalDefinition, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
-                diagnostics: context.Diagnostics, keepExtension: true, needDeclaration: true);
+                diagnostics: context.Diagnostics, ExtensionsEraseMode.None, needDeclaration: true);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/MethodReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/MethodReference.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         Cci.ITypeReference Cci.ISignature.GetType(EmitContext context)
         {
-            return ((PEModuleBuilder)context.Module).Translate(UnderlyingMethod.ReturnType, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics);
+            return ((PEModuleBuilder)context.Module).Translate(UnderlyingMethod.ReturnType, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: true);
         }
 
         public virtual Cci.IGenericMethodInstanceReference AsGenericMethodInstanceReference

--- a/src/Compilers/CSharp/Portable/Emitter/Model/MethodSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/MethodSymbolAdapter.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return moduleBeingBuilt.Translate(containingType,
                 syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
                 diagnostics: context.Diagnostics,
-                keepExtension: true,
+                AdaptedMethodSymbol.IsDefinition ? ExtensionsEraseMode.None : ExtensionsEraseMode.ExcludeSelf,
                 needDeclaration: AdaptedMethodSymbol.IsDefinition);
         }
 
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ((PEModuleBuilder)context.Module).Translate(AdaptedMethodSymbol.ReturnType,
                 syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
                 diagnostics: context.Diagnostics,
-                keepExtension: false);
+                eraseExtensions: true);
         }
 
         IEnumerable<Cci.ITypeReference> Cci.IGenericMethodInstanceReference.GetGenericArguments(EmitContext context)
@@ -257,7 +257,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(arg.CustomModifiers.IsEmpty);
                 yield return moduleBeingBuilt.Translate(arg.Type,
                                                         syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
-                                                        diagnostics: context.Diagnostics);
+                                                        diagnostics: context.Diagnostics,
+                                                        eraseExtensions: true);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ((object)baseType != null) ? moduleBeingBuilt.Translate(baseType,
                                                                    syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
                                                                    diagnostics: context.Diagnostics,
-                                                                   keepExtension: false) : null;
+                                                                   ExtensionsEraseMode.ExcludeSelf) : null;
         }
 
         IEnumerable<Cci.IEventDefinition> Cci.ITypeDefinition.GetEvents(EmitContext context)
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     @interface,
                     syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
                     diagnostics: context.Diagnostics,
-                    keepExtension: false,
+                    ExtensionsEraseMode.ExcludeSelf,
                     fromImplements: true);
 
                 var type = TypeWithAnnotations.Create(@interface);
@@ -840,7 +840,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return moduleBeingBuilt.Translate(AdaptedNamedTypeSymbol.ContainingType,
                                               syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
                                               diagnostics: context.Diagnostics,
-                                              keepExtension: true,
+                                              ExtensionsEraseMode.None,
                                               needDeclaration: AdaptedNamedTypeSymbol.IsDefinition);
         }
 
@@ -876,7 +876,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (int i = 0; i < arguments.Length; i++)
             {
-                var arg = moduleBeingBuilt.Translate(arguments[i].Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, keepExtension: context.KeepExtensions);
+                var arg = moduleBeingBuilt.Translate(arguments[i].Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: false);
                 var modifiers = arguments[i].CustomModifiers;
                 if (!modifiers.IsDefaultOrEmpty)
                 {
@@ -901,7 +901,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return (INamedTypeReference)moduleBeingBuilt.Translate(
                 AdaptedNamedTypeSymbol.OriginalDefinition, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
-                diagnostics: context.Diagnostics, keepExtension: true, needDeclaration: true);
+                diagnostics: context.Diagnostics, ExtensionsEraseMode.None, needDeclaration: true);
         }
 
         Cci.INestedTypeReference Cci.ISpecializedNestedTypeReference.GetUnspecializedVersion(EmitContext context)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1189,6 +1189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             return Translate((TypeSymbol)symbol, syntaxOpt, diagnostics, eraseExtensions: true);
         }
+
         /// <param name="eraseExtensions">
         /// When translating for purpose of serializing a type into a string for the extension erasure attribute, we should keep extensions.
         /// </param>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
 using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
 
@@ -845,7 +846,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return (Cci.INamedTypeReference)Translate(specialTypeSymbol,
                              diagnostics: diagnostics,
                              syntaxNodeOpt: syntaxNodeOpt,
-                             keepExtension: false, needDeclaration: true);
+                             extensionsEraseMode: ExtensionsEraseMode.None, needDeclaration: true);
         }
 
         public sealed override Cci.IMethodReference GetInitArrayHelper()
@@ -963,7 +964,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             }
         }
 
-        /// <param name="keepExtension">
+        /// <param name="extensionsEraseMode">
         /// There are a few reasons to keep an extension type un-erased:
         /// - translating a container type: `E.X` (we should keep the extension type `E`)
         /// - serializing a type into a string for the extension erasure attribute (we should keep all extensions)
@@ -974,23 +975,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             NamedTypeSymbol namedTypeSymbol,
             SyntaxNode syntaxNodeOpt,
             DiagnosticBag diagnostics,
-            bool keepExtension,
+            ExtensionsEraseMode extensionsEraseMode,
             bool fromImplements = false,
             bool needDeclaration = false)
         {
             Debug.Assert(namedTypeSymbol.IsDefinitionOrDistinct());
             Debug.Assert(diagnostics != null);
+            Debug.Assert(!needDeclaration || extensionsEraseMode == ExtensionsEraseMode.None);
 
-            if (!keepExtension
-                && namedTypeSymbol.GetExtendedTypeNoUseSiteDiagnostics(basesBeingResolved: null) is { } extendedType)
+            if (extensionsEraseMode != ExtensionsEraseMode.None)
             {
-                if (extendedType is NamedTypeSymbol extendedNamedType)
+                if (extensionsEraseMode == ExtensionsEraseMode.ExcludeSelf)
                 {
-                    namedTypeSymbol = extendedNamedType;
+                    namedTypeSymbol = ExtensionTypeEraser.TransformExcludingSelf(namedTypeSymbol, out _);
                 }
                 else
                 {
-                    return Translate(extendedType, syntaxNodeOpt, diagnostics);
+                    TypeSymbol transformed = ExtensionTypeEraser.TransformType(namedTypeSymbol, out _);
+
+                    if (transformed is NamedTypeSymbol transformedNamedType)
+                    {
+                        namedTypeSymbol = transformedNamedType;
+                    }
+                    else
+                    {
+                        return Translate(transformed, syntaxNodeOpt, diagnostics, eraseExtensions: false);
+                    }
                 }
             }
 
@@ -1165,14 +1175,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return param.GetCciAdapter();
         }
 
-        /// <param name="keepExtension">
+        internal override Cci.ITypeReference TranslateTypeOfConstant(TypeSymbol symbol, SyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
+        {
+            return Translate(symbol, syntaxNodeOpt, diagnostics, eraseExtensions: true);
+        }
+
+        internal override Cci.ITypeReference EncTranslateLocalVariableType(TypeSymbol type, DiagnosticBag diagnostics)
+        {
+            return Translate(type, syntaxNodeOpt: null, diagnostics, eraseExtensions: true);
+        }
+
+        internal override Cci.ITypeReference TranslateMarshallingTypeReference(ITypeSymbolInternal symbol, SyntaxNode syntaxOpt, DiagnosticBag diagnostics)
+        {
+            return Translate((TypeSymbol)symbol, syntaxOpt, diagnostics, eraseExtensions: true);
+        }
+        /// <param name="eraseExtensions">
         /// When translating for purpose of serializing a type into a string for the extension erasure attribute, we should keep extensions.
         /// </param>
-        internal sealed override Cci.ITypeReference Translate(
+        internal Cci.ITypeReference Translate(
             TypeSymbol typeSymbol,
             SyntaxNode syntaxNodeOpt,
             DiagnosticBag diagnostics,
-            bool keepExtension = false)
+            bool eraseExtensions)
         {
             Debug.Assert(diagnostics != null);
 
@@ -1182,20 +1206,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     return Translate(syntaxNodeOpt, diagnostics);
 
                 case SymbolKind.ArrayType:
-                    return Translate((ArrayTypeSymbol)typeSymbol);
+                    return Translate((ArrayTypeSymbol)typeSymbol, eraseExtensions);
 
                 case SymbolKind.ErrorType:
                 case SymbolKind.NamedType:
-                    return Translate((NamedTypeSymbol)typeSymbol, syntaxNodeOpt, diagnostics, keepExtension: keepExtension);
+                    return Translate((NamedTypeSymbol)typeSymbol, syntaxNodeOpt, diagnostics, eraseExtensions ? ExtensionsEraseMode.IncludeSelf : ExtensionsEraseMode.None);
 
                 case SymbolKind.PointerType:
-                    return Translate((PointerTypeSymbol)typeSymbol);
+                    return Translate((PointerTypeSymbol)typeSymbol, eraseExtensions);
 
                 case SymbolKind.TypeParameter:
                     return Translate((TypeParameterSymbol)typeSymbol);
 
                 case SymbolKind.FunctionPointerType:
-                    return Translate((FunctionPointerTypeSymbol)typeSymbol);
+                    return Translate((FunctionPointerTypeSymbol)typeSymbol, eraseExtensions);
             }
 
             throw ExceptionUtilities.UnexpectedValue(typeSymbol.Kind);
@@ -1263,7 +1287,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 {
                     @params[i] = new ArgListParameterTypeInformation(ordinal,
                                                                     !optArgList.ArgumentRefKindsOpt.IsDefaultOrEmpty && optArgList.ArgumentRefKindsOpt[i] != RefKind.None,
-                                                                    Translate(optArgList.Arguments[i].Type, syntaxNodeOpt, diagnostics));
+                                                                    Translate(optArgList.Arguments[i].Type, syntaxNodeOpt, diagnostics, eraseExtensions: true));
                     ordinal++;
                 }
 
@@ -1485,18 +1509,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return GetSpecialType(SpecialType.System_Object, syntaxNodeOpt, diagnostics);
         }
 
-        internal Cci.IArrayTypeReference Translate(ArrayTypeSymbol symbol)
+        internal Cci.IArrayTypeReference Translate(ArrayTypeSymbol symbol, bool eraseExtensions)
         {
+            if (eraseExtensions)
+            {
+                symbol = (ArrayTypeSymbol)ExtensionTypeEraser.TransformType(symbol, out _);
+            }
+
             return (Cci.IArrayTypeReference)GetCciAdapter(symbol);
         }
 
-        internal Cci.IPointerTypeReference Translate(PointerTypeSymbol symbol)
+        internal Cci.IPointerTypeReference Translate(PointerTypeSymbol symbol, bool eraseExtensions)
         {
+            if (eraseExtensions)
+            {
+                symbol = (PointerTypeSymbol)ExtensionTypeEraser.TransformType(symbol, out _);
+            }
+
             return (Cci.IPointerTypeReference)GetCciAdapter(symbol);
         }
 
-        internal Cci.IFunctionPointerTypeReference Translate(FunctionPointerTypeSymbol symbol)
+        internal Cci.IFunctionPointerTypeReference Translate(FunctionPointerTypeSymbol symbol, bool eraseExtensions)
         {
+            if (eraseExtensions)
+            {
+                symbol = (FunctionPointerTypeSymbol)ExtensionTypeEraser.TransformType(symbol, out _);
+            }
+
             return (Cci.IFunctionPointerTypeReference)GetCciAdapter(symbol);
         }
 
@@ -2133,5 +2172,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             return _translatedImportsMap.GetOrAdd(chain, imports);
         }
+    }
+
+    /// <summary>
+    /// Extension erasure mode for named types.
+    /// </summary>
+    internal enum ExtensionsEraseMode
+    {
+        None,
+        ExcludeSelf,
+        IncludeSelf
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/ParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/ParameterSymbolAdapter.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ((PEModuleBuilder)context.Module).Translate(AdaptedParameterSymbol.Type,
                                                       syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
                                                       diagnostics: context.Diagnostics,
-                                                      keepExtension: false);
+                                                      eraseExtensions: true);
         }
 
         ushort Cci.IParameterListEntry.Index

--- a/src/Compilers/CSharp/Portable/Emitter/Model/ParameterTypeInformation.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/ParameterTypeInformation.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         Cci.ITypeReference Cci.IParameterTypeInformation.GetType(EmitContext context)
         {
-            return ((PEModuleBuilder)context.Module).Translate(_underlyingParameter.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics);
+            return ((PEModuleBuilder)context.Module).Translate(_underlyingParameter.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: true);
         }
 
         ushort Cci.IParameterListEntry.Index

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PointerTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PointerTypeSymbolAdapter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         Cci.ITypeReference Cci.IPointerTypeReference.GetTargetType(EmitContext context)
         {
-            var type = ((PEModuleBuilder)context.Module).Translate(AdaptedPointerTypeSymbol.PointedAtType, syntaxNodeOpt: (CSharpSyntaxNode?)context.SyntaxNode, diagnostics: context.Diagnostics, keepExtension: context.KeepExtensions);
+            var type = ((PEModuleBuilder)context.Module).Translate(AdaptedPointerTypeSymbol.PointedAtType, syntaxNodeOpt: (CSharpSyntaxNode?)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: false);
 
             if (AdaptedPointerTypeSymbol.PointedAtTypeWithAnnotations.CustomModifiers.Length == 0)
             {

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PropertySymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PropertySymbolAdapter.cs
@@ -208,7 +208,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CheckDefinitionInvariantAllowEmbedded();
             return ((PEModuleBuilder)context.Module).Translate(AdaptedPropertySymbol.Type,
                                                       syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
-                                                      diagnostics: context.Diagnostics);
+                                                      diagnostics: context.Diagnostics,
+                                                      eraseExtensions: true);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedFieldReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedFieldReference.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             TypeWithAnnotations oldType = _underlyingField.TypeWithAnnotations;
             var customModifiers = oldType.CustomModifiers;
-            var type = ((PEModuleBuilder)context.Module).Translate(oldType.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics);
+            var type = ((PEModuleBuilder)context.Module).Translate(oldType.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: true);
 
             if (customModifiers.Length == 0)
             {

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedGenericMethodInstanceReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedGenericMethodInstanceReference.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             foreach (var arg in UnderlyingMethod.TypeArgumentsWithAnnotations)
             {
                 Debug.Assert(arg.CustomModifiers.IsEmpty);
-                yield return moduleBeingBuilt.Translate(arg.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics);
+                yield return moduleBeingBuilt.Translate(arg.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: true);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedGenericNestedTypeInstanceReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedGenericNestedTypeInstanceReference.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             var builder = ArrayBuilder<Cci.ITypeReference>.GetInstance();
             foreach (TypeWithAnnotations type in UnderlyingNamedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics)
             {
-                builder.Add(moduleBeingBuilt.Translate(type.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics));
+                builder.Add(moduleBeingBuilt.Translate(type.Type, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode, diagnostics: context.Diagnostics, eraseExtensions: false));
             }
 
             return builder.ToImmutableAndFree();
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             return (Cci.INamedTypeReference)moduleBeingBuilt.Translate(
                 this.UnderlyingNamedType.OriginalDefinition, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
-                diagnostics: context.Diagnostics, keepExtension: true, needDeclaration: true);
+                diagnostics: context.Diagnostics, ExtensionsEraseMode.None, needDeclaration: true);
         }
 
         public override Cci.IGenericTypeInstanceReference AsGenericTypeInstanceReference

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedNestedTypeReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedNestedTypeReference.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             Debug.Assert(UnderlyingNamedType.OriginalDefinition.IsDefinition);
             var result = ((PEModuleBuilder)context.Module).Translate(this.UnderlyingNamedType.OriginalDefinition,
-                                          (CSharpSyntaxNode)context.SyntaxNode, context.Diagnostics, keepExtension: true, needDeclaration: true).AsNestedTypeReference;
+                                          (CSharpSyntaxNode)context.SyntaxNode, context.Diagnostics, ExtensionsEraseMode.None, needDeclaration: true).AsNestedTypeReference;
 
             Debug.Assert(result != null);
             return result;
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         Cci.ITypeReference Cci.ITypeMemberReference.GetContainingType(EmitContext context)
         {
-            return ((PEModuleBuilder)context.Module).Translate(UnderlyingNamedType.ContainingType, (CSharpSyntaxNode)context.SyntaxNode, context.Diagnostics, keepExtension: true);
+            return ((PEModuleBuilder)context.Module).Translate(UnderlyingNamedType.ContainingType, (CSharpSyntaxNode)context.SyntaxNode, context.Diagnostics, ExtensionsEraseMode.None);
         }
 
         public override Cci.IGenericTypeInstanceReference AsGenericTypeInstanceReference

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeMemberReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeMemberReference.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         public virtual Cci.ITypeReference GetContainingType(EmitContext context)
         {
             PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
-            return moduleBeingBuilt.Translate(UnderlyingSymbol.ContainingType, (CSharpSyntaxNode)context.SyntaxNode, context.Diagnostics, keepExtension: true);
+            return moduleBeingBuilt.Translate(UnderlyingSymbol.ContainingType, (CSharpSyntaxNode)context.SyntaxNode, context.Diagnostics, ExtensionsEraseMode.ExcludeSelf);
         }
 
         string Cci.INamedEntity.Name

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -266,8 +266,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
                 }
                 var typeRef = moduleBeingBuilt.Translate(type.Type,
-                                                            syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
-                                                            diagnostics: context.Diagnostics);
+                                                         syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNode,
+                                                         diagnostics: context.Diagnostics,
+                                                         eraseExtensions: true);
 
                 yield return type.GetTypeRefWithAttributes(
                                                             moduleBeingBuilt,

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedEvent.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedEvent.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
 
         protected override Cci.ITypeReference GetType(PEModuleBuilder moduleBuilder, SyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
         {
-            return moduleBuilder.Translate(UnderlyingEvent.AdaptedEventSymbol.Type, syntaxNodeOpt, diagnostics);
+            return moduleBuilder.Translate(UnderlyingEvent.AdaptedEventSymbol.Type, syntaxNodeOpt, diagnostics, eraseExtensions: true);
         }
 
         protected override EmbeddedType ContainingType

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             foreach (NamedTypeSymbol @interface in UnderlyingNamedType.AdaptedNamedTypeSymbol.GetInterfacesToEmit())
             {
                 Debug.Assert(!@interface.IsExtension);
-                TypeManager.ModuleBeingBuilt.Translate(@interface, syntaxNodeOpt, diagnostics, keepExtension: false, fromImplements: true);
+                TypeManager.ModuleBeingBuilt.Translate(@interface, syntaxNodeOpt, diagnostics, ExtensionsEraseMode.ExcludeSelf, fromImplements: true);
             }
         }
 
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
         {
             NamedTypeSymbol baseType = UnderlyingNamedType.AdaptedNamedTypeSymbol.BaseTypeNoUseSiteDiagnostics;
             Debug.Assert(baseType?.IsExtension != true);
-            return (object)baseType != null ? moduleBuilder.Translate(baseType, syntaxNodeOpt, diagnostics, keepExtension: false) : null;
+            return (object)baseType != null ? moduleBuilder.Translate(baseType, syntaxNodeOpt, diagnostics, ExtensionsEraseMode.ExcludeSelf) : null;
         }
 
         protected override IEnumerable<FieldSymbolAdapter> GetFieldsToEmit()
@@ -136,7 +136,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                 var typeRef = moduleBeingBuilt.Translate(
                     @interface,
                     (CSharpSyntaxNode)context.SyntaxNode,
-                    context.Diagnostics, keepExtension: false);
+                    context.Diagnostics,
+                    ExtensionsEraseMode.ExcludeSelf);
 
                 var type = TypeWithAnnotations.Create(@interface);
                 yield return type.GetTypeRefWithAttributes(

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!_awaiterFields.TryGetValue(awaiterType, out result))
             {
                 int slotIndex;
-                if (slotAllocator == null || !slotAllocator.TryGetPreviousAwaiterSlotIndex(F.ModuleBuilderOpt.Translate(awaiterType, F.Syntax, F.Diagnostics.DiagnosticBag), F.Diagnostics.DiagnosticBag, out slotIndex))
+                if (slotAllocator == null || !slotAllocator.TryGetPreviousAwaiterSlotIndex(F.ModuleBuilderOpt.Translate(awaiterType, F.Syntax, F.Diagnostics.DiagnosticBag, eraseExtensions: true), F.Diagnostics.DiagnosticBag, out slotIndex))
                 {
                     slotIndex = _nextAwaiterId++;
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -674,7 +674,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (slotAllocator == null ||
                             !slotAllocator.TryGetPreviousHoistedLocalSlotIndex(
                                 awaitSyntaxOpt,
-                                F.ModuleBuilderOpt.Translate(fieldType, awaitSyntaxOpt, Diagnostics.DiagnosticBag),
+                                F.ModuleBuilderOpt.Translate(fieldType, awaitSyntaxOpt, Diagnostics.DiagnosticBag, eraseExtensions: true),
                                 kind,
                                 id,
                                 Diagnostics.DiagnosticBag,

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             int previousSlotIndex;
                             if (mapToPreviousFields && slotAllocatorOpt.TryGetPreviousHoistedLocalSlotIndex(
                                 declaratorSyntax,
-                                F.ModuleBuilderOpt.Translate(fieldType, declaratorSyntax, diagnostics.DiagnosticBag),
+                                F.ModuleBuilderOpt.Translate(fieldType, declaratorSyntax, diagnostics.DiagnosticBag, eraseExtensions: true),
                                 synthesizedKind,
                                 id,
                                 diagnostics.DiagnosticBag,

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
@@ -30,7 +30,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal abstract NamedTypeSymbol MapToImplementationSymbol();
 
-            internal abstract AnonymousTypeOrDelegatePublicSymbol SubstituteTypes(AbstractTypeMap typeMap);
+            internal AnonymousTypeOrDelegatePublicSymbol SubstituteTypes(AbstractTypeMap map)
+            {
+                var typeDescr = TypeDescriptor.SubstituteTypes(map, out bool changed);
+                return changed ?
+                    WithTypeDescriptor(typeDescr) :
+                    this;
+            }
+
+            internal abstract AnonymousTypeOrDelegatePublicSymbol WithTypeDescriptor(AnonymousTypeDescriptor typeDescr);
 
             protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData)
                 => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.DelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.DelegatePublicSymbol.cs
@@ -26,12 +26,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Manager.ConstructAnonymousDelegateImplementationSymbol(this, generation: 0);
             }
 
-            internal override AnonymousTypeOrDelegatePublicSymbol SubstituteTypes(AbstractTypeMap map)
+            internal override AnonymousTypeOrDelegatePublicSymbol WithTypeDescriptor(AnonymousTypeDescriptor typeDescr)
             {
-                var typeDescr = TypeDescriptor.SubstituteTypes(map, out bool changed);
-                return changed ?
-                    new AnonymousDelegatePublicSymbol(Manager, typeDescr) :
-                    this;
+                return new AnonymousDelegatePublicSymbol(Manager, typeDescr);
             }
 
             public override TypeKind TypeKind => TypeKind.Delegate;

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -66,13 +66,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Manager.ConstructAnonymousTypeImplementationSymbol(this);
             }
 
-            internal override AnonymousTypeOrDelegatePublicSymbol SubstituteTypes(AbstractTypeMap map)
+            internal override AnonymousTypeOrDelegatePublicSymbol WithTypeDescriptor(AnonymousTypeDescriptor typeDescr)
             {
-                var oldFieldTypes = TypeDescriptor.Fields.SelectAsArray(f => f.TypeWithAnnotations);
-                var newFieldTypes = map.SubstituteTypes(oldFieldTypes);
-                return (oldFieldTypes == newFieldTypes) ?
-                    this :
-                    new AnonymousTypePublicSymbol(Manager, TypeDescriptor.WithNewFieldsTypes(newFieldTypes));
+                return new AnonymousTypePublicSymbol(Manager, typeDescr);
             }
 
             public override TypeKind TypeKind

--- a/src/Compilers/CSharp/Portable/Symbols/ExtensionTypeEraser.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ExtensionTypeEraser.cs
@@ -32,17 +32,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case TypeKind.Delegate:
                 case TypeKind.Enum:
                 case TypeKind.Error:
-                    return TransformNamedType((NamedTypeSymbol)type, out changed);
+                    return TransformExcludingSelf((NamedTypeSymbol)type, out changed);
                 case TypeKind.Extension:
                     return TransformExtension((NamedTypeSymbol)type, out changed);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(type.TypeKind);
             }
-        }
-
-        internal static NamedTypeSymbol TransformExcludingSelf(NamedTypeSymbol type, out bool changed)
-        {
-            return TransformNamedType(type, out changed);
         }
 
         private static TypeSymbol TransformExtension(NamedTypeSymbol type, out bool changed)
@@ -63,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            TypeSymbol transformedExtended = TransformNamedType(type, out bool changedExtended);
+            TypeSymbol transformedExtended = TransformExcludingSelf(type, out bool changedExtended);
             if (changedExtended)
             {
                 changed = true;
@@ -84,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type.WithTypeAndModifiers(transformedType, type.CustomModifiers);
         }
 
-        private static NamedTypeSymbol TransformNamedType(NamedTypeSymbol type, out bool changed)
+        internal static NamedTypeSymbol TransformExcludingSelf(NamedTypeSymbol type, out bool changed)
         {
             changed = false;
 

--- a/src/Compilers/CSharp/Portable/Symbols/ExtensionTypeEraser.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ExtensionTypeEraser.cs
@@ -1,0 +1,202 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal static class ExtensionTypeEraser
+    {
+        internal static TypeSymbol TransformType(TypeSymbol type, out bool changed)
+        {
+            switch (type.TypeKind)
+            {
+                case TypeKind.Array:
+                    return TransformArrayType((ArrayTypeSymbol)type, out changed);
+                case TypeKind.Pointer:
+                    return TransformPointerType((PointerTypeSymbol)type, out changed);
+                case TypeKind.FunctionPointer:
+                    return TransformFunctionPointerType((FunctionPointerTypeSymbol)type, out changed);
+                case TypeKind.TypeParameter:
+                case TypeKind.Dynamic:
+                    changed = false;
+                    return type;
+                case TypeKind.Submission:
+                case TypeKind.Class:
+                case TypeKind.Struct:
+                case TypeKind.Interface:
+                case TypeKind.Delegate:
+                case TypeKind.Enum:
+                case TypeKind.Error:
+                    return TransformNamedType((NamedTypeSymbol)type, out changed);
+                case TypeKind.Extension:
+                    return TransformExtension((NamedTypeSymbol)type, out changed);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(type.TypeKind);
+            }
+        }
+
+        internal static NamedTypeSymbol TransformExcludingSelf(NamedTypeSymbol type, out bool changed)
+        {
+            return TransformNamedType(type, out changed);
+        }
+
+        private static TypeSymbol TransformExtension(NamedTypeSymbol type, out bool changed)
+        {
+            changed = false;
+
+            while (type.GetExtendedTypeNoUseSiteDiagnostics(null) is { } extended)
+            {
+                changed = true;
+
+                if (extended is NamedTypeSymbol named)
+                {
+                    type = named;
+                }
+                else
+                {
+                    return TransformType(extended, changed: out _);
+                }
+            }
+
+            TypeSymbol transformedExtended = TransformNamedType(type, out bool changedExtended);
+            if (changedExtended)
+            {
+                changed = true;
+            }
+
+            return transformedExtended;
+        }
+
+        private static TypeWithAnnotations TransformTypeWithAnnotations(TypeWithAnnotations type, out bool changed)
+        {
+            TypeSymbol transformedType = TransformType(type.Type, out changed);
+
+            if (!changed)
+            {
+                return type;
+            }
+
+            return type.WithTypeAndModifiers(transformedType, type.CustomModifiers);
+        }
+
+        private static NamedTypeSymbol TransformNamedType(NamedTypeSymbol type, out bool changed)
+        {
+            changed = false;
+
+            if (type.IsAnonymousType)
+            {
+                var anonymous = (AnonymousTypeManager.AnonymousTypeOrDelegatePublicSymbol)type;
+                AnonymousTypeDescriptor descriptor = anonymous.TypeDescriptor;
+
+                var fieldTypes = ArrayBuilder<TypeWithAnnotations>.GetInstance(descriptor.Fields.Length);
+                fieldTypes.AddRange(descriptor.Fields, static (f) => f.TypeWithAnnotations);
+
+                for (int i = 0; i < descriptor.Fields.Length; i++)
+                {
+                    TypeWithAnnotations transformed = TransformTypeWithAnnotations(fieldTypes[i], out bool typeArgumentChanged);
+                    if (typeArgumentChanged)
+                    {
+                        changed = true;
+                        fieldTypes[i] = transformed;
+                    }
+                }
+
+                anonymous = changed ? anonymous.WithTypeDescriptor(descriptor.WithNewFieldsTypes(fieldTypes.ToImmutable())) : anonymous;
+                fieldTypes.Free();
+                return anonymous;
+            }
+
+            if (!type.IsGenericType)
+            {
+                return type;
+            }
+
+            var allTypeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance();
+            type.GetAllTypeArgumentsNoUseSiteDiagnostics(allTypeArguments);
+
+            for (int i = 0; i < allTypeArguments.Count; i++)
+            {
+                TypeWithAnnotations transformed = TransformTypeWithAnnotations(allTypeArguments[i], out bool typeArgumentChanged);
+                if (typeArgumentChanged)
+                {
+                    changed = true;
+                    allTypeArguments[i] = transformed;
+                }
+            }
+
+            NamedTypeSymbol result = changed ? type.WithTypeArguments(allTypeArguments.ToImmutable()) : type;
+            allTypeArguments.Free();
+            return result;
+        }
+
+        private static ArrayTypeSymbol TransformArrayType(ArrayTypeSymbol type, out bool changed)
+        {
+            TypeWithAnnotations transformed = TransformTypeWithAnnotations(type.ElementTypeWithAnnotations, out changed);
+            if (changed)
+            {
+                return type.WithElementType(transformed);
+            }
+
+            return type;
+        }
+
+        private static PointerTypeSymbol TransformPointerType(PointerTypeSymbol type, out bool changed)
+        {
+            TypeWithAnnotations transformed = TransformTypeWithAnnotations(type.PointedAtTypeWithAnnotations, out changed);
+            if (changed)
+            {
+                return type.WithPointedAtType(transformed);
+            }
+
+            return type;
+        }
+
+        private static FunctionPointerTypeSymbol TransformFunctionPointerType(FunctionPointerTypeSymbol type, out bool changed)
+        {
+            var transformedParameterTypes = ImmutableArray<TypeWithAnnotations>.Empty;
+            changed = false;
+
+            if (type.Signature.ParameterCount > 0)
+            {
+                var builder = ArrayBuilder<TypeWithAnnotations>.GetInstance(type.Signature.ParameterCount);
+                foreach (var param in type.Signature.Parameters)
+                {
+                    TypeWithAnnotations transformedParam = TransformTypeWithAnnotations(param.TypeWithAnnotations, out bool paramChanged);
+                    if (paramChanged)
+                    {
+                        changed = true;
+                    }
+
+                    builder.Add(transformedParam);
+                }
+
+                if (changed)
+                {
+                    transformedParameterTypes = builder.ToImmutableAndFree();
+                }
+                else
+                {
+                    transformedParameterTypes = type.Signature.ParameterTypesWithAnnotations;
+                    builder.Free();
+                }
+            }
+
+            TypeWithAnnotations transformedReturnType = TransformTypeWithAnnotations(type.Signature.ReturnTypeWithAnnotations, out bool returnChanged);
+
+            if (changed || returnChanged)
+            {
+                changed = true;
+                return type.SubstituteTypeSymbol(transformedReturnType, transformedParameterTypes, refCustomModifiers: default, paramRefCustomModifiers: default);
+            }
+            else
+            {
+                return type;
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Emit/Context.cs
+++ b/src/Compilers/Core/Portable/Emit/Context.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CodeAnalysis.Emit
 
         public bool IncludePrivateMembers => (_flags & Flags.IncludePrivateMembers) != 0;
         public bool MetadataOnly => (_flags & Flags.MetadataOnly) != 0;
-        public bool KeepExtensions => (_flags & Flags.KeepExtensions) != 0;
         public bool IsRefAssembly => MetadataOnly && !IncludePrivateMembers;
         public SyntaxNode? SyntaxNode => _syntaxNode ?? SyntaxReference?.GetSyntax();
         public Location? Location => _syntaxNode?.Location ?? SyntaxReference?.GetLocation();
@@ -35,8 +34,7 @@ namespace Microsoft.CodeAnalysis.Emit
             bool includePrivateMembers,
             SyntaxNode? syntaxNode = null,
             RebuildData? rebuildData = null,
-            SyntaxReference? syntaxReference = null,
-            bool keepExtensions = false)
+            SyntaxReference? syntaxReference = null)
         {
             Debug.Assert(rebuildData is null || !metadataOnly);
             RebuildData = rebuildData;
@@ -60,16 +58,7 @@ namespace Microsoft.CodeAnalysis.Emit
             {
                 flags |= Flags.IncludePrivateMembers;
             }
-            if (keepExtensions)
-            {
-                flags |= Flags.KeepExtensions;
-            }
             _flags = flags;
-        }
-
-        public EmitContext WithKeepExtensions()
-        {
-            return new EmitContext(Module, Diagnostics, MetadataOnly, IncludePrivateMembers, _syntaxNode, RebuildData, SyntaxReference, keepExtensions: true);
         }
 
         [Flags]
@@ -78,7 +67,6 @@ namespace Microsoft.CodeAnalysis.Emit
             None = 0,
             MetadataOnly = 1,
             IncludePrivateMembers = 2,
-            KeepExtensions = 4
         }
     }
 }

--- a/src/Compilers/Core/Portable/IReferenceOrISignature.cs
+++ b/src/Compilers/Core/Portable/IReferenceOrISignature.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Cci;
 
@@ -20,29 +19,15 @@ namespace Microsoft.CodeAnalysis
     internal readonly struct IReferenceOrISignature : IEquatable<IReferenceOrISignature>
     {
         private readonly object _item;
-        private readonly bool KeepExtensions;
 
-        public IReferenceOrISignature(IReference item, bool keepExtensions = false)
-        {
-            Debug.Assert(!keepExtensions || item is ITypeReference);
-            _item = item;
-            KeepExtensions = keepExtensions;
-        }
+        public IReferenceOrISignature(IReference item) => _item = item;
 
-        public IReferenceOrISignature(ISignature item)
-        {
-            _item = item;
-            KeepExtensions = false;
-        }
+        public IReferenceOrISignature(ISignature item) => _item = item;
 
         // Needed to resolve ambiguity for types that implement both IReference and ISignature
-        public IReferenceOrISignature(IMethodReference item)
-        {
-            _item = item;
-            KeepExtensions = false;
-        }
+        public IReferenceOrISignature(IMethodReference item) => _item = item;
 
-        public bool Equals(IReferenceOrISignature other) => ReferenceEquals(_item, other._item) && KeepExtensions == other.KeepExtensions;
+        public bool Equals(IReferenceOrISignature other) => ReferenceEquals(_item, other._item);
 
         public override bool Equals(object? obj) => false;
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Cci
     /// </summary>
     internal abstract class MetadataVisitor
     {
-        public EmitContext Context;
+        public readonly EmitContext Context;
 
         public MetadataVisitor(EmitContext context)
         {
@@ -263,10 +263,7 @@ namespace Microsoft.Cci
         {
             if (serializedType.TypeToGet != null)
             {
-                var oldContext = this.Context;
-                this.Context = this.Context.WithKeepExtensions();
                 this.Visit(serializedType.TypeToGet);
-                this.Context = oldContext;
             }
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -3544,7 +3544,7 @@ namespace Microsoft.Cci
             else if (expression is MetadataSerializedType t)
             {
                 var scalarEncoder = encoder.Scalar();
-                string serializedTypeName = t.TypeToGet.GetSerializedTypeName(context.WithKeepExtensions(), allowTypeParameters: true);
+                string serializedTypeName = t.TypeToGet.GetSerializedTypeName(context, allowTypeParameters: true);
                 scalarEncoder.Constant(serializedTypeName);
             }
             else

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
@@ -15,12 +15,8 @@ namespace Microsoft.Cci
 {
     internal abstract class ReferenceIndexerBase : MetadataVisitor
     {
-        // Note: for the _alreadySeen set, we use the KeepExtensions flag to differentiate between
-        // a visit that erases extension types from one that doesn't.
-        // For example, for `C<Extension>` we'll need to collect references from the erased type `C<ExtendedType>`
-        // but also references needed to decode the extension erasure attribute `[ExtensionErasure("C'1[Extension]")]`.
-        private readonly HashSet<IReferenceOrISignature> _alreadySeen = new HashSet<IReferenceOrISignature>();
-        private readonly HashSet<IReferenceOrISignature> _alreadyHasToken = new HashSet<IReferenceOrISignature>();
+        private readonly HashSet<IReferenceOrISignature> _alreadySeen = new();
+        private readonly HashSet<IReferenceOrISignature> _alreadyHasToken = new();
 
         /// <summary>
         /// Set true before a type reference is visited but only if a token needs to be created for the type reference.
@@ -418,11 +414,7 @@ namespace Microsoft.Cci
         // Returns true if we need to look at the children, false otherwise.
         private bool VisitTypeReference(ITypeReference typeReference)
         {
-            // When visiting a MetadataSerializedType (representing the type we need to serialize in an extension erasure attribute),
-            // we set the KeepExtensions flag.
-            // We keep track of whether a type reference has been seen with this flag (as part of erasure attribute)
-            // and without this flag (normal type reference elsewhere) so that both translations can be indexed.
-            if (!_alreadySeen.Add(new IReferenceOrISignature(typeReference, keepExtensions: Context.KeepExtensions)))
+            if (!_alreadySeen.Add(new IReferenceOrISignature(typeReference)))
             {
                 if (!this.typeReferenceNeedsToken)
                 {
@@ -430,10 +422,6 @@ namespace Microsoft.Cci
                 }
 
                 this.typeReferenceNeedsToken = false;
-                // PROTOTYPE note that we don't use a keepExtensions flag for the _alreadyHasToken set yet.
-                //   But in case where a program has both `modopt(C<E>)` and `C<E>` (to be erased), we will need
-                //   tokens for both. This may be solved naturally by the alternative approach for keeping context (keepExtensions flag)
-                //   to support emitting modopts with extension types.
                 if (!_alreadyHasToken.Add(new IReferenceOrISignature(typeReference)))
                 {
                     return false;

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Cci
 {
     internal abstract class ReferenceIndexerBase : MetadataVisitor
     {
-        private readonly HashSet<IReferenceOrISignature> _alreadySeen = new();
-        private readonly HashSet<IReferenceOrISignature> _alreadyHasToken = new();
+        private readonly HashSet<IReferenceOrISignature> _alreadySeen = new HashSet<IReferenceOrISignature>();
+        private readonly HashSet<IReferenceOrISignature> _alreadyHasToken = new HashSet<IReferenceOrISignature>();
 
         /// <summary>
         /// Set true before a type reference is visited but only if a token needs to be created for the type reference.

--- a/src/Compilers/Core/Portable/Symbols/Attributes/MarshalPseudoCustomAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/MarshalPseudoCustomAttributeData.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis
             var typeSymbol = _marshalTypeNameOrSymbol as ITypeSymbolInternal;
             if (typeSymbol != null)
             {
-                return ((CommonPEModuleBuilder)context.Module).Translate(typeSymbol, context.SyntaxNode, context.Diagnostics);
+                return ((CommonPEModuleBuilder)context.Module).TranslateMarshallingTypeReference(typeSymbol, context.SyntaxNode, context.Diagnostics);
             }
             else
             {
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis
                 return null;
             }
 
-            return ((CommonPEModuleBuilder)context.Module).Translate((ITypeSymbolInternal)_marshalTypeNameOrSymbol, context.SyntaxNode, context.Diagnostics);
+            return ((CommonPEModuleBuilder)context.Module).TranslateMarshallingTypeReference((ITypeSymbolInternal)_marshalTypeNameOrSymbol, context.SyntaxNode, context.Diagnostics);
         }
 
         /// <summary>

--- a/src/Compilers/VisualBasic/Portable/Compilation/NamespaceScopeBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/NamespaceScopeBuilder.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return scopeBuilder.ToImmutableAndFree()
         End Function
 
-        Private Shared Function GetTypeReference(type As TypeSymbol, moduleBuilder As CommonPEModuleBuilder, diagnostics As DiagnosticBag) As Cci.ITypeReference
+        Private Shared Function GetTypeReference(type As TypeSymbol, moduleBuilder As Emit.PEModuleBuilder, diagnostics As DiagnosticBag) As Cci.ITypeReference
             Return moduleBuilder.Translate(type, Nothing, diagnostics)
         End Function
     End Class

--- a/src/Compilers/VisualBasic/Portable/Emit/SymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SymbolTranslator.vb
@@ -7,6 +7,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer
 
@@ -243,11 +244,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return [param].GetCciAdapter()
         End Function
 
-        Friend NotOverridable Overrides Function Translate(
+        Friend Overrides Function TranslateTypeOfConstant(symbol As TypeSymbol, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As ITypeReference
+            Return Translate(symbol, syntaxNodeOpt, diagnostics)
+        End Function
+
+        Friend Overrides Function EncTranslateLocalVariableType(type As TypeSymbol, diagnostics As DiagnosticBag) As ITypeReference
+            Return Translate(type, syntaxNodeOpt:=Nothing, diagnostics)
+        End Function
+
+        Friend Overrides Function TranslateMarshallingTypeReference(symbol As ITypeSymbolInternal, syntaxOpt As SyntaxNode, diagnostics As DiagnosticBag) As ITypeReference
+            Return Translate(DirectCast(symbol, TypeSymbol), syntaxOpt, diagnostics)
+        End Function
+
+        Friend Overloads Function Translate(
             typeSymbol As TypeSymbol,
             syntaxNodeOpt As SyntaxNode,
-            diagnostics As DiagnosticBag,
-            Optional keepExtensions As Boolean = False) As Microsoft.Cci.ITypeReference
+            diagnostics As DiagnosticBag) As Microsoft.Cci.ITypeReference
             Debug.Assert(diagnostics IsNot Nothing)
 
             Select Case typeSymbol.Kind

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -569,6 +569,14 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             }
         }
 
+        public void AddRange<U>(ImmutableArray<U> items, Func<U, T> selector)
+        {
+            foreach (var item in items)
+            {
+                _builder.Add(selector(item));
+            }
+        }
+
         public void AddRange<U>(ArrayBuilder<U> items) where U : T
         {
             _builder.AddRange(items._builder);

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -571,6 +571,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public void AddRange<U>(ImmutableArray<U> items, Func<U, T> selector)
         {
+            EnsureCapacity(Count + items.Length);
             foreach (var item in items)
             {
                 _builder.Add(selector(item));

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return new LocalDefinition(
                 local,
                 local.Name,
-                Translate(type, syntaxNodeOpt: null, diagnostics),
+                Translate(type, syntaxNodeOpt: null, diagnostics, eraseExtensions: true),
                 slot: index,
                 synthesizedKind: local.SynthesizedKind,
                 id: LocalDebugId.None,


### PR DESCRIPTION
Relates to test plan https://github.com/dotnet/roslyn/issues/66722