### PR TITLE
Disallow span conversions between spans which are not structs

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1343,6 +1343,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type is NamedTypeSymbol
             {
                 Name: "Span",
+                IsValueType: true,
                 Arity: 1,
                 ContainingType: null,
                 ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true },
@@ -1354,6 +1355,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type is NamedTypeSymbol
             {
                 Name: "ReadOnlySpan",
+                IsValueType: true,
                 Arity: 1,
                 ContainingType: null,
                 ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true },

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1344,6 +1344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 Name: "Span",
                 IsValueType: true,
+                IsRefLikeType: true,
                 Arity: 1,
                 ContainingType: null,
                 ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true },
@@ -1356,6 +1357,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 Name: "ReadOnlySpan",
                 IsValueType: true,
+                IsRefLikeType: true,
                 Arity: 1,
                 ContainingType: null,
                 ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true },

--- a/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
@@ -345,7 +345,8 @@ public class FirstClassSpanTests : CSharpTestBase
     }
 
     [Theory, CombinatorialData]
-    public void Conversion_Array_Span_Implicit_SpanClass(
+    public void Conversion_Array_Span_Implicit_SpanNotRefStruct(
+        [CombinatorialValues("class", "struct", "readonly struct", "record", "record struct", "readonly record struct")] string kind,
         [CombinatorialValues("Span", "ReadOnlySpan")] string type)
     {
         var source = $$"""
@@ -356,7 +357,7 @@ public class FirstClassSpanTests : CSharpTestBase
 
             namespace System
             {
-                public class {{type}}<T>;
+                public {{kind}} {{type}}<T>;
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FirstClassSpanTests.cs
@@ -345,6 +345,27 @@ public class FirstClassSpanTests : CSharpTestBase
     }
 
     [Theory, CombinatorialData]
+    public void Conversion_Array_Span_Implicit_SpanClass(
+        [CombinatorialValues("Span", "ReadOnlySpan")] string type)
+    {
+        var source = $$"""
+            using System;
+            {{type}}<int> s =
+                arr();
+            static int[] arr() => new int[] { 1, 2, 3 };
+
+            namespace System
+            {
+                public class {{type}}<T>;
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (3,5): error CS0029: Cannot implicitly convert type 'int[]' to 'System.Span<int>'
+            //     arr();
+            Diagnostic(ErrorCode.ERR_NoImplicitConv, "arr()").WithArguments("int[]", $"System.{type}<int>").WithLocation(3, 5));
+    }
+
+    [Theory, CombinatorialData]
     public void Conversion_Array_Span_Implicit_DifferentOperator(
         [CombinatorialValues("int[]", "T[][]")] string parameterType)
     {


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/73445
Corresponding speclet update: https://github.com/dotnet/csharplang/pull/8321