### PR TITLE
Automatically tag PRs which may affect the C# extension.

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -146,6 +146,28 @@ configuration:
       triggerOnOwnActions: false
     - if:
       - payloadType: Pull_Request
+      - filesMatchPattern:
+          pattern: src/(Analyzers|CodeStyle|Features|LanguageServer|Workspaces)/.*\.(cs|vb)
+      - not:
+          isActivitySender:
+            user: dotnet-bot
+            issueAuthor: False
+      - or:
+        - isAction:
+            action: Opened
+        - isAction:
+            action: Synchronize
+      - and:
+        - not:
+            hasLabel:
+              label: VSCode
+      then:
+      - addLabel:
+          label: VSCode
+      description: Adds "VSCode" tag on PRs which may affect C# extension.
+      triggerOnOwnActions: false
+    - if:
+      - payloadType: Pull_Request
       - isPullRequest
       - filesMatchPattern:
           pattern: '[xX][aA][mM][lL]$'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -8,6 +8,7 @@ where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
+
     - description: Close "Need More Info" Issues
       frequencies:
       - hourly:
@@ -23,8 +24,12 @@ configuration:
       - closeIssue
       - addReply:
           reply: "Closing this issue as we've seen no reply to the request for more information. If you are able to get the requested information, please add it to the issue and we will retriage it. "
+
     eventResponderTasks:
-    - if:
+
+    - description: Auto-approve auto-merge PRs
+      triggerOnOwnActions: false
+      if:
       - payloadType: Pull_Request
       - isPullRequest
       - labelAdded:
@@ -38,9 +43,10 @@ configuration:
       then:
       - approvePullRequest:
           comment: Auto-approval
-      description: Auto-approve auto-merge PRs
+
+    - description: Auto-approve maestro PRs
       triggerOnOwnActions: false
-    - if:
+      if:
       - payloadType: Pull_Request
       - isPullRequest
       - isActivitySender:
@@ -55,9 +61,10 @@ configuration:
       then:
       - approvePullRequest:
           comment: Auto-approve
-      description: Auto-approve maestro PRs
-      triggerOnOwnActions: false
-    - if:
+
+    - description: Milestone tracking
+      triggerOnOwnActions: true
+      if:
       - payloadType: Pull_Request
       - isPullRequest
       - or:
@@ -72,9 +79,10 @@ configuration:
       then:
       - addMilestone:
           milestone: Next
-      description: Milestone tracking
-      triggerOnOwnActions: true
-    - if:
+
+    - description: Auto-approve OneLoc PRs
+      triggerOnOwnActions: false
+      if:
       - payloadType: Pull_Request
       - isPullRequest
       - isActivitySender:
@@ -88,9 +96,10 @@ configuration:
       then:
       - addLabel:
           label: auto-merge
-      description: Auto-approve OneLoc PRs
+
+    - description: Remove "Need More Info" on comment
       triggerOnOwnActions: false
-    - if:
+      if:
       - payloadType: Issue_Comment
       - isIssue
       - isOpen
@@ -101,9 +110,10 @@ configuration:
           label: untriaged
       - removeLabel:
           label: Need More Info
-      description: Remove "Need More Info" on comment
+
+    - description: Label Community Pull Requests
       triggerOnOwnActions: false
-    - if:
+      if:
       - payloadType: Pull_Request
       - isPullRequest
       - isAction:
@@ -142,12 +152,14 @@ configuration:
       then:
       - addLabel:
           label: Community
-      description: Label Community Pull Requests
+
+    - description: Adds "VSCode" tag on PRs which may affect C# extension.
       triggerOnOwnActions: false
-    - if:
+      if:
       - payloadType: Pull_Request
+      - isPullRequest
       - filesMatchPattern:
-          pattern: src/(Analyzers|CodeStyle|Features|LanguageServer|Workspaces)/.*\.(cs|vb)
+          pattern: 'src/(Analyzers|CodeStyle|Features|LanguageServer|Workspaces)/.*\.(cs|vb)$'
       - not:
           isActivitySender:
             user: dotnet-bot
@@ -164,13 +176,14 @@ configuration:
       then:
       - addLabel:
           label: VSCode
-      description: Adds "VSCode" tag on PRs which may affect C# extension.
+
+    - description: Add "Needs UX Triage" on PRs
       triggerOnOwnActions: false
-    - if:
+      if:
       - payloadType: Pull_Request
       - isPullRequest
       - filesMatchPattern:
-          pattern: '[xX][aA][mM][lL]$'
+          pattern: '.*\.[xX][aA][mM][lL]$'
       - and:
         - not:
             hasLabel:
@@ -209,12 +222,14 @@ configuration:
       then:
       - addLabel:
           label: Needs UX Triage
-      description: Add "Needs UX Triage" on PRs
+
+    - description: Adds "Needs API Review" on PRs that touch public APIs
       triggerOnOwnActions: false
-    - if:
+      if:
       - payloadType: Pull_Request
+      - isPullRequest
       - filesMatchPattern:
-          pattern: .*/PublicAPI\.(Shipped|Unshipped)\.txt
+          pattern: '.*/PublicAPI\.(Shipped|Unshipped)\.txt'
       - not:
           isActivitySender:
             user: dotnet-bot
@@ -236,9 +251,10 @@ configuration:
           label: Needs API Review
       - addReply:
           reply: This PR modifies public API files. Please follow the instructions at https://github.com/dotnet/roslyn/blob/main/docs/contributing/API%20Review%20Process.md for ensuring all public APIs are reviewed before merging.
-      description: Adds "Needs API Review" on PRs that touch public APIs
+
+    - description: Close automatically generated PR tagger issues
       triggerOnOwnActions: false
-    - if:
+      if:
       - payloadType: Issues
       - isIssue
       - hasLabel:
@@ -248,7 +264,6 @@ configuration:
           isRegex: False
       then:
       - closeIssue
-      description: Close automatically generated PR tagger issues
-      triggerOnOwnActions: false
+
 onFailure: 
 onSuccess:


### PR DESCRIPTION
It can be tedious to determine what changes in Roslyn are relevant to the C# extension. The idea is that changes under these folders may change the behavior of the Roslyn LSP and thus impact the C# extension. PR authors may remove the label if they do not believe their change is impactful.