### PR TITLE
Reduce the number of sourcetexts fully recreated from the tree during brace completion enter

### DIFF
--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -120,7 +121,8 @@ internal abstract class AbstractCurlyBraceOrBracketCompletionService : AbstractC
 
             var rootToFormat = document.Root.ReplaceToken(closingToken, newClosingToken);
             annotatedNewline = rootToFormat.GetAnnotatedTrivia(s_closingBraceNewlineAnnotation).Single();
-            document = document.WithChangedRoot(rootToFormat, cancellationToken);
+
+            document = GetUpdatedDocument(document, new[] { new TextChange(closingToken.FullSpan, newClosingToken.ToFullString()) }, rootToFormat);
 
             // Calculate text change for adding a newline and adjust closing point location.
             closingPoint = annotatedNewline.Token.Span.End;
@@ -136,7 +138,7 @@ internal abstract class AbstractCurlyBraceOrBracketCompletionService : AbstractC
             options,
             cancellationToken);
 
-        var newDocument = document.WithChangedRoot(formattedRoot, cancellationToken);
+        var newDocument = GetUpdatedDocument(document, formattingChanges, formattedRoot);
 
         // Get the empty line between the curly braces.
         var desiredCaretLine = GetLineBetweenCurlys(newClosingPoint, newDocument.Text);
@@ -146,6 +148,17 @@ internal abstract class AbstractCurlyBraceOrBracketCompletionService : AbstractC
         var caretPosition = GetIndentedLinePosition(newDocument, newDocument.Text, desiredCaretLine.LineNumber, options, cancellationToken);
 
         return new BraceCompletionResult(GetMergedChanges(newLineEdit, formattingChanges, newDocument.Text), caretPosition);
+
+        // Create a new ParsedDocument given an old document, a set of changes and the new root. Typically, creating a new ParsedDocument is
+        // done with either a call to ParsedDocument.WithChangedRoot or ParsedDocument.WithChangedText. The former ends up creating
+        // a SourceText, while the latter parses the document. For performance reasons, we don't want to do either of those, so
+        // we'll just created the ParsedDocument directly with the information we already have.
+        static ParsedDocument GetUpdatedDocument(ParsedDocument oldDocument, IEnumerable<TextChange> changes, SyntaxNode newRoot)
+        {
+            var newText = oldDocument.Text.WithChanges(changes);
+
+            return new ParsedDocument(oldDocument.Id, newText, newRoot, oldDocument.HostLanguageServices);
+        }
 
         static TextLine GetLineBetweenCurlys(int closingPosition, SourceText text)
         {

--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -122,7 +122,7 @@ internal abstract class AbstractCurlyBraceOrBracketCompletionService : AbstractC
             var rootToFormat = document.Root.ReplaceToken(closingToken, newClosingToken);
             annotatedNewline = rootToFormat.GetAnnotatedTrivia(s_closingBraceNewlineAnnotation).Single();
 
-            document = GetUpdatedDocument(document, new[] { new TextChange(closingToken.FullSpan, newClosingToken.ToFullString()) }, rootToFormat);
+            document = GetUpdatedDocument(document, [new TextChange(closingToken.FullSpan, newClosingToken.ToFullString())], rootToFormat);
 
             // Calculate text change for adding a newline and adjust closing point location.
             closingPoint = annotatedNewline.Token.Span.End;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/AbstractIndentation.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/AbstractIndentation.Indenter.cs
@@ -41,6 +41,7 @@ internal abstract partial class AbstractIndentation<TSyntaxRoot>
         public Indenter(
             AbstractIndentation<TSyntaxRoot> service,
             SyntaxTree tree,
+            SourceText text,
             ImmutableArray<AbstractFormattingRule> rules,
             IndentationOptions options,
             TextLine lineToBeIndented,
@@ -51,8 +52,8 @@ internal abstract partial class AbstractIndentation<TSyntaxRoot>
             _syntaxFacts = service.SyntaxFacts;
             Options = options;
             Tree = tree;
-            Text = tree.GetText(cancellationToken);
             Root = (TSyntaxRoot)tree.GetRoot(cancellationToken);
+            Text = text;
             LineToBeIndented = lineToBeIndented;
             _tabSize = options.FormattingOptions.TabSize;
             SmartTokenFormatter = smartTokenFormatter;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Indentation/AbstractIndentationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Indentation/AbstractIndentationService.cs
@@ -59,6 +59,6 @@ internal abstract partial class AbstractIndentationService<TSyntaxRoot>
 
         var smartTokenFormatter = CreateSmartTokenFormatter(
             (TSyntaxRoot)document.Root, document.Text, lineToBeIndented, options, baseIndentationRule);
-        return new Indenter(this, document.SyntaxTree, formattingRules, options, lineToBeIndented, smartTokenFormatter, cancellationToken);
+        return new Indenter(this, document.SyntaxTree, document.Text, formattingRules, options, lineToBeIndented, smartTokenFormatter, cancellationToken);
     }
 }


### PR DESCRIPTION
In the speedometer trace I'm looking at, 2.3% of allocations during the typing phase of the test are due to recreating SourceText from trees during typing an enter. This also accounts for 2.5% of CPU during that period, all of which is on the UI thread.

Instead, this code just creates the new SourceText from the old SourceText and the set of changes between them.

*** old allocations from profile in speedometer scrolling test run ***
![image](https://github.com/user-attachments/assets/f2082484-0ffc-4432-83c5-71b0a14ee82b)