### PR TITLE
Modify ISyntaxFacts methods to allocate less

### DIFF
--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
@@ -745,8 +745,9 @@ internal abstract class AbstractRemoveUnnecessaryInlineSuppressionsDiagnosticAna
             return false;
         }
 
-        var declarationNodes = SyntaxFacts.GetTopLevelAndMethodLevelMembers(root);
-        using var _ = PooledHashSet<ISymbol>.GetInstance(out var processedPartialSymbols);
+        using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var declarationNodes);
+        SyntaxFacts.AddTopLevelAndMethodLevelMembers(root, declarationNodes);
+        using var _2 = PooledHashSet<ISymbol>.GetInstance(out var processedPartialSymbols);
         if (declarationNodes.Count > 0)
         {
             foreach (var node in declarationNodes)

--- a/src/EditorFeatures/Core/Editor/GoToAdjacentMemberCommandHandler.cs
+++ b/src/EditorFeatures/Core/Editor/GoToAdjacentMemberCommandHandler.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
@@ -17,7 +18,9 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Outlining;
-using Microsoft.VisualStudio.Utilities;
+
+using ContentTypeAttribute = Microsoft.VisualStudio.Utilities.ContentTypeAttribute;
+using NameAttribute = Microsoft.VisualStudio.Utilities.NameAttribute;
 
 namespace Microsoft.CodeAnalysis.Editor;
 
@@ -100,7 +103,9 @@ internal class GoToAdjacentMemberCommandHandler(IOutliningManagerService outlini
     /// </summary>
     internal static int? GetTargetPosition(ISyntaxFactsService service, SyntaxNode root, int caretPosition, bool next)
     {
-        var members = service.GetMethodLevelMembers(root);
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var members);
+
+        service.AddMethodLevelMembers(root, members);
         if (members.Count == 0)
         {
             return null;

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -215,8 +215,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return null;
                 }
 
+                using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var members);
+
                 var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-                var members = syntaxFacts.GetMethodLevelMembers(root);
+                syntaxFacts.AddMethodLevelMembers(root, members);
                 var memberSpans = members.SelectAsArray(member => member.FullSpan);
                 var changedMemberId = members.IndexOf(changedMember);
 

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer_MemberSpans.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer_MemberSpans.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -45,7 +46,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     var service = document.GetRequiredLanguageService<ISyntaxFactsService>();
                     var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-                    var members = service.GetMethodLevelMembers(root);
+
+                    using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var members);
+                    service.AddMethodLevelMembers(root, members);
                     return members.SelectAsArray(m => m.FullSpan);
                 }
             }

--- a/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.SemanticModelReuse;
 
@@ -105,7 +106,8 @@ internal abstract class AbstractSemanticModelReuseLanguageService<
         }
         else
         {
-            var currentMembers = this.SyntaxFacts.GetMethodLevelMembers(currentRoot);
+            using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var currentMembers);
+            this.SyntaxFacts.AddMethodLevelMembers(currentRoot, currentMembers);
             var index = currentMembers.IndexOf(currentBodyNode);
             if (index < 0)
             {
@@ -113,7 +115,8 @@ internal abstract class AbstractSemanticModelReuseLanguageService<
                 return null;
             }
 
-            var previousMembers = this.SyntaxFacts.GetMethodLevelMembers(previousRoot);
+            using var _2 = ArrayBuilder<SyntaxNode>.GetInstance(out var previousMembers);
+            this.SyntaxFacts.AddMethodLevelMembers(previousRoot, previousMembers);
             if (currentMembers.Count != previousMembers.Count)
             {
                 Debug.Fail("Member count shouldn't have changed as there were no top level edits.");

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -896,24 +896,20 @@ internal class CSharpSyntaxFacts : ISyntaxFacts
         }
     }
 
-    public List<SyntaxNode> GetTopLevelAndMethodLevelMembers(SyntaxNode? root)
+    public void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> list)
     {
-        var list = new List<SyntaxNode>();
         AppendMembers(root, list, topLevel: true, methodLevel: true);
-        return list;
     }
 
-    public List<SyntaxNode> GetMethodLevelMembers(SyntaxNode? root)
+    public void AddMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> list)
     {
-        var list = new List<SyntaxNode>();
         AppendMembers(root, list, topLevel: false, methodLevel: true);
-        return list;
     }
 
     public SyntaxList<SyntaxNode> GetMembersOfTypeDeclaration(SyntaxNode typeDeclaration)
         => ((TypeDeclarationSyntax)typeDeclaration).Members;
 
-    private void AppendMembers(SyntaxNode? node, List<SyntaxNode> list, bool topLevel, bool methodLevel)
+    private void AppendMembers(SyntaxNode? node, ArrayBuilder<SyntaxNode> list, bool topLevel, bool methodLevel)
     {
         Debug.Assert(topLevel || methodLevel);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 #if CODE_STYLE
 using Microsoft.CodeAnalysis.Internal.Editing;
@@ -409,9 +410,9 @@ internal interface ISyntaxFacts
     SyntaxNode? ConvertToSingleLine(SyntaxNode? node, bool useElasticTrivia = false);
 
     // Violation.  This is a feature level API.
-    List<SyntaxNode> GetTopLevelAndMethodLevelMembers(SyntaxNode? root);
+    void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> list);
     // Violation.  This is a feature level API.
-    List<SyntaxNode> GetMethodLevelMembers(SyntaxNode? root);
+    void AddMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> list);
     SyntaxList<SyntaxNode> GetMembersOfTypeDeclaration(SyntaxNode typeDeclaration);
 
     // Violation.  This is a feature level API.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -895,17 +895,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
         End Function
 
-        Public Function GetTopLevelAndMethodLevelMembers(root As SyntaxNode) As List(Of SyntaxNode) Implements ISyntaxFacts.GetTopLevelAndMethodLevelMembers
-            Dim list = New List(Of SyntaxNode)()
+        Public Sub AddTopLevelAndMethodLevelMembers(root As SyntaxNode, list As ArrayBuilder(Of SyntaxNode)) Implements ISyntaxFacts.AddTopLevelAndMethodLevelMembers
             AppendMembers(root, list, topLevel:=True, methodLevel:=True)
-            Return list
-        End Function
+        End Sub
 
-        Public Function GetMethodLevelMembers(root As SyntaxNode) As List(Of SyntaxNode) Implements ISyntaxFacts.GetMethodLevelMembers
-            Dim list = New List(Of SyntaxNode)()
+        Public Sub AddMethodLevelMembers(root As SyntaxNode, list As ArrayBuilder(Of SyntaxNode)) Implements ISyntaxFacts.AddMethodLevelMembers
             AppendMembers(root, list, topLevel:=False, methodLevel:=True)
-            Return list
-        End Function
+        End Sub
 
         Public Function GetMembersOfTypeDeclaration(typeDeclaration As SyntaxNode) As SyntaxList(Of SyntaxNode) Implements ISyntaxFacts.GetMembersOfTypeDeclaration
             Return DirectCast(typeDeclaration, TypeBlockSyntax).Members
@@ -1051,7 +1047,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             End If
         End Sub
 
-        Private Sub AppendMembers(node As SyntaxNode, list As List(Of SyntaxNode), topLevel As Boolean, methodLevel As Boolean)
+        Private Sub AppendMembers(node As SyntaxNode, list As ArrayBuilder(Of SyntaxNode), topLevel As Boolean, methodLevel As Boolean)
             Debug.Assert(topLevel OrElse methodLevel)
 
             For Each member In node.GetMembers()


### PR DESCRIPTION
CSharpSyntaxFacts.GetMethodLevelMembers shows up as 3.4% of allocations in the scrolling speedometer test during the typing phase of the test. This method (and it's partner GetTopLevelAndMethodLevelMembers) can be easily made to take in and populate an arraybuilder instead of allocating a list on each invocation.

*** relevant allocation data from scrolling speedometer profile during typing part of the test *** 
![image](https://github.com/user-attachments/assets/51342727-6973-4199-a9e7-7a53132f4347)