### PR TITLE
Remove unsupported servicing branches

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -143,24 +143,6 @@
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.3]"
     },
-    "release/dev17.4": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.4",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.4]"
-    },
-    "release/dev17.5-vs-deps": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.5",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.5]"
-    },
     "release/dev17.6": {
       "nugetKind": [
         "Shipping",


### PR DESCRIPTION
17.4 and 17.5 are no longer supported so removing their PublishData entries.

Strictly we could go through and remove 17.7 and 17.9 but I slightly prefer to just wait until the adjacent LTS release support is dropped at this moment.

@phil-allen-msft 