### PR TITLE
Reduce allocations during SourceText serialization

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
@@ -214,14 +214,7 @@ internal static partial class SourceTextExtensions
             var count = Math.Min(buffer.Length, length - offset);
             sourceText.CopyTo(offset, buffer, 0, count);
 
-            // In the case where the array is entirely full, we can pass that as is to the ObjectWriter.  It already
-            // supports sending the array all the way through to the underlying stream without allocations. In the case
-            // where it's partially full, we pass in a span to the section that is filled.  This will fast path on
-            // netcore, though will incur a copy to pooled memory on netfx.
-            if (count == buffer.Length)
-                writer.WriteCharArray(buffer);
-            else
-                writer.WriteSpan(buffer.AsSpan()[..count]);
+            writer.WriteCharArray(buffer, 0, count);
 
             offset += count;
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectWriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectWriter.cs
@@ -76,7 +76,7 @@ internal sealed partial class ObjectWriter : IDisposable
     /// </summary>
     private WriterReferenceMap _stringReferenceMap;
 
-    private static Encoding s_encoding = Encoding.UTF8;
+    private static readonly Encoding s_encoding = Encoding.UTF8;
 
     /// <summary>
     /// Creates a new instance of a <see cref="ObjectWriter"/>.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectWriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectWriter.cs
@@ -76,8 +76,6 @@ internal sealed partial class ObjectWriter : IDisposable
     /// </summary>
     private WriterReferenceMap _stringReferenceMap;
 
-    private static readonly Encoding s_encoding = Encoding.UTF8;
-
     /// <summary>
     /// Creates a new instance of a <see cref="ObjectWriter"/>.
     /// </summary>
@@ -97,7 +95,7 @@ internal sealed partial class ObjectWriter : IDisposable
         // It can be adjusted for BigEndian if needed.
         Debug.Assert(BitConverter.IsLittleEndian);
 
-        _writer = new BinaryWriter(stream, s_encoding, leaveOpen);
+        _writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen);
         _stringReferenceMap = new WriterReferenceMap();
 
         if (writeValidationBytes)
@@ -287,14 +285,14 @@ internal sealed partial class ObjectWriter : IDisposable
         //
         // Instead, emulate the .net core code which has the GetBytes
         // call fill up a pooled array instead
-        var maxByteCount = s_encoding.GetMaxByteCount(count);
+        var maxByteCount = Encoding.UTF8.GetMaxByteCount(count);
 
         if (maxByteCount <= BufferPool<byte>.BufferSize)
         {
             using var pooledObj = BufferPool<byte>.Shared.GetPooledObject();
             var buffer = pooledObj.Object;
 
-            var actualByteCount = s_encoding.GetBytes(array, index, count, buffer, 0);
+            var actualByteCount = Encoding.UTF8.GetBytes(array, index, count, buffer, 0);
             _writer.Write(buffer, 0, actualByteCount);
 
             return;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Serialization.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Serialization.cs
@@ -11,7 +11,7 @@ internal readonly partial struct BKTree
 {
     internal void WriteTo(ObjectWriter writer)
     {
-        writer.WriteCharArray(_concatenatedLowerCaseWords);
+        writer.WriteCharArray(_concatenatedLowerCaseWords, 0, _concatenatedLowerCaseWords.Length);
         writer.WriteArray(_nodes, static (w, n) => n.WriteTo(w));
         writer.WriteArray(_edges, static (w, n) => n.WriteTo(w));
     }


### PR DESCRIPTION
These allocations are showing up during the typing portion of the scrolling speedometer test as about 9.4% of allocations for that scenario.

The issue here is that in .Net framework, the BinaryWriter.Write method allocates a local array for the results of the Encoding.GetBytes call. .NET core does not allocate in this case, opting to call the GetBytes version that writes to an array given it (and uses a pooled array as such).

The change is to simulate what .NET core does, which should get rid of all these temporary array allocations when serializing source texts from .net fx.

*** relevant allocations from typing portion of scrolling speedometer test ***
![image](https://github.com/user-attachments/assets/94629b97-08dd-4f36-ba6c-d3b25f60c980)