### PR TITLE
Change SyntaxEquivalence.AreEquivalent to use a more appropriate pooling mechanism for the stack it uses to walk trees.

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxEquivalence.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxEquivalence.cs
@@ -121,6 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             }
             finally
             {
+                stack.Clear();
                 s_equivalenceCheckStack.Free(stack);
             }
 


### PR DESCRIPTION
The scrolling speedometer test indicates this method's pooling mechanism isn't working great for large files. Specifically, ArrayBuilder instances aren't returned to their pool once their length exceeds 128 items. For even relatively large files, I'm seeing this exceeded in this context.

Instead, I've switched this code to just use a pooled Stack. This was accounting for about 1.1% of allocations in the typing scenario for the scrolling speedometer test.

*** relevant allocations from the typing scenario in the scrolling speedometer test ***
![image](https://github.com/user-attachments/assets/a0625b69-e151-4d06-a1d2-1c5e6f1b1603)