### PR TITLE
Move 'use auto prop' check earlier

### DIFF
--- a/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -136,6 +136,11 @@ internal abstract class AbstractUseAutoPropertyAnalyzer<
                 if (namedType.TypeKind is not TypeKind.Class and not TypeKind.Struct and not TypeKind.Module)
                     return false;
 
+                // Serializable types can depend on fields (and their order).  Don't report these
+                // properties in that case.
+                if (namedType.IsSerializable)
+                    return false;
+
                 // Don't bother running on this type unless at least one of its parts has the 'prefer auto props' option
                 // on, and the diagnostic is not suppressed.
                 if (!namedType.DeclaringSyntaxReferences.Select(d => d.SyntaxTree).Distinct().Any(tree =>
@@ -234,11 +239,6 @@ internal abstract class AbstractUseAutoPropertyAnalyzer<
             return;
 
         if (!CanExplicitInterfaceImplementationsBeFixed() && property.ExplicitInterfaceImplementations.Length != 0)
-            return;
-
-        // Serializable types can depend on fields (and their order).  Don't report these
-        // properties in that case.
-        if (containingType.IsSerializable)
             return;
 
         var preferAutoProps = context.GetAnalyzerOptions().PreferAutoProperties;


### PR DESCRIPTION
Noticed while i was doing some refactoring here to get this code ready for the `field keyword` feature.