### PR TITLE
Reduce allocations in SymbolKey.ResolveString

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -764,7 +764,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IAssemblySymbol_Modules As IEnumerable(Of IModuleSymbol) Implements IAssemblySymbol.Modules
             Get
-                Return Me.Modules
+                Return ImmutableArray(Of IModuleSymbol).CastUp(Me.Modules)
             End Get
         End Property
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ModuleSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ModuleSymbolKey.cs
@@ -43,8 +43,7 @@ internal partial struct SymbolKey
                 }
                 else
                 {
-                    // Visual Basic implementation of IAssemblySymbol.Modules relies on covariance of IEnumerable<T>, so
-                    // the preceding concrete type check will fail.
+                    // Otherwise fall back to generic enumeration
                     result.AddValuesIfNotNull(assemblyModules);
                 }
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.cs
@@ -235,6 +235,7 @@ internal partial struct SymbolKey(string data) : IEquatable<SymbolKey>
     public override readonly string ToString()
         => _symbolKeyData;
 
+    // Note: this method may clear 'symbols' before returning.
     private static SymbolKeyResolution CreateResolution<TSymbol>(
         PooledArrayBuilder<TSymbol> symbols, string reasonIfFailed, out string? failureReason)
         where TSymbol : class, ISymbol
@@ -253,7 +254,7 @@ internal partial struct SymbolKey(string data) : IEquatable<SymbolKey>
         {
             failureReason = null;
             return new SymbolKeyResolution(
-                ImmutableArray<ISymbol>.CastUp(symbols.Builder.ToImmutable()),
+                ImmutableArray<ISymbol>.CastUp(symbols.Builder.ToImmutableAndClear()),
                 CandidateReason.Ambiguous);
         }
     }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2136177

Extracted from #74513, and only contains changes which do not affect the public APIs.