### PR TITLE
Reduce allocations in AbstractStructureTaggerProvider.GetMultiLineRegions

### DIFF
--- a/src/EditorFeatures/Core/Structure/AbstractStructureTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Structure/AbstractStructureTaggerProvider.cs
@@ -206,9 +206,9 @@ internal abstract partial class AbstractStructureTaggerProvider(
         ImmutableArray<BlockSpan> spans)
     {
         var snapshot = snapshotSpan.Snapshot;
-        spans = GetMultiLineRegions(outliningService, spans, snapshot);
+        var multiLineSpans = GetMultiLineRegions(outliningService, spans, snapshot);
 
-        foreach (var span in spans)
+        foreach (var span in multiLineSpans)
         {
             var tag = new StructureTag(this, span, snapshot);
             context.AddTag(new TagSpan<IContainerStructureTag>(span.TextSpan.ToSnapshotSpan(snapshot), tag));
@@ -226,12 +226,11 @@ internal abstract partial class AbstractStructureTaggerProvider(
 
     private static bool s_exceptionReported = false;
 
-    private static ImmutableArray<BlockSpan> GetMultiLineRegions(
+    private static IEnumerable<BlockSpan> GetMultiLineRegions(
         BlockStructureService service,
         ImmutableArray<BlockSpan> regions, ITextSnapshot snapshot)
     {
         // Remove any spans that aren't multiline.
-        var multiLineRegions = ArrayBuilder<BlockSpan>.GetInstance();
         foreach (var region in regions)
         {
             if (region.TextSpan.Length > 0)
@@ -262,12 +261,10 @@ internal abstract partial class AbstractStructureTaggerProvider(
                 var endLine = snapshot.GetLineNumberFromPosition(region.TextSpan.End);
                 if (startLine != endLine)
                 {
-                    multiLineRegions.Add(region);
+                    yield return region;
                 }
             }
         }
-
-        return multiLineRegions.ToImmutableAndFree();
     }
 
     #region Creating Preview Buffers

--- a/src/EditorFeatures/Core/Structure/AbstractStructureTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Structure/AbstractStructureTaggerProvider.cs
@@ -206,6 +206,10 @@ internal abstract partial class AbstractStructureTaggerProvider(
         ImmutableArray<BlockSpan> spans)
     {
         var snapshot = snapshotSpan.Snapshot;
+
+        // Use the returned enumerable directly instead of allocating into an array. The returned
+        // enumeration can contain a fairly large number of items for large files, so even
+        // using an ArrayBuilder could result in allocation issues without using a custom pool.
         var multiLineSpans = GetMultiLineRegions(outliningService, spans, snapshot);
 
         foreach (var span in multiLineSpans)


### PR DESCRIPTION
This is a private method, and the caller simply enumerates the results, so there is no need to allocate an intermediary array.

This shows up as 0.6% of allocations in the scrolling speedomenter profile that I'm looking at (in the typing section of a particularly poorly performing run)

*** relevant allocations from speedometer profile ***
![image](https://github.com/user-attachments/assets/387842c9-4d94-4c5e-97ac-de73de0658a2)
