### PR TITLE
Move existing RemoveWhere code into an extension method on ArrayBuilder

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1679,7 +1679,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             if (name == null)
-                FilterNotReferenceable(results);
+                results.RemoveWhere(static (symbol, _, _) => !symbol.CanBeReferencedByName, default(VoidResult));
 
             return results.ToImmutableAndFree();
         }
@@ -1794,24 +1794,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// symbols were reinferred. This should only be called when nullable semantic analysis is enabled.
         /// </summary>
         internal abstract Symbol RemapSymbolIfNecessaryCore(Symbol symbol);
-
-        private static void FilterNotReferenceable(ArrayBuilder<ISymbol> sealedResults)
-        {
-            var writeIndex = 0;
-            for (var i = 0; i < sealedResults.Count; i++)
-            {
-                var symbol = sealedResults[i];
-                if (symbol.CanBeReferencedByName)
-                {
-                    if (writeIndex != i)
-                        sealedResults[writeIndex] = symbol;
-
-                    writeIndex++;
-                }
-            }
-
-            sealedResults.Count = writeIndex;
-        }
 
         /// <summary>
         /// Determines if the symbol is accessible from the specified location. 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1679,7 +1679,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             if (name == null)
-                results.RemoveWhere(static (symbol, _, _) => !symbol.CanBeReferencedByName, default(VoidResult));
+                results.RemoveWhere(static (symbol, _, _) => !symbol.CanBeReferencedByName, arg: default(VoidResult));
 
             return results.ToImmutableAndFree();
         }

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -271,5 +271,23 @@ namespace Microsoft.CodeAnalysis
         }
 
 #endif
+
+        public static void RemoveWhere<TItem, TArg>(this ArrayBuilder<TItem> builder, Func<TItem, int, TArg, bool> filter, TArg arg)
+        {
+            var writeIndex = 0;
+            for (var i = 0; i < builder.Count; i++)
+            {
+                var item = builder[i];
+                if (!filter(item, i, arg))
+                {
+                    if (writeIndex != i)
+                        builder[writeIndex] = item;
+
+                    writeIndex++;
+                }
+            }
+
+            builder.Count = writeIndex;
+        }
     }
 }


### PR DESCRIPTION
I have an upcoming PR that needs to update an ArrayBuilder in place and I'd prefer not to duplicate that logic. Seems like a useful enough API to warrant an extension method.