### PR TITLE
Tag PRs where any file matches the specified patterns

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -161,10 +161,15 @@ configuration:
       - filesMatchPattern:
           pattern: 'src/(Analyzers|CodeStyle|Features|LanguageServer|Workspaces)/.*\.(cs|vb)$'
           matchAny: true
-      - not:
-          isActivitySender:
-            user: dotnet-bot
-            issueAuthor: False
+      - and:
+        - not:
+            isActivitySender:
+              user: dotnet-bot
+              issueAuthor: False
+        - not:
+            isActivitySender:
+              user: github-actions
+              issueAuthor: False
       - or:
         - isAction:
             action: Opened

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -160,6 +160,7 @@ configuration:
       - isPullRequest
       - filesMatchPattern:
           pattern: 'src/(Analyzers|CodeStyle|Features|LanguageServer|Workspaces)/.*\.(cs|vb)$'
+          matchAny: true
       - not:
           isActivitySender:
             user: dotnet-bot
@@ -184,6 +185,7 @@ configuration:
       - isPullRequest
       - filesMatchPattern:
           pattern: '.*\.[xX][aA][mM][lL]$'
+          matchAny: true
       - and:
         - not:
             hasLabel:
@@ -230,6 +232,7 @@ configuration:
       - isPullRequest
       - filesMatchPattern:
           pattern: '.*/PublicAPI\.(Shipped|Unshipped)\.txt'
+          matchAny: true
       - not:
           isActivitySender:
             user: dotnet-bot


### PR DESCRIPTION
`matchAny` is a new property on the `fileMatchPattern` which which controls how the condition is satisfied. The old behavior was that all changed files had to match the pattern. By setting `matchAny` to true the condition is met if any file matches the specified pattern.