### PR TITLE
Reduce allocations again in BlockStructure collection

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/CommentStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/CommentStructureTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Structure;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Structure;
@@ -25,8 +26,8 @@ public class CommentStructureTests : AbstractSyntaxStructureProviderTests
     private static ImmutableArray<BlockSpan> CreateCommentBlockSpan(
         SyntaxTriviaList triviaList)
     {
-        using var result = TemporaryArray<BlockSpan>.Empty;
-        CSharpStructureHelpers.CollectCommentBlockSpans(triviaList, ref result.AsRef());
+        using var _ = ArrayBuilder<BlockSpan>.GetInstance(out var result);
+        CSharpStructureHelpers.CollectCommentBlockSpans(triviaList, result);
         return result.ToImmutableAndClear();
     }
 

--- a/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxNodeStructureProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxNodeStructureProviderTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Structure;
 using Xunit;
@@ -41,10 +42,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Structure
             }
 
             var outliner = CreateProvider();
-            using var actualRegions = TemporaryArray<BlockSpan>.Empty;
+            using var _ = ArrayBuilder<BlockSpan>.GetInstance(out var actualRegions);
             // Calculate previousToken for tests the same way it is derived in production code
             var previousToken = root.DescendantNodesAndTokens(descendIntoTrivia: true).TakeWhile(nodeOrToken => nodeOrToken != node).LastOrDefault(nodeOrToken => nodeOrToken.IsToken).AsToken();
-            outliner.CollectBlockSpans(previousToken, node, ref actualRegions.AsRef(), options, CancellationToken.None);
+            outliner.CollectBlockSpans(previousToken, node, actualRegions, options, CancellationToken.None);
 
             // TODO: Determine why we get null outlining spans.
             return actualRegions.ToImmutableAndClear();

--- a/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxTriviaStructureProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxTriviaStructureProviderTests.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Structure;
 
@@ -22,8 +23,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Structure
             var trivia = root.FindTrivia(position, findInsideTrivia: true);
 
             var outliner = CreateProvider();
-            using var actualRegions = TemporaryArray<BlockSpan>.Empty;
-            outliner.CollectBlockSpans(trivia, ref actualRegions.AsRef(), options, CancellationToken.None);
+            using var _ = ArrayBuilder<BlockSpan>.GetInstance(out var actualRegions);
+            outliner.CollectBlockSpans(trivia, actualRegions, options, CancellationToken.None);
 
             // TODO: Determine why we get null outlining spans.
             return actualRegions.ToImmutableAndClear();

--- a/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Structure;
@@ -161,7 +162,7 @@ internal static class CSharpStructureHelpers
     }
 
     public static void CollectCommentBlockSpans(
-        SyntaxTriviaList triviaList, ref TemporaryArray<BlockSpan> spans)
+        SyntaxTriviaList triviaList, ArrayBuilder<BlockSpan> spans)
     {
         if (triviaList.Count > 0)
         {
@@ -186,14 +187,14 @@ internal static class CSharpStructureHelpers
                 else if (trivia is not SyntaxTrivia(
                     SyntaxKind.WhitespaceTrivia or SyntaxKind.EndOfLineTrivia or SyntaxKind.EndOfFileToken))
                 {
-                    completeSingleLineCommentGroup(ref spans);
+                    completeSingleLineCommentGroup(spans);
                 }
             }
 
-            completeSingleLineCommentGroup(ref spans);
+            completeSingleLineCommentGroup(spans);
             return;
 
-            void completeSingleLineCommentGroup(ref TemporaryArray<BlockSpan> spans)
+            void completeSingleLineCommentGroup(ArrayBuilder<BlockSpan> spans)
             {
                 if (startComment != null)
                 {
@@ -208,7 +209,7 @@ internal static class CSharpStructureHelpers
 
     public static void CollectCommentBlockSpans(
         SyntaxNode node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         in BlockStructureOptions options)
     {
         if (node == null)
@@ -223,7 +224,7 @@ internal static class CSharpStructureHelpers
         else
         {
             var triviaList = node.GetLeadingTrivia();
-            CollectCommentBlockSpans(triviaList, ref spans);
+            CollectCommentBlockSpans(triviaList, spans);
         }
 
         return;

--- a/src/Features/CSharp/Portable/Structure/Providers/AccessorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/AccessorDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class AccessorDeclarationStructureProvider : AbstractSyntaxNodeStructur
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         AccessorDeclarationSyntax accessorDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(accessorDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(accessorDeclaration, spans, options);
 
         // fault tolerance
         if (accessorDeclaration.Body == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/AnonymousMethodExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/AnonymousMethodExpressionStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,7 +14,7 @@ internal class AnonymousMethodExpressionStructureProvider : AbstractSyntaxNodeSt
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         AnonymousMethodExpressionSyntax anonymousMethod,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/AnonymousObjectCreationExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/AnonymousObjectCreationExpressionStructureProvider.cs
@@ -6,7 +6,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 
@@ -17,7 +17,7 @@ internal class AnonymousObjectCreationExpressionStructureProvider : AbstractSynt
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         AnonymousObjectCreationExpressionSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/ArgumentListStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ArgumentListStructureProvider.cs
@@ -4,14 +4,14 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
 
 internal sealed class ArgumentListStructureProvider : AbstractSyntaxNodeStructureProvider<ArgumentListSyntax>
 {
-    protected override void CollectBlockSpans(SyntaxToken previousToken, ArgumentListSyntax node, ref TemporaryArray<BlockSpan> spans, BlockStructureOptions options, CancellationToken cancellationToken)
+    protected override void CollectBlockSpans(SyntaxToken previousToken, ArgumentListSyntax node, ArrayBuilder<BlockSpan> spans, BlockStructureOptions options, CancellationToken cancellationToken)
     {
         if (!IsCandidate(node, cancellationToken))
         {

--- a/src/Features/CSharp/Portable/Structure/Providers/ArrowExpressionClauseStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ArrowExpressionClauseStructureProvider.cs
@@ -7,7 +7,7 @@
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 
@@ -18,7 +18,7 @@ internal class ArrowExpressionClauseStructureProvider : AbstractSyntaxNodeStruct
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         ArrowExpressionClauseSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Structure;
@@ -19,7 +20,7 @@ internal sealed class BlockSyntaxStructureProvider : AbstractSyntaxNodeStructure
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         BlockSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/CollectionExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/CollectionExpressionStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 
@@ -15,7 +15,7 @@ internal class CollectionExpressionStructureProvider : AbstractSyntaxNodeStructu
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         CollectionExpressionSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/CompilationUnitStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/CompilationUnitStructureProvider.cs
@@ -7,7 +7,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -17,11 +17,11 @@ internal class CompilationUnitStructureProvider : AbstractSyntaxNodeStructurePro
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         CompilationUnitSyntax compilationUnit,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(compilationUnit, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(compilationUnit, spans, options);
 
         // extern aliases and usings are outlined in a single region
         var externsAndUsings = new List<SyntaxNode>();
@@ -42,7 +42,7 @@ internal class CompilationUnitStructureProvider : AbstractSyntaxNodeStructurePro
             compilationUnit.Members.Count > 0 ||
             compilationUnit.AttributeLists.Count > 0)
         {
-            CSharpStructureHelpers.CollectCommentBlockSpans(compilationUnit.EndOfFileToken.LeadingTrivia, ref spans);
+            CSharpStructureHelpers.CollectCommentBlockSpans(compilationUnit.EndOfFileToken.LeadingTrivia, spans);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class ConstructorDeclarationStructureProvider : AbstractSyntaxNodeStruc
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         ConstructorDeclarationSyntax constructorDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(constructorDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(constructorDeclaration, spans, options);
 
         // fault tolerance
         if (constructorDeclaration.Body == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/ConversionOperatorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ConversionOperatorDeclarationStructureProvider.cs
@@ -6,7 +6,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -16,11 +16,11 @@ internal class ConversionOperatorDeclarationStructureProvider : AbstractSyntaxNo
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         ConversionOperatorDeclarationSyntax operatorDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(operatorDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(operatorDeclaration, spans, options);
 
         // fault tolerance
         if (operatorDeclaration.Body == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/DelegateDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DelegateDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,10 +14,10 @@ internal class DelegateDeclarationStructureProvider : AbstractSyntaxNodeStructur
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         DelegateDeclarationSyntax delegateDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(delegateDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(delegateDeclaration, spans, options);
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/DestructorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DestructorDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class DestructorDeclarationStructureProvider : AbstractSyntaxNodeStruct
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         DestructorDeclarationSyntax destructorDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(destructorDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(destructorDeclaration, spans, options);
 
         // fault tolerance
         if (destructorDeclaration.Body == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -14,17 +14,17 @@ internal sealed class DisabledTextTriviaStructureProvider : AbstractSyntaxTrivia
 {
     public override void CollectBlockSpans(
         SyntaxTrivia trivia,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(trivia.SyntaxTree);
-        CollectBlockSpans(trivia.SyntaxTree, trivia, ref spans, cancellationToken);
+        CollectBlockSpans(trivia.SyntaxTree, trivia, spans, cancellationToken);
     }
 
     public static void CollectBlockSpans(
         SyntaxTree syntaxTree, SyntaxTrivia trivia,
-        ref TemporaryArray<BlockSpan> spans, CancellationToken cancellationToken)
+        ArrayBuilder<BlockSpan> spans, CancellationToken cancellationToken)
     {
         // We'll always be leading trivia of some token.
         var startPos = trivia.FullSpan.Start;

--- a/src/Features/CSharp/Portable/Structure/Providers/DocumentationCommentStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DocumentationCommentStructureProvider.cs
@@ -5,7 +5,7 @@
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 
@@ -16,7 +16,7 @@ internal class DocumentationCommentStructureProvider : AbstractSyntaxNodeStructu
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         DocumentationCommentTriviaSyntax documentationComment,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/EnumDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EnumDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class EnumDeclarationStructureProvider : AbstractSyntaxNodeStructurePro
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         EnumDeclarationSyntax enumDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(enumDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(enumDeclaration, spans, options);
 
         if (!enumDeclaration.OpenBraceToken.IsMissing &&
             !enumDeclaration.CloseBraceToken.IsMissing)
@@ -45,7 +45,7 @@ internal class EnumDeclarationStructureProvider : AbstractSyntaxNodeStructurePro
         if (!enumDeclaration.CloseBraceToken.IsMissing)
         {
             var leadingTrivia = enumDeclaration.CloseBraceToken.LeadingTrivia;
-            CSharpStructureHelpers.CollectCommentBlockSpans(leadingTrivia, ref spans);
+            CSharpStructureHelpers.CollectCommentBlockSpans(leadingTrivia, spans);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/EnumMemberDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EnumMemberDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,10 +14,10 @@ internal class EnumMemberDeclarationStructureProvider : AbstractSyntaxNodeStruct
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         EnumMemberDeclarationSyntax enumMemberDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(enumMemberDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(enumMemberDeclaration, spans, options);
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/EventDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EventDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class EventDeclarationStructureProvider : AbstractSyntaxNodeStructurePr
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         EventDeclarationSyntax eventDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(eventDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(eventDeclaration, spans, options);
 
         // fault tolerance
         if (eventDeclaration.AccessorList == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/EventFieldDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/EventFieldDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,10 +14,10 @@ internal class EventFieldDeclarationStructureProvider : AbstractSyntaxNodeStruct
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         EventFieldDeclarationSyntax eventFieldDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(eventFieldDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(eventFieldDeclaration, spans, options);
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/FieldDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/FieldDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,10 +14,10 @@ internal class FieldDeclarationStructureProvider : AbstractSyntaxNodeStructurePr
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         FieldDeclarationSyntax fieldDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(fieldDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(fieldDeclaration, spans, options);
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/FileScopedNamespaceDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/FileScopedNamespaceDeclarationStructureProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Structure;
 
@@ -16,12 +17,12 @@ internal class FileScopedNamespaceDeclarationStructureProvider : AbstractSyntaxN
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         FileScopedNamespaceDeclarationSyntax fileScopedNamespaceDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
         // add leading comments
-        CSharpStructureHelpers.CollectCommentBlockSpans(fileScopedNamespaceDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(fileScopedNamespaceDeclaration, spans, options);
 
         // extern aliases and usings are outlined in a single region
         var externsAndUsings = Enumerable.Union<SyntaxNode>(fileScopedNamespaceDeclaration.Externs, fileScopedNamespaceDeclaration.Usings).ToImmutableArray();
@@ -29,7 +30,7 @@ internal class FileScopedNamespaceDeclarationStructureProvider : AbstractSyntaxN
         // add any leading comments before the extern aliases and usings
         if (externsAndUsings.Any())
         {
-            CSharpStructureHelpers.CollectCommentBlockSpans(externsAndUsings.First(), ref spans, options);
+            CSharpStructureHelpers.CollectCommentBlockSpans(externsAndUsings.First(), spans, options);
         }
 
         spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(

--- a/src/Features/CSharp/Portable/Structure/Providers/IfDirectiveTriviaStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/IfDirectiveTriviaStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 
@@ -19,7 +19,7 @@ internal sealed class IfDirectiveTriviaStructureProvider : AbstractSyntaxNodeStr
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         IfDirectiveTriviaSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/IndexerDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/IndexerDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class IndexerDeclarationStructureProvider : AbstractSyntaxNodeStructure
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         IndexerDeclarationSyntax indexerDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(indexerDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(indexerDeclaration, spans, options);
 
         // fault tolerance
         if (indexerDeclaration.AccessorList == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/InitializerExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/InitializerExpressionStructureProvider.cs
@@ -6,7 +6,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 
@@ -17,7 +17,7 @@ internal class InitializerExpressionStructureProvider : AbstractSyntaxNodeStruct
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         InitializerExpressionSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/InterpolatedStringExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/InterpolatedStringExpressionStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,7 +14,7 @@ internal sealed class InterpolatedStringExpressionStructureProvider : AbstractSy
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         InterpolatedStringExpressionSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/MethodDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/MethodDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class MethodDeclarationStructureProvider : AbstractSyntaxNodeStructureP
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         MethodDeclarationSyntax methodDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(methodDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(methodDeclaration, spans, options);
 
         // fault tolerance
         if (methodDeclaration.Body == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/MultilineCommentBlockStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/MultilineCommentBlockStructureProvider.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -12,7 +12,7 @@ internal class MultilineCommentBlockStructureProvider : AbstractSyntaxTriviaStru
 {
     public override void CollectBlockSpans(
         SyntaxTrivia trivia,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.cs
@@ -5,7 +5,7 @@
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -15,12 +15,12 @@ internal class NamespaceDeclarationStructureProvider : AbstractSyntaxNodeStructu
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         NamespaceDeclarationSyntax namespaceDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
         // add leading comments
-        CSharpStructureHelpers.CollectCommentBlockSpans(namespaceDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(namespaceDeclaration, spans, options);
 
         if (!namespaceDeclaration.OpenBraceToken.IsMissing &&
             !namespaceDeclaration.CloseBraceToken.IsMissing)
@@ -42,7 +42,7 @@ internal class NamespaceDeclarationStructureProvider : AbstractSyntaxNodeStructu
         // add any leading comments before the extern aliases and usings
         if (externsAndUsings.Count > 0)
         {
-            CSharpStructureHelpers.CollectCommentBlockSpans(externsAndUsings.First(), ref spans, options);
+            CSharpStructureHelpers.CollectCommentBlockSpans(externsAndUsings.First(), spans, options);
         }
 
         spans.AddIfNotNull(CSharpStructureHelpers.CreateBlockSpan(
@@ -53,7 +53,7 @@ internal class NamespaceDeclarationStructureProvider : AbstractSyntaxNodeStructu
         if (!namespaceDeclaration.CloseBraceToken.IsMissing)
         {
             CSharpStructureHelpers.CollectCommentBlockSpans(
-                namespaceDeclaration.CloseBraceToken.LeadingTrivia, ref spans);
+                namespaceDeclaration.CloseBraceToken.LeadingTrivia, spans);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/OperatorDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/OperatorDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class OperatorDeclarationStructureProvider : AbstractSyntaxNodeStructur
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         OperatorDeclarationSyntax operatorDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(operatorDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(operatorDeclaration, spans, options);
 
         // fault tolerance
         if (operatorDeclaration.Body == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/ParenthesizedLambdaExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ParenthesizedLambdaExpressionStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,7 +14,7 @@ internal class ParenthesizedLambdaExpressionStructureProvider : AbstractSyntaxNo
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         ParenthesizedLambdaExpressionSyntax lambdaExpression,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/PropertyDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/PropertyDeclarationStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,11 +14,11 @@ internal class PropertyDeclarationStructureProvider : AbstractSyntaxNodeStructur
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         PropertyDeclarationSyntax propertyDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(propertyDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(propertyDeclaration, spans, options);
 
         // fault tolerance
         if (propertyDeclaration.AccessorList == null ||

--- a/src/Features/CSharp/Portable/Structure/Providers/RegionDirectiveStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/RegionDirectiveStructureProvider.cs
@@ -5,7 +5,7 @@
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 
@@ -32,7 +32,7 @@ internal sealed class RegionDirectiveStructureProvider : AbstractSyntaxNodeStruc
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         RegionDirectiveTriviaSyntax regionDirective,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/SimpleLambdaExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/SimpleLambdaExpressionStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,7 +14,7 @@ internal class SimpleLambdaExpressionStructureProvider : AbstractSyntaxNodeStruc
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         SimpleLambdaExpressionSyntax lambdaExpression,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/StringLiteralExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/StringLiteralExpressionStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -14,7 +14,7 @@ internal sealed class StringLiteralExpressionStructureProvider : AbstractSyntaxN
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         LiteralExpressionSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/SwitchStatementStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/SwitchStatementStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 
@@ -15,7 +15,7 @@ internal class SwitchStatementStructureProvider : AbstractSyntaxNodeStructurePro
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         SwitchStatementSyntax node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/TypeDeclarationStructureProvider.cs
@@ -6,7 +6,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;
 
 namespace Microsoft.CodeAnalysis.CSharp.Structure;
@@ -16,11 +16,11 @@ internal class TypeDeclarationStructureProvider : AbstractSyntaxNodeStructurePro
     protected override void CollectBlockSpans(
         SyntaxToken previousToken,
         TypeDeclarationSyntax typeDeclaration,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
-        CSharpStructureHelpers.CollectCommentBlockSpans(typeDeclaration, ref spans, options);
+        CSharpStructureHelpers.CollectCommentBlockSpans(typeDeclaration, spans, options);
 
         if (!typeDeclaration.OpenBraceToken.IsMissing &&
             !typeDeclaration.CloseBraceToken.IsMissing)
@@ -53,7 +53,7 @@ internal class TypeDeclarationStructureProvider : AbstractSyntaxNodeStructurePro
         if (!typeDeclaration.CloseBraceToken.IsMissing)
         {
             var leadingTrivia = typeDeclaration.CloseBraceToken.LeadingTrivia;
-            CSharpStructureHelpers.CollectCommentBlockSpans(leadingTrivia, ref spans);
+            CSharpStructureHelpers.CollectCommentBlockSpans(leadingTrivia, spans);
         }
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureContext.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureContext.cs
@@ -12,12 +12,20 @@ namespace Microsoft.CodeAnalysis.Structure;
 [NonCopyable]
 internal readonly struct BlockStructureContext(SyntaxTree syntaxTree, BlockStructureOptions options, CancellationToken cancellationToken) : IDisposable
 {
-    public readonly ArrayBuilder<BlockSpan> Spans = ArrayBuilder<BlockSpan>.GetInstance();
+    // We keep our own ObjectPool of ArrayBuilders as we want to use ArrayBuilders for their ability to efficiently create ImmutableArrays, but don't
+    // want the maximum capacity the default pool uses for dropping items from the pool.
+    private static readonly ObjectPool<ArrayBuilder<BlockSpan>> _blockSpanArrayBuilderPool = new ObjectPool<ArrayBuilder<BlockSpan>>(() => new ArrayBuilder<BlockSpan>());
+
+    public readonly ArrayBuilder<BlockSpan> Spans = _blockSpanArrayBuilderPool.Allocate();
 
     public readonly SyntaxTree SyntaxTree = syntaxTree;
     public readonly BlockStructureOptions Options = options;
     public readonly CancellationToken CancellationToken = cancellationToken;
 
     public void Dispose()
-        => Spans.Free();
+    {
+        // Do not call Free on the builder as we are not using the default pool
+        Spans.Clear();
+        _blockSpanArrayBuilderPool.Free(Spans);
+    }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
@@ -73,11 +73,10 @@ internal abstract class BlockStructureServiceWithProviders : BlockStructureServi
 
     private static BlockStructure CreateBlockStructure(in BlockStructureContext context)
     {
-        var updatedSpans = new FixedSizeArrayBuilder<BlockSpan>(context.Spans.Count);
-        foreach (var span in context.Spans)
-            updatedSpans.Add(UpdateBlockSpan(span, context.Options));
+        for (var i = 0; i < context.Spans.Count; i++)
+            context.Spans[i] = UpdateBlockSpan(context.Spans[i], context.Options);
 
-        return new BlockStructure(updatedSpans.MoveToImmutable());
+        return new BlockStructure(context.Spans.ToImmutable());
     }
 
     private static BlockSpan UpdateBlockSpan(BlockSpan blockSpan, in BlockStructureOptions options)

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractSyntaxNodeStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractSyntaxNodeStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Threading;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Structure;
 
@@ -13,7 +13,7 @@ internal abstract class AbstractSyntaxNodeStructureProvider<TSyntaxNode> : Abstr
 {
     public sealed override void CollectBlockSpans(
         SyntaxTrivia trivia,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
@@ -23,20 +23,20 @@ internal abstract class AbstractSyntaxNodeStructureProvider<TSyntaxNode> : Abstr
     public sealed override void CollectBlockSpans(
         SyntaxToken previousToken,
         SyntaxNode node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {
         if (node is TSyntaxNode tSyntax)
         {
-            CollectBlockSpans(previousToken, tSyntax, ref spans, options, cancellationToken);
+            CollectBlockSpans(previousToken, tSyntax, spans, options, cancellationToken);
         }
     }
 
     protected abstract void CollectBlockSpans(
         SyntaxToken previousToken,
         TSyntaxNode node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractSyntaxStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractSyntaxStructureProvider.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Structure;
 
@@ -12,13 +12,13 @@ internal abstract class AbstractSyntaxStructureProvider
     public abstract void CollectBlockSpans(
         SyntaxToken previousToken,
         SyntaxNode node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken);
 
     public abstract void CollectBlockSpans(
         SyntaxTrivia trivia,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractSyntaxTriviaStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractSyntaxTriviaStructureProvider.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Threading;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Structure;
 
@@ -13,7 +13,7 @@ internal abstract class AbstractSyntaxTriviaStructureProvider : AbstractSyntaxSt
     public sealed override void CollectBlockSpans(
         SyntaxToken previousToken,
         SyntaxNode node,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         BlockStructureOptions options,
         CancellationToken cancellationToken)
     {

--- a/src/Features/Core/Portable/Structure/Syntax/BlockSpanCollector.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/BlockSpanCollector.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
-using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Structure;
@@ -34,14 +34,14 @@ internal sealed class BlockSpanCollector
         BlockStructureOptions options,
         ImmutableDictionary<Type, ImmutableArray<AbstractSyntaxStructureProvider>> nodeOutlinerMap,
         ImmutableDictionary<int, ImmutableArray<AbstractSyntaxStructureProvider>> triviaOutlinerMap,
-        ref TemporaryArray<BlockSpan> spans,
+        ArrayBuilder<BlockSpan> spans,
         CancellationToken cancellationToken)
     {
         var collector = new BlockSpanCollector(options, nodeOutlinerMap, triviaOutlinerMap, cancellationToken);
-        collector.Collect(syntaxRoot, ref spans);
+        collector.Collect(syntaxRoot, spans);
     }
 
-    private void Collect(SyntaxNode root, ref TemporaryArray<BlockSpan> spans)
+    private void Collect(SyntaxNode root, ArrayBuilder<BlockSpan> spans)
     {
         _cancellationToken.ThrowIfCancellationRequested();
 
@@ -50,17 +50,17 @@ internal sealed class BlockSpanCollector
         {
             if (nodeOrToken.AsNode(out var childNode))
             {
-                GetBlockSpans(previousToken, childNode, ref spans);
+                GetBlockSpans(previousToken, childNode, spans);
             }
             else
             {
-                GetBlockSpans(nodeOrToken.AsToken(), ref spans);
+                GetBlockSpans(nodeOrToken.AsToken(), spans);
                 previousToken = nodeOrToken.AsToken();
             }
         }
     }
 
-    private void GetBlockSpans(SyntaxToken previousToken, SyntaxNode node, ref TemporaryArray<BlockSpan> spans)
+    private void GetBlockSpans(SyntaxToken previousToken, SyntaxNode node, ArrayBuilder<BlockSpan> spans)
     {
         if (_nodeProviderMap.TryGetValue(node.GetType(), out var providers))
         {
@@ -68,18 +68,18 @@ internal sealed class BlockSpanCollector
             {
                 _cancellationToken.ThrowIfCancellationRequested();
 
-                provider.CollectBlockSpans(previousToken, node, ref spans, _options, _cancellationToken);
+                provider.CollectBlockSpans(previousToken, node, spans, _options, _cancellationToken);
             }
         }
     }
 
-    private void GetBlockSpans(SyntaxToken token, ref TemporaryArray<BlockSpan> spans)
+    private void GetBlockSpans(SyntaxToken token, ArrayBuilder<BlockSpan> spans)
     {
-        GetOutliningSpans(token.LeadingTrivia, ref spans);
-        GetOutliningSpans(token.TrailingTrivia, ref spans);
+        GetOutliningSpans(token.LeadingTrivia, spans);
+        GetOutliningSpans(token.TrailingTrivia, spans);
     }
 
-    private void GetOutliningSpans(SyntaxTriviaList triviaList, ref TemporaryArray<BlockSpan> spans)
+    private void GetOutliningSpans(SyntaxTriviaList triviaList, ArrayBuilder<BlockSpan> spans)
     {
         foreach (var trivia in triviaList)
         {
@@ -90,7 +90,7 @@ internal sealed class BlockSpanCollector
                 {
                     _cancellationToken.ThrowIfCancellationRequested();
 
-                    provider.CollectBlockSpans(trivia, ref spans, _options, _cancellationToken);
+                    provider.CollectBlockSpans(trivia, spans, _options, _cancellationToken);
                 }
             }
         }

--- a/src/Features/VisualBasic/Portable/Structure/Providers/AccessorDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/AccessorDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   accessorDeclaration As AccessorStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(accessorDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/CollectionInitializerStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/CollectionInitializerStructureProvider.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.[Shared].Collections
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As CollectionInitializerSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/CompilationUnitStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/CompilationUnitStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.Text
@@ -14,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   compilationUnit As CompilationUnitSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(compilationUnit, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   constructorDeclaration As SubNewStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DelegateDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DelegateDeclarationStructureProvider.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.[Shared].Collections
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   delegateDeclaration As DelegateStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(delegateDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.Text
@@ -12,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
         Inherits AbstractSyntaxTriviaStructureProvider
 
         Public Overrides Sub CollectBlockSpans(trivia As SyntaxTrivia,
-                                               ByRef spans As TemporaryArray(Of BlockSpan),
+                                               spans As ArrayBuilder(Of BlockSpan),
                                                options As BlockStructureOptions,
                                                cancellationToken As CancellationToken)
             If trivia.Kind = SyntaxKind.DisabledTextTrivia Then

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DoLoopBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DoLoopBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As DoLoopBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.Text
@@ -15,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   documentationComment As DocumentationCommentTriviaSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             Dim firstCommentToken = documentationComment.ChildNodesAndTokens().FirstOrNull()

--- a/src/Features/VisualBasic/Portable/Structure/Providers/EnumDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/EnumDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   enumDeclaration As EnumStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(enumDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/EnumMemberDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/EnumMemberDeclarationStructureProvider.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.[Shared].Collections
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   enumMemberDeclaration As EnumMemberDeclarationSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(enumMemberDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/EventDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/EventDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   eventDeclaration As EventStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(eventDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/ExternalMethodDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/ExternalMethodDeclarationStructureProvider.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.[Shared].Collections
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   externalMethodDeclaration As DeclareStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(externalMethodDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/FieldDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/FieldDeclarationStructureProvider.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.[Shared].Collections
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   fieldDeclaration As FieldDeclarationSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(fieldDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/ForBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/ForBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As ForBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/ForEachBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/ForEachBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As ForEachBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/InterpolatedStringExpressionStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/InterpolatedStringExpressionStructureProvider.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.[Shared].Collections
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As InterpolatedStringExpressionSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             If node.DollarSignDoubleQuoteToken.IsMissing OrElse

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MethodDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MethodDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   methodDeclaration As MethodStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(methodDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MultiLineIfBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MultiLineIfBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As MultiLineIfBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MultilineLambdaStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MultilineLambdaStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   lambdaExpression As MultiLineLambdaExpressionSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             If Not lambdaExpression.EndSubOrFunctionStatement.IsMissing Then

--- a/src/Features/VisualBasic/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   namespaceDeclaration As NamespaceStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(namespaceDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/ObjectCreationInitializerStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/ObjectCreationInitializerStructureProvider.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.[Shared].Collections
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As ObjectCreationInitializerSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/OperatorDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/OperatorDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   operatorDeclaration As OperatorStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(operatorDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/PropertyDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/PropertyDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   propertyDeclaration As PropertyStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(propertyDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/RegionDirectiveStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/RegionDirectiveStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.Text
@@ -24,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   regionDirective As RegionDirectiveTriviaSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   CancellationToken As CancellationToken)
             Dim matchingDirective = regionDirective.GetMatchingStartOrEndDirective(CancellationToken)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/SelectBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/SelectBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As SelectBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/StringLiteralExpressionStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/StringLiteralExpressionStructureProvider.vb
@@ -3,7 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.[Shared].Collections
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As LiteralExpressionSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             If node.IsKind(SyntaxKind.StringLiteralExpression) AndAlso

--- a/src/Features/VisualBasic/Portable/Structure/Providers/SyncLockBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/SyncLockBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As SyncLockBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/TryBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/TryBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As TryBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/TypeDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/TypeDeclarationStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   typeDeclaration As TypeStatementSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(typeDeclaration, spans, options)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/UsingBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/UsingBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As UsingBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/WhileBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/WhileBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As WhileBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/WithBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/WithBlockStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Shared.Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   node As WithBlockSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             spans.AddIfNotNull(CreateBlockSpanFromBlock(

--- a/src/Features/VisualBasic/Portable/Structure/Providers/XmlExpressionStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/XmlExpressionStructureProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Shared.Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Protected Overrides Sub CollectBlockSpans(previousToken As SyntaxToken,
                                                   xmlExpression As XmlNodeSyntax,
-                                                  ByRef spans As TemporaryArray(Of BlockSpan),
+                                                  spans As ArrayBuilder(Of BlockSpan),
                                                   options As BlockStructureOptions,
                                                   cancellationToken As CancellationToken)
             ' If this XML expression is inside structured trivia (i.e. an XML doc comment), don't outline.

--- a/src/Features/VisualBasic/Portable/Structure/VisualBasicStructureHelpers.vb
+++ b/src/Features/VisualBasic/Portable/Structure/VisualBasicStructureHelpers.vb
@@ -4,6 +4,7 @@
 
 Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.[Shared].Collections
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.Text
@@ -37,17 +38,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         ' For testing purposes
         Friend Function CreateCommentsRegions(triviaList As SyntaxTriviaList) As ImmutableArray(Of BlockSpan)
-            Dim spans = TemporaryArray(Of BlockSpan).Empty
-            Try
-                CollectCommentsRegions(triviaList, spans)
-                Return spans.ToImmutableAndClear()
-            Finally
-                spans.Dispose()
-            End Try
+            Dim spans = ArrayBuilder(Of BlockSpan).GetInstance()
+            CollectCommentsRegions(triviaList, spans)
+            Return spans.ToImmutableAndFree()
         End Function
 
         Friend Sub CollectCommentsRegions(triviaList As SyntaxTriviaList,
-                                          ByRef spans As TemporaryArray(Of BlockSpan))
+                                          spans As ArrayBuilder(Of BlockSpan))
             If triviaList.Count > 0 Then
                 Dim startComment As SyntaxTrivia? = Nothing
                 Dim endComment As SyntaxTrivia? = Nothing
@@ -77,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
         End Sub
 
         Friend Sub CollectCommentsRegions(node As SyntaxNode,
-                                          ByRef spans As TemporaryArray(Of BlockSpan),
+                                          spans As ArrayBuilder(Of BlockSpan),
                                           options As BlockStructureOptions)
             If node Is Nothing Then
                 Throw New ArgumentNullException(NameOf(node))


### PR DESCRIPTION
There are basically two places where array allocations have been improved (particularly when the array exceed the default array builder pool size).

1) AbstractBlockStructureProvider.ProvideBlockStructure now calls BlockSpanCollector.CollectBlockSpans with the context.Spans, not with a new TemporaryArray. This required a change to the Sort call to pass in the start index, and to the filtering code at the end of the method to only filter out from the range that the current provider added to context.Spans

2) BlockStructureContext has it's own pool for the ArrayBuilder<BlockSpan>. As this array was very commonly exceeding the maximum reusable size allowed in the default array pool, we were previously no placing these arrays back in a pool.

Note that BlockStructureServiceWithProviders.CreateBlockStructure no longer uses FixedSizeArrayBuilder, instead modifying the entries in place. There isn't really an allocation change in this method, as both old and new allocate a single array in this method.

After the GetMultiLineRegions change earlier today, these allocations are only about 0.8% in the scrolling speedometer profile I'm looking at. Of that, I'd expect this to only remove about half of that, so only somewhat impactful.

*** relevant allocations from scrolling speedometer profile ***
![image](https://github.com/user-attachments/assets/5a71f399-402c-47e1-997d-62f930578f27)