### PR TITLE
Modify SyntaxNodeExtensions.GetMembers to instead execute a given lambda over the collection.

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -757,15 +757,29 @@ internal static partial class SyntaxNodeExtensions
             _ => null,
         };
 
-    public static IEnumerable<MemberDeclarationSyntax> GetMembers(this SyntaxNode? node)
-        => node switch
+    public static void ForEachMember<TArg>(this SyntaxNode? node, Action<MemberDeclarationSyntax, TArg> callback, TArg arg)
+    {
+        // Separated out to allow for struct-based enumeration.
+        switch (node)
         {
-            CompilationUnitSyntax compilation => compilation.Members,
-            BaseNamespaceDeclarationSyntax @namespace => @namespace.Members,
-            TypeDeclarationSyntax type => type.Members,
-            EnumDeclarationSyntax @enum => @enum.Members,
-            _ => [],
-        };
+            case CompilationUnitSyntax compilation:
+                foreach (var member in compilation.Members)
+                    callback(member, arg);
+                break;
+            case BaseNamespaceDeclarationSyntax @namespace:
+                foreach (var member in @namespace.Members)
+                    callback(member, arg);
+                break;
+            case TypeDeclarationSyntax type:
+                foreach (var member in type.Members)
+                    callback(member, arg);
+                break;
+            case EnumDeclarationSyntax @enum:
+                foreach (var member in @enum.Members)
+                    callback(member, arg);
+                break;
+        }
+    }
 
     public static bool IsInExpressionTree(
         [NotNullWhen(true)] this SyntaxNode? node,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -913,24 +913,24 @@ internal class CSharpSyntaxFacts : ISyntaxFacts
     {
         Debug.Assert(topLevel || methodLevel);
 
-        foreach (var member in node.GetMembers())
-        {
-            if (IsTopLevelNodeWithMembers(member))
+        node.ForEachMember(static (member, arg) =>
             {
-                if (topLevel)
+                var (@this, list, topLevel, methodLevel) = arg;
+                if (@this.IsTopLevelNodeWithMembers(member))
+                {
+                    if (topLevel)
+                    {
+                        list.Add(member);
+                    }
+
+                    @this.AppendMembers(member, list, topLevel, methodLevel);
+                }
+                else if (methodLevel && @this.IsMethodLevelMember(member))
                 {
                     list.Add(member);
                 }
-
-                AppendMembers(member, list, topLevel, methodLevel);
-                continue;
-            }
-
-            if (methodLevel && IsMethodLevelMember(member))
-            {
-                list.Add(member);
-            }
-        }
+            },
+            (this, list, topLevel, methodLevel));
     }
 
     public TextSpan GetMemberBodySpanForSpeculativeBinding(SyntaxNode node)


### PR DESCRIPTION
The scrolling speedometer profile I'm looking at is showing 0.7% of allocations during it's typing phase as boxing of the struct enumerators previously returned from SyntaxNodeExtensions.GetMembers.

Instead, as there is only one caller of this method (CSharpSyntaxFacts.AppendMembers), I've changed the method to take in a lambda and have it do the enumeration over the members, invoking the callback on each.

*** relevant allocations from the typing scenario in the scrolling speedometer test ***
![image](https://github.com/user-attachments/assets/1578cef4-ac93-47bc-a99b-603d529b035f)