### PR TITLE
Include App.config item only for net472 builds

### DIFF
--- a/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
+++ b/src/Interactive/HostProcess/x64/InteractiveHost64.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\..\..\Scripting\Core\Microsoft.CodeAnalysis.Scripting.csproj" />
     <ProjectReference Include="..\..\..\Scripting\CSharp\Microsoft.CodeAnalysis.CSharp.Scripting.csproj" />
     <ProjectReference Include="..\..\Host\Microsoft.CodeAnalysis.InteractiveHost.csproj" />
-    <Content Include="..\App.config" />
+    <Content Include="..\App.config" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     <Compile Include="..\InteractiveHostEntryPoint.cs" />
   </ItemGroup>
   


### PR DESCRIPTION
Fixes intermittent build failures such as

```
44>InteractiveHost64 -> D:\github\roslyn\artifacts\bin\InteractiveHost64\Release\net472\win-x64\InteractiveHost64.exe
44>C:\Program Files\dotnet\sdk\9.0.100-preview.5.24307.3\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(355,5): 
error MSB3030: Could not copy the file "D:\github\roslyn\artifacts\obj\InteractiveHost64\Release\net472\win-x64\InteractiveHost64.exe.config" because it was not found.
 
```