### PR TITLE
Unsubscribe from UIContext events when the LSP server exits

### DIFF
--- a/src/EditorFeatures/Core/Shared/Utilities/IUIContextActivationService.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/IUIContextActivationService.cs
@@ -11,5 +11,5 @@ internal interface IUIContextActivationService
     /// <summary>
     /// Executes the specified action when the UIContext first becomes active, or immediately if it is already active
     /// </summary>
-    void ExecuteWhenActivated(Guid uiContext, Action action);
+    IDisposable ExecuteWhenActivated(Guid uiContext, Action action);
 }

--- a/src/Tools/ExternalAccess/Razor/Cohost/RazorDynamicRegistrationServiceFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/RazorDynamicRegistrationServiceFactory.cs
@@ -36,9 +36,12 @@ internal sealed class RazorDynamicRegistrationServiceFactory(
         IClientLanguageServerManager? clientLanguageServerManager) : ILspService, IOnInitialized, IDisposable
     {
         private readonly CancellationTokenSource _disposalTokenSource = new();
+        private IDisposable? _activation;
 
         public void Dispose()
         {
+            _activation?.Dispose();
+            _activation = null;
             _disposalTokenSource.Cancel();
         }
 
@@ -56,7 +59,7 @@ internal sealed class RazorDynamicRegistrationServiceFactory(
             }
             else
             {
-                uIContextActivationService.ExecuteWhenActivated(Constants.RazorCohostingUIContext, InitializeRazor);
+                _activation = uIContextActivationService.ExecuteWhenActivated(Constants.RazorCohostingUIContext, InitializeRazor);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
Fixes AB#2187901

The super convenient helper method I was lazily using was not ideal, and ended up causing us to hold on to solutions as the LSP server exited and re-started.