### PR TITLE
CodeQL fixes

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Emit/EmitOptionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Emit/EmitOptionsTests.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 tolerateErrors: true,
                 includePrivateMembers: false,
                 instrumentationKinds: ImmutableArray.Create(InstrumentationKind.TestCoverage),
-                pdbChecksumAlgorithm: HashAlgorithmName.MD5);
+                pdbChecksumAlgorithm: HashAlgorithmName.MD5); // CodeQL [SM02196] This is testing an algorithm that our codebase must support for PDBs
 
             Assert.Equal(options1, options2.WithInstrumentationKinds(default));
             Assert.Equal(options2, options3.WithPdbChecksumAlgorithm(HashAlgorithmName.SHA256));

--- a/src/Compilers/Core/Portable/CryptographicHashProvider.cs
+++ b/src/Compilers/Core/Portable/CryptographicHashProvider.cs
@@ -82,6 +82,7 @@ namespace Microsoft.CodeAnalysis
             switch (algorithmId)
             {
                 case SourceHashAlgorithm.Sha1:
+                    // CodeQL [SM02196] This is not enabled by default but exists as a compat option for existing builds.
                     return SHA1.Create();
 
                 case SourceHashAlgorithm.Sha256:
@@ -97,6 +98,7 @@ namespace Microsoft.CodeAnalysis
             switch (algorithmId)
             {
                 case SourceHashAlgorithm.Sha1:
+                    // CodeQL [SM02196] This is not enabled by default but exists as a compat option for existing builds.
                     return HashAlgorithmName.SHA1;
 
                 case SourceHashAlgorithm.Sha256:
@@ -113,6 +115,7 @@ namespace Microsoft.CodeAnalysis
             {
                 case AssemblyHashAlgorithm.None:
                 case AssemblyHashAlgorithm.Sha1:
+                    // CodeQL [SM02196] ECMA-335 requires us to support SHA-1
                     return SHA1.Create();
 
                 case AssemblyHashAlgorithm.Sha256:
@@ -166,6 +169,8 @@ namespace Microsoft.CodeAnalysis
             if (stream != null)
             {
                 stream.Seek(0, SeekOrigin.Begin);
+
+                // CodeQL [SM02196] ECMA-335 requires us to use SHA-1 and there is no alternative.
                 using (var hashProvider = SHA1.Create())
                 {
                     return ImmutableArray.Create(hashProvider.ComputeHash(stream));
@@ -182,6 +187,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static ImmutableArray<byte> ComputeSha1(byte[] bytes)
         {
+            // CodeQL [SM02196] ECMA-335 requires us to use SHA-1 and there is no alternative.
             using (var hashProvider = SHA1.Create())
             {
                 return ImmutableArray.Create(hashProvider.ComputeHash(bytes));

--- a/src/Compilers/Core/Portable/PEWriter/SigningUtilities.cs
+++ b/src/Compilers/Core/Portable/PEWriter/SigningUtilities.cs
@@ -19,23 +19,25 @@ namespace Microsoft.CodeAnalysis
     {
         internal static byte[] CalculateRsaSignature(IEnumerable<Blob> content, RSAParameters privateKey)
         {
-            var hash = CalculateSha1(content);
+            var hash = calculateSha1(content);
 
             using (var rsa = RSA.Create())
             {
                 rsa.ImportParameters(privateKey);
+                // CodeQL [SM02196] ECMA-335 requires us to use SHA-1 and there is no alternative.
                 var signature = rsa.SignHash(hash, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
                 Array.Reverse(signature);
                 return signature;
             }
-        }
 
-        internal static byte[] CalculateSha1(IEnumerable<Blob> content)
-        {
-            using (var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA1))
+            static byte[] calculateSha1(IEnumerable<Blob> content)
             {
-                hash.AppendData(content);
-                return hash.GetHashAndReset();
+                // CodeQL [SM02196] ECMA-335 requires us to use SHA-1 and there is no alternative.
+                using (var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA1))
+                {
+                    hash.AppendData(content);
+                    return hash.GetHashAndReset();
+                }
             }
         }
 

--- a/src/Compilers/Core/Portable/Text/SourceHashAlgorithms.cs
+++ b/src/Compilers/Core/Portable/Text/SourceHashAlgorithms.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.Text
         {
             return algorithm switch
             {
+                // CodeQL [SM02196] This is not enabled by default but exists as a compat option for existing builds.
                 SourceHashAlgorithm.Sha1 => SHA1.Create(),
                 SourceHashAlgorithm.Sha256 => SHA256.Create(),
                 _ => throw ExceptionUtilities.UnexpectedValue(algorithm)

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -330,8 +330,8 @@ namespace BuildBoss
 
         private static string GetChecksum(Stream stream)
         {
-            using var md5 = MD5.Create();
-            return BitConverter.ToString(md5.ComputeHash(stream));
+            using var hash = SHA256.Create();
+            return BitConverter.ToString(hash.ComputeHash(stream));
         }
 
         /// <summary>


### PR DESCRIPTION
This takes care of a number of CodeQL violations in our code base. Virtually all of these were about uses of MD5 or SHA-1 that we have to support due to the file formats we produce and consume. As such I added suppressions for those cases. There was one real case that could be migrated that I took care of.