### PR TITLE
Exclude BuildValidator from VMR when building without tests

### DIFF
--- a/src/Tools/BuildValidator/BuildValidator.csproj
+++ b/src/Tools/BuildValidator/BuildValidator.csproj
@@ -9,6 +9,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsShipping>false</IsShipping>
+    <ExcludeFromDotNetBuild Condition="'$(DotNetBuildTests)' != 'true'">true</ExcludeFromDotNetBuild>
 
     <!-- Explicit AnyCPU so it runs as AnyCPU even on Debug builds -->
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Fixes SDK insertion: https://github.com/dotnet/sdk/pull/42443