### PR TITLE
Add ProjectInfo.WithId public API

### DIFF
--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
+Microsoft.CodeAnalysis.ProjectInfo.WithId(Microsoft.CodeAnalysis.ProjectId id) -> Microsoft.CodeAnalysis.ProjectInfo
 virtual Microsoft.CodeAnalysis.Host.HostLanguageServices.Dispose() -> void
 virtual Microsoft.CodeAnalysis.Host.HostWorkspaceServices.Dispose() -> void

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -326,6 +326,9 @@ public sealed class ProjectInfo
             newHostObjectType);
     }
 
+    public ProjectInfo WithId(ProjectId id)
+        => With(attributes: Attributes.With(id: id ?? throw new ArgumentNullException(nameof(id))));
+
     public ProjectInfo WithVersion(VersionStamp version)
         => With(attributes: Attributes.With(version: version));
 
@@ -511,6 +514,7 @@ public sealed class ProjectInfo
             }, this);
 
         public ProjectAttributes With(
+            ProjectId? id = null,
             VersionStamp? version = null,
             string? name = null,
             string? assemblyName = null,
@@ -525,6 +529,7 @@ public sealed class ProjectInfo
             Optional<bool> runAnalyzers = default,
             Optional<Guid> telemetryId = default)
         {
+            var newId = id ?? Id;
             var newVersion = version ?? Version;
             var newName = name ?? Name;
             var newAssemblyName = assemblyName ?? AssemblyName;
@@ -539,7 +544,8 @@ public sealed class ProjectInfo
             var newRunAnalyzers = runAnalyzers.HasValue ? runAnalyzers.Value : RunAnalyzers;
             var newTelemetryId = telemetryId.HasValue ? telemetryId.Value : TelemetryId;
 
-            if (newVersion == Version &&
+            if (newId == Id &&
+                newVersion == Version &&
                 newName == Name &&
                 newAssemblyName == AssemblyName &&
                 newFilePath == FilePath &&
@@ -557,7 +563,7 @@ public sealed class ProjectInfo
             }
 
             return new ProjectAttributes(
-                Id,
+                newId,
                 newVersion,
                 newName,
                 newAssemblyName,

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
@@ -182,6 +182,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(projectId), "doc");
             var instance = ProjectInfo.Create(name: "Name", id: ProjectId.CreateNewId(), version: VersionStamp.Default, assemblyName: "AssemblyName", language: "C#");
 
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithId(value), opt => opt.Id, ProjectId.CreateNewId(), defaultThrows: true);
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithVersion(value), opt => opt.Version, VersionStamp.Create());
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithName(value), opt => opt.Name, "New", defaultThrows: true);
             SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithAssemblyName(value), opt => opt.AssemblyName, "New", defaultThrows: true);


### PR DESCRIPTION
Useful for dotnet-watch, where we need to take `ProjectInfo` returned `MSBuildProjectLoader` and remap its ID to a project with the same project file path.

Implements https://github.com/dotnet/roslyn/issues/74665