### PR TITLE
Remove test dependency from BuildValidator

### DIFF
--- a/src/Tools/BuildValidator/BuildValidator.csproj
+++ b/src/Tools/BuildValidator/BuildValidator.csproj
@@ -20,7 +20,6 @@
     <ProjectReference Include="..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
     <ProjectReference Include="..\..\Compilers\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
     <ProjectReference Include="..\..\Compilers\Core\Rebuild\Microsoft.CodeAnalysis.Rebuild.csproj" />
-    <ProjectReference Include="..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/BuildValidator/IldasmUtilities.cs
+++ b/src/Tools/BuildValidator/IldasmUtilities.cs
@@ -12,6 +12,15 @@ namespace BuildValidator
 {
     internal static class IldasmUtilities
     {
+        private static string GetArchitecture()
+        {
+#if NET8_0_OR_GREATER
+            return RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+#else
+            return "x64";
+#endif
+        }
+
         private static string GetIldasmPath()
         {
             var ildasmExeName = PlatformInformation.IsWindows ? "ildasm.exe" : "ildasm";
@@ -27,8 +36,7 @@ namespace BuildValidator
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                var architecture = Microsoft.CodeAnalysis.Test.Utilities.IlasmUtilities.Architecture;
-                ridName = $"linux-{architecture}";
+                ridName = $"linux-{GetArchitecture()}";
             }
             else
             {


### PR DESCRIPTION
Another attempt to fix https://github.com/dotnet/sdk/pull/42443/checks?check_run_id=28431211393

Actually, not required but it would still be better to remove the test dependency imo.