### PR TITLE
Reduce allocations in AbstractSymbolCompletionProvider.CreateItems

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -170,7 +170,7 @@ internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext>
     /// <summary>
     /// Alternative comparer to SymbolAndSelectionInfo's default which considers both the full symbol and preselect.
     /// </summary>
-    protected sealed class SymbolReferenceEquivalenceComparer : IEqualityComparer<SymbolAndSelectionInfo>
+    private sealed class SymbolReferenceEquivalenceComparer : IEqualityComparer<SymbolAndSelectionInfo>
     {
         public static readonly SymbolReferenceEquivalenceComparer Instance = new();
 


### PR DESCRIPTION
The linq expression shows up as about 0.3% of allocations in the profile I'm looking for in the typing section of the scrolling speedometer test.

MultiDictionary has a struct-based value that is great for the case where the valueset typically is only a single object (which is the case for this code).

*** Relevant allocations from the profile I'm looking at ***
![image](https://github.com/user-attachments/assets/471d6b93-ee33-4bd1-b730-01cdc5769d18)