### PR TITLE
Mark compiler-generated list type with `[CompilerGenerated]` attribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -914,6 +915,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             guidString = null;
             return false;
+        }
+
+        internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+            AddSynthesizedAttribute(ref attributes, DeclaringCompilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
         }
 
         internal override bool HasCollectionBuilderAttribute(out TypeSymbol? builderType, out string? methodName)

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -11438,6 +11438,11 @@ static class Program
                     var synthesizedType = module.GlobalNamespace.GetTypeMember("<>z__ReadOnlyArray");
                     Assert.Equal("<>z__ReadOnlyArray<T>", synthesizedType.ToTestDisplayString());
                     Assert.Equal("<>z__ReadOnlyArray`1", synthesizedType.MetadataName);
+
+                    Assert.Contains(synthesizedType.GetAttributes(),
+                        a => a.AttributeClass?.ToTestDisplayString() == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
+                    Assert.DoesNotContain(synthesizedType.GetMembers(),
+                        m => m.GetAttributes().Any(a => a.AttributeClass?.ToTestDisplayString() == "System.Runtime.CompilerServices.CompilerGeneratedAttribute"));
                 },
                 expectedOutput: """
                     IEnumerable.GetEnumerator(): (System.Int32[]) [], 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/74676
Fixes: https://github.com/dotnet/roslyn/issues/72539