### PR TITLE
Only report project load events for initial load in VSCode

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectToLoad.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectToLoad.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 /// <summary>
 /// The project path (and the guid if it game from a solution) of the project to load.
 /// </summary>
-internal record ProjectToLoad(string Path, string? ProjectGuid)
+internal record ProjectToLoad(string Path, string? ProjectGuid, bool ReportTelemetry)
 {
     public static IEqualityComparer<ProjectToLoad> Comparer = new ProjectToLoadComparer();
 


### PR DESCRIPTION
This was requested to match how VS and DevKit report project load telemetry (once when the solution is opened).  Before we would report the event every time the project loaded or reloaded.

This does mean we do not report telemetry when things like the TFM change, but that is known and expected.

Verified in VSCode that the initial event is reported and changes to the project to not trigger the event to be fired.
