### PR TITLE
Remove most usage of "new ArrayBuilder"

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/FilterSet.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/FilterSet.cs
@@ -131,7 +131,7 @@ internal sealed class FilterSet(bool supportExpander)
 
     public (ImmutableArray<CompletionFilter> filters, int data) GetFiltersAndAddToSet(RoslynCompletionItem item)
     {
-        var listBuilder = new ArrayBuilder<CompletionFilter>();
+        using var _ = ArrayBuilder<CompletionFilter>.GetInstance(out var listBuilder);
         var vectorForSingleItem = new BitVector32();
 
         if (item.Flags.IsExpanded())
@@ -150,7 +150,7 @@ internal sealed class FilterSet(bool supportExpander)
             }
         }
 
-        return (listBuilder.ToImmutableAndFree(), vectorForSingleItem.Data);
+        return (listBuilder.ToImmutableAndClear(), vectorForSingleItem.Data);
     }
 
     // test only

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
@@ -1390,9 +1390,12 @@ class C
         private static string[] GetLocalNames(EvaluationContext context)
         {
             string unused;
-            var locals = new ArrayBuilder<LocalAndMethod>();
+            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
             context.CompileGetLocals(locals, argumentsOnly: false, typeName: out unused, testData: null);
-            return locals.Select(l => l.LocalName).ToArray();
+            var result = locals.Select(l => l.LocalName).ToArray();
+
+            locals.Free();
+            return result;
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -3863,7 +3863,7 @@ class C
                 EvaluationContext context;
                 context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext", atLineNumber: 500);
                 string unused;
-                var locals = new ArrayBuilder<LocalAndMethod>();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 context.CompileGetLocals(locals, argumentsOnly: true, typeName: out unused, testData: null);
                 var names = locals.Select(l => l.LocalName).ToArray();
                 // The order must confirm the order of the arguments in the method signature.
@@ -3877,7 +3877,7 @@ class C
                 EvaluationContext context;
                 context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext", atLineNumber: 500);
                 string unused;
-                var locals = new ArrayBuilder<LocalAndMethod>();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 context.CompileGetLocals(locals, argumentsOnly: true, typeName: out unused, testData: null);
                 var names = locals.Select(l => l.LocalName).ToArray();
                 // The problem is not fixed in versions before 4.5: the order of arguments can be wrong.
@@ -3913,7 +3913,7 @@ class C
                 EvaluationContext context;
                 context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext", atLineNumber: 500);
                 string unused;
-                var locals = new ArrayBuilder<LocalAndMethod>();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 context.CompileGetLocals(locals, argumentsOnly: true, typeName: out unused, testData: null);
                 var names = locals.Select(l => l.LocalName).ToArray();
                 // The order must confirm the order of the arguments in the method signature.

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionSession.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionSession.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
             internal Dispatcher(ImmutableArray<TInterface> items)
             {
                 _implementations = items;
-                _calls = new ArrayBuilder<InstanceAndMethod>();
+                _calls = ArrayBuilder<InstanceAndMethod>.GetInstance();
             }
 
             internal TResult Invoke<TResult>(object instance, MethodId method, Func<TInterface, TResult> f)

--- a/src/Features/Core/Portable/SemanticSearch/AbstractSemanticSearchService.cs
+++ b/src/Features/Core/Portable/SemanticSearch/AbstractSemanticSearchService.cs
@@ -388,7 +388,7 @@ internal abstract partial class AbstractSemanticSearchService : ISemanticSearchS
     {
         try
         {
-            var candidates = new ArrayBuilder<MethodInfo>();
+            using var _ = ArrayBuilder<MethodInfo>.GetInstance(out var candidates);
 
             foreach (var candidate in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
             {

--- a/src/Features/TestUtilities/EditAndContinue/ActiveStatementsDescription.cs
+++ b/src/Features/TestUtilities/EditAndContinue/ActiveStatementsDescription.cs
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             var activeStatementCount = Math.Max(OldStatements.Length, (newActiveStatementMarkers.Length == 0) ? -1 : newActiveStatementMarkers.Max(m => m.Id));
 
-            var newMappedSpans = new ArrayBuilder<SourceFileSpan>();
-            var newMappedRegions = new ArrayBuilder<ImmutableArray<SourceFileSpan>>();
+            using var _1 = ArrayBuilder<SourceFileSpan>.GetInstance(out var newMappedSpans);
+            using var _2 = ArrayBuilder<ImmutableArray<SourceFileSpan>>.GetInstance(out var newMappedRegions);
             var newExceptionRegionMarkers = SourceMarkers.GetExceptionRegions(newMarkedSource);
 
             newMappedSpans.ZeroInit(activeStatementCount);
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         {
             var map = new Dictionary<string, List<ActiveStatement>>();
 
-            var activeStatements = new ArrayBuilder<UnmappedActiveStatement>();
+            using var _ = ArrayBuilder<UnmappedActiveStatement>.GetInstance(out var activeStatements);
 
             var sourceIndex = 0;
             foreach (var markedSource in markedSources)

--- a/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
             RoslynDebug.Assert(configurationsFromClient.Length == SupportedOptions.Sum(option => option is IPerLanguageValuedOption ? 2 : 1));
 
             // LSP ensures the order of result from client should match the order we sent from server.
-            var optionsToUpdate = new ArrayBuilder<KeyValuePair<OptionKey2, object?>>();
+            using var _ = ArrayBuilder<KeyValuePair<OptionKey2, object?>>.GetInstance(out var optionsToUpdate);
 
             for (var i = 0; i < configurationsFromClient.Length; i++)
             {

--- a/src/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/AbstractFormatDocumentHandlerBase.cs
@@ -42,9 +42,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var services = document.Project.Solution.Services;
             var textChanges = Formatter.GetFormattedTextChanges(root, [formattingSpan], services, formattingOptions, rules: default, cancellationToken);
 
-            var edits = new ArrayBuilder<LSP.TextEdit>();
+            using var _ = ArrayBuilder<LSP.TextEdit>.GetInstance(out var edits);
             edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text)));
-            return edits.ToArrayAndFree();
+            return edits.ToArray();
         }
 
         public abstract LSP.TextDocumentIdentifier GetTextDocumentIdentifier(RequestType request);

--- a/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -72,9 +72,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return [];
             }
 
-            var edits = new ArrayBuilder<TextEdit>();
+            using var _ = ArrayBuilder<TextEdit>.GetInstance(out var edits);
             edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, documentSyntax.Text)));
-            return edits.ToArrayAndFree();
+            return edits.ToArray();
         }
     }
 }

--- a/src/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
@@ -136,9 +136,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             return sb.ToString();
         }
+
         private static ClassifiedTextElement GetSignatureClassifiedText(SignatureHelpItem item)
         {
-            var taggedTexts = new ArrayBuilder<TaggedText>();
+            using var _ = ArrayBuilder<TaggedText>.GetInstance(out var taggedTexts);
 
             taggedTexts.AddRange(item.PrefixDisplayParts);
 
@@ -160,7 +161,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             taggedTexts.AddRange(item.SuffixDisplayParts);
             taggedTexts.AddRange(item.DescriptionParts);
 
-            return new ClassifiedTextElement(taggedTexts.ToArrayAndFree().Select(part => new ClassifiedTextRun(part.Tag.ToClassificationTypeName(), part.Text)));
+            return new ClassifiedTextElement(taggedTexts.ToArray().Select(part => new ClassifiedTextRun(part.Tag.ToClassificationTypeName(), part.Text)));
         }
     }
 }

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -861,7 +861,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
         [Fact]
         public void DebuggerProxy_ArrayBuilder()
         {
-            var obj = new ArrayBuilder<int>();
+            var obj = ArrayBuilder<int>.GetInstance();
             obj.AddRange(new[] { 1, 2, 3, 4, 5 });
 
             var str = s_formatter.FormatObject(obj, SingleLineOptions);
@@ -875,6 +875,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
                  "4",
                  "5"
             );
+
+            obj.Free();
         }
 
         [Fact, WorkItem(8542, "https://github.com/dotnet/roslyn/issues/8452")]

--- a/src/VisualStudio/LiveShare/Impl/ProjectsHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/ProjectsHandler.cs
@@ -21,11 +21,11 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     {
         public async Task<object[]> HandleAsync(object param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var projects = new ArrayBuilder<CustomProtocol.Project>();
+            using var _1 = ArrayBuilder<CustomProtocol.Project>.GetInstance(out var projects);
+            using var _2 = ArrayBuilder<Uri>.GetInstance(out var externalUris);
             var solution = requestContext.Context;
             foreach (var project in solution.Projects)
             {
-                var externalUris = new ArrayBuilder<Uri>();
                 foreach (var sourceFile in project.Documents)
                 {
                     var uri = new Uri(sourceFile.FilePath);
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                     }
                 }
 #pragma warning disable 0612
-                await requestContext.ProtocolConverter.RegisterExternalFilesAsync(externalUris.ToArrayAndFree()).ConfigureAwait(false);
+                await requestContext.ProtocolConverter.RegisterExternalFilesAsync(externalUris.ToArray()).ConfigureAwait(false);
 #pragma warning restore 0612
 
                 var lspProject = new CustomProtocol.Project
@@ -48,9 +48,10 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                 };
 
                 projects.Add(lspProject);
+                externalUris.Clear();
             }
 
-            return projects.ToArrayAndFree();
+            return projects.ToArray();
         }
     }
 }

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/PerfMargin/DataModel.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/PerfMargin/DataModel.cs
@@ -22,7 +22,7 @@ namespace Roslyn.Hosting.Diagnostics.PerfMargin
                          where !field.IsSpecialName
                          select field;
 
-            var builder = new ArrayBuilder<ActivityLevel?>();
+            using var _ = ArrayBuilder<ActivityLevel?>.GetInstance(out var builder);
 
             var features = new Dictionary<string, ActivityLevel>();
             var root = new ActivityLevel("All");

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -33,12 +33,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
 
         public async Task<TextEdit[]> HandleRequestAsync(DocumentOnTypeFormattingParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var edits = new ArrayBuilder<TextEdit>();
             if (string.IsNullOrEmpty(request.Character))
             {
-                return edits.ToArrayAndFree();
+                return [];
             }
 
+            using var _ = ArrayBuilder<TextEdit>.GetInstance(out var edits);
             var document = context.Document;
             var formattingService = document?.Project.Services.GetService<IXamlFormattingService>();
             if (document != null && formattingService != null)
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 }
             }
 
-            return edits.ToArrayAndFree();
+            return edits.ToArray();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -188,7 +188,7 @@ internal sealed class GlobalOptionService(
 
     private bool SetGlobalOptions(OneOrMany<KeyValuePair<OptionKey2, object?>> options)
     {
-        var changedOptions = new ArrayBuilder<(OptionKey2, object?)>(options.Count);
+        using var _ = ArrayBuilder<(OptionKey2, object?)>.GetInstance(options.Count, out var changedOptions);
         var persisters = GetOptionPersisters();
 
         lock (_gate)

--- a/src/Workspaces/CoreTest/UtilityTest/NameGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/NameGeneratorTests.cs
@@ -96,10 +96,10 @@ public class NameGeneratorTests
 
     private static void VerifyEnsureUniquenessInPlace(string[] names, bool[]? isFixed, Func<string, bool>? canUse, bool isCaseSensitive, string[] expectedResult)
     {
-        var namesBuilder = new ArrayBuilder<string>();
+        using var _1 = ArrayBuilder<string>.GetInstance(out var namesBuilder);
         namesBuilder.AddRange(names);
 
-        var isFixedBuilder = new ArrayBuilder<bool>();
+        using var _2 = ArrayBuilder<bool>.GetInstance(out var isFixedBuilder);
         isFixedBuilder.AddRange(isFixed ?? Enumerable.Repeat(false, names.Length));
 
         NameGenerator.EnsureUniquenessInPlace(namesBuilder, isFixedBuilder, canUse, isCaseSensitive);


### PR DESCRIPTION
Most callers of this were intending to instead use ArrayBuilder.GetInstance (as that actually is what pulls items from the pool). Otherwise, the code would create a new ArrayBuilder (and consequently the ImmutableArray.Builder), reallocate until the array hit the appropriate size, and likely return the item to a pool that would never be pulled from.