### PR TITLE
Rewrite BulidSolution in Integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpBuild.cs
@@ -42,8 +42,8 @@ class Program
 
         await TestServices.Editor.SetTextAsync(editorText, HangMitigatingCancellationToken);
 
-        var buildSummary = await TestServices.SolutionExplorer.BuildSolutionAndWaitAsync(HangMitigatingCancellationToken);
-        Assert.Equal("========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========", buildSummary);
+        var succeed = await TestServices.SolutionExplorer.BuildSolutionAndWaitAsync(HangMitigatingCancellationToken);
+        Assert.True(succeed);
 
         await TestServices.ErrorList.ShowBuildErrorsAsync(HangMitigatingCancellationToken);
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
@@ -630,67 +630,27 @@ internal partial class SolutionExplorerInProcess
     }
 
     /// <returns>
-    /// The summary line for the build, which generally looks something like this:
-    ///
-    /// <code>
-    /// ========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
-    /// </code>
+    /// true if build succeeds, otherwise false.
     /// </returns>
-    public async Task<string> BuildSolutionAndWaitAsync(CancellationToken cancellationToken)
+    public async Task<bool> BuildSolutionAndWaitAsync(CancellationToken cancellationToken)
     {
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-        var buildOutputWindowPane = await GetBuildOutputWindowPaneAsync(cancellationToken);
-        buildOutputWindowPane.Clear();
 
         var buildManager = await GetRequiredGlobalServiceAsync<SVsSolutionBuildManager, IVsSolutionBuildManager2>(cancellationToken);
         using var solutionEvents = new UpdateSolutionEvents(buildManager);
         var buildCompleteTaskCompletionSource = new TaskCompletionSource<bool>();
 
-        void HandleUpdateSolutionDone() => buildCompleteTaskCompletionSource.SetResult(true);
+        void HandleUpdateSolutionDone(bool buildSucceed) => buildCompleteTaskCompletionSource.SetResult(buildSucceed);
         solutionEvents.OnUpdateSolutionDone += HandleUpdateSolutionDone;
         try
         {
-            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd97CmdID.BuildSln, cancellationToken);
-
-            await buildCompleteTaskCompletionSource.Task;
+            ErrorHandler.ThrowOnFailure(buildManager.StartSimpleUpdateSolutionConfiguration((uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD, 0, 0));
+            return await buildCompleteTaskCompletionSource.Task;
         }
         finally
         {
             solutionEvents.OnUpdateSolutionDone -= HandleUpdateSolutionDone;
         }
-
-        // Force the error list to update
-        ErrorHandler.ThrowOnFailure(buildOutputWindowPane.FlushToTaskList());
-
-        var textView = (IVsTextView)buildOutputWindowPane;
-        var wpfTextViewHost = await textView.GetTextViewHostAsync(JoinableTaskFactory, cancellationToken);
-        var lines = wpfTextViewHost.TextView.TextViewLines;
-        if (lines.Count < 1)
-        {
-            return string.Empty;
-        }
-
-        // Find the build summary line
-        for (var index = lines.Count - 1; index >= 0; index--)
-        {
-            var lineText = lines[index].Extent.GetText();
-            if (lineText.StartsWith("========== Build:"))
-            {
-                return lineText;
-            }
-        }
-
-        return string.Empty;
-    }
-
-    public async Task<IVsOutputWindowPane> GetBuildOutputWindowPaneAsync(CancellationToken cancellationToken)
-    {
-        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-        var outputWindow = await GetRequiredGlobalServiceAsync<SVsOutputWindow, IVsOutputWindow>(cancellationToken);
-        ErrorHandler.ThrowOnFailure(outputWindow.GetPane(VSConstants.OutputWindowPaneGuid.BuildOutputPane_guid, out var pane));
-        return pane;
     }
 
     private static string ConvertLanguageName(string languageName)
@@ -802,7 +762,7 @@ internal sealed class UpdateSolutionEvents : IVsUpdateSolutionEvents, IDisposabl
     private uint _cookie;
     private readonly IVsSolutionBuildManager2 _solutionBuildManager;
 
-    public event Action? OnUpdateSolutionDone;
+    public event Action<bool>? OnUpdateSolutionDone;
 
     internal UpdateSolutionEvents(IVsSolutionBuildManager2 solutionBuildManager)
     {
@@ -819,8 +779,9 @@ internal sealed class UpdateSolutionEvents : IVsUpdateSolutionEvents, IDisposabl
 
     int IVsUpdateSolutionEvents.UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
     {
-        OnUpdateSolutionDone?.Invoke();
-        return 0;
+        var buildSucceeded = fSucceeded == 1;
+        OnUpdateSolutionDone?.Invoke(buildSucceeded);
+        return VSConstants.S_OK;
     }
 
     void IDisposable.Dispose()

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicBuild.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicBuild.cs
@@ -40,8 +40,8 @@ End Module";
 
         await TestServices.Editor.SetTextAsync(editorText, HangMitigatingCancellationToken);
 
-        var buildSummary = await TestServices.SolutionExplorer.BuildSolutionAndWaitAsync(HangMitigatingCancellationToken);
-        Assert.Equal("========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========", buildSummary);
+        var succeed = await TestServices.SolutionExplorer.BuildSolutionAndWaitAsync(HangMitigatingCancellationToken);
+        Assert.True(succeed);
 
         await TestServices.ErrorList.ShowBuildErrorsAsync(HangMitigatingCancellationToken);
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicErrorListCommon.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicErrorListCommon.cs
@@ -121,8 +121,8 @@ End Namespace
         await TestServices.SolutionExplorer.CloseActiveWindow(HangMitigatingCancellationToken);
 
         // Build and verify build failure in the output window.
-        var buildSummary = await TestServices.SolutionExplorer.BuildSolutionAndWaitAsync(HangMitigatingCancellationToken);
-        Assert.Equal("========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========", buildSummary);
+        var succeed = await TestServices.SolutionExplorer.BuildSolutionAndWaitAsync(HangMitigatingCancellationToken);
+        Assert.False(succeed);
 
         await TestServices.Workspace.WaitForAllAsyncOperationsAsync([FeatureAttribute.Workspace, FeatureAttribute.SolutionCrawlerLegacy, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles, FeatureAttribute.ErrorList], HangMitigatingCancellationToken);
 


### PR DESCRIPTION
In integration tests we depends on checking if the output contains
`========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========` to decide if solution build passed.

I feel it's strange and I found another good way to do the check from `IVsUpdateSolutionEvents`