### PR TITLE
Ensure that GetContentHash produces the same value on different endian machines

### DIFF
--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -1299,6 +1299,8 @@ namespace Microsoft.CodeAnalysis.Text
 #if NET8_0_OR_GREATER
         private static void ReverseEndianness(ReadOnlySpan<short> source, Span<short> destination)
         {
+            // Defer to the platform to do the reversal.  It ships with a fast
+            // implementation for this on .Net 8 and above.
             BinaryPrimitives.ReverseEndianness(source, destination);
         }
 #elif NET7_0_OR_GREATER

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -655,6 +655,7 @@ namespace Microsoft.CodeAnalysis.Text
                             // implementation for this on .Net 8 and above.
                             BinaryPrimitives.ReverseEndianness(source: shortSpan, destination: shortSpan);
 #else
+                            // Otherwise, fallback to the simple approach of reversign each pair of bytes.
                             for (var i = 0; i < shortSpan.Length; i++)
                                 shortSpan[i] = BinaryPrimitives.ReverseEndianness(shortSpan[i]);
 #endif

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -12,17 +12,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Hashing;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
-
-#if NET7_0
-using System.Runtime.Intrinsics;
-#endif
 
 namespace Microsoft.CodeAnalysis.Text
 {

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -649,7 +649,15 @@ namespace Microsoft.CodeAnalysis.Text
                         if (!BitConverter.IsLittleEndian)
                         {
                             var shortSpan = MemoryMarshal.Cast<char, short>(charSpan);
-                            reverseEndianness(source: shortSpan, destination: shortSpan);
+
+#if NET8_0_OR_GREATER
+                            // Defer to the platform to do the reversal.  It ships with a vectorized
+                            // implementation for this on .Net 8 and above.
+                            BinaryPrimitives.ReverseEndianness(source: shortSpan, destination: shortSpan);
+#else
+                            for (var i = 0; i < shortSpan.Length; i++)
+                                shortSpan[i] = BinaryPrimitives.ReverseEndianness(shortSpan[i]);
+#endif
                         }
 
                         hash.Append(MemoryMarshal.AsBytes(charSpan));
@@ -669,21 +677,6 @@ namespace Microsoft.CodeAnalysis.Text
                     s_contentHashPool.Free(hash);
                 }
             }
-
-#if NET8_0_OR_GREATER
-            static void reverseEndianness(ReadOnlySpan<short> source, Span<short> destination)
-            {
-                // Defer to the platform to do the reversal.  It ships with a fast
-                // implementation for this on .Net 8 and above.
-                BinaryPrimitives.ReverseEndianness(source, destination);
-            }
-#else
-            static void reverseEndianness(ReadOnlySpan<short> source, Span<short> destination)
-            {
-                for (var i = 0; i < source.Length; i++)
-                    destination[i] = BinaryPrimitives.ReverseEndianness(source[i]);
-            }
-#endif
         }
 
         internal static ImmutableArray<byte> CalculateChecksum(byte[] buffer, int offset, int count, SourceHashAlgorithm algorithmId)

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -655,7 +655,7 @@ namespace Microsoft.CodeAnalysis.Text
                             // implementation for this on .Net 8 and above.
                             BinaryPrimitives.ReverseEndianness(source: shortSpan, destination: shortSpan);
 #else
-                            // Otherwise, fallback to the simple approach of reversign each pair of bytes.
+                            // Otherwise, fallback to the simple approach of reversing each pair of bytes.
                             for (var i = 0; i < shortSpan.Length; i++)
                                 shortSpan[i] = BinaryPrimitives.ReverseEndianness(shortSpan[i]);
 #endif

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
@@ -12,12 +12,17 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Hashing;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
+
+#if NET7_0
+using System.Runtime.Intrinsics;
+#endif
 
 namespace Microsoft.CodeAnalysis.Text
 {
@@ -631,6 +636,7 @@ namespace Microsoft.CodeAnalysis.Text
                 var hash = s_contentHashPool.Allocate();
                 var charBuffer = s_charArrayPool.Allocate();
                 Debug.Assert(charBuffer.Length == CharBufferSize);
+                var isBigEndian = !BitConverter.IsLittleEndian;
                 try
                 {
                     // Grab chunks of this SourceText, copying into 'charBuffer'.  Then reinterpret that buffer as a
@@ -642,7 +648,16 @@ namespace Microsoft.CodeAnalysis.Text
                             sourceIndex: index, destination: charBuffer,
                             destinationIndex: 0, count: charsToCopy);
 
-                        hash.Append(MemoryMarshal.AsBytes(charBuffer.AsSpan(0, charsToCopy)));
+                        var charSpan = charBuffer.AsSpan(0, charsToCopy);
+
+                        // Ensure everything is always little endian, so we get the same results across all platforms.
+                        if (isBigEndian)
+                        {
+                            var shortSpan = MemoryMarshal.Cast<char, short>(charSpan);
+                            ReverseEndianness(source: shortSpan, destination: shortSpan);
+                        }
+
+                        hash.Append(MemoryMarshal.AsBytes(charSpan));
                     }
 
                     // Switch this to ImmutableCollectionsMarshal.AsImmutableArray(hash.GetHashAndReset()) when we move to S.C.I v8.
@@ -1278,5 +1293,130 @@ namespace Microsoft.CodeAnalysis.Text
 
             throw new IOException(CodeAnalysisResources.StreamIsTooLong);
         }
+
+        #region ReverseEndianness
+
+#if NET8_0_OR_GREATER
+        private static void ReverseEndianness(ReadOnlySpan<short> source, Span<short> destination)
+        {
+            BinaryPrimitives.ReverseEndianness(source, destination);
+        }
+#elif NET7_0_OR_GREATER
+        // Copied from: https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReverseEndianness.cs#L181C46-L182C83
+        private static void ReverseEndianness(ReadOnlySpan<short> source, Span<short> destination)
+        {
+            ReverseEndianness<short, Int16EndiannessReverser>(source, destination);
+        }
+
+        private static void ReverseEndianness<T, TReverser>(ReadOnlySpan<T> source, Span<T> destination)
+            where T : struct
+            where TReverser : IEndiannessReverser<T>
+        {
+            if (destination.Length < source.Length)
+            {
+                throw new InvalidOperationException();
+            }
+
+            ref T sourceRef = ref MemoryMarshal.GetReference(source);
+            ref T destRef = ref MemoryMarshal.GetReference(destination);
+
+            if (Unsafe.AreSame(ref sourceRef, ref destRef) ||
+                !source.Overlaps(destination, out int elementOffset) ||
+                elementOffset < 0)
+            {
+                // Either there's no overlap between the source and the destination, or there's overlap but the
+                // destination starts at or before the source.  That means we can safely iterate from beginning
+                // to end of the source and not have to worry about writing into the destination and clobbering
+                // source data we haven't yet read.
+
+                int i = 0;
+
+                if (Vector256.IsHardwareAccelerated)
+                {
+                    while (i <= source.Length - Vector256<T>.Count)
+                    {
+                        Vector256.StoreUnsafe(TReverser.Reverse(Vector256.LoadUnsafe(ref sourceRef, (uint)i)), ref destRef, (uint)i);
+                        i += Vector256<T>.Count;
+                    }
+                }
+
+                if (Vector128.IsHardwareAccelerated)
+                {
+                    while (i <= source.Length - Vector128<T>.Count)
+                    {
+                        Vector128.StoreUnsafe(TReverser.Reverse(Vector128.LoadUnsafe(ref sourceRef, (uint)i)), ref destRef, (uint)i);
+                        i += Vector128<T>.Count;
+                    }
+                }
+
+                while (i < source.Length)
+                {
+                    Unsafe.Add(ref destRef, i) = TReverser.Reverse(Unsafe.Add(ref sourceRef, i));
+                    i++;
+                }
+            }
+            else
+            {
+                // There's overlap between the source and the destination, and the source starts before the destination.
+                // That means if we were to iterate from beginning to end, reading from the source and writing to the
+                // destination, we'd overwrite source elements not yet read.  To avoid that, we iterate from end to beginning.
+
+                int i = source.Length;
+
+                if (Vector256.IsHardwareAccelerated)
+                {
+                    while (i >= Vector256<T>.Count)
+                    {
+                        i -= Vector256<T>.Count;
+                        Vector256.StoreUnsafe(TReverser.Reverse(Vector256.LoadUnsafe(ref sourceRef, (uint)i)), ref destRef, (uint)i);
+                    }
+                }
+
+                if (Vector128.IsHardwareAccelerated)
+                {
+                    while (i >= Vector128<T>.Count)
+                    {
+                        i -= Vector128<T>.Count;
+                        Vector128.StoreUnsafe(TReverser.Reverse(Vector128.LoadUnsafe(ref sourceRef, (uint)i)), ref destRef, (uint)i);
+                    }
+                }
+
+                while (i > 0)
+                {
+                    i--;
+                    Unsafe.Add(ref destRef, i) = TReverser.Reverse(Unsafe.Add(ref sourceRef, i));
+                }
+            }
+        }
+
+        private interface IEndiannessReverser<T> where T : struct
+        {
+            static abstract T Reverse(T value);
+            static abstract Vector128<T> Reverse(Vector128<T> vector);
+            static abstract Vector256<T> Reverse(Vector256<T> vector);
+        }
+
+        private readonly struct Int16EndiannessReverser : IEndiannessReverser<short>
+        {
+            public static short Reverse(short value) =>
+               BinaryPrimitives.ReverseEndianness(value);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static Vector128<short> Reverse(Vector128<short> vector) =>
+                Vector128.ShiftLeft(vector, 8) | Vector128.ShiftRightLogical(vector, 8);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static Vector256<short> Reverse(Vector256<short> vector) =>
+                Vector256.ShiftLeft(vector, 8) | Vector256.ShiftRightLogical(vector, 8);
+        }
+#else
+        private static void ReverseEndianness(ReadOnlySpan<short> source, Span<short> destination)
+        {
+            for (var i = 0; i < source.Length; i++)
+                destination[i] = BinaryPrimitives.ReverseEndianness(source[i]);
+        }
+#endif
+
+        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -652,7 +652,7 @@ namespace Microsoft.CodeAnalysis.Text
 
 #if NET8_0_OR_GREATER
                             // Defer to the platform to do the reversal.  It ships with a vectorized
-                            // implementation for this on .Net 8 and above.
+                            // implementation for this on .NET 8 and above.
                             BinaryPrimitives.ReverseEndianness(source: shortSpan, destination: shortSpan);
 #else
                             // Otherwise, fallback to the simple approach of reversing each pair of bytes.

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.Text
                         var charSpan = charBuffer.AsSpan(0, charsToCopy);
 
                         // Ensure everything is always little endian, so we get the same results across all platforms.
-                        // This will eb entirely elided by the jit on a little endian machine.
+                        // This will be entirely elided by the jit on a little endian machine.
                         if (!BitConverter.IsLittleEndian)
                         {
                             var shortSpan = MemoryMarshal.Cast<char, short>(charSpan);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74682

1. We don't have a good way to test htis, absent a dedicated test run on a big endian machine (which is what the runtime team does).
2. We can definitely take out that copy of the vectorized code, and say if you're before .net 8 that you get the slow impl.