### PR TITLE
Modify MergedNamespaceDeclaration.MakeChildren to to allocate less

### DIFF
--- a/src/Compilers/CSharp/Portable/Declarations/MergedNamespaceDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/MergedNamespaceDeclaration.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         namespaces.Free();
 
-                        foreach (var namespaceGroup in namespaceGroups.Values)
+                        foreach (var (_, namespaceGroup) in namespaceGroups)
                         {
                             children.Add(MergedNamespaceDeclaration.Create(namespaceGroup.ToImmutableAndFree()));
                         }
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
-                        foreach (var typeGroup in typeGroups.Values)
+                        foreach (var (_, typeGroup) in typeGroups)
                         {
                             if (typeGroup is SingleTypeDeclaration t)
                             {
@@ -230,6 +230,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         types.Free();
+
+                        // ArrayBuilder values were freed above.
                         typeGroups.Free();
                     }
                 }

--- a/src/Compilers/Core/Portable/Collections/DictionaryExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/DictionaryExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Collections;
@@ -31,6 +32,28 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
+                dictionary.Add(key, value);
+                return value;
+            }
+        }
+
+        /// <summary>
+        /// If the given key is not found in the dictionary, add it with the result of invoking getValue and return the value.
+        /// Otherwise return the existing value associated with that key.
+        /// </summary>
+        public static TValue GetOrAdd<TKey, TValue>(
+            this Dictionary<TKey, TValue> dictionary,
+            TKey key,
+            Func<TValue> getValue)
+            where TKey : notnull
+        {
+            if (dictionary.TryGetValue(key, out var existingValue))
+            {
+                return existingValue;
+            }
+            else
+            {
+                var value = getValue();
                 dictionary.Add(key, value);
                 return value;
             }


### PR DESCRIPTION
This method is showing up in a profile via the ArrayBuilder.ToDictionary calls.

1) Two dictionaries are created each call. The second Dictionary is only used for enumeration, and thus we can avoid it. 
2) The ToDictionary implementation cannot use a PooledDictionary, whereas our invocation for types can. 
3) The ToDictionary creates ArrayBuilders for each unique key. This is bad if there are a large number of unique keys (such as for our invocation for types). By creating such a large number of ArrayBuilders, we lose the benefit of the pooling, as the vast majority of the time we won't be able to return or get builders from the pool.

I separated the processing of the namespaces and types collections into their own methods, as they have slightly different characteristics. Specifically:

1) The namespaces collection has few unique keys, but potentially large numbers of items in their value collections. 
2) The types collection has many unique keys, and usually small numbers of items in their value collections.

Handling namespaces is pretty straight forward using a  Dictionary<string, ArrayBuilder<SingleNamespaceDeclaration>>. However, handling types required a bit less convention to get around the issue of creating a large number of ArrayBuilder instances. Instead, we use an object as the value, with it either being an ArrayBuilder<SingleTypeDeclaration> when an identity has been seen multiple times, or just a SingleTypeDeclaration when the identity has only been seen once.

MergedNamespaceDeclaration.MakeChildren is showing up as about 1.5% of allocations in the typing section of the speedometer scrolling perf test profile. These changes should shave that down to about 0.5% or so.

*** Relevant allocations from the typing section of the scrolling speedometer profile ***
![image](https://github.com/user-attachments/assets/2e336ce7-67c6-450c-9f3c-e19f72b30f7f)