### PR TITLE
Fix issues with VSCode LSP EA causing handlers to fail to load

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
@@ -87,7 +87,9 @@ internal sealed class ExportProviderBuilder
         //         part definition Microsoft.CodeAnalysis.ExternalAccess.Pythia.PythiaSignatureHelpProvider
         var erroredParts = configuration.CompositionErrors.FirstOrDefault()?.SelectMany(error => error.Parts).Select(part => part.Definition.Type.Name) ?? Enumerable.Empty<string>();
         var expectedErroredParts = new string[] { "PythiaSignatureHelpProvider" };
-        if (erroredParts.Count() != expectedErroredParts.Length || !erroredParts.All(part => expectedErroredParts.Contains(part)) || !catalog.DiscoveredParts.DiscoveryErrors.IsEmpty)
+        var hasUnexpectedErroredParts = erroredParts.Any(part => !expectedErroredParts.Contains(part));
+
+        if (hasUnexpectedErroredParts || !catalog.DiscoveredParts.DiscoveryErrors.IsEmpty)
         {
             try
             {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ExportProviderBuilder.cs
@@ -57,7 +57,7 @@ internal sealed class ExportProviderBuilder
         var config = CompositionConfiguration.Create(catalog);
 
         // Verify we only have expected errors.
-        ThrowOnUnexpectedErrors(config, logger);
+        ThrowOnUnexpectedErrors(config, catalog, logger);
 
         // Prepare an ExportProvider factory based on this graph.
         var exportProviderFactory = config.CreateExportProviderFactory();
@@ -75,7 +75,7 @@ internal sealed class ExportProviderBuilder
         return exportProvider;
     }
 
-    private static void ThrowOnUnexpectedErrors(CompositionConfiguration configuration, ILogger logger)
+    private static void ThrowOnUnexpectedErrors(CompositionConfiguration configuration, ComposableCatalog catalog, ILogger logger)
     {
         // Verify that we have exactly the MEF errors that we expect.  If we have less or more this needs to be updated to assert the expected behavior.
         // Currently we are expecting the following:
@@ -87,15 +87,16 @@ internal sealed class ExportProviderBuilder
         //         part definition Microsoft.CodeAnalysis.ExternalAccess.Pythia.PythiaSignatureHelpProvider
         var erroredParts = configuration.CompositionErrors.FirstOrDefault()?.SelectMany(error => error.Parts).Select(part => part.Definition.Type.Name) ?? Enumerable.Empty<string>();
         var expectedErroredParts = new string[] { "PythiaSignatureHelpProvider" };
-        if (erroredParts.Count() != expectedErroredParts.Length || !erroredParts.All(part => expectedErroredParts.Contains(part)))
+        if (erroredParts.Count() != expectedErroredParts.Length || !erroredParts.All(part => expectedErroredParts.Contains(part)) || !catalog.DiscoveredParts.DiscoveryErrors.IsEmpty)
         {
             try
             {
+                catalog.DiscoveredParts.ThrowOnErrors();
                 configuration.ThrowOnErrors();
             }
             catch (CompositionFailedException ex)
             {
-                // The ToString for the composition failed exception doesn't output a nice set of errors by default, so log it separately here.
+                // The ToString for the composition failed exception doesn't output a nice set of errors by default, so log it separately
                 logger.LogError($"Encountered errors in the MEF composition:{Environment.NewLine}{ex.ErrorsAsString}");
                 throw;
             }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -78,6 +78,7 @@
     <ProjectReference Include="..\..\Features\ExternalAccess\AspNetCore\Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj" />
     <ProjectReference Include="..\ExternalAccess\VisualDiagnostics\Microsoft.CodeAnalysis.ExternalAccess.VisualDiagnostics.csproj" />
     <ProjectReference Include="..\..\Tools\ExternalAccess\Xaml\Microsoft.CodeAnalysis.ExternalAccess.Xaml.csproj" />
+    <ProjectReference Include="..\ExternalAccess\CompilerDeveloperSDK\Microsoft.CodeAnalysis.ExternalAccess.CompilerDeveloperSDK.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/ExternalAccess/Xaml/External/ExportXamlLspServiceFactoryAttribute.cs
+++ b/src/Tools/ExternalAccess/Xaml/External/ExportXamlLspServiceFactoryAttribute.cs
@@ -14,8 +14,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Xaml;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false), MetadataAttribute]
 internal sealed class ExportXamlLspServiceFactoryAttribute : ExportLspServiceFactoryAttribute
 {
-    public ExportXamlLspServiceFactoryAttribute(Type type, WellKnownLspServerKinds serverKind = WellKnownLspServerKinds.Any)
+    [Obsolete("Use the constructor that takes only a type")]
+    public ExportXamlLspServiceFactoryAttribute(Type type, WellKnownLspServerKinds serverKind)
         : base(type, ProtocolConstants.RoslynLspLanguagesContract, serverKind)
+    {
+    }
+
+    public ExportXamlLspServiceFactoryAttribute(Type type)
+        : base(type, ProtocolConstants.RoslynLspLanguagesContract)
     {
     }
 }

--- a/src/Tools/ExternalAccess/Xaml/InternalAPI.Unshipped.txt
+++ b/src/Tools/ExternalAccess/Xaml/InternalAPI.Unshipped.txt
@@ -17,7 +17,8 @@ Microsoft.CodeAnalysis.ExternalAccess.Xaml.DescriptionService.DescriptionService
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.DescriptionService.GetDescriptionAsync(Microsoft.CodeAnalysis.ISymbol! symbol, Microsoft.CodeAnalysis.Project! project, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.TaggedText>!>!
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.DescriptionService.GetMarkupContent(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.TaggedText> tags, string! language, bool featureSupportsMarkdown) -> (string! content, bool isMarkdown)
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.ExportXamlLspServiceFactoryAttribute
-Microsoft.CodeAnalysis.ExternalAccess.Xaml.ExportXamlLspServiceFactoryAttribute.ExportXamlLspServiceFactoryAttribute(System.Type! type, Microsoft.CodeAnalysis.LanguageServer.WellKnownLspServerKinds serverKind = Microsoft.CodeAnalysis.LanguageServer.WellKnownLspServerKinds.Any) -> void
+Microsoft.CodeAnalysis.ExternalAccess.Xaml.ExportXamlLspServiceFactoryAttribute.ExportXamlLspServiceFactoryAttribute(System.Type! type) -> void
+Microsoft.CodeAnalysis.ExternalAccess.Xaml.ExportXamlLspServiceFactoryAttribute.ExportXamlLspServiceFactoryAttribute(System.Type! type, Microsoft.CodeAnalysis.LanguageServer.WellKnownLspServerKinds serverKind) -> void
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.ExportXamlStatelessLspServiceAttribute
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.ExportXamlStatelessLspServiceAttribute.ExportXamlStatelessLspServiceAttribute(System.Type! handlerType) -> void
 Microsoft.CodeAnalysis.ExternalAccess.Xaml.IClientCapabilityProvider


### PR DESCRIPTION
https://github.com/dotnet/roslyn/commit/2d311bd0fa69603143b1acfc2455865f5460309c caused both @333fred 's compiler SDK extension and some XAML handlers to break.

This was caused due to the removal of the enum member, changing the numerical value of each.  Code compiled against an older version of Roslyn that used the enum would be broken.

For the compiler SDK extension, this caused an issue because the enum was exposed in the EA library, which was being loaded from the extension (and not from roslyn).  The fix is to ship and load the EA library from Roslyn (only 21kb).

For XAML, the LSP service factory exposed the enum as a default parameter, so all XAML LSP service factories had the wrong enum value.  Xaml is updating their Roslyn version to fix, but here I also obsolete the API that exposed the enum (it wasn't necessary).

Also fixed an issue where MEF discovery errors werent being recorded.