### PR TITLE
Modify ISyntaxTreeFactoryService.CreateSyntaxTree to take in an optional SourceText.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.cs
@@ -55,10 +55,10 @@ internal partial class CSharpSyntaxTreeFactoryService : AbstractSyntaxTreeFactor
         return csharpOptions1.WithPreprocessorSymbols(csharpOptions2.PreprocessorSymbolNames) == csharpOptions2;
     }
 
-    public override SyntaxTree CreateSyntaxTree(string filePath, ParseOptions options, Encoding encoding, SourceHashAlgorithm checksumAlgorithm, SyntaxNode root)
+    public override SyntaxTree CreateSyntaxTree(string filePath, ParseOptions options, SourceText text, Encoding encoding, SourceHashAlgorithm checksumAlgorithm, SyntaxNode root)
     {
         options ??= GetDefaultParseOptions();
-        return new ParsedSyntaxTree(lazyText: null, (CSharpSyntaxNode)root, (CSharpParseOptions)options, filePath, encoding, checksumAlgorithm);
+        return new ParsedSyntaxTree(text, (CSharpSyntaxNode)root, (CSharpParseOptions)options, filePath, encoding, checksumAlgorithm);
     }
 
     public override SyntaxTree ParseSyntaxTree(string filePath, ParseOptions options, SourceText text, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.cs
@@ -17,6 +17,6 @@ internal abstract partial class AbstractSyntaxTreeFactoryService : ISyntaxTreeFa
     public abstract ParseOptions GetDefaultParseOptionsWithLatestLanguageVersion();
     public abstract bool OptionsDifferOnlyByPreprocessorDirectives(ParseOptions options1, ParseOptions options2);
     public abstract ParseOptions TryParsePdbParseOptions(IReadOnlyDictionary<string, string> metadata);
-    public abstract SyntaxTree CreateSyntaxTree(string filePath, ParseOptions options, Encoding encoding, SourceHashAlgorithm checksumAlgorithm, SyntaxNode root);
+    public abstract SyntaxTree CreateSyntaxTree(string filePath, ParseOptions options, SourceText text, Encoding encoding, SourceHashAlgorithm checksumAlgorithm, SyntaxNode root);
     public abstract SyntaxTree ParseSyntaxTree(string filePath, ParseOptions options, SourceText text, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/ISyntaxTreeFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/ISyntaxTreeFactoryService.cs
@@ -26,8 +26,8 @@ internal interface ISyntaxTreeFactoryService : ILanguageService
     /// </summary>
     bool OptionsDifferOnlyByPreprocessorDirectives(ParseOptions options1, ParseOptions options2);
 
-    // new tree from root node
-    SyntaxTree CreateSyntaxTree(string? filePath, ParseOptions options, Encoding? encoding, SourceHashAlgorithm checksumAlgorithm, SyntaxNode root);
+    // new tree from root node and optional text
+    SyntaxTree CreateSyntaxTree(string? filePath, ParseOptions options, SourceText? text, Encoding? encoding, SourceHashAlgorithm checksumAlgorithm, SyntaxNode root);
 
     // new tree from text
     SyntaxTree ParseSyntaxTree(string? filePath, ParseOptions options, SourceText text, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -358,7 +358,7 @@ internal partial class DocumentState : TextDocumentState
             if (existingTree.TryGetRoot(out var existingRoot) && !existingRoot.ContainsDirective(syntaxKinds.IfDirectiveTrivia))
             {
                 var treeFactory = LanguageServices.GetRequiredService<ISyntaxTreeFactoryService>();
-                newTree = treeFactory.CreateSyntaxTree(Attributes.SyntaxTreeFilePath, options, existingTree.Encoding, LoadTextOptions.ChecksumAlgorithm, existingRoot);
+                newTree = treeFactory.CreateSyntaxTree(Attributes.SyntaxTreeFilePath, options, text: null, existingTree.Encoding, LoadTextOptions.ChecksumAlgorithm, existingRoot);
             }
 
             if (newTree is not null)
@@ -538,7 +538,7 @@ internal partial class DocumentState : TextDocumentState
             ParseOptions options,
             ISyntaxTreeFactoryService factory)
         {
-            var tree = factory.CreateSyntaxTree(attributes.SyntaxTreeFilePath, options, encoding, checksumAlgorithm, newRoot);
+            var tree = factory.CreateSyntaxTree(attributes.SyntaxTreeFilePath, options, text: null, encoding, checksumAlgorithm, newRoot);
 
             // its okay to use a strong cached AsyncLazy here because the compiler layer SyntaxTree will also keep the text alive once its built.
             var lazyTextAndVersion = new TreeTextSource(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
@@ -133,6 +133,7 @@ internal partial class DocumentState
             // with our own data (*except* for the new root).  However, we think it's safe as the encoding really is
             // a property of the file, and that should stay the same even if linked into multiple projects.
 
+            // Attempt to obtain, and subsequently reuse, the SourceText from the sibling tree.
             siblingTree.TryGetText(out var lazyText);
 
             var newTree = treeFactory.CreateSyntaxTree(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_LinkedFileReuse.cs
@@ -133,9 +133,12 @@ internal partial class DocumentState
             // with our own data (*except* for the new root).  However, we think it's safe as the encoding really is
             // a property of the file, and that should stay the same even if linked into multiple projects.
 
+            siblingTree.TryGetText(out var lazyText);
+
             var newTree = treeFactory.CreateSyntaxTree(
                 filePath,
                 parseOptions,
+                lazyText,
                 siblingTree.Encoding,
                 loadTextOptions.ChecksumAlgorithm,
                 siblingRoot);

--- a/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
@@ -70,12 +70,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return SyntaxFactory.ParseSyntaxTree(text, options, filePath, cancellationToken)
         End Function
 
-        Public Overrides Function CreateSyntaxTree(filePath As String, options As ParseOptions, encoding As Encoding, checksumAlgorithm As SourceHashAlgorithm, root As SyntaxNode) As SyntaxTree
+        Public Overrides Function CreateSyntaxTree(filePath As String, options As ParseOptions, text As SourceText, encoding As Encoding, checksumAlgorithm As SourceHashAlgorithm, root As SyntaxNode) As SyntaxTree
             If options Is Nothing Then
                 options = GetDefaultParseOptions()
             End If
 
-            Return New ParsedSyntaxTree(lazyText:=Nothing, DirectCast(root, VisualBasicSyntaxNode), DirectCast(options, VisualBasicParseOptions), filePath, encoding, checksumAlgorithm)
+            Return New ParsedSyntaxTree(text, DirectCast(root, VisualBasicSyntaxNode), DirectCast(options, VisualBasicParseOptions), filePath, encoding, checksumAlgorithm)
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
I've noticed debugging locally that for every keystroke I'm seeing two StringTexts created that span the entire buffer. The creation of these texts originates from ParsedSyntaxTree needing to create SourceText, and the only way it knowing to do so is by serializing the tree into a string and creating a StringText from it.

I *feel* like DocumentState.TryReuseSiblingRoot should be able to utilize the sibling's sourcetext in addition to it's tree, but I'm not 100% positive.