### PR TITLE
Refactor semantic snippets

### DIFF
--- a/src/EditorFeatures/Test/Snippets/RoslynLSPSnippetConvertTests.cs
+++ b/src/EditorFeatures/Test/Snippets/RoslynLSPSnippetConvertTests.cs
@@ -506,9 +506,9 @@ public class RoslynLSPSnippetConvertTests
             if (kvp.Key.Length > 0)
             {
                 var spans = kvp.Value;
-                var identifier = text.Substring(spans[0].Start, spans[0].Length);
+                var placeholderText = text.Substring(spans[0].Start, spans[0].Length);
                 var placeholders = spans.Select(span => span.Start).ToImmutableArray();
-                arrayBuilder.Add(new SnippetPlaceholder(identifier, placeholders));
+                arrayBuilder.Add(new SnippetPlaceholder(placeholderText, placeholders));
             }
         }
 

--- a/src/Features/Core/Portable/Snippets/AbstractSnippetService.cs
+++ b/src/Features/Core/Portable/Snippets/AbstractSnippetService.cs
@@ -42,8 +42,8 @@ internal abstract class AbstractSnippetService(IEnumerable<Lazy<ISnippetProvider
         using var _ = ArrayBuilder<SnippetData>.GetInstance(out var arrayBuilder);
         foreach (var provider in GetSnippetProviders(context.Document))
         {
-            var snippetData = await provider.GetSnippetDataAsync(context, cancellationToken).ConfigureAwait(false);
-            arrayBuilder.AddIfNotNull(snippetData);
+            if (await provider.IsValidSnippetLocationAsync(in context, cancellationToken).ConfigureAwait(false))
+                arrayBuilder.Add(new(provider.Identifier, provider.Description, provider.AdditionalFilterTexts));
         }
 
         return arrayBuilder.ToImmutableAndClear();

--- a/src/Features/Core/Portable/Snippets/SnippetChange.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetChange.cs
@@ -25,7 +25,7 @@ internal readonly struct SnippetChange
     public readonly ImmutableArray<SnippetPlaceholder> Placeholders;
 
     /// <summary>
-    /// The position that the cursor should end up on
+    /// The position that the caret should end up on
     /// </summary>
     public readonly int FinalCaretPosition;
 

--- a/src/Features/Core/Portable/Snippets/SnippetChange.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetChange.cs
@@ -19,20 +19,20 @@ internal readonly struct SnippetChange
     public readonly ImmutableArray<TextChange> TextChanges;
 
     /// <summary>
-    /// The position that the cursor should end up on
-    /// </summary>
-    public readonly int CursorPosition;
-
-    /// <summary>
     /// The items that we will want to rename as well as the ordering
     /// in which to visit those items.
     /// </summary>
     public readonly ImmutableArray<SnippetPlaceholder> Placeholders;
 
+    /// <summary>
+    /// The position that the cursor should end up on
+    /// </summary>
+    public readonly int FinalCaretPosition;
+
     public SnippetChange(
         ImmutableArray<TextChange> textChanges,
-        int cursorPosition,
-        ImmutableArray<SnippetPlaceholder> placeholders)
+        ImmutableArray<SnippetPlaceholder> placeholders,
+        int finalCaretPosition)
     {
         if (textChanges.IsEmpty)
         {
@@ -40,7 +40,7 @@ internal readonly struct SnippetChange
         }
 
         TextChanges = textChanges;
-        CursorPosition = cursorPosition;
         Placeholders = placeholders;
+        FinalCaretPosition = finalCaretPosition;
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetData.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetData.cs
@@ -11,9 +11,9 @@ namespace Microsoft.CodeAnalysis.Snippets;
 /// Avoids using the Snippet and creating a TextChange/finding cursor
 /// position before we know it was the selected CompletionItem.
 /// </summary>
-internal readonly struct SnippetData(string description, string identifier, ImmutableArray<string> additionalFilterTexts)
+internal readonly struct SnippetData(string identifier, string description, ImmutableArray<string> additionalFilterTexts)
 {
-    public readonly string Description = description;
     public readonly string Identifier = identifier;
+    public readonly string Description = description;
     public readonly ImmutableArray<string> AdditionalFilterTexts = additionalFilterTexts;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetPlaceholder.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetPlaceholder.cs
@@ -10,15 +10,15 @@ namespace Microsoft.CodeAnalysis.Snippets;
 internal readonly struct SnippetPlaceholder
 {
     /// <summary>
-    /// The identifier in the snippet that needs to be renamed.
+    /// Editable text in the snippet.
     /// </summary>
-    public readonly string Identifier;
+    public readonly string Text;
 
     /// <summary>
     /// The positions associated with the identifier that will need to
     /// be converted into LSP formatted strings.
     /// </summary>
-    public readonly ImmutableArray<int> PlaceHolderPositions;
+    public readonly ImmutableArray<int> StartingPositions;
 
     /// <summary>
     /// <example> 
@@ -26,26 +26,26 @@ internal readonly struct SnippetPlaceholder
     /// <code>
     ///     for (var {1:i} = 0; {1:i} &lt; {2:length}; {1:i}++)
     /// </code>
-    /// Identifier: i, 3 associated positions <br/>
-    /// Identifier: length, 1 associated position <br/>
+    /// Text: <c>i</c>, 3 associated positions <br/>
+    /// Text: <c>length</c>, 1 associated position <br/>
     /// </example>
     /// </summary>
-    public SnippetPlaceholder(string identifier, ImmutableArray<int> placeholderPositions)
+    public SnippetPlaceholder(string text, ImmutableArray<int> startingPositions)
     {
-        if (string.IsNullOrEmpty(identifier))
+        if (string.IsNullOrEmpty(text))
         {
-            throw new ArgumentException($"{nameof(identifier)} must not be an null or empty.");
+            throw new ArgumentException($"{nameof(text)} must not be an null or empty.");
         }
 
-        Identifier = identifier;
-        PlaceHolderPositions = placeholderPositions;
+        Text = text;
+        StartingPositions = startingPositions;
     }
 
     /// <summary>
     /// Initialize a placeholder with a single position
     /// </summary>
-    public SnippetPlaceholder(string identifier, int placeholderPosition)
-        : this(identifier, [placeholderPosition])
+    public SnippetPlaceholder(string text, int startingPosition)
+        : this(text, [startingPosition])
     {
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -50,25 +50,16 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
     /// </summary>
     protected abstract ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TSnippetSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken);
 
-    /// <summary>
-    /// Determines if the location is valid for a snippet,
-    /// if so, then it creates a SnippetData.
-    /// </summary>
-    public ValueTask<SnippetData?> GetSnippetDataAsync(SnippetContext context, CancellationToken cancellationToken)
+    public ValueTask<bool> IsValidSnippetLocationAsync(in SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxFacts = context.Document.GetRequiredLanguageService<ISyntaxFactsService>();
         var syntaxTree = context.SyntaxContext.SyntaxTree;
         if (syntaxFacts.IsInNonUserCode(syntaxTree, context.Position, cancellationToken))
         {
-            return ValueTaskFactory.FromResult<SnippetData?>(null);
+            return ValueTaskFactory.FromResult(false);
         }
 
-        if (!IsValidSnippetLocation(in context, cancellationToken))
-        {
-            return ValueTaskFactory.FromResult<SnippetData?>(null);
-        }
-
-        return ValueTaskFactory.FromResult<SnippetData?>(new SnippetData(Description, Identifier, AdditionalFilterTexts));
+        return ValueTaskFactory.FromResult(IsValidSnippetLocation(in context, cancellationToken));
     }
 
     /// <summary>

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -27,7 +27,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
 
     public virtual ImmutableArray<string> AdditionalFilterTexts => [];
 
-    protected readonly SyntaxAnnotation FindSnippetAnnotation = new();
+    protected static readonly SyntaxAnnotation FindSnippetAnnotation = new();
 
     /// <summary>
     /// Implemented by each SnippetProvider to determine if that particular position is a valid
@@ -136,7 +136,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
         return nodeWithTrivia;
     }
 
-    private async Task<Document> CleanupDocumentAsync(
+    private static async Task<Document> CleanupDocumentAsync(
         Document document, CancellationToken cancellationToken)
     {
         if (document.SupportsSyntaxTree)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -67,7 +67,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
     /// Reformats the document with the snippet TextChange and annotates 
     /// appropriately for the cursor to get the target cursor position.
     /// </summary>
-    public async Task<SnippetChange> GetSnippetAsync(Document document, int position, CancellationToken cancellationToken)
+    public async Task<SnippetChange> GetSnippetChangeAsync(Document document, int position, CancellationToken cancellationToken)
     {
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
@@ -110,8 +110,8 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
 
         return new SnippetChange(
             textChanges: changesArray,
-            cursorPosition: GetTargetCaretPosition(mainChangeNode, sourceText),
-            placeholders: placeholders);
+            placeholders: placeholders,
+            finalCaretPosition: GetTargetCaretPosition(mainChangeNode, sourceText));
     }
 
     /// <summary>

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
@@ -31,7 +31,7 @@ internal interface ISnippetProvider
     ValueTask<bool> IsValidSnippetLocationAsync(in SnippetContext context, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Gets the Snippet from the corresponding snippet provider.
+    /// Gets the Snippet change from the corresponding snippet provider.
     /// </summary>
-    Task<SnippetChange> GetSnippetAsync(Document document, int position, CancellationToken cancellationToken);
+    Task<SnippetChange> GetSnippetChangeAsync(Document document, int position, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,9 +21,14 @@ internal interface ISnippetProvider
     string Description { get; }
 
     /// <summary>
+    /// Additional filter texts for snippet completion item
+    /// </summary>
+    ImmutableArray<string> AdditionalFilterTexts { get; }
+
+    /// <summary>
     /// Determines if a snippet can exist at a particular location.
     /// </summary>
-    ValueTask<SnippetData?> GetSnippetDataAsync(SnippetContext context, CancellationToken cancellationToken);
+    ValueTask<bool> IsValidSnippetLocationAsync(in SnippetContext context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the Snippet from the corresponding snippet provider.


### PR DESCRIPTION
I was working on another snippet-related PR and saw a few things that IMO can be improved. So I extracted all these refactorings into this PR. What have I done and why:
- `ISnippetProvider` had `GetSnippetDataAsync` and `GetSnippetAsync` methods and for an external person it is somewhat confusing what is the difference between them. Moreover, from the name `GetSnippetDataAsync` I expect to get eigher `Task<SnippetData>` or a `ValueTask<SnippetData>`, but not `ValueTask<SnippetData?>`. By pooling `AdditionalFilterTexts` up to the interface I can replace confusing `GetSnippetDataAsync` with `IsValidSnippetLocationAsync` and construct `SnippetData` struct when this method returns `true`
- Applied `static` to a few things
- Renamed and reordered a few members for clarity