### PR TITLE
Fix allow ref like types for synthesized TypeParameterSymbols in Ad-Hoc Delegates

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AllowsRefLikeTypeSymbolVisitVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AllowsRefLikeTypeSymbolVisitVisitor.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class AllowsRefLikeTypeSymbolVisitVisitor : SymbolVisitor
+    {
+        public bool Result { get; private set; } = true;
+
+        public required ITypeParameterSymbol TypeParameter { get; init; }
+
+        private bool IsTypeParameterSymbol(ITypeSymbol typeSymbol)
+        {
+            return Microsoft.CodeAnalysis.SymbolEqualityComparer.Default.Equals(typeSymbol, TypeParameter);
+        }
+
+        public override void VisitArrayType(IArrayTypeSymbol symbol)
+        {
+            if (IsTypeParameterSymbol(symbol.ElementType))
+            {
+                Result = false;
+                return;
+            }
+            Visit(symbol.ElementType);
+        }
+
+        public override void VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
+        {
+            Visit(symbol.Signature);
+        }
+
+        public override void VisitMethod(IMethodSymbol symbol)
+        {
+            Visit(symbol.ReturnType);
+            if (!Result) return;
+
+            foreach (var p in symbol.Parameters)
+            {
+                Visit(p);
+                if (!Result) return;
+            }
+        }
+
+        public override void VisitParameter(IParameterSymbol symbol)
+        {
+            Visit(symbol.Type);
+        }
+
+        public override void VisitPointerType(IPointerTypeSymbol symbol)
+        {
+            Visit(symbol.PointedAtType);
+        }
+
+        public override void VisitNamedType(INamedTypeSymbol symbol)
+        {
+            int idx = 0;
+            foreach (var arg in symbol.TypeArguments)
+            {
+                if (IsTypeParameterSymbol(arg))
+                {
+                    var parameter = symbol.TypeParameters[idx];
+                    if (!parameter.AllowsRefLikeType)
+                    {
+                        Result = false;
+                        return;
+                    }
+                }
+                idx++;
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         TypeParameter = this.GetPublicSymbol()
                     };
-                    visitor.Visit(_container.GetPublicSymbol());
+                    visitor.Visit(_container.GetMembers("Invoke")[0].GetPublicSymbol());
                     return visitor.Result;
                 }
                 return false;


### PR DESCRIPTION
Currently synthesized TypeParameterSymbols for array params return AllowsRefLikeType=true, which is not true.
An array can not contain ref-structs.