### PR TITLE
Revise usage of `<code>` tag in `IOperation` docs

### DIFF
--- a/src/Compilers/Core/Portable/Generated/FlowAnalysis.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/FlowAnalysis.Generated.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// </summary>
         CaptureId Id { get; }
         /// <summary>
-        /// True if this reference to the capture initializes the capture. Used when the capture is being initialized by being passed as an <code>out</code> parameter.
+        /// True if this reference to the capture initializes the capture. Used when the capture is being initialized by being passed as an <see langword="out" /> parameter.
         /// </summary>
         bool IsInitialization { get; }
     }

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IOperation StepValue { get; }
         /// <summary>
-        /// <code>true</code> if arithmetic operations behind this loop are 'checked'.
+        /// <see langword="true" /> if arithmetic operations behind this loop are 'checked'.
         /// </summary>
         bool IsChecked { get; }
         /// <summary>
@@ -695,12 +695,12 @@ namespace Microsoft.CodeAnalysis.Operations
     /// Current usage:
     ///  (1) C# method invocation expression.
     ///  (2) C# collection element initializer.
-    ///      For example, in the following collection initializer: <code>new C() { 1, 2, 3 }</code>, we will have
+    ///      For example, in the following collection initializer: <c>new C() { 1, 2, 3 }</c>, we will have
     ///      3 <see cref="IInvocationOperation" /> nodes, each of which will be a call to the corresponding Add method
     ///      with either 1, 2, 3 as the argument.
     ///  (3) VB method invocation expression.
     ///  (4) VB collection element initializer.
-    ///      Similar to the C# example, <code>New C() From {1, 2, 3}</code> will have 3 <see cref="IInvocationOperation" />
+    ///      Similar to the C# example, <c>New C() From {1, 2, 3}</c> will have 3 <see cref="IInvocationOperation" />
     ///      nodes with 1, 2, and 3 as their arguments, respectively.
     /// </para>
     /// </summary>
@@ -1771,12 +1771,12 @@ namespace Microsoft.CodeAnalysis.Operations
     /// Current usage:
     ///  (1) C# dynamic invocation expression.
     ///  (2) C# dynamic collection element initializer.
-    ///      For example, in the following collection initializer: <code>new C() { do1, do2, do3 }</code> where
+    ///      For example, in the following collection initializer: <c>new C() { do1, do2, do3 }</c> where
     ///      the doX objects are of type dynamic, we'll have 3 <see cref="IDynamicInvocationOperation" /> with do1, do2, and
     ///      do3 as their arguments.
     ///  (3) VB late bound invocation expression.
     ///  (4) VB dynamic collection element initializer.
-    ///      Similar to the C# example, <code>New C() From {do1, do2, do3}</code> will generate 3 <see cref="IDynamicInvocationOperation" />
+    ///      Similar to the C# example, <c>New C() From {do1, do2, do3}</c> will generate 3 <see cref="IDynamicInvocationOperation" />
     ///      nodes with do1, do2, and do3 as their arguments, respectively.
     /// </para>
     /// </summary>
@@ -2712,7 +2712,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IDeclarationPatternOperation : IPatternOperation
     {
         /// <summary>
-        /// The type explicitly specified, or null if it was inferred (e.g. using <code>var</code> in C#).
+        /// The type explicitly specified, or null if it was inferred (e.g. using <see langword="var" /> in C#).
         /// </summary>
         ITypeSymbol? MatchedType { get; }
         /// <summary>
@@ -2853,7 +2853,7 @@ namespace Microsoft.CodeAnalysis.Operations
     /// The result of the entire expression is<see cref="IAssignmentOperation.Target" />, which is only evaluated once.
     /// <para>
     /// Current usage:
-    ///  (1) C# null-coalescing assignment operation <code>Target ??= Value</code>.
+    ///  (1) C# null-coalescing assignment operation <c>Target ??= Value</c>.
     /// </para>
     /// </summary>
     /// <remarks>
@@ -2893,7 +2893,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IOperation? RightOperand { get; }
         /// <summary>
-        /// <code>true</code> if this is a 'lifted' range operation.  When there is an
+        /// <see langword="true" /> if this is a 'lifted' range operation.  When there is an
         /// operator that is defined to work on a value type, 'lifted' operators are
         /// created to work on the <see cref="System.Nullable{T}" /> versions of those
         /// value types.
@@ -2975,8 +2975,8 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         ITypeSymbol MatchedType { get; }
         /// <summary>
-        /// The symbol, if any, used for the fetching values for subpatterns. This is either a <code>Deconstruct</code>
-        /// method, the type <code>System.Runtime.CompilerServices.ITuple</code>, or null (for example, in
+        /// The symbol, if any, used for the fetching values for subpatterns. This is either a <c>Deconstruct</c>
+        /// method, the type <c>System.Runtime.CompilerServices.ITuple</c>, or null (for example, in
         /// error cases or when matching a tuple type).
         /// </summary>
         ISymbol? DeconstructSymbol { get; }
@@ -3296,7 +3296,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface ITypePatternOperation : IPatternOperation
     {
         /// <summary>
-        /// The type explicitly specified, or null if it was inferred (e.g. using <code>var</code> in C#).
+        /// The type explicitly specified, or null if it was inferred (e.g. using <see langword="var" /> in C#).
         /// </summary>
         ITypeSymbol MatchedType { get; }
     }

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -266,7 +266,7 @@
     <Property Name="IsChecked" Type="bool">
       <Comments>
         <summary>
-          <code>true</code> if arithmetic operations behind this loop are 'checked'.</summary>
+          <see langword="true" /> if arithmetic operations behind this loop are 'checked'.</summary>
       </Comments>
     </Property>
     <Property Name="NextVariables" Type="ImmutableArray&lt;IOperation&gt;">
@@ -656,12 +656,12 @@
         Current usage:
          (1) C# method invocation expression.
          (2) C# collection element initializer.
-             For example, in the following collection initializer: <code>new C() { 1, 2, 3 }</code>, we will have
+             For example, in the following collection initializer: <c>new C() { 1, 2, 3 }</c>, we will have
              3 <see cref="IInvocationOperation" /> nodes, each of which will be a call to the corresponding Add method
              with either 1, 2, 3 as the argument.
          (3) VB method invocation expression.
          (4) VB collection element initializer.
-             Similar to the C# example, <code>New C() From {1, 2, 3}</code> will have 3 <see cref="IInvocationOperation" />
+             Similar to the C# example, <c>New C() From {1, 2, 3}</c> will have 3 <see cref="IInvocationOperation" />
              nodes with 1, 2, and 3 as their arguments, respectively.
         </para>
       </summary>
@@ -1646,12 +1646,12 @@
         Current usage:
          (1) C# dynamic invocation expression.
          (2) C# dynamic collection element initializer.
-             For example, in the following collection initializer: <code>new C() { do1, do2, do3 }</code> where
+             For example, in the following collection initializer: <c>new C() { do1, do2, do3 }</c> where
              the doX objects are of type dynamic, we'll have 3 <see cref="IDynamicInvocationOperation" /> with do1, do2, and
              do3 as their arguments.
          (3) VB late bound invocation expression.
          (4) VB dynamic collection element initializer.
-             Similar to the C# example, <code>New C() From {do1, do2, do3}</code> will generate 3 <see cref="IDynamicInvocationOperation" />
+             Similar to the C# example, <c>New C() From {do1, do2, do3}</c> will generate 3 <see cref="IDynamicInvocationOperation" />
              nodes with do1, do2, and do3 as their arguments, respectively.
         </para>
       </summary>
@@ -2466,7 +2466,7 @@
     <Property Name="MatchedType" Type="ITypeSymbol?">
       <Comments>
         <summary>
-          The type explicitly specified, or null if it was inferred (e.g. using <code>var</code> in C#).
+          The type explicitly specified, or null if it was inferred (e.g. using <see langword="var" /> in C#).
         </summary>
       </Comments>
     </Property>
@@ -2624,7 +2624,7 @@
     </Property>
     <Property Name="IsInitialization" Type="bool">
       <Comments>
-        <summary>True if this reference to the capture initializes the capture. Used when the capture is being initialized by being passed as an <code>out</code> parameter.</summary>
+        <summary>True if this reference to the capture initializes the capture. Used when the capture is being initialized by being passed as an <see langword="out" /> parameter.</summary>
       </Comments>
     </Property>
   </Node>
@@ -2695,7 +2695,7 @@
         The result of the entire expression is<see cref="IAssignmentOperation.Target" />, which is only evaluated once.
         <para>
         Current usage:
-         (1) C# null-coalescing assignment operation <code>Target ??= Value</code>.
+         (1) C# null-coalescing assignment operation <c>Target ??= Value</c>.
         </para>
       </summary>
     </Comments>
@@ -2723,7 +2723,7 @@
     <Property Name="IsLifted" Type="bool">
       <Comments>
         <summary>
-          <code>true</code> if this is a 'lifted' range operation.  When there is an
+          <see langword="true" /> if this is a 'lifted' range operation.  When there is an
           operator that is defined to work on a value type, 'lifted' operators are
           created to work on the <see cref="System.Nullable{T}" /> versions of those
           value types.
@@ -2793,8 +2793,8 @@
     <Property Name="DeconstructSymbol" Type="ISymbol?">
       <Comments>
         <summary>
-          The symbol, if any, used for the fetching values for subpatterns. This is either a <code>Deconstruct</code>
-          method, the type <code>System.Runtime.CompilerServices.ITuple</code>, or null (for example, in
+          The symbol, if any, used for the fetching values for subpatterns. This is either a <c>Deconstruct</c>
+          method, the type <c>System.Runtime.CompilerServices.ITuple</c>, or null (for example, in
           error cases or when matching a tuple type).
         </summary>
       </Comments>
@@ -3070,7 +3070,7 @@
     <Property Name="MatchedType" Type="ITypeSymbol">
       <Comments>
         <summary>
-          The type explicitly specified, or null if it was inferred (e.g. using <code>var</code> in C#).
+          The type explicitly specified, or null if it was inferred (e.g. using <see langword="var" /> in C#).
         </summary>
       </Comments>
     </Property>


### PR DESCRIPTION
Noticed, that in all places in `IOperation` doc `<code>` tag was used incorrectly. In many cases `<see langword...` should be used instead. In several places inline code (`<c>`) looks a lot better

**Example:**

**Before:**
![vjpm3C5pUl](https://github.com/user-attachments/assets/00ec2fc1-d25e-4b9b-a38e-243a2f2a14de)

**After:**
![0wfaz8IIH5](https://github.com/user-attachments/assets/f4e61d4e-28d5-46e6-8224-2943556401a9)
