### PR TITLE
Remove unused parameter in analyzer loading code

### DIFF
--- a/src/EditorFeatures/Core/Workspaces/VSAnalyzerAssemblyLoaderProvider.cs
+++ b/src/EditorFeatures/Core/Workspaces/VSAnalyzerAssemblyLoaderProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -11,11 +12,8 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.Workspaces;
 
 [ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), [WorkspaceKind.Host]), Shared]
-internal class VSAnalyzerAssemblyLoaderProvider : AbstractAnalyzerAssemblyLoaderProvider
-{
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public VSAnalyzerAssemblyLoaderProvider([ImportMany] IEnumerable<IAnalyzerAssemblyResolver> externalResolvers) : base(externalResolvers)
-    {
-    }
-}
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class VSAnalyzerAssemblyLoaderProvider(
+    [ImportMany] IEnumerable<IAnalyzerAssemblyResolver> externalResolvers)
+    : AbstractAnalyzerAssemblyLoaderProvider(externalResolvers.ToImmutableArray());

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
@@ -56,7 +56,7 @@ internal sealed class LanguageServerWorkspaceFactory
     public async Task InitializeSolutionLevelAnalyzersAsync(ImmutableArray<string> analyzerPaths)
     {
         var references = new List<AnalyzerFileReference>();
-        var analyzerLoader = Workspace.Services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>().GetLoader(shadowCopy: true);
+        var analyzerLoader = Workspace.Services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>().GetLoader();
 
         foreach (var analyzerPath in analyzerPaths)
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DebugConfiguration;
-using Microsoft.CodeAnalysis.LanguageServer.Services;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.Extensions.Logging;
@@ -56,7 +55,7 @@ internal sealed class LanguageServerWorkspaceFactory
     public async Task InitializeSolutionLevelAnalyzersAsync(ImmutableArray<string> analyzerPaths)
     {
         var references = new List<AnalyzerFileReference>();
-        var analyzerLoader = Workspace.Services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>().GetLoader();
+        var analyzerLoader = Workspace.Services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>().GetShadowCopyLoader();
 
         foreach (var analyzerPath in analyzerPaths)
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VSCodeAnalyzerLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/VSCodeAnalyzerLoader.cs
@@ -13,21 +13,16 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 
 [ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), [WorkspaceKind.Host]), Shared]
-internal class VSCodeAnalyzerLoaderProvider : AbstractAnalyzerAssemblyLoaderProvider
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class VSCodeAnalyzerLoaderProvider(
+    ExtensionAssemblyManager extensionAssemblyManager,
+    ILoggerFactory loggerFactory,
+    [ImportMany] IEnumerable<IAnalyzerAssemblyResolver> externalResolvers)
+    : AbstractAnalyzerAssemblyLoaderProvider(externalResolvers.ToImmutableArray())
 {
-    private readonly ExtensionAssemblyManager _extensionAssemblyManager;
-    private readonly ILoggerFactory _loggerFactory;
-
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public VSCodeAnalyzerLoaderProvider(
-        ExtensionAssemblyManager extensionAssemblyManager,
-        ILoggerFactory loggerFactory,
-        [ImportMany] IEnumerable<IAnalyzerAssemblyResolver> externalResolvers) : base(externalResolvers)
-    {
-        _extensionAssemblyManager = extensionAssemblyManager;
-        _loggerFactory = loggerFactory;
-    }
+    private readonly ExtensionAssemblyManager _extensionAssemblyManager = extensionAssemblyManager;
+    private readonly ILoggerFactory _loggerFactory = loggerFactory;
 
     protected override IAnalyzerAssemblyLoader CreateShadowCopyLoader(ImmutableArray<IAnalyzerAssemblyResolver> externalResolvers)
     {

--- a/src/LanguageServer/Protocol/Features/AbstractAnalyzerAssemblyLoaderProvider.cs
+++ b/src/LanguageServer/Protocol/Features/AbstractAnalyzerAssemblyLoaderProvider.cs
@@ -16,20 +16,18 @@ namespace Microsoft.CodeAnalysis.Host;
 /// </summary>
 internal abstract class AbstractAnalyzerAssemblyLoaderProvider : IAnalyzerAssemblyLoaderProvider
 {
-    private readonly DefaultAnalyzerAssemblyLoader _loader;
     private readonly Lazy<IAnalyzerAssemblyLoader> _shadowCopyLoader;
 
     public AbstractAnalyzerAssemblyLoaderProvider([ImportMany] IEnumerable<IAnalyzerAssemblyResolver> externalResolvers)
     {
         var resolvers = externalResolvers.ToImmutableArray();
-        _loader = new(resolvers);
 
         // We use a lazy here in case creating the loader requires MEF imports in the derived constructor.
         _shadowCopyLoader = new Lazy<IAnalyzerAssemblyLoader>(() => CreateShadowCopyLoader(resolvers));
     }
 
-    public IAnalyzerAssemblyLoader GetLoader(bool shadowCopy)
-        => shadowCopy ? _shadowCopyLoader.Value : _loader;
+    public IAnalyzerAssemblyLoader GetLoader()
+        => _shadowCopyLoader.Value;
 
     protected virtual IAnalyzerAssemblyLoader CreateShadowCopyLoader(ImmutableArray<IAnalyzerAssemblyResolver> externalResolvers)
     {

--- a/src/LanguageServer/Protocol/Features/AbstractAnalyzerAssemblyLoaderProvider.cs
+++ b/src/LanguageServer/Protocol/Features/AbstractAnalyzerAssemblyLoaderProvider.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.IO;
 
 namespace Microsoft.CodeAnalysis.Host;
@@ -18,15 +16,13 @@ internal abstract class AbstractAnalyzerAssemblyLoaderProvider : IAnalyzerAssemb
 {
     private readonly Lazy<IAnalyzerAssemblyLoader> _shadowCopyLoader;
 
-    public AbstractAnalyzerAssemblyLoaderProvider([ImportMany] IEnumerable<IAnalyzerAssemblyResolver> externalResolvers)
+    public AbstractAnalyzerAssemblyLoaderProvider(ImmutableArray<IAnalyzerAssemblyResolver> externalResolvers)
     {
-        var resolvers = externalResolvers.ToImmutableArray();
-
         // We use a lazy here in case creating the loader requires MEF imports in the derived constructor.
-        _shadowCopyLoader = new Lazy<IAnalyzerAssemblyLoader>(() => CreateShadowCopyLoader(resolvers));
+        _shadowCopyLoader = new Lazy<IAnalyzerAssemblyLoader>(() => CreateShadowCopyLoader(externalResolvers));
     }
 
-    public IAnalyzerAssemblyLoader GetLoader()
+    public IAnalyzerAssemblyLoader GetShadowCopyLoader()
         => _shadowCopyLoader.Value;
 
     protected virtual IAnalyzerAssemblyLoader CreateShadowCopyLoader(ImmutableArray<IAnalyzerAssemblyResolver> externalResolvers)

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         Public Sub GetReferenceCalledMultipleTimes()
             Using workspace = New TestWorkspace(composition:=s_compositionWithMockDiagnosticUpdateSourceRegistrationService)
                 Dim provider = workspace.Services.GetRequiredService(Of IAnalyzerAssemblyLoaderProvider)
-                Dim service = provider.GetLoader()
+                Dim service = provider.GetShadowCopyLoader()
                 Using tempRoot = New TempRoot(), analyzer = New ProjectAnalyzerReference(tempRoot.CreateFile().Path, service, HostDiagnosticUpdateSource.Instance, ProjectId.CreateNewId(), LanguageNames.VisualBasic)
                     Dim reference1 = analyzer.GetReference()
                     Dim reference2 = analyzer.GetReference()

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
@@ -21,14 +21,14 @@ Imports Roslyn.Test.Utilities
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     <UseExportProvider>
     <Trait(Traits.Feature, Traits.Features.Diagnostics)>
-    Public Class VisualStudioAnalyzerTests
+    Public NotInheritable Class VisualStudioAnalyzerTests
         Private Shared ReadOnly s_compositionWithMockDiagnosticUpdateSourceRegistrationService As TestComposition = EditorTestCompositions.EditorFeatures
 
         <WpfFact>
         Public Sub GetReferenceCalledMultipleTimes()
             Using workspace = New TestWorkspace(composition:=s_compositionWithMockDiagnosticUpdateSourceRegistrationService)
                 Dim provider = workspace.Services.GetRequiredService(Of IAnalyzerAssemblyLoaderProvider)
-                Dim service = provider.GetLoader(shadowCopy:=True)
+                Dim service = provider.GetLoader()
                 Using tempRoot = New TempRoot(), analyzer = New ProjectAnalyzerReference(tempRoot.CreateFile().Path, service, HostDiagnosticUpdateSource.Instance, ProjectId.CreateNewId(), LanguageNames.VisualBasic)
                     Dim reference1 = analyzer.GetReference()
                     Dim reference2 = analyzer.GetReference()

--- a/src/Workspaces/Core/Portable/Diagnostics/DefaultAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DefaultAnalyzerAssemblyLoaderService.cs
@@ -14,15 +14,15 @@ namespace Microsoft.CodeAnalysis.Host;
 [ExportWorkspaceServiceFactory(typeof(IAnalyzerAssemblyLoaderProvider)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class DefaultAnalyzerAssemblyLoaderServiceFactory([ImportMany] IEnumerable<IAnalyzerAssemblyResolver> externalResolvers) : IWorkspaceServiceFactory
+internal sealed class DefaultAnalyzerAssemblyLoaderServiceFactory(
+    [ImportMany] IEnumerable<IAnalyzerAssemblyResolver> externalResolvers) : IWorkspaceServiceFactory
 {
     public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         => new DefaultAnalyzerAssemblyLoaderProvider(workspaceServices.Workspace.Kind ?? "default", [.. externalResolvers]);
 
-    private sealed class DefaultAnalyzerAssemblyLoaderProvider(string workspaceKind, ImmutableArray<IAnalyzerAssemblyResolver> externalResolvers) : IAnalyzerAssemblyLoaderProvider
+    private sealed class DefaultAnalyzerAssemblyLoaderProvider(string workspaceKind, ImmutableArray<IAnalyzerAssemblyResolver> externalResolvers)
+        : IAnalyzerAssemblyLoaderProvider
     {
-        private readonly DefaultAnalyzerAssemblyLoader _loader = new(externalResolvers);
-
         /// <summary>
         /// We include the <see cref="WorkspaceKind"/> of the workspace in the path we produce.  That way we don't
         /// collide in the common case of a normal host workspace and OOP workspace running together.  This avoids an
@@ -34,7 +34,7 @@ internal sealed class DefaultAnalyzerAssemblyLoaderServiceFactory([ImportMany] I
             Path.Combine(Path.GetTempPath(), "CodeAnalysis", "WorkspacesAnalyzerShadowCopies", workspaceKind),
             externalResolvers: externalResolvers);
 
-        public IAnalyzerAssemblyLoader GetLoader(bool shadowCopy)
-            => shadowCopy ? _shadowCopyLoader : _loader;
+        public IAnalyzerAssemblyLoader GetLoader()
+            => _shadowCopyLoader;
     }
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/DefaultAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DefaultAnalyzerAssemblyLoaderService.cs
@@ -34,7 +34,7 @@ internal sealed class DefaultAnalyzerAssemblyLoaderServiceFactory(
             Path.Combine(Path.GetTempPath(), "CodeAnalysis", "WorkspacesAnalyzerShadowCopies", workspaceKind),
             externalResolvers: externalResolvers);
 
-        public IAnalyzerAssemblyLoader GetLoader()
+        public IAnalyzerAssemblyLoader GetShadowCopyLoader()
             => _shadowCopyLoader;
     }
 }

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -69,7 +69,6 @@ internal partial class SerializerService
             {
                 case AnalyzerFileReference file:
                     writer.WriteString(file.FullPath);
-                    writer.WriteBoolean(IsAnalyzerReferenceWithShadowCopyLoader(file));
                     break;
 
                 case AnalyzerImageReference analyzerImageReference:
@@ -124,7 +123,6 @@ internal partial class SerializerService
             case AnalyzerFileReference file:
                 writer.WriteString(nameof(AnalyzerFileReference));
                 writer.WriteString(file.FullPath);
-                writer.WriteBoolean(IsAnalyzerReferenceWithShadowCopyLoader(file));
                 break;
 
             case AnalyzerImageReference analyzerImageReference:
@@ -147,8 +145,7 @@ internal partial class SerializerService
         {
             case nameof(AnalyzerFileReference):
                 var fullPath = reader.ReadRequiredString();
-                var shadowCopy = reader.ReadBoolean();
-                return new AnalyzerFileReference(fullPath, _analyzerLoaderProvider.GetLoader(shadowCopy));
+                return new AnalyzerFileReference(fullPath, _analyzerLoaderProvider.GetLoader());
 
             case nameof(AnalyzerImageReference):
                 var guid = reader.ReadGuid();

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -145,7 +145,7 @@ internal partial class SerializerService
         {
             case nameof(AnalyzerFileReference):
                 var fullPath = reader.ReadRequiredString();
-                return new AnalyzerFileReference(fullPath, _analyzerLoaderProvider.GetLoader());
+                return new AnalyzerFileReference(fullPath, _analyzerLoaderProvider.GetShadowCopyLoader());
 
             case nameof(AnalyzerImageReference):
                 var guid = reader.ReadGuid();

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -54,9 +54,6 @@ internal partial class SerializerService
         throw ExceptionUtilities.UnexpectedValue(reference.GetType());
     }
 
-    private static bool IsAnalyzerReferenceWithShadowCopyLoader(AnalyzerFileReference reference)
-        => reference.AssemblyLoader is ShadowCopyAnalyzerAssemblyLoader;
-
     public static Checksum CreateChecksum(AnalyzerReference reference, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IAnalyzerAssemblyLoaderProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IAnalyzerAssemblyLoaderProvider.cs
@@ -6,5 +6,5 @@ namespace Microsoft.CodeAnalysis.Host;
 
 internal interface IAnalyzerAssemblyLoaderProvider : IWorkspaceService
 {
-    IAnalyzerAssemblyLoader GetLoader(bool shadowCopy);
+    IAnalyzerAssemblyLoader GetLoader();
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IAnalyzerAssemblyLoaderProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/IAnalyzerAssemblyLoaderProvider.cs
@@ -6,5 +6,5 @@ namespace Microsoft.CodeAnalysis.Host;
 
 internal interface IAnalyzerAssemblyLoaderProvider : IWorkspaceService
 {
-    IAnalyzerAssemblyLoader GetLoader();
+    IAnalyzerAssemblyLoader GetShadowCopyLoader();
 }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -161,9 +161,9 @@ internal sealed partial class ProjectSystemProject
         _displayName = displayName;
 
         var provider = _projectSystemProjectFactory.Workspace.Services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>();
-        // NOTE: The provider will always return the same singleton analyzer loader instance, which is important to
-        // ensure that shadow copied analyzer dependencies are correctly loaded.
-        _analyzerAssemblyLoader = provider.GetLoader();
+        // NOTE: The provider will always return the same singleton, shadow copying, analyzer loader instance, which is
+        // important to ensure that analyzer dependencies are correctly loaded.
+        _analyzerAssemblyLoader = provider.GetShadowCopyLoader();
 
         _sourceFiles = new BatchingDocumentCollection(
             this,

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -161,10 +161,9 @@ internal sealed partial class ProjectSystemProject
         _displayName = displayName;
 
         var provider = _projectSystemProjectFactory.Workspace.Services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>();
-        // Shadow copy analyzer files coming from packages to avoid locking the files in NuGet cache.
         // NOTE: The provider will always return the same singleton analyzer loader instance, which is important to
         // ensure that shadow copied analyzer dependencies are correctly loaded.
-        _analyzerAssemblyLoader = provider.GetLoader(shadowCopy: true);
+        _analyzerAssemblyLoader = provider.GetLoader();
 
         _sourceFiles = new BatchingDocumentCollection(
             this,


### PR DESCRIPTION
IDE always passes 'true' for shadow-copy, so i'm just removing that parameter from the method signature.  This also conceptually makes later changed i'm making simpler as we always know the data is shadow copied.