### PR TITLE
Reenable workspace pull diagnostics

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
@@ -69,6 +69,10 @@ internal class AlwaysActivateInProcLanguageClient(
         serverCapabilities.BreakableRangeProvider = true;
 
         serverCapabilities.SupportsDiagnosticRequests = true;
+
+        serverCapabilities.DiagnosticOptions ??= new();
+        serverCapabilities.DiagnosticOptions.WorkspaceDiagnostics = true;
+
         serverCapabilities.DiagnosticProvider ??= new();
 
         // VS does not distinguish between document and workspace diagnostics, so we need to merge them.


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2183668

Broke with a VSCLient change here: https://dev.azure.com/devdiv/DevDiv/_git/VSLanguageServerClient?path=/src/product/RemoteLanguage/Impl/Features/Diagnostics/WorkspaceDiagnosticsRequestFactory.cs&version=GBdevelop&_a=contents

Validating now.