### PR TITLE
Expose document symbols to Razor cohosting

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// </summary>
     [ExportCSharpVisualBasicStatelessLspService(typeof(DocumentSymbolsHandler)), Shared]
     [Method(Methods.TextDocumentDocumentSymbolName)]
-    internal sealed class DocumentSymbolsHandler : ILspServiceDocumentRequestHandler<RoslynDocumentSymbolParams, SumType<DocumentSymbol[], SymbolInformation[]>>
+    internal sealed class DocumentSymbolsHandler : ILspServiceDocumentRequestHandler<RoslynDocumentSymbolParams, SumType<RoslynDocumentSymbol[], SymbolInformation[]>>
     {
         public bool MutatesSolutionState => false;
         public bool RequiresLSPSolution => true;
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
         public TextDocumentIdentifier GetTextDocumentIdentifier(RoslynDocumentSymbolParams request) => request.TextDocument;
 
-        public Task<SumType<DocumentSymbol[], SymbolInformation[]>> HandleRequestAsync(RoslynDocumentSymbolParams request, RequestContext context, CancellationToken cancellationToken)
+        public Task<SumType<RoslynDocumentSymbol[], SymbolInformation[]>> HandleRequestAsync(RoslynDocumentSymbolParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var document = context.GetRequiredDocument();
             var clientCapabilities = context.GetRequiredClientCapabilities();
@@ -48,17 +48,17 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             return GetDocumentSymbolsAsync(document, useHierarchicalSymbols, service, cancellationToken);
         }
 
-        internal static async Task<SumType<DocumentSymbol[], SymbolInformation[]>> GetDocumentSymbolsAsync(Document document, bool useHierarchicalSymbols, ILspSymbolInformationCreationService symbolInformationCreationService, CancellationToken cancellationToken)
+        internal static async Task<SumType<RoslynDocumentSymbol[], SymbolInformation[]>> GetDocumentSymbolsAsync(Document document, bool useHierarchicalSymbols, ILspSymbolInformationCreationService symbolInformationCreationService, CancellationToken cancellationToken)
         {
             var navBarService = document.Project.Services.GetRequiredService<INavigationBarItemService>();
             var navBarItems = await navBarService.GetItemsAsync(document, supportsCodeGeneration: false, frozenPartialSemantics: false, cancellationToken).ConfigureAwait(false);
             if (navBarItems.IsEmpty)
-                return Array.Empty<DocumentSymbol>();
+                return Array.Empty<RoslynDocumentSymbol>();
 
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
             if (useHierarchicalSymbols)
             {
-                using var _ = ArrayBuilder<DocumentSymbol>.GetInstance(out var symbols);
+                using var _ = ArrayBuilder<RoslynDocumentSymbol>.GetInstance(out var symbols);
                 // only top level ones
                 foreach (var item in navBarItems)
                     symbols.AddIfNotNull(GetDocumentSymbol(item, text, cancellationToken));

--- a/src/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// </summary>
     [ExportCSharpVisualBasicStatelessLspService(typeof(DocumentSymbolsHandler)), Shared]
     [Method(Methods.TextDocumentDocumentSymbolName)]
-    internal sealed class DocumentSymbolsHandler : ILspServiceDocumentRequestHandler<RoslynDocumentSymbolParams, SumType<RoslynDocumentSymbol[], SymbolInformation[]>>
+    internal sealed class DocumentSymbolsHandler : ILspServiceDocumentRequestHandler<RoslynDocumentSymbolParams, SumType<DocumentSymbol[], SymbolInformation[]>>
     {
         public bool MutatesSolutionState => false;
         public bool RequiresLSPSolution => true;
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
         public TextDocumentIdentifier GetTextDocumentIdentifier(RoslynDocumentSymbolParams request) => request.TextDocument;
 
-        public Task<SumType<RoslynDocumentSymbol[], SymbolInformation[]>> HandleRequestAsync(RoslynDocumentSymbolParams request, RequestContext context, CancellationToken cancellationToken)
+        public Task<SumType<DocumentSymbol[], SymbolInformation[]>> HandleRequestAsync(RoslynDocumentSymbolParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var document = context.GetRequiredDocument();
             var clientCapabilities = context.GetRequiredClientCapabilities();
@@ -48,17 +48,17 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             return GetDocumentSymbolsAsync(document, useHierarchicalSymbols, service, cancellationToken);
         }
 
-        internal static async Task<SumType<RoslynDocumentSymbol[], SymbolInformation[]>> GetDocumentSymbolsAsync(Document document, bool useHierarchicalSymbols, ILspSymbolInformationCreationService symbolInformationCreationService, CancellationToken cancellationToken)
+        internal static async Task<SumType<DocumentSymbol[], SymbolInformation[]>> GetDocumentSymbolsAsync(Document document, bool useHierarchicalSymbols, ILspSymbolInformationCreationService symbolInformationCreationService, CancellationToken cancellationToken)
         {
             var navBarService = document.Project.Services.GetRequiredService<INavigationBarItemService>();
             var navBarItems = await navBarService.GetItemsAsync(document, supportsCodeGeneration: false, frozenPartialSemantics: false, cancellationToken).ConfigureAwait(false);
             if (navBarItems.IsEmpty)
-                return Array.Empty<RoslynDocumentSymbol>();
+                return Array.Empty<DocumentSymbol>();
 
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
             if (useHierarchicalSymbols)
             {
-                using var _ = ArrayBuilder<RoslynDocumentSymbol>.GetInstance(out var symbols);
+                using var _ = ArrayBuilder<DocumentSymbol>.GetInstance(out var symbols);
                 // only top level ones
                 foreach (var item in navBarItems)
                     symbols.AddIfNotNull(GetDocumentSymbol(item, text, cancellationToken));

--- a/src/LanguageServer/Protocol/Protocol/Internal/Converters/VSInternalExtensionUtilities.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Converters/VSInternalExtensionUtilities.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 namespace Roslyn.LanguageServer.Protocol;
 
@@ -47,6 +48,7 @@ internal static class VSInternalExtensionUtilities
         AddOrReplaceConverter<TextDocumentClientCapabilities, VSInternalTextDocumentClientCapabilities>();
         AddOrReplaceConverter<RenameRange, VSInternalRenameRange>();
         AddOrReplaceConverter<RenameParams, VSInternalRenameParams>();
+        AddOrReplaceConverter<DocumentSymbol, RoslynDocumentSymbol>();
 
         void AddOrReplaceConverter<TBase, TExtension>()
             where TExtension : TBase

--- a/src/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
@@ -48,7 +48,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Symbols
             CreateDocumentSymbol(LSP.SymbolKind.Method, "M", "M()", testLspServer.GetLocations("method").Single(), testLspServer.GetLocations("methodSelection").Single(), expected.First());
 
             var results = await RunGetDocumentSymbolsAsync<LSP.DocumentSymbol[]>(testLspServer);
-            AssertJsonEquals(expected, results);
+            Assert.Equal(expected.Length, results.Length);
+            for (var i = 0; i < results.Length; i++)
+            {
+                AssertDocumentSymbolEquals(expected[i], results[i]);
+            }
         }
 
         [Theory, CombinatorialData]

--- a/src/Tools/ExternalAccess/Razor/Cohost/Handlers/DocumentSymbols.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/Handlers/DocumentSymbols.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Roslyn.LanguageServer.Protocol;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
+
+internal static class DocumentSymbols
+{
+    public static Task<SumType<DocumentSymbol[], SymbolInformation[]>> GetDocumentSymbolsAsync(Document document, bool useHierarchicalSymbols, CancellationToken cancellationToken)
+    {
+        // The symbol information service in Roslyn lives in EditorFeatures and has VS dependencies. for glyph images,
+        // so isn't available in OOP. The default implementation is available in OOP, but not in the Roslyn MEF composition,
+        // so we have to provide our own.
+        return DocumentSymbolsHandler.GetDocumentSymbolsAsync(document, useHierarchicalSymbols, RazorLspSymbolInformationCreationService.Instance, cancellationToken);
+    }
+
+    private sealed class RazorLspSymbolInformationCreationService : ILspSymbolInformationCreationService
+    {
+        public static readonly RazorLspSymbolInformationCreationService Instance = new();
+
+        public SymbolInformation Create(string name, string? containerName, LSP.SymbolKind kind, LSP.Location location, Glyph glyph)
+            => new()
+            {
+                Name = name,
+                ContainerName = containerName,
+                Kind = kind,
+                Location = location,
+            };
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/Cohost/Handlers/DocumentSymbols.cs
+++ b/src/Tools/ExternalAccess/Razor/Cohost/Handlers/DocumentSymbols.cs
@@ -13,22 +13,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 
 internal static class DocumentSymbols
 {
-    public static async Task<SumType<DocumentSymbol[], SymbolInformation[]>> GetDocumentSymbolsAsync(Document document, bool useHierarchicalSymbols, CancellationToken cancellationToken)
+    public static Task<SumType<DocumentSymbol[], SymbolInformation[]>> GetDocumentSymbolsAsync(Document document, bool useHierarchicalSymbols, CancellationToken cancellationToken)
     {
         // The symbol information service in Roslyn lives in EditorFeatures and has VS dependencies. for glyph images,
         // so isn't available in OOP. The default implementation is available in OOP, but not in the Roslyn MEF composition,
         // so we have to provide our own.
-        var result = await DocumentSymbolsHandler.GetDocumentSymbolsAsync(document, useHierarchicalSymbols, RazorLspSymbolInformationCreationService.Instance, cancellationToken).ConfigureAwait(false);
-
-        // Roslyn returns their RoslynDocumentSymbol type from the above call, which inherits from DocumentSymbol, so it's
-        // fine to use, but we have to pull it out of the SumType to satisfy the compiler.
-        if (result.TryGetFirst(out var documentSymbols))
-        {
-            Contract.ThrowIfNull(documentSymbols);
-            return documentSymbols!;
-        }
-
-        return result.Second;
+        return DocumentSymbolsHandler.GetDocumentSymbolsAsync(document, useHierarchicalSymbols, RazorLspSymbolInformationCreationService.Instance, cancellationToken);
     }
 
     private sealed class RazorLspSymbolInformationCreationService : ILspSymbolInformationCreationService


### PR DESCRIPTION
Roslyn side of https://github.com/dotnet/razor/issues/10689
Razor side: https://github.com/dotnet/razor/pull/10728

Slightly annoying having to work around the VS dependency for images, but seems to look good in VS regardless:
![image](https://github.com/user-attachments/assets/b29dcb11-e1ac-4f22-b397-763d8822661e)
