### PR TITLE
Fix URI comparisons for different casing

### DIFF
--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -84,11 +84,11 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 //
                 // Instead, we will always create the hash code ignoring case, and will rely on the Equals implementation
                 // to handle collisions (between two Uris with different casing).  This should be very rare in practice.
+                // Collisions can happen for non UNC URIs (e.g. `git:/blah` vs `git:/Blah`).
                 return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.AbsoluteUri);
             }
             else
             {
-                obj.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);
                 return obj.GetHashCode();
             }
         }

--- a/src/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -210,7 +210,7 @@ public class UriTests : AbstractLanguageServerProtocolTests
         Assert.Same(originalText, encodedText);
     }
 
-    [Theory, CombinatorialData]
+    [Theory, CombinatorialData, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2208409")]
     public async Task TestFindsExistingDocumentWhenUriHasDifferentCasingForCaseInsensitiveUriAsync(bool mutatingLspWorkspace)
     {
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
@@ -258,7 +258,7 @@ public class UriTests : AbstractLanguageServerProtocolTests
         Assert.Same(originalText, lowerCaseText);
     }
 
-    [Theory, CombinatorialData]
+    [Theory, CombinatorialData, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2208409")]
     public async Task TestUsesDifferentDocumentForDifferentCaseWithNonUncUriAsync(bool mutatingLspWorkspace)
     {
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });


### PR DESCRIPTION
Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2208409

Issue was caused by https://github.com/dotnet/roslyn/pull/74544

Prior to my change, absolute URIs would ignore case when comparing UNC URIs (default impl of `Uri.GetHashCode`.  However once I manually started comparing AbsolutePaths, case was never ignored (due to the hashcode being different for upper vs lower case strings).

This showed up as an issue in C# DevKit because files in the workspace get added with an upper case drive letter (by devkit project system).  But VSCode sends LSP requests always with a lower case drive letter.  We'd end up always ignoring the diagnostics requests because we thought the file was not tracked by LSP.

This did not show up as an issue in the C# extension because we populate the workspace there with lower case drive letters (what vscode gives us).

The change here is to use an ignoring case hashcode for absolute path.  This will potentially cause collisions if a path exists with both cases, but that is generally rare.  We will fallback to the URI implementation of comparison in `Equals`, which appropriately handles case depending on the kind of URI.