### PR TITLE
Disable build on test refresh

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,6 @@
     "azure-pipelines.customSchemaFile": ".vscode/dnceng-schema.json",
     "dotnet.defaultSolution": "Roslyn.sln",
     "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
-    "dotnet.testWindow.disableAutoDiscovery": true
+    "dotnet.testWindow.disableAutoDiscovery": true,
+    "dotnet.testWindow.disableBuildOnRefresh": true
 }


### PR DESCRIPTION
Our VS Code settings presently disable discovery during build. In order to get a test list we must do an explicit refresh operation. By default that builds which incurs another build hit and seems to break discovery. This disables build during refresh so we avoid the double build. 