### PR TITLE
Remove net35 reference assemblies

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -265,7 +265,6 @@
     <PackageVersion Include="Microsoft.ILVerification" Version="8.0.0-rtm.23523.3" />
     <PackageVersion Include="Microsoft.NET.Build.Extensions" Version="2.2.101" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="5.0.0" />
-    <PackageVersion Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Cache" Version="17.3.26-alpha" />
     <PackageVersion Include="Microsoft.VisualStudio.Diagnostics.Measurement" Version="17.9.36343-preview.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="17.8.36726" />

--- a/src/Compilers/Test/Core/Generate.ps1
+++ b/src/Compilers/Test/Core/Generate.ps1
@@ -121,10 +121,6 @@ Add-TargetFramework "Net20" '$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net
   'System.dll',
   'Microsoft.VisualBasic.dll')
 
-Add-TargetFramework "Net35" '$(Pkgjnm2_ReferenceAssemblies_net35)\build\.NETFramework\v3.5' @(
-  'System.Core.dll'
-)
-
 Add-TargetFramework "Net40" '$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0' @(
   'mscorlib.dll',
   'System.dll',
@@ -186,5 +182,11 @@ $codeContent += @"
 }
 "@
 
-$targetsContent | Out-File "Generated.targets" -Encoding Utf8
-$codeContent | Out-File "Generated.cs" -Encoding Utf8
+try {
+  Push-Location $PSScriptRoot
+  $targetsContent | Out-File "Generated.targets" -Encoding Utf8
+  $codeContent | Out-File "Generated.cs" -Encoding Utf8
+}
+finally {
+  Pop-Location
+}

--- a/src/Compilers/Test/Core/Generated.cs
+++ b/src/Compilers/Test/Core/Generated.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -42,19 +42,6 @@ namespace Roslyn.Test.Utilities
             public static PortableExecutableReference mscorlib { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet20.mscorlib).GetReference(display: "mscorlib.dll (net20)", filePath: "mscorlib.dll");
             public static PortableExecutableReference System { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet20.System).GetReference(display: "System.dll (net20)", filePath: "System.dll");
             public static PortableExecutableReference MicrosoftVisualBasic { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet20.MicrosoftVisualBasic).GetReference(display: "Microsoft.VisualBasic.dll (net20)", filePath: "Microsoft.VisualBasic.dll");
-        }
-        public static class ResourcesNet35
-        {
-            private static byte[] _SystemCore;
-            public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net35.System.Core.dll");
-            public static ReferenceInfo[] All => new[]
-            {
-                new ReferenceInfo("System.Core.dll", SystemCore),
-            };
-        }
-        public static class Net35
-        {
-            public static PortableExecutableReference SystemCore { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet35.SystemCore).GetReference(display: "System.Core.dll (net35)", filePath: "System.Core.dll");
         }
         public static class ResourcesNet40
         {

--- a/src/Compilers/Test/Core/Generated.targets
+++ b/src/Compilers/Test/Core/Generated.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
     <ItemGroup>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net20)\build\.NETFramework\v2.0\mscorlib.dll">
           <LogicalName>net20.mscorlib.dll</LogicalName>
@@ -11,10 +11,6 @@
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net20)\build\.NETFramework\v2.0\Microsoft.VisualBasic.dll">
           <LogicalName>net20.Microsoft.VisualBasic.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\net20\Microsoft.VisualBasic.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(Pkgjnm2_ReferenceAssemblies_net35)\build\.NETFramework\v3.5\System.Core.dll">
-          <LogicalName>net35.System.Core.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net35\System.Core.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\mscorlib.dll">
           <LogicalName>net40.mscorlib.dll</LogicalName>

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -110,7 +110,6 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net20" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Build.Extensions" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="jnm2.ReferenceAssemblies.net35" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.Threading.Tasks.Extensions" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CSharp" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualBasic" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />


### PR DESCRIPTION
This will save us 100MB of disk I/O in CI. It was only being used in one test. Reworked that a bit to not need `net35` anymore