### PR TITLE
Snippet refactoring 2

### DIFF
--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -30,7 +30,7 @@ internal abstract class AbstractCSharpAutoPropertySnippetProvider : AbstractProp
     protected virtual AccessorDeclarationSyntax? GenerateSetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator, CancellationToken cancellationToken)
         => (AccessorDeclarationSyntax)generator.SetAccessorDeclaration();
 
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         return context.SyntaxContext.SyntaxTree.IsMemberDeclarationContext(context.Position, (CSharpSyntaxContext)context.SyntaxContext,
             SyntaxKindSet.AllMemberModifiers, SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: true, cancellationToken);

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -30,7 +30,7 @@ internal abstract class AbstractCSharpAutoPropertySnippetProvider : AbstractProp
     protected virtual AccessorDeclarationSyntax? GenerateSetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator, CancellationToken cancellationToken)
         => (AccessorDeclarationSyntax)generator.SetAccessorDeclaration();
 
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         return context.SyntaxContext.SyntaxTree.IsMemberDeclarationContext(context.Position, (CSharpSyntaxContext)context.SyntaxContext,
             SyntaxKindSet.AllMemberModifiers, SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: true, cancellationToken);

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 internal abstract class AbstractCSharpMainMethodSnippetProvider
     : AbstractMainMethodSnippetProvider<MethodDeclarationSyntax, StatementSyntax, TypeSyntax>
 {
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         var semanticModel = context.SyntaxContext.SemanticModel;
         var syntaxContext = (CSharpSyntaxContext)context.SyntaxContext;

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 internal abstract class AbstractCSharpMainMethodSnippetProvider
     : AbstractMainMethodSnippetProvider<MethodDeclarationSyntax, StatementSyntax, TypeSyntax>
 {
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var semanticModel = context.SyntaxContext.SemanticModel;
         var syntaxContext = (CSharpSyntaxContext)context.SyntaxContext;

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
@@ -17,7 +17,7 @@ internal abstract class AbstractCSharpMainMethodSnippetProvider
 {
     protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
-        var semanticModel = context.SyntaxContext.SemanticModel;
+        var semanticModel = context.SemanticModel;
         var syntaxContext = (CSharpSyntaxContext)context.SyntaxContext;
 
         if (!syntaxContext.IsMemberDeclarationContext(

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -27,7 +27,7 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
 {
     protected abstract ISet<SyntaxKind> ValidModifiers { get; }
 
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = (CSharpSyntaxContext)context.SyntaxContext;
 

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -27,7 +27,7 @@ internal abstract class AbstractCSharpTypeSnippetProvider<TTypeDeclarationSyntax
 {
     protected abstract ISet<SyntaxKind> ValidModifiers { get; }
 
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = (CSharpSyntaxContext)context.SyntaxContext;
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpConsoleSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConsoleSnippetProvider.cs
@@ -24,8 +24,9 @@ internal sealed class CSharpConsoleSnippetProvider() : AbstractConsoleSnippetPro
     protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
+        var semanticModel = context.SemanticModel;
 
-        var consoleSymbol = GetConsoleSymbolFromMetaDataName(syntaxContext.SemanticModel.Compilation);
+        var consoleSymbol = GetConsoleSymbolFromMetaDataName(semanticModel.Compilation);
         if (consoleSymbol is null)
             return false;
 
@@ -33,7 +34,6 @@ internal sealed class CSharpConsoleSnippetProvider() : AbstractConsoleSnippetPro
         // Action a = () => Console.WriteLine("Action called");
         if (syntaxContext.TargetToken is { RawKind: (int)SyntaxKind.EqualsGreaterThanToken, Parent: LambdaExpressionSyntax lambda })
         {
-            var semanticModel = syntaxContext.SemanticModel;
             var lambdaSymbol = semanticModel.GetSymbolInfo(lambda, cancellationToken).Symbol;
 
             // Given that we are in a partially written lambda state compiler might not always infer return type correctly.

--- a/src/Features/CSharp/Portable/Snippets/CSharpConsoleSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConsoleSnippetProvider.cs
@@ -21,7 +21,7 @@ internal sealed class CSharpConsoleSnippetProvider() : AbstractConsoleSnippetPro
     ArgumentListSyntax,
     LambdaExpressionSyntax>
 {
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpConsoleSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConsoleSnippetProvider.cs
@@ -21,7 +21,7 @@ internal sealed class CSharpConsoleSnippetProvider() : AbstractConsoleSnippetPro
     ArgumentListSyntax,
     LambdaExpressionSyntax>
 {
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
@@ -36,7 +36,7 @@ internal sealed class CSharpConstructorSnippetProvider() : AbstractConstructorSn
         SyntaxKind.StaticKeyword,
     };
 
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = (CSharpSyntaxContext)context.SyntaxContext;
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
@@ -36,7 +36,7 @@ internal sealed class CSharpConstructorSnippetProvider() : AbstractConstructorSn
         SyntaxKind.StaticKeyword,
     };
 
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = (CSharpSyntaxContext)context.SyntaxContext;
 

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -24,7 +24,7 @@ internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider<
 
     public override string Description => FeaturesResources.else_statement;
 
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
         var token = syntaxContext.TargetToken;
@@ -51,7 +51,7 @@ internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider<
             }
         }
 
-        return isAfterIfStatement && base.IsValidSnippetLocation(context, cancellationToken);
+        return isAfterIfStatement && base.IsValidSnippetLocationCore(context, cancellationToken);
     }
 
     protected override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -24,7 +24,7 @@ internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider<
 
     public override string Description => FeaturesResources.else_statement;
 
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
         var token = syntaxContext.TargetToken;
@@ -51,7 +51,7 @@ internal sealed class CSharpElseSnippetProvider() : AbstractElseSnippetProvider<
             }
         }
 
-        return isAfterIfStatement && base.IsValidSnippetLocation(in context, cancellationToken);
+        return isAfterIfStatement && base.IsValidSnippetLocation(context, cancellationToken);
     }
 
     protected override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -34,7 +34,7 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
 
     public override string Description => FeaturesResources.foreach_loop;
 
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
         var token = syntaxContext.TargetToken;
@@ -48,7 +48,7 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
             return true;
         }
 
-        return base.IsValidSnippetLocation(context, cancellationToken);
+        return base.IsValidSnippetLocationCore(context, cancellationToken);
     }
 
     protected override ForEachStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -34,7 +34,7 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
 
     public override string Description => FeaturesResources.foreach_loop;
 
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
         var token = syntaxContext.TargetToken;
@@ -48,7 +48,7 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
             return true;
         }
 
-        return base.IsValidSnippetLocation(in context, cancellationToken);
+        return base.IsValidSnippetLocation(context, cancellationToken);
     }
 
     protected override ForEachStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -82,7 +82,7 @@ internal abstract class AbstractSnippetCompletionProvider : CompletionProvider
 
         var syntaxContext = await context.GetSyntaxContextWithExistingSpeculativeModelAsync(document, cancellationToken).ConfigureAwait(false);
         var snippetContext = new SnippetContext(syntaxContext);
-        var snippets = await service.GetSnippetsAsync(snippetContext, cancellationToken).ConfigureAwait(false);
+        var snippets = service.GetSnippets(snippetContext, cancellationToken);
 
         foreach (var snippetData in snippets)
         {

--- a/src/Features/Core/Portable/Snippets/AbstractSnippetService.cs
+++ b/src/Features/Core/Portable/Snippets/AbstractSnippetService.cs
@@ -42,7 +42,7 @@ internal abstract class AbstractSnippetService(IEnumerable<Lazy<ISnippetProvider
         using var _ = ArrayBuilder<SnippetData>.GetInstance(out var arrayBuilder);
         foreach (var provider in GetSnippetProviders(context.Document))
         {
-            if (await provider.IsValidSnippetLocationAsync(in context, cancellationToken).ConfigureAwait(false))
+            if (await provider.IsValidSnippetLocationAsync(context, cancellationToken).ConfigureAwait(false))
                 arrayBuilder.Add(new(provider.Identifier, provider.Description, provider.AdditionalFilterTexts));
         }
 

--- a/src/Features/Core/Portable/Snippets/AbstractSnippetService.cs
+++ b/src/Features/Core/Portable/Snippets/AbstractSnippetService.cs
@@ -8,7 +8,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
@@ -37,12 +36,12 @@ internal abstract class AbstractSnippetService(IEnumerable<Lazy<ISnippetProvider
     /// Iterates through all providers and determines if the snippet 
     /// can be added to the Completion list at the corresponding position.
     /// </summary>
-    public async Task<ImmutableArray<SnippetData>> GetSnippetsAsync(SnippetContext context, CancellationToken cancellationToken)
+    public ImmutableArray<SnippetData> GetSnippets(SnippetContext context, CancellationToken cancellationToken)
     {
         using var _ = ArrayBuilder<SnippetData>.GetInstance(out var arrayBuilder);
         foreach (var provider in GetSnippetProviders(context.Document))
         {
-            if (await provider.IsValidSnippetLocationAsync(context, cancellationToken).ConfigureAwait(false))
+            if (provider.IsValidSnippetLocation(context, cancellationToken))
                 arrayBuilder.Add(new(provider.Identifier, provider.Description, provider.AdditionalFilterTexts));
         }
 

--- a/src/Features/Core/Portable/Snippets/ISnippetService.cs
+++ b/src/Features/Core/Portable/Snippets/ISnippetService.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
@@ -15,7 +14,7 @@ internal interface ISnippetService : ILanguageService
     /// <summary>
     /// Retrieves all possible types of snippets for a particular position
     /// </summary>
-    Task<ImmutableArray<SnippetData>> GetSnippetsAsync(SnippetContext context, CancellationToken cancellationToken);
+    ImmutableArray<SnippetData> GetSnippets(SnippetContext context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the corresponding provider from a snippet identifier.

--- a/src/Features/Core/Portable/Snippets/SnippetContext.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetContext.cs
@@ -28,5 +28,10 @@ internal readonly struct SnippetContext
     /// </summary>
     public int Position => SyntaxContext.Position;
 
+    /// <summary>
+    /// The semantic model of the document.
+    /// </summary>
+    public SemanticModel SemanticModel => SyntaxContext.SemanticModel;
+
     internal SyntaxContext SyntaxContext { get; }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -39,7 +39,7 @@ internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax>
     /// </summary>
     protected bool ConstructedFromInlineExpression { get; private set; }
 
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
         var semanticModel = syntaxContext.SemanticModel;
@@ -51,7 +51,7 @@ internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax>
             return IsValidAccessingType(type, semanticModel.Compilation);
         }
 
-        return base.IsValidSnippetLocation(in context, cancellationToken);
+        return base.IsValidSnippetLocation(context, cancellationToken);
     }
 
     protected sealed override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -42,7 +42,7 @@ internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax>
     protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
-        var semanticModel = syntaxContext.SemanticModel;
+        var semanticModel = context.SemanticModel;
         var targetToken = syntaxContext.TargetToken;
 
         var syntaxFacts = context.Document.GetRequiredLanguageService<ISyntaxFactsService>();

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -39,7 +39,7 @@ internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax>
     /// </summary>
     protected bool ConstructedFromInlineExpression { get; private set; }
 
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxContext = context.SyntaxContext;
         var semanticModel = syntaxContext.SemanticModel;
@@ -51,7 +51,7 @@ internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax>
             return IsValidAccessingType(type, semanticModel.Compilation);
         }
 
-        return base.IsValidSnippetLocation(context, cancellationToken);
+        return base.IsValidSnippetLocationCore(context, cancellationToken);
     }
 
     protected sealed override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -50,16 +50,16 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
     /// </summary>
     protected abstract ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TSnippetSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken);
 
-    public ValueTask<bool> IsValidSnippetLocationAsync(SnippetContext context, CancellationToken cancellationToken)
+    public bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxFacts = context.Document.GetRequiredLanguageService<ISyntaxFactsService>();
         var syntaxTree = context.SyntaxContext.SyntaxTree;
         if (syntaxFacts.IsInNonUserCode(syntaxTree, context.Position, cancellationToken))
         {
-            return ValueTaskFactory.FromResult(false);
+            return false;
         }
 
-        return ValueTaskFactory.FromResult(IsValidSnippetLocationCore(context, cancellationToken));
+        return IsValidSnippetLocationCore(context, cancellationToken);
     }
 
     /// <summary>

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -33,7 +33,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
     /// Implemented by each SnippetProvider to determine if that particular position is a valid
     /// location for the snippet to be inserted.
     /// </summary>
-    protected abstract bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken);
+    protected abstract bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Generates the new snippet's TextChanges that are being inserted into the document.
@@ -50,7 +50,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
     /// </summary>
     protected abstract ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(TSnippetSyntax node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken);
 
-    public ValueTask<bool> IsValidSnippetLocationAsync(in SnippetContext context, CancellationToken cancellationToken)
+    public ValueTask<bool> IsValidSnippetLocationAsync(SnippetContext context, CancellationToken cancellationToken)
     {
         var syntaxFacts = context.Document.GetRequiredLanguageService<ISyntaxFactsService>();
         var syntaxTree = context.SyntaxContext.SyntaxTree;
@@ -59,7 +59,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
             return ValueTaskFactory.FromResult(false);
         }
 
-        return ValueTaskFactory.FromResult(IsValidSnippetLocation(in context, cancellationToken));
+        return ValueTaskFactory.FromResult(IsValidSnippetLocation(context, cancellationToken));
     }
 
     /// <summary>

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -33,7 +33,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
     /// Implemented by each SnippetProvider to determine if that particular position is a valid
     /// location for the snippet to be inserted.
     /// </summary>
-    protected abstract bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken);
+    protected abstract bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Generates the new snippet's TextChanges that are being inserted into the document.
@@ -59,7 +59,7 @@ internal abstract class AbstractSnippetProvider<TSnippetSyntax> : ISnippetProvid
             return ValueTaskFactory.FromResult(false);
         }
 
-        return ValueTaskFactory.FromResult(IsValidSnippetLocation(context, cancellationToken));
+        return ValueTaskFactory.FromResult(IsValidSnippetLocationCore(context, cancellationToken));
     }
 
     /// <summary>

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractStatementSnippetProvider.cs
@@ -9,6 +9,6 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 internal abstract class AbstractStatementSnippetProvider<TStatementSyntax> : AbstractSingleChangeSnippetProvider<TStatementSyntax>
     where TStatementSyntax : SyntaxNode
 {
-    protected override bool IsValidSnippetLocation(in SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
         => context.SyntaxContext.IsStatementContext || context.SyntaxContext.IsGlobalStatementContext;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractStatementSnippetProvider.cs
@@ -9,6 +9,6 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 internal abstract class AbstractStatementSnippetProvider<TStatementSyntax> : AbstractSingleChangeSnippetProvider<TStatementSyntax>
     where TStatementSyntax : SyntaxNode
 {
-    protected override bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken)
+    protected override bool IsValidSnippetLocationCore(SnippetContext context, CancellationToken cancellationToken)
         => context.SyntaxContext.IsStatementContext || context.SyntaxContext.IsGlobalStatementContext;
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
@@ -28,7 +28,7 @@ internal interface ISnippetProvider
     /// <summary>
     /// Determines if a snippet can exist at a particular location.
     /// </summary>
-    ValueTask<bool> IsValidSnippetLocationAsync(in SnippetContext context, CancellationToken cancellationToken);
+    ValueTask<bool> IsValidSnippetLocationAsync(SnippetContext context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the Snippet change from the corresponding snippet provider.

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
@@ -28,7 +28,7 @@ internal interface ISnippetProvider
     /// <summary>
     /// Determines if a snippet can exist at a particular location.
     /// </summary>
-    ValueTask<bool> IsValidSnippetLocationAsync(SnippetContext context, CancellationToken cancellationToken);
+    bool IsValidSnippetLocation(SnippetContext context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the Snippet change from the corresponding snippet provider.


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/74712

2 changes here:
1. Do not pass `SnippetContext` around by `in` reference. The only actual data, that `SnippetContext` holds is 1 reference to a `SyntaxContext`. Therefore passing it around by `in` doesn't win anything, but adds unnecessary cognitive overhead when reading that code
2. Since `SnippetContext` already holds a `SyntaxContext` instance, all async work of getting syntax tree and semantic model from the document has already been done. Therefore it isn't practical to keep this path async. I remember there was a discussion, that semantic snippets engine is a potential candidate for becoming public API. And since there is no way `SyntaxContext` become public, I additionaly exposed `SemanticModel` as a public property of `SnippetContext`. That way a potential API user can get everything they need without having to deal with any async stuff:
- Syntax tree: `context.SemanticModel.SyntaxTree`
- Syntax root: `context.SemanticModel.SyntaxTree.GetRoot()`
- Semantic model: `context.SemanticModel`
- Compilation: `context.SemanticModel.Compilation`