### PR TITLE
17.11 cherry-pick: fix bug with on-the-fly-docs option not working when clicked (#74781)

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioCopilotOptionsService.cs
@@ -77,7 +77,7 @@ internal sealed class CSharpVisualStudioCopilotOptionsService : ICopilotOptionsS
         var settingManager = await _settingsManagerTask.ConfigureAwait(false);
         // The bool setting is persisted as 0=None, 1=True, 2=False, so it needs to be retrieved as an int.
         return settingManager.TryGetValue($"{CopilotOptionNamePrefix}.{optionName}", out int isEnabled) == GetValueResult.Success
-            && isEnabled == 1;
+            && isEnabled != 2;
     }
 
     public Task<bool> IsCodeAnalysisOptionEnabledAsync()


### PR DESCRIPTION
Tracked by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2221667 for 17.11.2.