### PR TITLE
Reduce allocations in CSharpSyntaxFacts.AppendMembers (again)

### DIFF
--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
@@ -745,9 +745,11 @@ internal abstract class AbstractRemoveUnnecessaryInlineSuppressionsDiagnosticAna
             return false;
         }
 
-        using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var declarationNodes);
+        using var pooledDeclarationNodes = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+        var declarationNodes = pooledDeclarationNodes.Object;
+
         SyntaxFacts.AddTopLevelAndMethodLevelMembers(root, declarationNodes);
-        using var _2 = PooledHashSet<ISymbol>.GetInstance(out var processedPartialSymbols);
+        using var _ = PooledHashSet<ISymbol>.GetInstance(out var processedPartialSymbols);
         if (declarationNodes.Count > 0)
         {
             foreach (var node in declarationNodes)

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs
@@ -745,10 +745,9 @@ internal abstract class AbstractRemoveUnnecessaryInlineSuppressionsDiagnosticAna
             return false;
         }
 
-        using var pooledDeclarationNodes = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+        using var pooledDeclarationNodes = SyntaxFacts.GetTopLevelAndMethodLevelMembers(root);
         var declarationNodes = pooledDeclarationNodes.Object;
 
-        SyntaxFacts.AddTopLevelAndMethodLevelMembers(root, declarationNodes);
         using var _ = PooledHashSet<ISymbol>.GetInstance(out var processedPartialSymbols);
         if (declarationNodes.Count > 0)
         {

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -352,14 +352,14 @@ namespace Microsoft.CodeAnalysis
             if (array.IsEmpty)
                 return ImmutableArray<TResult>.Empty;
 
-            var builder = ArrayBuilder<TResult>.GetInstance(array.Length);
+            var builder = new TResult[array.Length];
 
-            foreach (var item in array)
+            for (var i = 0; i < array.Length; i++)
             {
-                builder.Add(await selector(item, cancellationToken).ConfigureAwait(false));
+                builder[i] = await selector(array[i], cancellationToken).ConfigureAwait(false);
             }
 
-            return builder.ToImmutableAndFree();
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
         /// <summary>
@@ -370,14 +370,14 @@ namespace Microsoft.CodeAnalysis
             if (array.IsEmpty)
                 return ImmutableArray<TResult>.Empty;
 
-            var builder = ArrayBuilder<TResult>.GetInstance(array.Length);
+            var builder = new TResult[array.Length];
 
-            foreach (var item in array)
+            for (var i = 0; i < array.Length; i++)
             {
-                builder.Add(await selector(item, arg, cancellationToken).ConfigureAwait(false));
+                builder[i] = await selector(array[i], arg, cancellationToken).ConfigureAwait(false);
             }
 
-            return builder.ToImmutableAndFree();
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
         public static ValueTask<ImmutableArray<TResult>> SelectManyAsArrayAsync<TItem, TArg, TResult>(this ImmutableArray<TItem> source, Func<TItem, TArg, CancellationToken, ValueTask<ImmutableArray<TResult>>> selector, TArg arg, CancellationToken cancellationToken)
@@ -432,13 +432,13 @@ namespace Microsoft.CodeAnalysis
                     return ImmutableArray.Create(map(self[0], other[0]), map(self[1], other[1]), map(self[2], other[2]), map(self[3], other[3]));
 
                 default:
-                    var builder = ArrayBuilder<TResult>.GetInstance(self.Length);
+                    var builder = new TResult[self.Length];
                     for (int i = 0; i < self.Length; i++)
                     {
-                        builder.Add(map(self[i], other[i]));
+                        builder[i] = map(self[i], other[i]);
                     }
 
-                    return builder.ToImmutableAndFree();
+                    return ImmutableCollectionsMarshal.AsImmutableArray(builder);
             }
         }
 
@@ -815,44 +815,124 @@ namespace Microsoft.CodeAnalysis
 
         internal static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third)
         {
-            var builder = ArrayBuilder<T>.GetInstance(first.Length + second.Length + third.Length);
-            builder.AddRange(first);
-            builder.AddRange(second);
-            builder.AddRange(third);
-            return builder.ToImmutableAndFree();
+            var builder = new T[first.Length + second.Length + third.Length];
+            var index = 0;
+
+            foreach (var item in first)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in second)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in third)
+            {
+                builder[index++] = item;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
         internal static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth)
         {
-            var builder = ArrayBuilder<T>.GetInstance(first.Length + second.Length + third.Length + fourth.Length);
-            builder.AddRange(first);
-            builder.AddRange(second);
-            builder.AddRange(third);
-            builder.AddRange(fourth);
-            return builder.ToImmutableAndFree();
+            var builder = new T[first.Length + second.Length + third.Length + fourth.Length];
+            var index = 0;
+
+            foreach (var item in first)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in second)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in third)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fourth)
+            {
+                builder[index++] = item;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
         internal static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth, ImmutableArray<T> fifth)
         {
-            var builder = ArrayBuilder<T>.GetInstance(first.Length + second.Length + third.Length + fourth.Length + fifth.Length);
-            builder.AddRange(first);
-            builder.AddRange(second);
-            builder.AddRange(third);
-            builder.AddRange(fourth);
-            builder.AddRange(fifth);
-            return builder.ToImmutableAndFree();
+            var builder = new T[first.Length + second.Length + third.Length + fourth.Length + fifth.Length];
+            var index = 0;
+
+            foreach (var item in first)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in second)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in third)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fourth)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fifth)
+            {
+                builder[index++] = item;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
         internal static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, ImmutableArray<T> second, ImmutableArray<T> third, ImmutableArray<T> fourth, ImmutableArray<T> fifth, ImmutableArray<T> sixth)
         {
-            var builder = ArrayBuilder<T>.GetInstance(first.Length + second.Length + third.Length + fourth.Length + fifth.Length + sixth.Length);
-            builder.AddRange(first);
-            builder.AddRange(second);
-            builder.AddRange(third);
-            builder.AddRange(fourth);
-            builder.AddRange(fifth);
-            builder.AddRange(sixth);
-            return builder.ToImmutableAndFree();
+            var builder = new T[first.Length + second.Length + third.Length + fourth.Length + fifth.Length + sixth.Length];
+            var index = 0;
+
+            foreach (var item in first)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in second)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in third)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fourth)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in fifth)
+            {
+                builder[index++] = item;
+            }
+
+            foreach (var item in sixth)
+            {
+                builder[index++] = item;
+            }
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
         internal static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, T second)
@@ -872,15 +952,20 @@ namespace Microsoft.CodeAnalysis
                 return self.Add(items[0]);
             }
 
-            var builder = ArrayBuilder<T>.GetInstance(self.Length + items.Count);
-            builder.AddRange(self);
+            var builder = new T[self.Length + items.Count];
+            var index = 0;
+
+            foreach (var item in self)
+            {
+                builder[index++] = item;
+            }
 
             foreach (var item in items)
             {
-                builder.Add(item);
+                builder[index++] = item;
             }
 
-            return builder.ToImmutableAndFree();
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -385,11 +386,15 @@ namespace Roslyn.Utilities
             if (source == null)
                 return ImmutableArray<TResult>.Empty;
 
-            var builder = ArrayBuilder<TResult>.GetInstance(source.Count);
+            var builder = new TResult[source.Count];
+            var index = 0;
             foreach (var item in source)
-                builder.Add(selector(item));
+            {
+                builder[index] = selector(item);
+                index++;
+            }
 
-            return builder.ToImmutableAndFree();
+            return ImmutableCollectionsMarshal.AsImmutableArray(builder);
         }
 
         public static ImmutableArray<TResult> SelectManyAsArray<TSource, TResult>(this IEnumerable<TSource>? source, Func<TSource, IEnumerable<TResult>> selector)

--- a/src/EditorFeatures/Core/Editor/GoToAdjacentMemberCommandHandler.cs
+++ b/src/EditorFeatures/Core/Editor/GoToAdjacentMemberCommandHandler.cs
@@ -5,12 +5,12 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
@@ -103,7 +103,8 @@ internal class GoToAdjacentMemberCommandHandler(IOutliningManagerService outlini
     /// </summary>
     internal static int? GetTargetPosition(ISyntaxFactsService service, SyntaxNode root, int caretPosition, bool next)
     {
-        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var members);
+        using var pooledMembers = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+        var members = pooledMembers.Object;
 
         service.AddMethodLevelMembers(root, members);
         if (members.Count == 0)

--- a/src/EditorFeatures/Core/Editor/GoToAdjacentMemberCommandHandler.cs
+++ b/src/EditorFeatures/Core/Editor/GoToAdjacentMemberCommandHandler.cs
@@ -103,10 +103,8 @@ internal class GoToAdjacentMemberCommandHandler(IOutliningManagerService outlini
     /// </summary>
     internal static int? GetTargetPosition(ISyntaxFactsService service, SyntaxNode root, int caretPosition, bool next)
     {
-        using var pooledMembers = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+        using var pooledMembers = service.GetMethodLevelMembers(root);
         var members = pooledMembers.Object;
-
-        service.AddMethodLevelMembers(root, members);
         if (members.Count == 0)
         {
             return null;

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -216,11 +216,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return null;
                 }
 
-                using var pooledMembers = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+                var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+                using var pooledMembers = syntaxFacts.GetMethodLevelMembers(root);
                 var members = pooledMembers.Object;
 
-                var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-                syntaxFacts.AddMethodLevelMembers(root, members);
                 var memberSpans = members.SelectAsArray(member => member.FullSpan);
                 var changedMemberId = members.IndexOf(changedMember);
 

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -215,7 +216,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return null;
                 }
 
-                using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var members);
+                using var pooledMembers = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+                var members = pooledMembers.Object;
 
                 var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
                 syntaxFacts.AddMethodLevelMembers(root, members);

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer_MemberSpans.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer_MemberSpans.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -47,7 +47,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var service = document.GetRequiredLanguageService<ISyntaxFactsService>();
                     var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-                    using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var members);
+                    using var pooledMembers = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+                    var members = pooledMembers.Object;
+
                     service.AddMethodLevelMembers(root, members);
                     return members.SelectAsArray(m => m.FullSpan);
                 }

--- a/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer_MemberSpans.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer_MemberSpans.cs
@@ -47,10 +47,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var service = document.GetRequiredLanguageService<ISyntaxFactsService>();
                     var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-                    using var pooledMembers = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+                    using var pooledMembers = service.GetMethodLevelMembers(root);
                     var members = pooledMembers.Object;
 
-                    service.AddMethodLevelMembers(root, members);
                     return members.SelectAsArray(m => m.FullSpan);
                 }
             }

--- a/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
@@ -3,12 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.SemanticModelReuse;
 
@@ -106,7 +106,9 @@ internal abstract class AbstractSemanticModelReuseLanguageService<
         }
         else
         {
-            using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var currentMembers);
+            using var pooledCurrentMembers = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+            var currentMembers = pooledCurrentMembers.Object;
+
             this.SyntaxFacts.AddMethodLevelMembers(currentRoot, currentMembers);
             var index = currentMembers.IndexOf(currentBodyNode);
             if (index < 0)
@@ -115,7 +117,9 @@ internal abstract class AbstractSemanticModelReuseLanguageService<
                 return null;
             }
 
-            using var _2 = ArrayBuilder<SyntaxNode>.GetInstance(out var previousMembers);
+            using var pooledPreviousMembers = SharedPools.Default<List<SyntaxNode>>().GetPooledObject();
+            var previousMembers = pooledPreviousMembers.Object;
+
             this.SyntaxFacts.AddMethodLevelMembers(previousRoot, previousMembers);
             if (currentMembers.Count != previousMembers.Count)
             {

--- a/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
@@ -116,7 +116,7 @@ internal abstract class AbstractSemanticModelReuseLanguageService<
                 return null;
             }
 
-            var pooledPreviousMembers = this.SyntaxFacts.GetMethodLevelMembers(previousRoot);
+            using var pooledPreviousMembers = this.SyntaxFacts.GetMethodLevelMembers(previousRoot);
             var previousMembers = pooledPreviousMembers.Object;
 
             if (currentMembers.Count != previousMembers.Count)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -896,12 +896,12 @@ internal class CSharpSyntaxFacts : ISyntaxFacts
         }
     }
 
-    public void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> list)
+    public void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, List<SyntaxNode> list)
     {
         AppendMembers(root, list, topLevel: true, methodLevel: true);
     }
 
-    public void AddMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> list)
+    public void AddMethodLevelMembers(SyntaxNode? root, List<SyntaxNode> list)
     {
         AppendMembers(root, list, topLevel: false, methodLevel: true);
     }
@@ -909,7 +909,7 @@ internal class CSharpSyntaxFacts : ISyntaxFacts
     public SyntaxList<SyntaxNode> GetMembersOfTypeDeclaration(SyntaxNode typeDeclaration)
         => ((TypeDeclarationSyntax)typeDeclaration).Members;
 
-    private void AppendMembers(SyntaxNode? node, ArrayBuilder<SyntaxNode> list, bool topLevel, bool methodLevel)
+    private void AppendMembers(SyntaxNode? node, List<SyntaxNode> list, bool topLevel, bool methodLevel)
     {
         Debug.Assert(topLevel || methodLevel);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 #if CODE_STYLE
 using Microsoft.CodeAnalysis.Internal.Editing;
@@ -410,9 +409,9 @@ internal interface ISyntaxFacts
     SyntaxNode? ConvertToSingleLine(SyntaxNode? node, bool useElasticTrivia = false);
 
     // Violation.  This is a feature level API.
-    void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> list);
+    void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, List<SyntaxNode> list);
     // Violation.  This is a feature level API.
-    void AddMethodLevelMembers(SyntaxNode? root, ArrayBuilder<SyntaxNode> list);
+    void AddMethodLevelMembers(SyntaxNode? root, List<SyntaxNode> list);
     SyntaxList<SyntaxNode> GetMembersOfTypeDeclaration(SyntaxNode typeDeclaration);
 
     // Violation.  This is a feature level API.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -409,9 +409,9 @@ internal interface ISyntaxFacts
     SyntaxNode? ConvertToSingleLine(SyntaxNode? node, bool useElasticTrivia = false);
 
     // Violation.  This is a feature level API.
-    void AddTopLevelAndMethodLevelMembers(SyntaxNode? root, List<SyntaxNode> list);
+    PooledObject<List<SyntaxNode>> GetTopLevelAndMethodLevelMembers(SyntaxNode? root);
     // Violation.  This is a feature level API.
-    void AddMethodLevelMembers(SyntaxNode? root, List<SyntaxNode> list);
+    PooledObject<List<SyntaxNode>> GetMethodLevelMembers(SyntaxNode? root);
     SyntaxList<SyntaxNode> GetMembersOfTypeDeclaration(SyntaxNode typeDeclaration);
 
     // Violation.  This is a feature level API.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -916,10 +916,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return pooledList
         End Function
 
-        Private Shared Sub Releaser(pool As ObjectPool(Of List(Of SyntaxNode)), obj As List(Of SyntaxNode))
-            pool.ClearAndFree(obj, pool.TrimOnFree)
-        End Sub
-
         Public Function GetMembersOfTypeDeclaration(typeDeclaration As SyntaxNode) As SyntaxList(Of SyntaxNode) Implements ISyntaxFacts.GetMembersOfTypeDeclaration
             Return DirectCast(typeDeclaration, TypeBlockSyntax).Members
         End Function

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -895,11 +895,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
         End Function
 
-        Public Sub AddTopLevelAndMethodLevelMembers(root As SyntaxNode, list As ArrayBuilder(Of SyntaxNode)) Implements ISyntaxFacts.AddTopLevelAndMethodLevelMembers
+        Public Sub AddTopLevelAndMethodLevelMembers(root As SyntaxNode, list As List(Of SyntaxNode)) Implements ISyntaxFacts.AddTopLevelAndMethodLevelMembers
             AppendMembers(root, list, topLevel:=True, methodLevel:=True)
         End Sub
 
-        Public Sub AddMethodLevelMembers(root As SyntaxNode, list As ArrayBuilder(Of SyntaxNode)) Implements ISyntaxFacts.AddMethodLevelMembers
+        Public Sub AddMethodLevelMembers(root As SyntaxNode, list As List(Of SyntaxNode)) Implements ISyntaxFacts.AddMethodLevelMembers
             AppendMembers(root, list, topLevel:=False, methodLevel:=True)
         End Sub
 
@@ -1047,7 +1047,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             End If
         End Sub
 
-        Private Sub AppendMembers(node As SyntaxNode, list As ArrayBuilder(Of SyntaxNode), topLevel As Boolean, methodLevel As Boolean)
+        Private Sub AppendMembers(node As SyntaxNode, list As List(Of SyntaxNode), topLevel As Boolean, methodLevel As Boolean)
             Debug.Assert(topLevel OrElse methodLevel)
 
             For Each member In node.GetMembers()


### PR DESCRIPTION
A recent change(https://github.com/dotnet/roslyn/pull/74596) modified this code to take in an ArrayBuilder to allow callers to easily use pooled arrays. However, the size of the data populated into those arrays commonly exceeds the ArrayBuilder reuse threshold, those reducing the allocation benefit realized in those codepaths.

This PR changes the callers to instead use a pooled list, thus avoiding the threshold issue. Current scrolling speedometer results for the typing scenario still show this as allocating around 35 MB (which was about 3.5% at the time of the earlier PR, about 4.6% of allocations currently). My hope is that this PR will get rid of nearly all those allocations this time.

*** relevant allocations from the typing scenario in the scrolling speedometer ***
![image](https://github.com/user-attachments/assets/6e4ac551-21fd-491b-8e5b-caf812bd81c4)