### PR TITLE
Fix issue where output path set in construction never updated the project update state

### DIFF
--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/ProjectSystemProjectFactoryTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/ProjectSystemProjectFactoryTests.vb
@@ -1,0 +1,38 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.Workspaces.ProjectSystem
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
+    <[UseExportProvider]>
+    Public Class ProjectSystemProjectFactoryTests
+        <WpfFact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/7402")>
+        Public Async Function ProjectInstantiatedWithCompilationOutputAssemblyFilePathCanBeChanged() As Task
+            Using environment = New TestEnvironment()
+                Dim creationInfo = New VisualStudioProjectCreationInfo()
+                creationInfo.CompilationOutputAssemblyFilePath = "C:\output\project.dll"
+                Dim project1 = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "project1", LanguageNames.CSharp, creationInfo, CancellationToken.None)
+
+                Dim projectInSolution = environment.Workspace.CurrentSolution.GetProject(project1.Id)
+
+                Assert.Equal(creationInfo.CompilationOutputAssemblyFilePath, projectInSolution.CompilationOutputInfo.AssemblyPath)
+
+                ' Change the path and ensure it's updated
+                Dim newOutputPath = "C:\output\new\project.dll"
+                project1.CompilationOutputAssemblyFilePath = newOutputPath
+
+                Dim newProjectInSolution As Project = environment.Workspace.CurrentSolution.GetProject(project1.Id)
+                Assert.Equal(newOutputPath, newProjectInSolution.CompilationOutputInfo.AssemblyPath)
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -149,8 +149,7 @@ internal sealed partial class ProjectSystemProject
         string assemblyName,
         CompilationOptions? compilationOptions,
         string? filePath,
-        ParseOptions? parseOptions,
-        string? compilationOutputAssemblyFilePath)
+        ParseOptions? parseOptions)
     {
         _projectSystemProjectFactory = projectSystemProjectFactory;
         _hostInfo = hostInfo;
@@ -197,7 +196,6 @@ internal sealed partial class ProjectSystemProject
         _compilationOptions = compilationOptions;
         _filePath = filePath;
         _parseOptions = parseOptions;
-        _compilationOutputAssemblyFilePath = compilationOutputAssemblyFilePath;
 
         var watchedDirectories = GetWatchedDirectories(language, filePath);
         _documentFileChangeContext = _projectSystemProjectFactory.FileChangeWatcher.CreateContext(watchedDirectories);

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -102,8 +102,7 @@ internal sealed partial class ProjectSystemProjectFactory
             assemblyName,
             creationInfo.CompilationOptions,
             creationInfo.FilePath,
-            creationInfo.ParseOptions,
-            creationInfo.CompilationOutputAssemblyFilePath);
+            creationInfo.ParseOptions);
 
         var versionStamp = creationInfo.FilePath != null
             ? VersionStamp.Create(File.GetLastWriteTimeUtc(creationInfo.FilePath))
@@ -163,6 +162,10 @@ internal sealed partial class ProjectSystemProjectFactory
                 onBeforeUpdate: null,
                 onAfterUpdate: null);
         }).ConfigureAwait(false);
+
+        // Set this value early after solution is created so it is available to Razor.  This will get updated
+        // when the command line is set, but we want a non-null value to be available as soon as possible.
+        project.CompilationOutputAssemblyFilePath = creationInfo.CompilationOutputAssemblyFilePath;
 
         return project;
     }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -165,6 +165,11 @@ internal sealed partial class ProjectSystemProjectFactory
 
         // Set this value early after solution is created so it is available to Razor.  This will get updated
         // when the command line is set, but we want a non-null value to be available as soon as possible.
+        //
+        // Set the property in a batch; if we set the property directly we'll be taking a synchronous lock here and
+        // potentially block up thread pool threads. Doing this in a batch means the global lock will be acquired asynchronously.
+        var disposableBatchScope = await project.CreateBatchScopeAsync(CancellationToken.None).ConfigureAwait(false);
+        await using var _ = disposableBatchScope.ConfigureAwait(false);
         project.CompilationOutputAssemblyFilePath = creationInfo.CompilationOutputAssemblyFilePath;
 
         return project;


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/7402

https://github.com/dotnet/roslyn/commit/863962d8dd2e0151b1387259eeef0cbf66dfba75 added support to set the backing field for `CompilationOutputAssemblyFilePath` when creating the `ProjectSystemProject`.  This had an issue where the project update state ever observed this value as it did not go through appropriate setter on `CompilationOutputAssemblyFilePath` which is responsible for updating that.

This caused us to later throw exceptions when attempting to remove that path as there was nothing to remove in the project update state.

I updated the code to instead update the path immediately after the `ProjectSystemProject` (and the corresponding solution) was created, which resolves the issue on the test project linked in the issue.