### PR TITLE
Move to basic ref assemblies for net40

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -5,7 +5,7 @@
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview.23468.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.1.3-beta1.24319.1</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.187-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
-    <_BasicReferenceAssembliesVersion>1.7.2</_BasicReferenceAssembliesVersion>
+    <_BasicReferenceAssembliesVersion>1.7.4</_BasicReferenceAssembliesVersion>
     <!-- CodeStyleAnalyzerVersion should we updated together with version of dotnet-format in dotnet-tools.json -->
     <CodeStyleAnalyzerVersion>4.8.0-3.final</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>17.10.191</VisualStudioEditorPackagesVersion>
@@ -183,7 +183,6 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.3" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net20" Version="1.0.3" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
@@ -300,6 +299,7 @@
     <PackageVersion Include="runtime.osx-x64.Microsoft.NETCore.ILAsm" Version="$(ILAsmPackageVersion)" />
     <PackageVersion Include="Basic.CompilerLog.Util" Version="0.6.1" />
     <PackageVersion Include="Basic.Reference.Assemblies.NetStandard20" Version="$(_BasicReferenceAssembliesVersion)" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net40" Version="$(_BasicReferenceAssembliesVersion)" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net50" Version="$(_BasicReferenceAssembliesVersion)" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net60" Version="$(_BasicReferenceAssembliesVersion)" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net70" Version="$(_BasicReferenceAssembliesVersion)" />

--- a/scripts/vscode-build.ps1
+++ b/scripts/vscode-build.ps1
@@ -14,7 +14,7 @@ $projectFileInfo = Get-ProjectFile $fileInfo
 if ($projectFileInfo) {
   $buildTool = InitializeBuildTool
   $frameworkArg = if ($framework -ne "") { " -p:TargetFramework=$framework" } else { "" }
-  $buildArgs = "$($buildTool.Command) -v:m -m -p:RunAnalyzersDuringBuild=false -p:GenerateFullPaths=true$frameworkArg $($projectFileInfo.FullName)"
+  $buildArgs = "$($buildTool.Command) -v:m -tl:off -m -p:RunAnalyzersDuringBuild=false -p:GenerateFullPaths=true$frameworkArg $($projectFileInfo.FullName)"
 
   Exec-Command $buildTool.Path $buildArgs
   exit 0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
@@ -3304,7 +3304,7 @@ class C
 }
 ";
 
-            var comp = CSharpTestBase.CreateEmptyCompilation(source, new[] { Net40.mscorlib }, TestOptions.ReleaseDll); // NOTE: 4.0, not 4.5, so it's missing the async helpers.
+            var comp = CSharpTestBase.CreateEmptyCompilation(source, new[] { Net40.References.mscorlib }, TestOptions.ReleaseDll); // NOTE: 4.0, not 4.5, so it's missing the async helpers.
 
             // CONSIDER: It would be nice if we didn't squiggle the whole method body, but this is a corner case.
             comp.VerifyEmitDiagnostics(
@@ -3334,7 +3334,7 @@ class C
 {
     async Task M() {}
 }";
-            var comp = CSharpTestBase.CreateEmptyCompilation(source, new[] { Net40.mscorlib }, TestOptions.ReleaseDll); // NOTE: 4.0, not 4.5, so it's missing the async helpers.
+            var comp = CSharpTestBase.CreateEmptyCompilation(source, new[] { Net40.References.mscorlib }, TestOptions.ReleaseDll); // NOTE: 4.0, not 4.5, so it's missing the async helpers.
             comp.VerifyEmitDiagnostics(
                 // (4,16): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     async Task M() {}
@@ -3365,7 +3365,7 @@ class C
 {
     async Task<int> F() => 3;
 }";
-            var comp = CSharpTestBase.CreateEmptyCompilation(source, new[] { Net40.mscorlib }, TestOptions.ReleaseDll); // NOTE: 4.0, not 4.5, so it's missing the async helpers.
+            var comp = CSharpTestBase.CreateEmptyCompilation(source, new[] { Net40.References.mscorlib }, TestOptions.ReleaseDll); // NOTE: 4.0, not 4.5, so it's missing the async helpers.
             comp.VerifyEmitDiagnostics(
                 // (4,21): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     async Task<int> F() => 3;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
@@ -3512,7 +3513,7 @@ class Program
 
             var comp = CreateEmptyCompilation(
                 new[] { source, ExpressionTestLibrary },
-                new[] { TestMetadata.Net40.mscorlib, TestMetadata.Net40.SystemCore },
+                new[] { Net40.References.mscorlib, Net40.References.SystemCore },
                 TestOptions.ReleaseExe);
 
             CompileAndVerify(comp, expectedOutput: expectedOutput);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
@@ -1061,7 +1062,7 @@ class C
 ";
 
             // PEVerify: Cannot change initonly field outside its .ctor.
-            var comp = CompileAndVerifyWithMscorlib40(source, references: new[] { TestMetadata.Net40.System, ValueTupleRef, TestMetadata.Net40.SystemCore }, expectedOutput: "00", verify: Verification.FailsPEVerify);
+            var comp = CompileAndVerifyWithMscorlib40(source, references: new[] { Net40.References.System, ValueTupleRef, Net40.References.SystemCore }, expectedOutput: "00", verify: Verification.FailsPEVerify);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("Program.Main", @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -21,6 +21,7 @@ using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 using static Roslyn.Test.Utilities.TestMetadata;
 using static TestResources.NetFX.ValueTuple;
 
@@ -19056,7 +19057,7 @@ class C {
             var tupleComp1 = CreateCompilationWithMscorlib40(trivial2uple + trivial3uple + trivialRemainingTuples);
 
             var tree = Parse(text);
-            var comp = (Compilation)CSharpCompilation.Create("test", syntaxTrees: new[] { tree }, references: new[] { (MetadataReference)Net40.mscorlib, tupleComp1.ToMetadataReference() });
+            var comp = (Compilation)CSharpCompilation.Create("test", syntaxTrees: new[] { tree }, references: new[] { (MetadataReference)Net40.References.mscorlib, tupleComp1.ToMetadataReference() });
 
             var model = comp.GetSemanticModel(tree);
             var exprs = GetBindingNodes<ExpressionSyntax>(comp);
@@ -19095,7 +19096,7 @@ class C {
             var tupleComp1 = CreateCompilationWithMscorlib40(trivial2uple + trivial3uple + trivialRemainingTuples);
 
             var tree = Parse(text);
-            var comp = (Compilation)CSharpCompilation.Create("test", syntaxTrees: new[] { tree }, references: new[] { (MetadataReference)Net40.mscorlib, tupleComp1.ToMetadataReference() });
+            var comp = (Compilation)CSharpCompilation.Create("test", syntaxTrees: new[] { tree }, references: new[] { (MetadataReference)Net40.References.mscorlib, tupleComp1.ToMetadataReference() });
 
             var model = comp.GetSemanticModel(tree);
             var exprs = GetBindingNodes<ExpressionSyntax>(comp);

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitCustomModifiers.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitCustomModifiers.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 using System.Linq;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
 {
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
         [Fact]
         public void Test1()
         {
-            var mscorlibRef = TestMetadata.Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
             string source = @"
 public class A
 {

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Assembly.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -1739,14 +1740,14 @@ class Program
                 public class Test { }
                 ";
 
-            var netModuleRef = GetNetModuleWithAssemblyAttributesRef(mod, new[] { TestMetadata.Net40.SystemCore });
+            var netModuleRef = GetNetModuleWithAssemblyAttributesRef(mod, new[] { Net40.References.SystemCore });
             var appCompilation = CreateCompilationWithMscorlib40(app, references: new[] { netModuleRef }, options: TestOptions.ReleaseDll);
             appCompilation.VerifyDiagnostics(
                 // error CS0012: The type 'ExtensionAttribute' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.
                 Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1)
                 );
 
-            appCompilation = CreateCompilationWithMscorlib40(app, references: new[] { netModuleRef, TestMetadata.Net40.SystemCore }, options: TestOptions.ReleaseDll);
+            appCompilation = CreateCompilationWithMscorlib40(app, references: new[] { netModuleRef, Net40.References.SystemCore }, options: TestOptions.ReleaseDll);
             appCompilation.VerifyEmitDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -21,6 +21,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -6033,7 +6034,7 @@ public static class TestExtension
     public static void ObsoleteExtensionMethod1(this Test t) { }
 }
 ";
-            CreateCompilationWithMscorlib40(source, new[] { TestMetadata.Net40.SystemCore }).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(source, new[] { Net40.References.SystemCore }).VerifyDiagnostics(
                 // (98,10): error CS8423: Attribute 'System.ObsoleteAttribute' is not valid on event accessors. It is only valid on 'class, struct, enum, constructor, method, property, indexer, field, event, interface, delegate' declarations.
                 //         [Obsolete] add {}
                 Diagnostic(ErrorCode.ERR_AttributeNotOnEventAccessor, "Obsolete").WithArguments("System.ObsoleteAttribute", "class, struct, enum, constructor, method, property, indexer, field, event, interface, delegate").WithLocation(98, 10),

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/OutVarTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Basic.Reference.Assemblies;
 using static Roslyn.Test.Utilities.TestMetadata;
 using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
 
@@ -33425,7 +33426,7 @@ public static class S
 {
     public static void M2(this A self, out B x) { x = null; }
 }";
-            var comp = CreateCompilationWithMscorlib40(source, options: TestOptions.DebugDll, references: new[] { Net40.SystemCore });
+            var comp = CreateCompilationWithMscorlib40(source, options: TestOptions.DebugDll, references: new[] { Net40.References.SystemCore });
             comp.VerifyDiagnostics(
                 // (7,18): error CS1503: Argument 2: cannot convert from 'out A' to 'out B'
                 //         a.M2(out A x);

--- a/src/Compilers/CSharp/Test/Emit3/RefStructInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/RefStructInterfacesTests.cs
@@ -21704,14 +21704,7 @@ ref struct S
 ";
             var comp = CreateCompilation(sourceA, targetFramework: s_targetFrameworkSupportingByRefLikeGenerics);
 
-            comp.VerifyDiagnostics(
-                // (7,30): error CS9244: The type 'T' may not be a ref struct or a type parameter allowing ref structs in order to use it as parameter 'T' in the generic type or method 'Activator.CreateInstance<T>()'
-                //         _ = System.Activator.CreateInstance<T>();
-                Diagnostic(ErrorCode.ERR_NotRefStructConstraintNotSatisfied, "CreateInstance<T>").WithArguments("System.Activator.CreateInstance<T>()", "T", "T").WithLocation(7, 30),
-                // (12,30): error CS9244: The type 'S' may not be a ref struct or a type parameter allowing ref structs in order to use it as parameter 'T' in the generic type or method 'Activator.CreateInstance<T>()'
-                //         _ = System.Activator.CreateInstance<S>();
-                Diagnostic(ErrorCode.ERR_NotRefStructConstraintNotSatisfied, "CreateInstance<S>").WithArguments("System.Activator.CreateInstance<T>()", "T", "S").WithLocation(12, 30)
-                );
+            comp.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
@@ -2830,7 +2831,7 @@ class Repro
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib461(source, new[] { TestMetadata.Net40.SystemCore, TestMetadata.Net40.MicrosoftCSharp }, TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithMscorlib461(source, new[] { Net40.References.SystemCore, Net40.References.MicrosoftCSharp }, TestOptions.ReleaseExe);
             comp.VerifyDiagnostics(
                 // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
                 Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
@@ -2871,7 +2872,7 @@ public static class LazyToStringExtension
             .Select(x => x.GetValue(obj))
     }
 }";
-            var compilation = CreateCompilationWithMscorlib40(sourceText, new[] { TestMetadata.Net40.SystemCore }, options: TestOptions.DebugDll);
+            var compilation = CreateCompilationWithMscorlib40(sourceText, new[] { Net40.References.SystemCore }, options: TestOptions.DebugDll);
             compilation.VerifyDiagnostics(
                 // (12,42): error CS1002: ; expected
                 //             .Select(x => x.GetValue(obj))
@@ -3022,7 +3023,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib40(source, new[] { TestMetadata.Net40.SystemCore });
+            var comp = CreateCompilationWithMscorlib40(source, new[] { Net40.References.SystemCore });
 
             comp.VerifyDiagnostics(
     // (41,38): error CS7036: There is no argument given that corresponds to the required parameter 'authenticationScheme' of 'AuthenticationManager.AuthenticateAsync(string)'
@@ -3102,7 +3103,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib40(source, new[] { TestMetadata.Net40.SystemCore });
+            var comp = CreateCompilationWithMscorlib40(source, new[] { Net40.References.SystemCore });
 
             comp.VerifyDiagnostics(
     // (41,38): error CS7036: There is no argument given that corresponds to the required parameter 'authenticationScheme' of 'AuthenticationManager.AuthenticateAsync(string)'
@@ -3260,7 +3261,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib40(source, new[] { TestMetadata.Net40.SystemCore });
+            var comp = CreateCompilationWithMscorlib40(source, new[] { Net40.References.SystemCore });
 
             comp.VerifyDiagnostics(
     // (41,38): error CS7036: There is no argument given that corresponds to the required parameter 'authenticationScheme' of 'AuthenticationManager.AuthenticateAsync(string)'

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -1835,7 +1836,7 @@ public class Example
         {
             var tree = Parse(text);
 
-            var comp = CreateCompilationWithMscorlib40(new[] { tree }, new[] { TestMetadata.Net40.SystemCore });
+            var comp = CreateCompilationWithMscorlib40(new[] { tree }, new[] { Net40.References.SystemCore });
             comp.VerifyDiagnostics(expectedDiagnostics);
 
             var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MethodTypeInferenceTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MethodTypeInferenceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -968,7 +969,7 @@ class Program
 }
 
 ";
-            CreateCompilationWithMscorlib40(source, references: new[] { TestMetadata.Net40.SystemCore }).VerifyDiagnostics();
+            CreateCompilationWithMscorlib40(source, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics();
         }
 
         [WorkItem(543691, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543691")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
@@ -157,10 +158,10 @@ public class C
         c.M(a: 1, 2);
     }
 }";
-            var verifier = CompileAndVerifyWithMscorlib40(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2, references: new[] { TestMetadata.Net40.SystemCore });
+            var verifier = CompileAndVerifyWithMscorlib40(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2, references: new[] { Net40.References.SystemCore });
             verifier.VerifyDiagnostics();
 
-            var comp = CreateCompilationWithMscorlib40(source, parseOptions: TestOptions.Regular7_1, references: new[] { TestMetadata.Net40.SystemCore });
+            var comp = CreateCompilationWithMscorlib40(source, parseOptions: TestOptions.Regular7_1, references: new[] { Net40.References.SystemCore });
             comp.VerifyDiagnostics(
                 // (14,19): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         c.M(a: 1, 2);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -8192,7 +8193,7 @@ namespace ConsoleApplication2
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib40(source1, new[] { TestMetadata.Net40.SystemCore }, options: TestOptions.DebugExe);
+            var compilation = CreateCompilationWithMscorlib40(source1, new[] { Net40.References.SystemCore }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics();
         }
 
@@ -8228,7 +8229,7 @@ namespace ConsoleApplication2
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib40(source1, new[] { TestMetadata.Net40.SystemCore }, options: TestOptions.DebugExe);
+            var compilation = CreateCompilationWithMscorlib40(source1, new[] { Net40.References.SystemCore }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics();
         }
 
@@ -11497,7 +11498,7 @@ public static class Extensions
 }
 ";
 
-            var libComp = CreateCompilationWithMscorlib40(librarySrc, references: new[] { TestMetadata.Net40.SystemCore }).VerifyDiagnostics();
+            var libComp = CreateCompilationWithMscorlib40(librarySrc, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics();
 
             var code = @"
  class D

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 using static Roslyn.Test.Utilities.TestMetadata;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -9936,7 +9937,7 @@ struct S
             // Note that none of these errors except the first one are reported by the native compiler, because
             // it does not report additional errors after an error is found in a parameter of a method.
 
-            CreateCompilationWithMscorlib40(text, references: new[] { Net40.SystemCore }).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(text, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics(
                 // (9,36): error CS0310: 'U' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'D<T>'
                 //     internal static void E<U>(D<U> d) { } // Error: missing constraint on E<U> to satisfy constraint on D<U>
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "d").WithArguments("D<T>", "T", "U").WithLocation(9, 36),
@@ -10046,7 +10047,7 @@ static class S
 {
     internal static void E<T>(this T t) where T : new() { }
 }";
-            CreateCompilationWithMscorlib40(text, references: new[] { Net40.SystemCore }).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(text, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics(
                 // (15,9): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'V' in the generic type or method 'C<T, U>.M<V>(V)'
                 //         M(b);
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M").WithArguments("C<T, U>.M<V>(V)", "V", "B").WithLocation(15, 9),
@@ -13740,7 +13741,7 @@ static class SC
     static void M4(this S s) { }
     static void M5(this double d) { }
 }";
-            CreateCompilationWithMscorlib40(source, references: new[] { Net40.SystemCore }).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(source, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics(
                 // (24,29): error CS1113: Extension methods 'SC.M3(E)' defined on value type 'E' cannot be used to create delegates
                 Diagnostic(ErrorCode.ERR_ValueTypeExtDelegate, "e.M3").WithArguments("SC.M3(E)", "E").WithLocation(24, 29),
                 // (26,29): error CS1113: Extension methods 'SC.M4(S)' defined on value type 'S' cannot be used to create delegates
@@ -13786,7 +13787,7 @@ static class E
     internal static void M1<T>(this T t) { }
     internal static void M2<T, U>(this T t) { }
 }";
-            CreateCompilationWithMscorlib40(source, references: new[] { Net40.SystemCore }).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(source, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics(
                 // (13,13): error CS1113: Extension methods 'E.M1<int>(int)' defined on value type 'int' cannot be used to create delegates
                 Diagnostic(ErrorCode.ERR_ValueTypeExtDelegate, "i.M1").WithArguments("E.M1<int>(int)", "int").WithLocation(13, 13),
                 // (14,13): error CS1113: Extension methods 'E.M2<int, object>(int)' defined on value type 'int' cannot be used to create delegates
@@ -13847,7 +13848,7 @@ static class E
     internal static void M1<T>(this T t) { }
     internal static void M2<T, U>(this T t) { }
 }";
-            CreateCompilation(source, references: new[] { Net40.SystemCore }).VerifyDiagnostics(
+            CreateCompilation(source, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics(
                 // (12,11): error CS1113: Extension methods 'E.M1<int>(int)' defined on value type 'int' cannot be used to create delegates
                 Diagnostic(ErrorCode.ERR_ValueTypeExtDelegate, "i.M1").WithArguments("E.M1<int>(int)", "int").WithLocation(12, 11),
                 // (13,11): error CS1113: Extension methods 'E.M2<int, object>(int)' defined on value type 'int' cannot be used to create delegates
@@ -16974,7 +16975,7 @@ static class S
 {
     internal static void F(this double d) { }
 }";
-            var compilation = CreateCompilationWithMscorlib40(text, references: new[] { Net40.SystemCore });
+            var compilation = CreateCompilationWithMscorlib40(text, references: new[] { Net40.References.SystemCore });
             // Previously ERR_BadExtensionArgTypes.
             compilation.VerifyDiagnostics(
                 // (5,9): error CS1929: 'float' does not contain a definition for 'F' and the best extension method overload 'S.F(double)' requires a receiver of type 'double'
@@ -16997,7 +16998,7 @@ static class S
 {
     internal static void E(this B b) { }
 }";
-            var compilation = CreateCompilationWithMscorlib40(source, references: new[] { Net40.SystemCore });
+            var compilation = CreateCompilationWithMscorlib40(source, references: new[] { Net40.References.SystemCore });
             compilation.VerifyDiagnostics(
                 // (6,9): error CS1929: 'A' does not contain a definition for 'E' and the best extension method overload 'S.E(B)' requires a receiver of type 'B'
                 //         a.E();
@@ -22579,7 +22580,7 @@ static class C
     }
     static void E(this object o) { }
 }";
-            CreateCompilationWithMscorlib40(source, references: new[] { Net40.SystemCore }, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(source, references: new[] { Net40.References.SystemCore }, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics(
                 // (20,9): warning CS1720: Expression will always cause a System.NullReferenceException because the default value of 'object' is null
                 //         default(object).GetHashCode();
                 Diagnostic(ErrorCode.WRN_DotOnDefault, "default(object).GetHashCode").WithArguments("object").WithLocation(20, 9),
@@ -22592,7 +22593,7 @@ static class C
                 // (28,9): warning CS1720: Expression will always cause a System.NullReferenceException because the default value of 'T6' is null
                 //         default(T6).P = null;
                 Diagnostic(ErrorCode.WRN_DotOnDefault, "default(T6).P").WithArguments("T6").WithLocation(28, 9));
-            CreateCompilationWithMscorlib40(source, references: new[] { Net40.SystemCore }, options: TestOptions.ReleaseDll.WithNullableContextOptions(NullableContextOptions.Disable)).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(source, references: new[] { Net40.References.SystemCore }, options: TestOptions.ReleaseDll.WithNullableContextOptions(NullableContextOptions.Disable)).VerifyDiagnostics(
                 );
         }
 
@@ -22686,13 +22687,13 @@ class C
     }
 }
 ";
-            CompileAndVerifyWithMscorlib40(source, expectedOutput: "True", references: new[] { Net40.SystemCore }, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics(
+            CompileAndVerifyWithMscorlib40(source, expectedOutput: "True", references: new[] { Net40.References.SystemCore }, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics(
                 // Do not report the following warning:
                 // (5,34): warning CS1720: Expression will always cause a System.NullReferenceException because the default value of 'string' is null
                 //         System.Console.WriteLine(default(string).IsNull());
                 // Diagnostic(ErrorCode.WRN_DotOnDefault, "default(string).IsNull").WithArguments("string").WithLocation(5, 34)
                 );
-            CompileAndVerifyWithMscorlib40(source, expectedOutput: "True", references: new[] { Net40.SystemCore }).VerifyDiagnostics();
+            CompileAndVerifyWithMscorlib40(source, expectedOutput: "True", references: new[] { Net40.References.SystemCore }).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
@@ -370,7 +371,7 @@ class Test
         [Fact]
         public void RetargetedSynthesizedStructConstructor()
         {
-            var oldMsCorLib = TestMetadata.Net40.mscorlib;
+            var oldMsCorLib = Net40.References.mscorlib;
 
             var c1 = CSharpCompilation.Create("C1",
                 new[] { Parse(@"public struct S { }") },

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -3123,7 +3123,7 @@ class C1 {
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
                 {
                     TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 });
 
             var globalNamespace = assemblies[0].GlobalNamespace;
@@ -3252,7 +3252,7 @@ class C1 {
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var globalNamespace = assemblies[0].GlobalNamespace;
@@ -3313,7 +3313,7 @@ class C1 {
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var globalNamespace = assemblies[0].GlobalNamespace;
@@ -3374,7 +3374,7 @@ class C1 {
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var globalNamespace = assemblies[0].GlobalNamespace;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
         [Fact]
         public void Test1()
         {
-            var mscorlibRef = TestMetadata.Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
             var compilation = CSharpCompilation.Create("Test", references: new MetadataReference[] { mscorlibRef });
             var sys = compilation.GlobalNamespace.ChildNamespace("System");
             Conversions c = new BuckStopsHereBinder(compilation, associatedFileIdentifier: null).Conversions;
@@ -221,7 +222,7 @@ class X {
     O<dynamic> f10;
 }
 ";
-            var mscorlibRef = TestMetadata.Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
             var compilation = CSharpCompilation.Create("Test", new[] { Parse(code) }, new[] { mscorlibRef });
             var global = compilation.GlobalNamespace;
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/Choosing.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/Choosing.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
 {
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CorLibrary.GuidTest2.exe,
-                TestMetadata.Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             Assert.Same(assemblies[1], assemblies[0].Modules[0].CorLibrary());

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -15,8 +15,8 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 using Utils = Microsoft.CodeAnalysis.CSharp.UnitTests.CompilationUtils;
-using static Roslyn.Test.Utilities.TestMetadata;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
@@ -1005,7 +1005,7 @@ static class S3
 {
     internal static object F3(this N.C x, object y) { return null; }
 }";
-            CreateCompilationWithMscorlib40(source, references: new[] { Net40.SystemCore },
+            CreateCompilationWithMscorlib40(source, references: new[] { Net40.References.SystemCore },
                     parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (10,16): error CS0407: 'void S2.F1(object, object)' has the wrong return type
                 //             M1(c.F1); // wrong return type
@@ -1028,7 +1028,7 @@ static class S3
             // diagnostic (the caller has to grub through the diagnostic bag to see that there is no error there) and then the caller
             // has to produce a generic error message, which we see below. It does not appear that all callers have that test, though,
             // suggesting there may be a latent bug of missing diagnostics.
-            CreateCompilationWithMscorlib40(source, references: new[] { Net40.SystemCore }).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(source, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics(
                 // (10,16): error CS1503: Argument 1: cannot convert from 'method group' to 'Func<object, object>'
                 //             M1(c.F1); // wrong return type
                 Diagnostic(ErrorCode.ERR_BadArgType, "c.F1").WithArguments("1", "method group", "System.Func<object, object>").WithLocation(10, 16),
@@ -2202,7 +2202,7 @@ internal static class C
     private static void Main(string[] args) { }
 }
 ";
-            var compilation = CreateEmptyCompilation(source, new[] { Net40.mscorlib });
+            var compilation = CreateEmptyCompilation(source, new[] { Net40.References.mscorlib });
             compilation.VerifyDiagnostics(
                 // (4,29): error CS1110: Cannot define a new extension method because the compiler required type 'System.Runtime.CompilerServices.ExtensionAttribute' cannot be found. Are you missing a reference to System.Core.dll?
                 Diagnostic(ErrorCode.ERR_ExtensionAttrNotFound, "this").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(4, 29));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 using Utils = Microsoft.CodeAnalysis.CSharp.UnitTests.CompilationUtils;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
@@ -1095,12 +1096,12 @@ static class C
     static void F(this object o) { }
     static void F<T>(this T t) where T : struct { }
 }";
-            CreateCompilationWithMscorlib40(text, references: new[] { TestMetadata.Net40.SystemCore }, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40(text, references: new[] { Net40.References.SystemCore }, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (7,9): error CS0310: 'I' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C.E<T>(T)'
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "i.E").WithArguments("C.E<T>(T)", "T", "I").WithLocation(7, 9),
                 // (9,9): error CS0453: The type 'I' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.F<T>(T)'
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "i.F").WithArguments("C.F<T>(T)", "T", "I").WithLocation(9, 9));
-            CreateCompilationWithMscorlib40(text, references: new[] { TestMetadata.Net40.SystemCore }).VerifyDiagnostics();
+            CreateCompilationWithMscorlib40(text, references: new[] { Net40.References.SystemCore }).VerifyDiagnostics();
         }
 
         [ClrOnlyFact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
@@ -2829,7 +2830,7 @@ class Test
 ";
             #endregion
 
-            var comp1 = CreateEmptyCompilation(src1, new[] { TestMetadata.Net40.mscorlib });
+            var comp1 = CreateEmptyCompilation(src1, new[] { Net40.References.mscorlib });
             var comp2 = CreateCompilation(src2, new[] { new CSharpCompilationReference(comp1) });
 
             var typeSymbol = comp1.SourceModule.GlobalNamespace.GetMember<NamedTypeSymbol>("IGoo");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataTypeTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -275,11 +276,11 @@ namespace System.Diagnostics.Eventing
 }
 ";
 
-            var compilation1 = CreateEmptyCompilation(source1, new[] { TestMetadata.Net40.mscorlib, TestMetadata.Net40.SystemCore });
+            var compilation1 = CreateEmptyCompilation(source1, new[] { Net40.References.mscorlib, Net40.References.SystemCore });
             compilation1.VerifyDiagnostics();
 
             var source2 = "public class A {}";
-            var compilation2 = CreateEmptyCompilation(source2, new MetadataReference[] { TestMetadata.Net40.mscorlib, TestMetadata.Net40.SystemCore, compilation1.EmitToImageReference() },
+            var compilation2 = CreateEmptyCompilation(source2, new MetadataReference[] { Net40.References.mscorlib, Net40.References.SystemCore, compilation1.EmitToImageReference() },
                 options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.Internal));
 
             var compilation1Lib = compilation2.ExternalReferences[2];

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/BaseTypeResolution.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/BaseTypeResolution.cs
@@ -15,7 +15,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using CSReferenceManager = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.ReferenceManager;
 using System.Reflection.Metadata;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 {
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test1()
         {
-            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.mscorlib);
+            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.References.mscorlib);
 
             TestBaseTypeResolutionHelper1(assembly);
 
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.MDTestLib1,
                 TestReferences.SymbolsTests.MDTestLib2,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             TestBaseTypeResolutionHelper2(assemblies);
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test3()
         {
-            var mscorlibRef = Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
 
             var c1 = CSharpCompilation.Create("Test", references: new MetadataReference[] { mscorlibRef });
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadCustomModifiers.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadCustomModifiers.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 {
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var modifiersModule = assemblies[0].Modules[0];
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var globalNamespace = assemblies[0].GlobalNamespace;
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var globalNamespace = assemblies[0].GlobalNamespace;
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var globalNamespace = assemblies[0].GlobalNamespace;
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var globalNamespace = assemblies[0].GlobalNamespace;
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var globalNamespace = assemblies[0].GlobalNamespace;
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
                 {
                     TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll,
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 });
 
             var globalNamespace = assemblies[0].GlobalNamespace;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var assembly0 = assemblies[0];
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var assembly1 = assemblies[1];
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             //<AString("C1")>
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var aBoolClass = assemblies[1].Modules[0].GlobalNamespace.GetMember("ABooleanAttribute") as NamedTypeSymbol;
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var aBoolClass = assemblies[1].Modules[0].GlobalNamespace.GetMember("ABooleanAttribute") as NamedTypeSymbol;
@@ -354,7 +354,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             //<AString("C1")>
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             //Public Class C2(Of T1)
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.Metadata.MDTestAttributeDefLib ,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var assemblyArgs = new AttributeArgs[] {
@@ -580,7 +580,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.Metadata.AttributeInterop01,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             //[assembly: ImportedFromTypeLib("InteropAttributes")]
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.Metadata.AttributeInterop01,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             //[ComImport, Guid("ABCDEF5D-2448-447A-B786-64682CBEF123")]
@@ -726,7 +726,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.Metadata.AttributeInterop01,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             // [Serializable, ComVisible(false)]
@@ -767,7 +767,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.Metadata.AttributeInterop02,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             // [Guid("31230DD5-2448-447A-B786-64682CBEFEEE"), Flags]
@@ -805,7 +805,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
             {
                 TestReferences.SymbolsTests.Metadata.AttributeInterop01,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             //[ComImport, TypeLibType(TypeLibTypeFlags.FAggregatable)]
@@ -905,7 +905,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.AttributeTestLib01,
                 TestReferences.SymbolsTests.Metadata.AttributeTestDef01,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var caNS = (NamespaceSymbol)assemblies[1].GlobalNamespace.GetMember("CustomAttribute");
@@ -940,7 +940,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Metadata.AttributeTestLib01 ,
                 TestReferences.SymbolsTests.Metadata.AttributeTestDef01 ,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var caNS = (NamespaceSymbol)assemblies[1].GlobalNamespace.GetMember("CustomAttribute");
@@ -1042,7 +1042,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(mrefs: new[]{
                 TestReferences.SymbolsTests.Metadata.AttributeTestLib01,
                 TestReferences.SymbolsTests.Metadata.AttributeTestDef01,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var caNS = (NamespaceSymbol)assemblies[1].GlobalNamespace.GetMember("CustomAttribute");
@@ -1172,7 +1172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(mrefs: new[] {
                 NetFramework.SystemCore,
                 NetFramework.System,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var sysNS = (NamespaceSymbol)assemblies[2].GlobalNamespace.GetMember("System");
@@ -1194,7 +1194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assemblies = MetadataTestHelpers.GetSymbolsForReferences(mrefs: new[]{
                 NetFramework.SystemCore,
                 NetFramework.System,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var corsysNS = assemblies[2].GlobalNamespace.GetMembers("System").Single() as NamespaceSymbol;
@@ -1255,7 +1255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                 NetFramework.SystemData,
                 NetFramework.SystemCore,
                 NetFramework.System,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             var sysNS = (NamespaceSymbol)assemblies[0].GlobalNamespace.GetMember("System");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingFields.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingFields.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 {
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 TestReferences.SymbolsTests.Fields.CSFields.dll,
                 TestReferences.SymbolsTests.Fields.VBFields.dll,
-                TestMetadata.Net40.mscorlib
+                Net40.References.mscorlib
             },
             options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.Internal));
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingGenericTypeParameters.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingGenericTypeParameters.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 {
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test1()
         {
-            var assembly = MetadataTestHelpers.GetSymbolForReference(TestMetadata.Net40.mscorlib);
+            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.References.mscorlib);
             var module0 = assembly.Modules[0];
 
             var objectType = module0.GlobalNamespace.GetMembers("System").

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 using System.Reflection;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 //test
 
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                 TestReferences.SymbolsTests.MDTestLib2,
                 TestReferences.SymbolsTests.Methods.CSMethods,
                 TestReferences.SymbolsTests.Methods.VBMethods,
-                Net40.mscorlib,
+                Net40.References.mscorlib,
                 TestReferences.SymbolsTests.Methods.ByRefReturn
             },
             options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.Internal));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingNamespacesAndTypes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingNamespacesAndTypes.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 {
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test1()
         {
-            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.mscorlib);
+            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.References.mscorlib);
             XElement dumpXML = LoadChildNamespace1(assembly.Modules[0].GlobalNamespace);
 
             var baseLine = XElement.Load(new MemoryStream(TestResources.SymbolsTests.Metadata.MscorlibNamespacesAndTypes));
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test2()
         {
-            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.mscorlib);
+            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.References.mscorlib);
             XElement dumpXML = LoadChildNamespace2(assembly.Modules[0].GlobalNamespace);
 
             var baseLine = XElement.Load(new MemoryStream(TestResources.SymbolsTests.Metadata.MscorlibNamespacesAndTypes));
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test3()
         {
-            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.mscorlib);
+            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.References.mscorlib);
             var module0 = assembly.Modules[0];
             var globalNS = module0.GlobalNamespace;
 
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test4()
         {
-            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.mscorlib);
+            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.References.mscorlib);
             TestGetMembersOfName(assembly.Modules[0]);
 
             var assembly2 = MetadataTestHelpers.GetSymbolForReference(TestReferences.SymbolsTests.DifferByCase.TypeAndNamespaceDifferByCase);
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var compilation = CSharpCompilation.Create("C1", references:
                 new[]
                 {
-                    Net40.mscorlib,
+                    Net40.References.mscorlib,
                     TestReferences.SymbolsTests.WithSpaces
                 });
 
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var compilation = CSharpCompilation.Create("C1", references:
                 new[]
                 {
-                    Net40.mscorlib,
+                    Net40.References.mscorlib,
                     TestReferences.SymbolsTests.WithSpacesModule
                 });
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/MissingTypeReferences.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/MissingTypeReferences.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 //test
 
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                     {
                                         TestReferences.SymbolsTests.MissingTypes.MDMissingType,
                                         TestReferences.SymbolsTests.MissingTypes.MDMissingTypeLib,
-                                        TestMetadata.Net40.mscorlib
+                                        Net40.References.mscorlib
                                     });
 
             TestMissingTypeReferencesHelper2(assemblies);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPia.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 using static Roslyn.Test.Utilities.TestMetadata;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
@@ -49,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                         TestReferences.SymbolsTests.NoPia.LocalTypes1,
                                         TestReferences.SymbolsTests.NoPia.LocalTypes2,
                                         TestReferences.SymbolsTests.NoPia.Pia1,
-                                        Net40.mscorlib,
+                                        Net40.References.mscorlib,
                                         TestReferences.SymbolsTests.MDTestLib1
                                     });
 
@@ -92,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                         TestReferences.SymbolsTests.NoPia.LocalTypes1,
                                         TestReferences.SymbolsTests.NoPia.LocalTypes2,
                                         TestReferences.SymbolsTests.NoPia.Pia1,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     });
 
             var localTypes1_2 = assemblies2[0];
@@ -169,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                         TestReferences.SymbolsTests.NoPia.LocalTypes1,
                                         TestReferences.SymbolsTests.NoPia.LocalTypes2,
                                         TestReferences.SymbolsTests.NoPia.Pia1,
-                                        Net40.mscorlib,
+                                        Net40.References.mscorlib,
                                         TestReferences.SymbolsTests.MDTestLib1
                                     });
 
@@ -183,7 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                         TestReferences.SymbolsTests.NoPia.LocalTypes1,
                                         TestReferences.SymbolsTests.NoPia.LocalTypes2,
                                         TestReferences.SymbolsTests.NoPia.Pia2,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     });
 
             var localTypes1_5 = assemblies5[0];
@@ -220,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                         TestReferences.SymbolsTests.NoPia.LocalTypes1,
                                         TestReferences.SymbolsTests.NoPia.LocalTypes2,
                                         TestReferences.SymbolsTests.NoPia.Pia3,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     });
 
             var localTypes1_6 = assemblies6[0];
@@ -251,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                         TestReferences.SymbolsTests.NoPia.LocalTypes1,
                                         TestReferences.SymbolsTests.NoPia.LocalTypes2,
                                         TestReferences.SymbolsTests.NoPia.Pia4,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     });
 
             var localTypes1_7 = assemblies7[0];
@@ -283,7 +284,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                         TestReferences.SymbolsTests.NoPia.LocalTypes2,
                                         TestReferences.SymbolsTests.NoPia.Pia4,
                                         TestReferences.SymbolsTests.NoPia.Pia1,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     });
 
             var localTypes1_8 = assemblies8[0];
@@ -316,7 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                       TestReferences.SymbolsTests.NoPia.Library1,
                                       TestReferences.SymbolsTests.NoPia.LocalTypes1,
                                       TestReferences.SymbolsTests.NoPia.Pia4,
-                                      Net40.mscorlib
+                                      Net40.References.mscorlib
                                   });
 
             var library1_9 = assemblies9[0];
@@ -327,7 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                        TestReferences.SymbolsTests.NoPia.Library1,
                                        TestReferences.SymbolsTests.NoPia.LocalTypes1,
                                        TestReferences.SymbolsTests.NoPia.Pia4,
-                                       Net40.mscorlib,
+                                       Net40.References.mscorlib,
                                        TestReferences.SymbolsTests.MDTestLib1
                                    });
 
@@ -362,7 +363,7 @@ public class LocalTypes2
     { }
 }
 ";
-            var mscorlibRef = Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
             var pia1CopyLink = TestReferences.SymbolsTests.NoPia.Pia1Copy.WithEmbedInteropTypes(true);
             var pia1CopyRef = TestReferences.SymbolsTests.NoPia.Pia1Copy.WithEmbedInteropTypes(false);
 
@@ -378,7 +379,7 @@ public class LocalTypes2
             var assemblies1 = MetadataTestHelpers.GetSymbolsForReferences(new[]
                     {
                         TestReferences.SymbolsTests.NoPia.Pia1,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         TestReferences.SymbolsTests.MDTestLib1,
                         TestReferences.SymbolsTests.MDTestLib2
                     },
@@ -431,7 +432,7 @@ public class LocalTypes2
             var assemblies2 = MetadataTestHelpers.GetSymbolsForReferences(new[]
                                     {
                                         TestReferences.SymbolsTests.NoPia.Pia1,
-                                        Net40.mscorlib,
+                                        Net40.References.mscorlib,
                                         TestReferences.SymbolsTests.MDTestLib1
                                     },
                                 new CSharpCompilation[] { localTypes1, localTypes2 });
@@ -462,7 +463,7 @@ public class LocalTypes2
             var assemblies3 = MetadataTestHelpers.GetSymbolsForReferences(new[]
                                     {
                                         TestReferences.SymbolsTests.NoPia.Pia1,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     },
                                 new CSharpCompilation[] { localTypes1, localTypes2 });
 
@@ -494,7 +495,7 @@ public class LocalTypes2
             var assemblies4 = MetadataTestHelpers.GetSymbolsForReferences(new[]
                                     {
                                         TestReferences.SymbolsTests.NoPia.Pia1,
-                                        Net40.mscorlib,
+                                        Net40.References.mscorlib,
                                         TestReferences.SymbolsTests.MDTestLib1,
                                         TestReferences.SymbolsTests.MDTestLib2
                                     },
@@ -508,7 +509,7 @@ public class LocalTypes2
             var assemblies5 = MetadataTestHelpers.GetSymbolsForReferences(new[]
                                     {
                                         TestReferences.SymbolsTests.NoPia.Pia2,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     },
                                 new CSharpCompilation[] { localTypes1, localTypes2 });
 
@@ -553,7 +554,7 @@ public class LocalTypes2
             var assemblies6 = MetadataTestHelpers.GetSymbolsForReferences(new[]
                                     {
                                         TestReferences.SymbolsTests.NoPia.Pia3,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     },
                                 new CSharpCompilation[] { localTypes1, localTypes2 });
 
@@ -583,7 +584,7 @@ public class LocalTypes2
             var assemblies7 = MetadataTestHelpers.GetSymbolsForReferences(new[]
                                     {
                                         TestReferences.SymbolsTests.NoPia.Pia4,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     },
                                 new CSharpCompilation[] { localTypes1, localTypes2 });
 
@@ -618,7 +619,7 @@ public class LocalTypes2
                                     {
                                         TestReferences.SymbolsTests.NoPia.Pia4,
                                         TestReferences.SymbolsTests.NoPia.Pia1,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     },
                                 new CSharpCompilation[] { localTypes1, localTypes2 });
 
@@ -650,7 +651,7 @@ public class LocalTypes2
                                 {
                     TestReferences.SymbolsTests.NoPia.Library1,
                     TestReferences.SymbolsTests.NoPia.Pia4,
-                    Net40.mscorlib,
+                    Net40.References.mscorlib,
                     new CSharpCompilationReference(localTypes1)
             });
 
@@ -662,7 +663,7 @@ public class LocalTypes2
             var assemblies10 = MetadataTestHelpers.GetSymbolsForReferences(
                 TestReferences.SymbolsTests.NoPia.Library1,
                 TestReferences.SymbolsTests.NoPia.Pia4,
-                Net40.mscorlib,
+                Net40.References.mscorlib,
                 TestReferences.SymbolsTests.MDTestLib1,
                 new CSharpCompilationReference(localTypes1));
 
@@ -728,7 +729,7 @@ public class LocalTypes2
                                 {
                 TestReferences.SymbolsTests.NoPia.LocalTypes3,
                 TestReferences.SymbolsTests.NoPia.Pia1,
-                Net40.mscorlib
+                Net40.References.mscorlib
             });
 
             localTypes3 = assemblies[0].GlobalNamespace.GetTypeMembers("LocalTypes3").Single();
@@ -744,7 +745,7 @@ public class LocalTypes2
         [ConditionalFact(typeof(DesktopOnly))]
         public void GenericsClosedOverLocalTypes2()
         {
-            var mscorlibRef = Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
             var pia5Link = TestReferences.SymbolsTests.NoPia.Pia5.WithEmbedInteropTypes(true);
             var pia5Ref = TestReferences.SymbolsTests.NoPia.Pia5.WithEmbedInteropTypes(false);
             var library2Ref = TestReferences.SymbolsTests.NoPia.Library2.WithEmbedInteropTypes(false);
@@ -869,7 +870,7 @@ public class LocalTypes2
         [Fact]
         public void GenericsClosedOverLocalTypes3()
         {
-            var varmscorlibRef = Net40.mscorlib;
+            var varmscorlibRef = Net40.References.mscorlib;
             var varALink = TestReferences.SymbolsTests.NoPia.A.WithEmbedInteropTypes(true);
             var varARef = TestReferences.SymbolsTests.NoPia.A.WithEmbedInteropTypes(false);
             var varBLink = TestReferences.SymbolsTests.NoPia.B.WithEmbedInteropTypes(true);
@@ -1001,7 +1002,7 @@ public class C33
 {}
 ";
 
-            var mscorlibRef = Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
             var pia1CopyLink = TestReferences.SymbolsTests.NoPia.Pia1Copy.WithEmbedInteropTypes(true);
             var pia1CopyRef = TestReferences.SymbolsTests.NoPia.Pia1Copy.WithEmbedInteropTypes(false);
 
@@ -1028,7 +1029,7 @@ public class C33
             assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[]
                                 {
                                     TestReferences.SymbolsTests.NoPia.Pia1,
-                                    Net40.mscorlib
+                                    Net40.References.mscorlib
                                 },
                                 new CSharpCompilation[] { varC_LocalTypes3 });
 
@@ -1100,7 +1101,7 @@ public interface I7
 }
 ";
 
-            var mscorlibRef = Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
 
             // vbc /t:library /vbruntime- Pia5.vb
             var varC_Pia5 = CSharpCompilation.Create("Pia5", new[] { Parse(pia5Source) }, new[] { mscorlibRef });
@@ -1262,7 +1263,7 @@ public interface I7
         [Fact]
         public void GenericsClosedOverLocalTypes6()
         {
-            var mscorlibRef = Net40.mscorlib;
+            var mscorlibRef = Net40.References.mscorlib;
 
             var varC_A = CSharpCompilation.Create("A", references: new[] { mscorlibRef });
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeAccessibility.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeAccessibility.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 {
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test1()
         {
-            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.mscorlib);
+            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.References.mscorlib);
 
             TestTypeAccessibilityHelper(assembly.Modules[0]);
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
@@ -18,7 +18,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 {
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                         TestReferences.SymbolsTests.TypeForwarders.TypeForwarder.dll,
                                         TestReferences.SymbolsTests.TypeForwarders.TypeForwarderLib.dll,
                                         TestReferences.SymbolsTests.TypeForwarders.TypeForwarderBase.dll,
-                                        Net40.mscorlib
+                                        Net40.References.mscorlib
                                     });
 
             TestTypeForwarderHelper(assemblies);
@@ -93,9 +93,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         {
             var compilation = CreateCompilationWithMscorlib40AndSystemCore(new SyntaxTree[0]);
 
-            var corlibAssembly = compilation.GetReferencedAssemblySymbol(Net40.mscorlib);
+            var corlibAssembly = compilation.GetReferencedAssemblySymbol(Net40.References.mscorlib);
             Assert.NotNull(corlibAssembly);
-            var systemCoreAssembly = compilation.GetReferencedAssemblySymbol(Net40.SystemCore);
+            var systemCoreAssembly = compilation.GetReferencedAssemblySymbol(Net40.References.SystemCore);
             Assert.NotNull(systemCoreAssembly);
 
             const string funcTypeMetadataName = "System.Func`1";

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeKindTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeKindTests.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 {
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         [Fact]
         public void Test1()
         {
-            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.mscorlib);
+            var assembly = MetadataTestHelpers.GetSymbolForReference(Net40.References.mscorlib);
 
             TestTypeKindHelper(assembly);
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -122,7 +122,7 @@ public static class Program
 
     public static void Extension(this string x) {}
 }";
-            var comp = CreateEmptyCompilation(source, new[] { Net40.mscorlib }, options: TestOptions.ReleaseDll);
+            var comp = CreateEmptyCompilation(source, new[] { Net40.References.mscorlib }, options: TestOptions.ReleaseDll);
 
             comp.MakeMemberMissing(WellKnownMember.System_Diagnostics_DebuggerHiddenAttribute__ctor);
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -2639,7 +2639,7 @@ public struct Test
 }
 ";
 
-            var piaCompilation = CreateEmptyCompilation(pia, references: [Net40.mscorlib], options: TestOptions.DebugDll, assemblyName: "Pia");
+            var piaCompilation = CreateEmptyCompilation(pia, references: [Net40.References.mscorlib], options: TestOptions.DebugDll, assemblyName: "Pia");
 
             string consumer1 = @"
 public class UsePia1
@@ -2663,7 +2663,7 @@ class UsePia2
 
             foreach (MetadataReference piaRef in new[] { piaCompilation.EmitToImageReference(), piaCompilation.ToMetadataReference() })
             {
-                var compilation1 = CreateEmptyCompilation(consumer1, references: [Net40.mscorlib, piaRef.WithEmbedInteropTypes(true)]);
+                var compilation1 = CreateEmptyCompilation(consumer1, references: [Net40.References.mscorlib, piaRef.WithEmbedInteropTypes(true)]);
 
                 foreach (MetadataReference consumer1Ref in new[] { compilation1.EmitToImageReference(), compilation1.ToMetadataReference() })
                 {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetCustomAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetCustomAttributes.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System.Collections.Generic;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Retargeting
 {
@@ -160,7 +161,7 @@ class TestClass
         {
             get
             {
-                return TestMetadata.Net40.mscorlib;
+                return Net40.References.mscorlib;
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetCustomModifiers.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetCustomModifiers.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Roslyn.Test.Utilities;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Retargeting
 {
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Retargeting
         [Fact]
         public void Test1()
         {
-            var oldMsCorLib = TestMetadata.Net40.mscorlib;
+            var oldMsCorLib = Net40.References.mscorlib;
             var newMsCorLib = NetFramework.mscorlib;
 
             var c1 = CSharpCompilation.Create("C1", references: new[]
@@ -129,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Retargeting
         [Fact]
         public void Test2()
         {
-            var oldMsCorLib = TestMetadata.Net40.mscorlib;
+            var oldMsCorLib = Net40.References.mscorlib;
             var newMsCorLib = NetFramework.mscorlib;
 
             var source = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -14933,7 +14934,7 @@ class B
 {
     public static void M4(this object o) { }
 }";
-            var compilation = CreateEmptyCompilation(source, new[] { TestMetadata.Net40.mscorlib });
+            var compilation = CreateEmptyCompilation(source, new[] { Net40.References.mscorlib });
             compilation.VerifyDiagnostics(
                 // (3,27): error CS1110: Cannot define a new extension method because the compiler required type 'System.Runtime.CompilerServices.ExtensionAttribute' cannot be found. Are you missing a reference to System.Core.dll?
                 Diagnostic(ErrorCode.ERR_ExtensionAttrNotFound, "this").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(3, 27),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeResolutionTests.cs
@@ -16,7 +16,7 @@ using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
@@ -49,7 +49,7 @@ namespace System
 
             var c1 = CSharpCompilation.Create("Test1",
                 syntaxTrees: new[] { Parse(source1) },
-                references: new[] { Net40.mscorlib });
+                references: new[] { Net40.References.mscorlib });
 
             Assert.Null(c1.GetTypeByMetadataName("DoesntExist"));
             Assert.Null(c1.GetTypeByMetadataName("DoesntExist`1"));
@@ -66,7 +66,7 @@ namespace System
                 references: new MetadataReference[]
                 {
                     new CSharpCompilationReference(c1),
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 });
 
             NamedTypeSymbol c2TestClass = c2.GetTypeByMetadataName("System.TestClass");
@@ -76,7 +76,7 @@ namespace System
                 references: new MetadataReference[]
                 {
                     new CSharpCompilationReference(c2),
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 });
 
             NamedTypeSymbol c3TestClass = c3.GetTypeByMetadataName("System.TestClass");
@@ -90,7 +90,7 @@ namespace System
                 {
                     new CSharpCompilationReference(c1),
                     new CSharpCompilationReference(c2),
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 });
 
             NamedTypeSymbol c4TestClass = c4.GetTypeByMetadataName("System.TestClass");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
@@ -533,7 +534,7 @@ public class A {
 }
 ";
 
-            var compilation = CreateEmptyCompilation(text, new[] { TestMetadata.Net40.mscorlib });
+            var compilation = CreateEmptyCompilation(text, new[] { Net40.References.mscorlib });
             int[] ary = new int[2];
 
             var globalNS = compilation.SourceModule.GlobalNamespace;

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -1244,7 +1244,7 @@ End Module
         public async Task AssemblyIdentityComparer1()
         {
             _tempDirectory.CreateFile("mscorlib20.dll").WriteAllBytes(TestMetadata.ResourcesNet20.mscorlib);
-            _tempDirectory.CreateFile("mscorlib40.dll").WriteAllBytes(TestMetadata.ResourcesNet40.mscorlib);
+            _tempDirectory.CreateFile("mscorlib40.dll").WriteAllBytes(Net40.Resources.mscorlib);
 
             // Create DLL "lib.dll"
             Dictionary<string, string> files =

--- a/src/Compilers/Test/Core/Generate.ps1
+++ b/src/Compilers/Test/Core/Generate.ps1
@@ -121,17 +121,6 @@ Add-TargetFramework "Net20" '$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net
   'System.dll',
   'Microsoft.VisualBasic.dll')
 
-Add-TargetFramework "Net40" '$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0' @(
-  'mscorlib.dll',
-  'System.dll',
-  'System.Core.dll',
-  'System.Data.dll',
-  'System.Xml.dll',
-  'System.Xml.Linq.dll',
-  'Microsoft.VisualBasic.dll',
-  'Microsoft.CSharp.dll'
-)
-
 Add-TargetFramework "MicrosoftCSharp" '$(PkgMicrosoft_CSharp)' @(
   'Netstandard10#ref\netstandard1.0\Microsoft.CSharp.dll'
   'Netstandard13Lib#lib\netstandard1.3\Microsoft.CSharp.dll'

--- a/src/Compilers/Test/Core/Generated.cs
+++ b/src/Compilers/Test/Core/Generated.cs
@@ -43,47 +43,6 @@ namespace Roslyn.Test.Utilities
             public static PortableExecutableReference System { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet20.System).GetReference(display: "System.dll (net20)", filePath: "System.dll");
             public static PortableExecutableReference MicrosoftVisualBasic { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet20.MicrosoftVisualBasic).GetReference(display: "Microsoft.VisualBasic.dll (net20)", filePath: "Microsoft.VisualBasic.dll");
         }
-        public static class ResourcesNet40
-        {
-            private static byte[] _mscorlib;
-            public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net40.mscorlib.dll");
-            private static byte[] _System;
-            public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net40.System.dll");
-            private static byte[] _SystemCore;
-            public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net40.System.Core.dll");
-            private static byte[] _SystemData;
-            public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net40.System.Data.dll");
-            private static byte[] _SystemXml;
-            public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net40.System.Xml.dll");
-            private static byte[] _SystemXmlLinq;
-            public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net40.System.Xml.Linq.dll");
-            private static byte[] _MicrosoftVisualBasic;
-            public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net40.Microsoft.VisualBasic.dll");
-            private static byte[] _MicrosoftCSharp;
-            public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net40.Microsoft.CSharp.dll");
-            public static ReferenceInfo[] All => new[]
-            {
-                new ReferenceInfo("mscorlib.dll", mscorlib),
-                new ReferenceInfo("System.dll", System),
-                new ReferenceInfo("System.Core.dll", SystemCore),
-                new ReferenceInfo("System.Data.dll", SystemData),
-                new ReferenceInfo("System.Xml.dll", SystemXml),
-                new ReferenceInfo("System.Xml.Linq.dll", SystemXmlLinq),
-                new ReferenceInfo("Microsoft.VisualBasic.dll", MicrosoftVisualBasic),
-                new ReferenceInfo("Microsoft.CSharp.dll", MicrosoftCSharp),
-            };
-        }
-        public static class Net40
-        {
-            public static PortableExecutableReference mscorlib { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet40.mscorlib).GetReference(display: "mscorlib.dll (net40)", filePath: "mscorlib.dll");
-            public static PortableExecutableReference System { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet40.System).GetReference(display: "System.dll (net40)", filePath: "System.dll");
-            public static PortableExecutableReference SystemCore { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet40.SystemCore).GetReference(display: "System.Core.dll (net40)", filePath: "System.Core.dll");
-            public static PortableExecutableReference SystemData { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet40.SystemData).GetReference(display: "System.Data.dll (net40)", filePath: "System.Data.dll");
-            public static PortableExecutableReference SystemXml { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet40.SystemXml).GetReference(display: "System.Xml.dll (net40)", filePath: "System.Xml.dll");
-            public static PortableExecutableReference SystemXmlLinq { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet40.SystemXmlLinq).GetReference(display: "System.Xml.Linq.dll (net40)", filePath: "System.Xml.Linq.dll");
-            public static PortableExecutableReference MicrosoftVisualBasic { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet40.MicrosoftVisualBasic).GetReference(display: "Microsoft.VisualBasic.dll (net40)", filePath: "Microsoft.VisualBasic.dll");
-            public static PortableExecutableReference MicrosoftCSharp { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet40.MicrosoftCSharp).GetReference(display: "Microsoft.CSharp.dll (net40)", filePath: "Microsoft.CSharp.dll");
-        }
         public static class ResourcesMicrosoftCSharp
         {
             private static byte[] _Netstandard10;

--- a/src/Compilers/Test/Core/Generated.targets
+++ b/src/Compilers/Test/Core/Generated.targets
@@ -12,38 +12,6 @@
           <LogicalName>net20.Microsoft.VisualBasic.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\net20\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\mscorlib.dll">
-          <LogicalName>net40.mscorlib.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net40\mscorlib.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.dll">
-          <LogicalName>net40.System.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net40\System.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.Core.dll">
-          <LogicalName>net40.System.Core.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net40\System.Core.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.Data.dll">
-          <LogicalName>net40.System.Data.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net40\System.Data.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.Xml.dll">
-          <LogicalName>net40.System.Xml.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net40\System.Xml.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\System.Xml.Linq.dll">
-          <LogicalName>net40.System.Xml.Linq.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net40\System.Xml.Linq.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\Microsoft.VisualBasic.dll">
-          <LogicalName>net40.Microsoft.VisualBasic.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net40\Microsoft.VisualBasic.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net40)\build\.NETFramework\v4.0\Microsoft.CSharp.dll">
-          <LogicalName>net40.Microsoft.CSharp.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\net40\Microsoft.CSharp.dll</Link>
-        </EmbeddedResource>
         <EmbeddedResource Include="$(PkgMicrosoft_CSharp)\ref\netstandard1.0\Microsoft.CSharp.dll">
           <LogicalName>netstandard10.microsoftcsharp.Microsoft.CSharp.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\microsoftcsharp\Microsoft.CSharp.dll</Link>

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -106,7 +106,6 @@
 
     <!-- Needed to find the Unsafe.dll binary to lay out at runtime for the compiler when testing analyzers. -->
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net20" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Build.Extensions" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.Threading.Tasks.Extensions" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
@@ -115,6 +114,7 @@
 
     <PackageReference Include="Basic.Reference.Assemblies.NetStandard20" />
     <PackageReference Include="Basic.Reference.Assemblies.Net70" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net40" />
     <PackageReference Include="Basic.Reference.Assemblies.Net461" />
     <PackageReference Include="Microsoft.ILVerification" />
   </ItemGroup>

--- a/src/Compilers/Test/Core/TargetFrameworkUtil.cs
+++ b/src/Compilers/Test/Core/TargetFrameworkUtil.cs
@@ -13,11 +13,11 @@ using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Basic.Reference.Assemblies;
-using static TestReferences;
-using static Roslyn.Test.Utilities.TestMetadata;
 using Microsoft.CodeAnalysis.CodeGen;
 using System.Reflection;
 using System.Collections.Concurrent;
+using static TestReferences;
+using static Roslyn.Test.Utilities.TestMetadata;
 
 namespace Roslyn.Test.Utilities
 {
@@ -203,24 +203,24 @@ namespace Roslyn.Test.Utilities
 
         public static ImmutableArray<MetadataReference> Mscorlib40References { get; } =
         [
-            Net40.mscorlib
+            Net40.References.mscorlib
         ];
         public static ImmutableArray<MetadataReference> Mscorlib40ExtendedReferences { get; } =
         [
-            Net40.mscorlib,
-            Net40.System,
-            Net40.SystemCore
+            Net40.References.mscorlib,
+            Net40.References.System,
+            Net40.References.SystemCore
         ];
         public static ImmutableArray<MetadataReference> Mscorlib40andSystemCoreReferences { get; } =
         [
-            Net40.mscorlib,
-            Net40.SystemCore
+            Net40.References.mscorlib,
+            Net40.References.SystemCore
         ];
         public static ImmutableArray<MetadataReference> Mscorlib40andVBRuntimeReferences { get; } =
         [
-            Net40.mscorlib,
-            Net40.System,
-            Net40.MicrosoftVisualBasic
+            Net40.References.mscorlib,
+            Net40.References.System,
+            Net40.References.MicrosoftVisualBasic
         ];
         public static ImmutableArray<MetadataReference> Mscorlib45References { get; } =
         [

--- a/src/Compilers/Test/Core/TestBase.cs
+++ b/src/Compilers/Test/Core/TestBase.cs
@@ -81,7 +81,7 @@ namespace Roslyn.Test.Utilities
         #region Metadata References
 
         private static readonly Lazy<MetadataReference[]> s_lazyDefaultVbReferences = new Lazy<MetadataReference[]>(
-            () => new[] { Net40.mscorlib, Net40.System, Net40.SystemCore, Net40.MicrosoftVisualBasic },
+            () => new[] { Net40.References.mscorlib, Net40.References.System, Net40.References.SystemCore, Net40.References.MicrosoftVisualBasic },
             LazyThreadSafetyMode.PublicationOnly);
         public static MetadataReference[] DefaultVbReferences => s_lazyDefaultVbReferences.Value;
 

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -171,7 +171,7 @@ Friend Module CompilationUtils
                                                                references As IEnumerable(Of MetadataReference),
                                                                Optional options As VisualBasicCompilationOptions = Nothing,
                                                                Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
-        Return CreateEmptyCompilationWithReferences(source, {CType(Net40.mscorlib, MetadataReference)}.Concat(references), options, parseOptions:=parseOptions)
+        Return CreateEmptyCompilationWithReferences(source, {CType(Net40.References.mscorlib, MetadataReference)}.Concat(references), options, parseOptions:=parseOptions)
     End Function
 
     ''' <summary>
@@ -187,7 +187,7 @@ Friend Module CompilationUtils
     Public Function CreateCompilationWithMscorlib40(source As XElement,
                                                   outputKind As OutputKind,
                                                   Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
-        Return CreateEmptyCompilationWithReferences(source, {Net40.mscorlib}, New VisualBasicCompilationOptions(outputKind), parseOptions:=parseOptions)
+        Return CreateEmptyCompilationWithReferences(source, {Net40.References.mscorlib}, New VisualBasicCompilationOptions(outputKind), parseOptions:=parseOptions)
     End Function
 
     ''' <summary>
@@ -208,7 +208,7 @@ Friend Module CompilationUtils
         Optional assemblyName As String = Nothing) As VisualBasicCompilation
 
         If additionalRefs Is Nothing Then additionalRefs = {}
-        Dim references = {CType(Net40.mscorlib, MetadataReference), Net40.System, Net40.MicrosoftVisualBasic}.Concat(additionalRefs)
+        Dim references = {CType(Net40.References.mscorlib, MetadataReference), Net40.References.System, Net40.References.MicrosoftVisualBasic}.Concat(additionalRefs)
 
         Return CreateEmptyCompilationWithReferences(source, references, options, parseOptions:=parseOptions, assemblyName:=assemblyName)
     End Function
@@ -228,7 +228,7 @@ Friend Module CompilationUtils
 
     Public ReadOnly XmlReferences As MetadataReference() = {SystemRef, SystemCoreRef, SystemXmlRef, SystemXmlLinqRef}
 
-    Public ReadOnly Net40XmlReferences As MetadataReference() = {Net40.SystemCore, Net40.SystemXml, Net40.SystemXmlLinq}
+    Public ReadOnly Net40XmlReferences As MetadataReference() = {Net40.References.SystemCore, Net40.References.SystemXml, Net40.References.SystemXmlLinq}
 
     Public ReadOnly Net461XmlReferences As MetadataReference() = {Net461.References.SystemCore, Net461.References.SystemXml, Net461.References.SystemXmlLinq}
 
@@ -249,7 +249,7 @@ Friend Module CompilationUtils
         Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
 
         If references Is Nothing Then references = {}
-        Dim allReferences = {CType(Net40.mscorlib, MetadataReference), Net40.System, Net40.MicrosoftVisualBasic}.Concat(references)
+        Dim allReferences = {CType(Net40.References.mscorlib, MetadataReference), Net40.References.System, Net40.References.MicrosoftVisualBasic}.Concat(references)
         If parseOptions Is Nothing AndAlso options IsNot Nothing Then
             parseOptions = options.ParseOptions
         End If

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -272,7 +273,7 @@ End Module
 ]]>
     </file>
 </compilation>
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {TestMetadata.Net40.SystemCore}).AssertTheseDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}).AssertTheseDiagnostics(
             <![CDATA[
 BC40008: 'Public Shared Sub ObsoleteMethod1()' is obsolete.
         ObsoleteMethod1()

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -14,6 +14,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 #Disable Warning SYSLIB0050 ' 'TypeAttributes.Serializable' is obsolete
 
@@ -2220,7 +2221,7 @@ End Class
     </file>
 </compilation>
 
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {TestMetadata.Net40.SystemCore}).VerifyDiagnostics()
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}).VerifyDiagnostics()
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -9361,7 +9362,7 @@ Public Class TestCase
 End Class
     </file>
 </compilation>
-            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.mscorlib}, TestOptions.ReleaseDll) ' NOTE: 4.0, Not 4.5, so it's missing the async helpers.
+            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.References.mscorlib}, TestOptions.ReleaseDll) ' NOTE: 4.0, Not 4.5, so it's missing the async helpers.
             comp.AssertTheseEmitDiagnostics(
  <errors>
 BC31091: Import of type 'AsyncVoidMethodBuilder' from assembly or module 'AsyncVoid.dll' failed.
@@ -9397,7 +9398,7 @@ Public Class TestCase
 End Class
     </file>
 </compilation>
-            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.mscorlib}, TestOptions.ReleaseDll) ' NOTE: 4.0, Not 4.5, so it's missing the async helpers.
+            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.References.mscorlib}, TestOptions.ReleaseDll) ' NOTE: 4.0, Not 4.5, so it's missing the async helpers.
             comp.AssertTheseEmitDiagnostics(
  <errors>
 BC31091: Import of type 'AsyncTaskMethodBuilder' from assembly or module 'AsyncTask.dll' failed.
@@ -9434,7 +9435,7 @@ Public Class TestCase
 End Class
     </file>
 </compilation>
-            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.mscorlib}, TestOptions.ReleaseDll) ' NOTE: 4.0, Not 4.5, so it's missing the async helpers.
+            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.References.mscorlib}, TestOptions.ReleaseDll) ' NOTE: 4.0, Not 4.5, so it's missing the async helpers.
             comp.AssertTheseEmitDiagnostics(
  <errors>
 BC31091: Import of type 'AsyncTaskMethodBuilder(Of )' from assembly or module 'AsyncTask_T.dll' failed.

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -10481,7 +10482,7 @@ Public Class C1(Of T)
     End Function
 End Class
                     </file>
-                </compilation>, references:={MetadataReference.CreateFromImage(ResourcesNet40.mscorlib.AsImmutableOrNull())}))
+                </compilation>, references:={MetadataReference.CreateFromImage(Net40.Resources.mscorlib.AsImmutableOrNull())}))
 
             Dim comp = CompilationUtils.CreateEmptyCompilationWithReferences(
                 <compilation>
@@ -10498,7 +10499,7 @@ Public Class C2(Of U)
     End Function
 End Class
                     </file>
-                </compilation>, references:={MetadataReference.CreateFromImage(ResourcesNet40.mscorlib.AsImmutableOrNull()), ref1})
+                </compilation>, references:={MetadataReference.CreateFromImage(Net40.Resources.mscorlib.AsImmutableOrNull()), ref1})
 
             CompileAndVerify(comp)
 
@@ -10539,7 +10540,7 @@ Public Class C1
     End Sub
 End Class
                     </file>
-                </compilation>, references:={MetadataReference.CreateFromImage(ResourcesNet40.mscorlib.AsImmutableOrNull())}))
+                </compilation>, references:={MetadataReference.CreateFromImage(Net40.Resources.mscorlib.AsImmutableOrNull())}))
 
             Dim comp = CompilationUtils.CreateEmptyCompilationWithReferences(
                 <compilation>
@@ -10566,7 +10567,7 @@ Public Class C2
     End Sub
 End Class
                     </file>
-                </compilation>, references:={MetadataReference.CreateFromImage(ResourcesNet40.mscorlib.AsImmutableOrNull()), ref1})
+                </compilation>, references:={MetadataReference.CreateFromImage(Net40.Resources.mscorlib.AsImmutableOrNull()), ref1})
 
             Dim compilationVerifier = CompileAndVerify(comp)
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EmitCustomModifiers.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EmitCustomModifiers.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Xunit
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 
@@ -20,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 
         <Fact>
         Public Sub Test1()
-            Dim mscorlibRef = TestMetadata.Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
 
             Dim source As String = <text> 
 Public Class A

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EmitMetadata.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EmitMetadata.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 
@@ -26,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 
         <Fact>
         Public Sub InstantiatedGenerics()
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim source As String = <text> 
 Class A(Of T)
 
@@ -218,7 +219,7 @@ Public Class D
     Shared arrayField As String()
 End Class 
 </file>
-</compilation>, {Net40.mscorlib}, TestOptions.ReleaseExe)
+</compilation>, {Net40.References.mscorlib}, TestOptions.ReleaseExe)
 
             CompileAndVerify(comp,
                              expectedOutput:=
@@ -229,7 +230,7 @@ End Class
 
         <Fact>
         Public Sub AssemblyRefs()
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim metadataTestLib1 = TestReferences.SymbolsTests.MDTestLib1
             Dim metadataTestLib2 = TestReferences.SymbolsTests.MDTestLib2
 
@@ -289,7 +290,7 @@ End Class
 
         <Fact>
         Public Sub AddModule()
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim netModule1 = ModuleMetadata.CreateFromImage(TestResources.SymbolsTests.netModule.netModule1)
             Dim netModule2 = ModuleMetadata.CreateFromImage(TestResources.SymbolsTests.netModule.netModule2)
 
@@ -346,7 +347,7 @@ End Class
 
         <Fact>
         Public Sub ImplementingAnInterface()
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
 
             Dim source As String = <text>
 Public Interface I1
@@ -403,7 +404,7 @@ End Class
 
         <Fact>
         Public Sub Types()
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim source As String = <text>
 Public MustInherit Class A
 
@@ -551,7 +552,7 @@ End Class
 
         <Fact>
         Public Sub Fields()
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim source As String = <text> 
 Public Class A
     public F1 As Integer

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EntryPointTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EntryPointTests.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 
@@ -990,7 +991,7 @@ End Class
         End Module
     </file>
 </compilation>
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore}, options:=TestOptions.ReleaseExe).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe).VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_InValidSubMainsFound1).WithArguments("a"))
         End Sub
 
@@ -1009,7 +1010,7 @@ End Class
         End Module
     </file>
 </compilation>
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore}, options:=TestOptions.ReleaseExe).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe).VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_InValidSubMainsFound1).WithArguments("a"))
         End Sub
 
@@ -1028,7 +1029,7 @@ End Class
         End Module
     </file>
 </compilation>
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore}, options:=TestOptions.ReleaseExe).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe).VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_InValidSubMainsFound1).WithArguments("a"))
         End Sub
 
@@ -1281,10 +1282,10 @@ End Class
         End Module
     </file>
 </compilation>
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("B")).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("B")).VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_StartupCodeNotFound1).WithArguments("B"))
 
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("Extension")).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("Extension")).VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_InValidSubMainsFound1).WithArguments("Extension"))
         End Sub
 
@@ -1302,13 +1303,13 @@ End Class
         Delegate Sub mydelegate(args As String()) 
     </file>
 </compilation>
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("I1")).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("I1")).VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_StartupCodeNotFound1).WithArguments("i1"))
 
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("COLOR")).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("COLOR")).VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_StartupCodeNotFound1).WithArguments("color"))
 
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("mydelegate")).VerifyDiagnostics(
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe.WithMainTypeName("mydelegate")).VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_StartupCodeNotFound1).WithArguments("mydelegate"))
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
@@ -16,6 +16,7 @@ Imports System.Reflection.Metadata
 Imports Microsoft.CodeAnalysis.Emit
 Imports System.Collections.Immutable
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -1743,7 +1744,7 @@ End Structure
                                                        End Sub
             Dim compilation1 = CreateEmptyCompilationWithReferences(
                 sources1,
-                references:={Net40.mscorlib, Net40.System, compilation0.EmitToImageReference(embedInteropTypes:=True)})
+                references:={Net40.References.mscorlib, Net40.References.System, compilation0.EmitToImageReference(embedInteropTypes:=True)})
             verifier = CompileAndVerify(compilation1, symbolValidator:=validator)
             AssertTheseDiagnostics(verifier, (<errors/>))
             verifier.VerifyIL("S.F", <![CDATA[

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -8,6 +8,7 @@ Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     ''' <summary>
@@ -38,7 +39,7 @@ End Module]]></file>
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe.WithOverflowChecks(True),
                  expectedOutput:=<![CDATA[
 Lambda(
@@ -733,13 +734,13 @@ Lambda(
 ]]>
 
             CompileAndVerify(source,
-                          references:={Net40.SystemCore},
+                          references:={Net40.References.SystemCore},
                           options:=TestOptions.ReleaseExe.WithOverflowChecks(True),
                           expectedOutput:=expected
             )
 
             CompileAndVerify(source,
-                        references:={Net40.SystemCore},
+                        references:={Net40.References.SystemCore},
                         options:=TestOptions.ReleaseExe.WithOverflowChecks(False),
                         expectedOutput:=expected
             )
@@ -1201,7 +1202,7 @@ Lambda(
                          </compilation>
 
             CompileAndVerify(source,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              options:=TestOptions.ReleaseExe.WithOverflowChecks(checked),
                              expectedOutput:=result.Trim
             ).VerifyDiagnostics()
@@ -1223,7 +1224,7 @@ Lambda(
                          </compilation>
 
             CompileAndVerify(source,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              options:=TestOptions.ReleaseExe.WithOverflowChecks(checked),
                              expectedOutput:=result.Trim
             ).VerifyDiagnostics()
@@ -1448,7 +1449,7 @@ Lambda(
                          </compilation>
 
             CompileAndVerify(source,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              options:=TestOptions.ReleaseExe.WithOverflowChecks(checked),
                              expectedOutput:=result.Trim
             ).VerifyDiagnostics(Diagnostic(ERRID.WRN_ObsoleteIdentityDirectCastForValueType, "x"),
@@ -1918,7 +1919,7 @@ End Module
             Dim src = source...<file>.Value
 
             CompileAndVerify(source,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              options:=TestOptions.ReleaseExe.WithOverflowChecks(checked),
                              expectedOutput:=result.Trim
             ).VerifyDiagnostics(If(diagnostics, {}))
@@ -2012,7 +2013,7 @@ End Module
 ]]></file>
                          </compilation>
 
-            CompileAndVerify(source, references:={Net40.SystemCore}).VerifyDiagnostics()
+            CompileAndVerify(source, references:={Net40.References.SystemCore}).VerifyDiagnostics()
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72456")>
@@ -6628,7 +6629,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:=<![CDATA[
 Lambda(
   Parameter(
@@ -6686,7 +6687,7 @@ End Class
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:=<![CDATA[
 Lambda(
   Parameter(
@@ -6791,7 +6792,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:=<![CDATA[
 Infer A=System.Decimal
 Infer B=System.String
@@ -6834,7 +6835,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:=<![CDATA[Where Select]]>).VerifyDiagnostics()
         End Sub
 
@@ -6884,7 +6885,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:="GroupBy 1;Select;GroupBy 2;Select;").VerifyDiagnostics()
         End Sub
 
@@ -6927,7 +6928,7 @@ End Module]]></file>
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:="GroupJoin;").VerifyDiagnostics()
         End Sub
 
@@ -7010,7 +7011,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:=<![CDATA[A1 B2 C1 D2 E1 F2]]>)
         End Sub
 
@@ -7051,7 +7052,7 @@ End Module]]></file>
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:=<![CDATA[f1 f1 g1]]>)
         End Sub
 
@@ -7078,7 +7079,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:="() => (value(Form1+_Closure$__0-0).$VB$Local_s1_a ?? Convert(value(Form1+_Closure$__0-0).$VB$Local_s1_b))").VerifyDiagnostics()
         End Sub
 
@@ -7196,7 +7197,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:="10").VerifyDiagnostics()
         End Sub
 
@@ -7275,7 +7276,7 @@ end class
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:="m => m").VerifyDiagnostics()
         End Sub
 
@@ -7314,7 +7315,7 @@ End Class
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  expectedOutput:="").VerifyDiagnostics()
         End Sub
 
@@ -8310,7 +8311,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 () => (value(M+_Closure$__2-0`1[M+X]).$VB$Local_x == null)
@@ -8370,7 +8371,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 () => (value(M+_Closure$__2-0`1[M+X]).$VB$Local_x == null)
@@ -8412,7 +8413,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 () => Concat(value(M+_Closure$__0-0).$VB$Local_str, null)
@@ -8466,7 +8467,7 @@ End Namespace
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 In catch
@@ -8531,7 +8532,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 x => x.set_City(ItIs(s => IsNullOrEmpty(s)))
@@ -8607,7 +8608,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 x => x.set_City(1, ItIs(s => IsNullOrEmpty(s)))
@@ -8672,7 +8673,7 @@ End Module
                          </compilation>
 
             Dim compilation = CreateCompilationWithMscorlib45AndVBRuntime(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe)
 
             compilation.VerifyDiagnostics(
@@ -8722,7 +8723,7 @@ End Class
                          </compilation>
 
             CompileAndVerify(source,
-                 references:={Net40.SystemCore},
+                 references:={Net40.References.SystemCore},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 42

--- a/src/Compilers/VisualBasic/Test/Emit/Perf.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Perf.vb
@@ -4,6 +4,7 @@
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
     Public Class Perf : Inherits BasicTestBase
@@ -29,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
                                  <file name="VBPerfTest.vb">
                                      <%= TestResources.PerfTests.VBPerfTest %>
                                  </file>
-                             </compilation>, references:={TestMetadata.Net40.SystemCore}).VerifyDiagnostics()
+                             </compilation>, references:={Net40.References.SystemCore}).VerifyDiagnostics()
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/PrivateProtected.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PrivateProtected.vb
@@ -4,6 +4,7 @@
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class PrivateProtected
@@ -931,7 +932,7 @@ End Class
 ]]>
                              </file>
                          </compilation>
-            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {TestMetadata.Net40.SystemCore},
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore},
                     parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <errors>

--- a/src/Compilers/VisualBasic/Test/Emit/XmlLiteralTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/XmlLiteralTests.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -4962,9 +4963,9 @@ End Class
             Dim tree = VisualBasicSyntaxTree.ParseText(source)
 
             Dim refBuilder = ArrayBuilder(Of MetadataReference).GetInstance()
-            refBuilder.Add(TestMetadata.Net40.mscorlib)
-            refBuilder.Add(TestMetadata.Net40.System)
-            refBuilder.Add(TestMetadata.Net40.MicrosoftVisualBasic)
+            refBuilder.Add(Net40.References.mscorlib)
+            refBuilder.Add(Net40.References.System)
+            refBuilder.Add(Net40.References.MicrosoftVisualBasic)
             refBuilder.AddRange(Net40XmlReferences)
             Dim refs = refBuilder.ToImmutableAndFree()
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -1988,7 +1989,7 @@ Class MyAttribute
     End Sub
 End Class
     ]]></file>
-    </compilation>, references:={Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_RequiredConstExpr, "(From x In q Select x).Count()"))
+    </compilation>, references:={Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_RequiredConstExpr, "(From x In q Select x).Count()"))
         End Sub
 
         <WorkItem(542967, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542967")>
@@ -2015,7 +2016,7 @@ Class MyAttribute
     End Sub
 End Class
     ]]></file>
-    </compilation>, references:={Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_BadInstanceMemberAccess, "F1"))
+    </compilation>, references:={Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_BadInstanceMemberAccess, "F1"))
         End Sub
 
         <WorkItem(542967, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542967")>
@@ -2043,7 +2044,7 @@ Class MyAttribute
     End Sub
 End Class
     ]]></file>
-    </compilation>, references:={Net40.SystemCore}).VerifyDiagnostics({Diagnostic(ERRID.ERR_RequiredConstExpr, "(From x In ""s"" Select x).Count()"),
+    </compilation>, references:={Net40.References.SystemCore}).VerifyDiagnostics({Diagnostic(ERRID.ERR_RequiredConstExpr, "(From x In ""s"" Select x).Count()"),
                                                                     Diagnostic(ERRID.ERR_ObjectReferenceNotSupplied, "Program.F1")})
         End Sub
 
@@ -5909,7 +5910,7 @@ Class DerivedClass
     End Sub
 End Class
     </file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
 BC30393: 'Exit Try' can only appear inside a 'Try' statement.
@@ -8176,7 +8177,7 @@ Class DerivedClass
     End Sub
 End Class
     </file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
 BC30101: Branching out of a 'Finally' is not valid.
@@ -11512,7 +11513,7 @@ Module M
     End Function
 End Module
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             Dim expectedErrors1 = <errors>
 BC30978: Range variable 'foo' hides a variable in an enclosing block or a range variable previously defined in the query expression.
@@ -11540,7 +11541,7 @@ BC30978: Range variable 'foo' hides a variable in an enclosing block or a range 
                 End Sub
             End Module
         </file>
-    </compilation>, {Net40.SystemCore}, options:=TestOptions.ReleaseExe)
+    </compilation>, {Net40.References.SystemCore}, options:=TestOptions.ReleaseExe)
 
             Dim expectedErrors1 = <errors>
 BC30978: Range variable 'x' hides a variable in an enclosing block or a range variable previously defined in the query expression.
@@ -14485,7 +14486,7 @@ BC32006: 'Char' values cannot be converted to 'Short'. Use 'Microsoft.VisualBasi
         Public Structure S
         End Structure
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC32006: 'Char' values cannot be converted to 'Integer'. Use 'Microsoft.VisualBasic.AscW' to interpret a character as a Unicode value or 'Microsoft.VisualBasic.Val' to interpret it as a digit.
@@ -16347,7 +16348,7 @@ BC36532: Nested function does not have the same signature as delegate 'Func(Of E
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
@@ -16375,7 +16376,7 @@ BC36533: 'ByRef' parameter 'filterValue' cannot be used in a query expression.
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation, <expected></expected>)
         End Sub
 
@@ -16394,7 +16395,7 @@ BC36533: 'ByRef' parameter 'filterValue' cannot be used in a query expression.
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
 BC36534: Expression cannot be converted into an expression tree.
@@ -16418,7 +16419,7 @@ BC36534: Expression cannot be converted into an expression tree.
             End Sub
         End Structure
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36535: Instance members and 'Me' cannot be used within query expressions in structures.
@@ -16442,7 +16443,7 @@ BC36535: Instance members and 'Me' cannot be used within query expressions in st
             End Sub
         End Structure
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36535: Instance members and 'Me' cannot be used within query expressions in structures.
@@ -16494,7 +16495,7 @@ BC30311: Value of type 'Integer' cannot be converted to 'Object()'.
             End Sub
         End Module
     </file>
-    </compilation>, references:={Net40.SystemCore})
+    </compilation>, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36538: References to 'ByRef' parameters cannot be converted to an expression tree.
@@ -16540,7 +16541,7 @@ BC36547: Anonymous type member or property 'GetHashCode' is already declared.
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.System, Net40.SystemCore, Net40.MicrosoftVisualBasic})
+    </compilation>, {Net40.References.System, Net40.References.SystemCore, Net40.References.MicrosoftVisualBasic})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36548: Cannot convert anonymous type to an expression tree because a property of the type is used to initialize another property.
@@ -16559,7 +16560,7 @@ BC36548: Cannot convert anonymous type to an expression tree because a property 
             Dim x = New With {.y = 1, .z = From y In "" Select .y}
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseEmitDiagnostics(compilation,
     <expected>
@@ -16672,7 +16673,7 @@ BC36558: The custom-designed version of 'System.Runtime.CompilerServices.Extensi
             End Function
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36559: Anonymous type member property 'X' cannot be used to infer the type of another member property because the type of 'X' is not yet established.
@@ -16758,7 +16759,7 @@ Imports System
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
@@ -16785,7 +16786,7 @@ BC36582: Too many arguments to extension method 'Public Sub FooGeneric01()' defi
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_NamedArgAlsoOmitted3, "Y").WithArguments("Y", "Public Sub ABC([Y As Byte = 0], [Z As Byte = 0])", "M"))
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_NamedArgAlsoOmitted3, "Y").WithArguments("Y", "Public Sub ABC([Y As Byte = 0], [Z As Byte = 0])", "M"))
         End Sub
 
         <Fact()>
@@ -16805,7 +16806,7 @@ BC36582: Too many arguments to extension method 'Public Sub FooGeneric01()' defi
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_NamedArgUsedTwice3, "Y").WithArguments("Y", "Public Sub ABC(Y As Byte, [Z As Byte = 0])", "M"),
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_NamedArgUsedTwice3, "Y").WithArguments("Y", "Public Sub ABC(Y As Byte, [Z As Byte = 0])", "M"),
     Diagnostic(ERRID.ERR_NamedArgUsedTwice3, "Y").WithArguments("Y", "Public Sub ABC(Y As Byte, [Z As Byte = 0])", "M"))
 
         End Sub
@@ -16835,7 +16836,7 @@ BC36582: Too many arguments to extension method 'Public Sub FooGeneric01()' defi
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_QueryOperatorNotFound, "Group Join").WithArguments("GroupJoin"))
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_QueryOperatorNotFound, "Group Join").WithArguments("GroupJoin"))
 
         End Sub
 
@@ -16861,7 +16862,7 @@ BC36582: Too many arguments to extension method 'Public Sub FooGeneric01()' defi
             Implements Ifoo(Of T)
         End Class
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC42104: Variable 'x' is used before it has been assigned a value. A null reference exception could result at runtime.
@@ -16895,7 +16896,7 @@ BC36590: Too few type arguments to extension method 'Public Sub foo(Of t2, t3)(p
             Implements Ifoo(Of T)
         End Class
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
@@ -16942,7 +16943,7 @@ BC36593: Expression of type 'S1' is not queryable. Make sure you are not missing
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36594: Definition of method 'y' is not accessible in this context.
@@ -16992,7 +16993,7 @@ BC36597: 'Goto Label1' is not valid because 'Label1' is inside a scope that defi
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             compilation.VerifyDiagnostics(
                 Diagnostic(ERRID.ERR_QueryAnonymousTypeFieldNameInference, "Nothing"),
@@ -17024,7 +17025,7 @@ BC36597: 'Goto Label1' is not valid because 'Label1' is inside a scope that defi
             End Function
         End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(
     Diagnostic(ERRID.ERR_QueryDuplicateAnonTypeMemberName1, "Bar").WithArguments("Bar"))
 
         End Sub
@@ -17041,7 +17042,7 @@ BC36597: 'Goto Label1' is not valid because 'Label1' is inside a scope that defi
             Dim q = From x% In New Integer() {1}
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
@@ -17112,7 +17113,7 @@ BC36602: 'ReadOnly' variable cannot be the target of an assignment in a lambda e
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36603: Multi-dimensional array cannot be converted to an expression tree.
@@ -17134,7 +17135,7 @@ BC36603: Multi-dimensional array cannot be converted to an expression tree.
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36604: Late binding operations cannot be converted to an expression tree.
@@ -17155,7 +17156,7 @@ BC36604: Late binding operations cannot be converted to an expression tree.
             Dim x = From y In "" Select ToString()
         End Class
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36606: Range variable name cannot match the name of a member of the 'Object' class.
@@ -17166,7 +17167,7 @@ BC36606: Range variable name cannot match the name of a member of the 'Object' c
 
         <Fact()>
         Public Sub BC36610ERR_QueryNameNotDeclared()
-            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(references:={Net40.SystemCore}, source:=
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(references:={Net40.References.SystemCore}, source:=
     <compilation name="QueryNameNotDeclared">
         <file name="a.vb">
 Imports System
@@ -17234,7 +17235,7 @@ BC36614: Range variable name cannot be inferred from an XML identifier that is n
             End Function
         End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_TypeCharOnAggregation, "Bar$"),
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_TypeCharOnAggregation, "Bar$"),
     Diagnostic(ERRID.ERR_QueryAnonymousTypeDisallowsTypeChar, "Bar$"))
 
         End Sub
@@ -17355,7 +17356,7 @@ Module M1
     End Sub
 End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_IterationVariableShadowLocal2, "implicit").WithArguments("implicit"),
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_IterationVariableShadowLocal2, "implicit").WithArguments("implicit"),
     Diagnostic(ERRID.ERR_IterationVariableShadowLocal2, "implicit").WithArguments("implicit"),
     Diagnostic(ERRID.ERR_IterationVariableShadowLocal2, "implicit").WithArguments("implicit"),
     Diagnostic(ERRID.ERR_IterationVariableShadowLocal2, "implicit").WithArguments("implicit"),
@@ -17440,7 +17441,7 @@ BC36635: Lambda expressions are not valid in the first expression of a 'Select C
             End Sub
         End Structure
     </file>
-    </compilation>, references:={Net40.SystemCore})
+    </compilation>, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36638: Instance members and 'Me' cannot be used within a lambda expression in structures.
@@ -17775,7 +17776,7 @@ BC42104: Variable 'y' is used before it has been assigned a value. A null refere
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_LambdaBindingMismatch2,
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_LambdaBindingMismatch2,
             <![CDATA[Sub(x As Integer(,))
                            Action()
                        End Sub]]>.Value.Replace(vbLf, Environment.NewLine)).WithArguments("System.Action")
@@ -17799,7 +17800,7 @@ BC42104: Variable 'y' is used before it has been assigned a value. A null refere
             End Sub
         End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(
             Diagnostic(ERRID.ERR_StatementLambdaInExpressionTree, <![CDATA[Function()
                                                                                                Return x
                                                                                                End Function]]>.Value.Replace(vbLf, Environment.NewLine)))
@@ -17832,7 +17833,7 @@ BC42104: Variable 'y' is used before it has been assigned a value. A null refere
             End Function
         End Module
     </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(
     Diagnostic(ERRID.ERR_DelegateBindingMismatchStrictOff3, "o.moo(Of Integer)").WithArguments("Public Function moo(Of Integer)(y As Integer) As String", "Delegate Function M.del1g(Of String)(x As String) As String", "m1"))
 
         End Sub
@@ -18394,7 +18395,7 @@ Module Extension01
     End Sub
 End Module
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(compilation,
     <expected>
 BC36907: Extension method 'Public Sub FooGeneric01()' defined in 'Extension01' is not generic (or has no free type parameters) and so cannot have type arguments.
@@ -19162,7 +19163,7 @@ Class E
     End Property
 End Class
         </file>
-    </compilation>, {Net40.SystemCore}).VerifyDiagnostics(
+    </compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(
             Diagnostic(ERRID.WRN_SharedMemberThroughInstance, "1"))
         End Sub
 
@@ -21303,7 +21304,7 @@ Class DerivedClass
     End Sub
 End Class
                 </file>
-            </compilation>, {Net40.SystemCore})
+            </compilation>, {Net40.References.SystemCore})
 
             VerifyDiagnostics(compilation, Diagnostic(ERRID.WRN_DefAsgNoRetValFuncVal1, "End Function").WithArguments("<anonymous method>"))
         End Sub
@@ -21331,7 +21332,7 @@ Class DerivedClass
     End Sub
 End Class
                 </file>
-            </compilation>, {Net40.SystemCore})
+            </compilation>, {Net40.References.SystemCore})
 
             AssertTheseDiagnostics(compilation,
                                    <expected><![CDATA[
@@ -21390,7 +21391,7 @@ Class DerivedClass
     End Sub
 End Class
                 </file>
-            </compilation>, {Net40.SystemCore})
+            </compilation>, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -23648,7 +23649,7 @@ Return item.ToString() = ""
 End Function).ToList()    
 End Sub 
     </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             VerifyDiagnostics(compilation, Diagnostic(ERRID.ERR_Syntax, """"""),
                 Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "Return lab1"),
                 Diagnostic(ERRID.ERR_InvalidEndFunction, "End Function"),
@@ -24290,7 +24291,7 @@ Class Test
     End Sub
 End Class
                     ]]></file>
-                </compilation>, {Net40.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
+                </compilation>, {Net40.References.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
 
             AssertTheseDiagnostics(compilation,
 <expected>
@@ -24328,7 +24329,7 @@ Class Test
     End Sub
 End Class
                     ]]></file>
-                </compilation>, {Net40.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
+                </compilation>, {Net40.References.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
 
             AssertTheseDiagnostics(compilation,
 <expected>
@@ -24363,7 +24364,7 @@ Class Test
     End Sub
 End Class
                     ]]></file>
-                </compilation>, {Net40.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
+                </compilation>, {Net40.References.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
 
             AssertTheseDiagnostics(compilation,
 <expected>
@@ -24411,7 +24412,7 @@ Class C1
     End Sub
 End Class
                     ]]></file>
-                </compilation>, {Net40.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
+                </compilation>, {Net40.References.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
 
             AssertTheseDiagnostics(compilation,
 <expected>
@@ -24454,7 +24455,7 @@ Class C1
     End Sub
 End Class
                     ]]></file>
-                </compilation>, {Net40.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
+                </compilation>, {Net40.References.SystemCore}, TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
 
             AssertTheseDiagnostics(compilation,
 <expected>
@@ -26134,7 +26135,7 @@ End Module
         ]]></file>
     </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.SystemCore})
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/ForEachTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/ForEachTests.vb
@@ -11,9 +11,9 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class ForLoopTests
@@ -2325,7 +2325,7 @@ Module Program
 End Module    
 </file>
 </compilation>
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, references:={TestMetadata.Net40.SystemCore})
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, references:={Net40.References.SystemCore})
             compilation.AssertNoDiagnostics()
             ' NOTE: this did not succeed in Dev10, but it does in Roslyn because we do a full overload resolution and can decide whether this 
             ' is ambiguous or not.
@@ -2375,7 +2375,7 @@ Module Program
 End Module
 </file>
 </compilation>
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, references:={TestMetadata.Net40.SystemCore})
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, references:={Net40.References.SystemCore})
             AssertTheseDiagnostics(compilation,
                               <expected>
 BC42025: Access of shared member, constant member, enum member or nested type through an instance; qualifying expression will not be evaluated.
@@ -2428,7 +2428,7 @@ Module Program
 End Module
 </file>
 </compilation>
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, references:={TestMetadata.Net40.SystemCore})
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, references:={Net40.References.SystemCore})
             AssertTheseDiagnostics(compilation,
                               <expected>
 BC42025: Access of shared member, constant member, enum member or nested type through an instance; qualifying expression will not be evaluated.
@@ -3240,7 +3240,7 @@ BC30105: Number of indices is less than the number of dimensions of the indexed 
 1
 2
 3
-]]>, references:={TestMetadata.Net40.SystemCore})
+]]>, references:={Net40.References.SystemCore})
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/SyncLockTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/SyncLockTests.vb
@@ -4,6 +4,7 @@
 
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class SyncLockTests
@@ -88,7 +89,7 @@ Class Program
     End Sub
 End Class
     </file>
-</compilation>, {TestMetadata.Net40.SystemCore}).VerifyDiagnostics()
+</compilation>, {Net40.References.SystemCore}).VerifyDiagnostics()
         End Sub
 
         <Fact()>
@@ -180,7 +181,7 @@ Module StringExtensions
     End Sub
 End Module
     </file>
-</compilation>, {TestMetadata.Net40.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_SyncLockRequiresReferenceType1, "syncroot.PrintInt()").WithArguments("Integer"),
+</compilation>, {Net40.References.SystemCore}).VerifyDiagnostics(Diagnostic(ERRID.ERR_SyncLockRequiresReferenceType1, "syncroot.PrintInt()").WithArguments("Integer"),
                                 Diagnostic(ERRID.ERR_VoidValue, "syncroot.PrintVoid"),
                                 Diagnostic(ERRID.WRN_DefAsgUseNullRef, "syncroot").WithArguments("syncroot"))
         End Sub

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
@@ -7,8 +7,8 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -4549,7 +4549,7 @@ Namespace Global.Microsoft.CodeAnalysis.VisualBasic
     End Class
 End Namespace
     ]]></file>
-</compilation>, {TestMetadata.Net40.SystemCore}, options:=TestOptions.DebugDll.WithRootNamespace("Microsoft.CodeAnalysis.VisualBasic.UnitTests"))
+</compilation>, {Net40.References.SystemCore}, options:=TestOptions.DebugDll.WithRootNamespace("Microsoft.CodeAnalysis.VisualBasic.UnitTests"))
 
             Dim semanticModel = CompilationUtils.GetSemanticModel(compilation, "a.vb")
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelLookupSymbolsAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelLookupSymbolsAPITests.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
@@ -308,7 +308,7 @@ Module E
     End Sub
 End Module
 ]]></file>
-</compilation>, {TestMetadata.Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
 
             Dim tree = compilation.SyntaxTrees.Single()
             Dim semanticModel = compilation.GetSemanticModel(tree)

--- a/src/Compilers/VisualBasic/Test/Semantic/ExtensionMethods/SemanticModelTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/ExtensionMethods/SemanticModelTests.vb
@@ -5,8 +5,8 @@
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.ExtensionMethods
 
@@ -1420,7 +1420,7 @@ Module E
     End Sub
 End Module
 ]]></file>
-</compilation>, {TestMetadata.Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             compilation.AssertTheseDiagnostics(<errors><![CDATA[
 BC30456: 'F' is not a member of 'B'.
         _b.F()

--- a/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
 Imports Xunit
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class SimpleFlowTests
@@ -240,7 +241,7 @@ L1:
 End Module
     </file>
 </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(comp,
 <errors>
 BC42104: Variable 'x' is used before it has been assigned a value. A null reference exception could result at runtime.
@@ -278,7 +279,7 @@ Friend Module TestNone
 End Module
     </file>
 </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(comp, <errors></errors>)
         End Sub
 
@@ -311,7 +312,7 @@ Friend Module TestStruct
 End Module
     </file>
 </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(comp, <errors></errors>)
         End Sub
 
@@ -344,7 +345,7 @@ Friend Module TestClass
 End Module
     </file>
 </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(comp,
 <errors>
 BC42109: Variable 's1' is used before it has been assigned a value. A null reference exception could result at runtime. Make sure the structure or all the reference members are initialized before use
@@ -384,7 +385,7 @@ Friend Module TestNewAndDisposable
 End Module
     </file>
 </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(comp, <errors></errors>)
         End Sub
 
@@ -473,7 +474,7 @@ Friend Class TestNewAndDisposable(Of T As {IDisposable, New})
 End Class
     </file>
 </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(comp,
 <errors>
 BC42109: Variable 's1' is used before it has been assigned a value. A null reference exception could result at runtime. Make sure the structure or all the reference members are initialized before use
@@ -507,7 +508,7 @@ Structure MEMORY_BASIC_INFORMATION
 End Structure
     </file>
 </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, references:={Net40.References.SystemCore})
             CompilationUtils.AssertTheseDiagnostics(comp, <errors></errors>)
         End Sub
 
@@ -1474,7 +1475,7 @@ End Module
                             ]]></file>
                           </compilation>
 
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, {Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(program, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(comp,
 <errors>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/AsyncAwait.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/AsyncAwait.vb
@@ -6,9 +6,9 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Imports Roslyn.Test.Utilities
 Imports System.Collections.ObjectModel
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -2004,7 +2004,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CreateEmptyCompilationWithReferences(source, {TestMetadata.Net40.mscorlib, TestMetadata.Net40.MicrosoftVisualBasic}, TestOptions.ReleaseExe)
+            Dim compilation = CreateEmptyCompilationWithReferences(source, {Net40.References.mscorlib, Net40.References.MicrosoftVisualBasic}, TestOptions.ReleaseExe)
 
             AssertTheseDiagnostics(compilation,
 <expected>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalAccessTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalAccessTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -2318,7 +2319,7 @@ End Module
     ]]></file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.SystemCore}, TestOptions.ReleaseExe, TestOptions.ReleaseExe.ParseOptions)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.References.SystemCore}, TestOptions.ReleaseExe, TestOptions.ReleaseExe.ParseOptions)
 
             AssertTheseDiagnostics(compilation,
 <expected><![CDATA[
@@ -2656,7 +2657,7 @@ End Structure
     ]]></file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.SystemCore}, TestOptions.ReleaseExe, TestOptions.ReleaseExe.ParseOptions)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.References.SystemCore}, TestOptions.ReleaseExe, TestOptions.ReleaseExe.ParseOptions)
 
             Dim verifier = CompileAndVerify(compilation, expectedOutput:=
             <![CDATA[
@@ -2831,7 +2832,7 @@ End Class
     ]]></file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.SystemCore}, TestOptions.ReleaseExe, TestOptions.ReleaseExe.ParseOptions)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.References.SystemCore}, TestOptions.ReleaseExe, TestOptions.ReleaseExe.ParseOptions)
 
             Dim verifier = CompileAndVerify(compilation, expectedOutput:=
             <![CDATA[
@@ -2963,7 +2964,7 @@ End Class
     ]]></file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.SystemCore}, TestOptions.ReleaseExe, TestOptions.ReleaseExe.ParseOptions)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.References.SystemCore}, TestOptions.ReleaseExe, TestOptions.ReleaseExe.ParseOptions)
 
             Dim verifier = CompileAndVerify(compilation, expectedOutput:=
             <![CDATA[
@@ -3340,7 +3341,7 @@ End Class
     ]]></file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.SystemCore},
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.References.SystemCore},
                                                                                          TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom),
                                                                                          TestOptions.ReleaseExe.ParseOptions)
 
@@ -3983,7 +3984,7 @@ End Class
     ]]></file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.SystemCore},
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef, {Net40.References.SystemCore},
                                                                                          TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom),
                                                                                          TestOptions.ReleaseExe.ParseOptions)
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -15,6 +15,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics.ConversionsTests.Parameters
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -41,7 +42,7 @@ End Class
             Dim vbConversionsRef = TestReferences.SymbolsTests.VBConversions
             Dim modifiersRef = TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll
 
-            Dim c1 = VisualBasicCompilation.Create("Test", syntaxTrees:={dummyTree}, references:={Net40.mscorlib, vbConversionsRef, modifiersRef})
+            Dim c1 = VisualBasicCompilation.Create("Test", syntaxTrees:={dummyTree}, references:={Net40.References.mscorlib, vbConversionsRef, modifiersRef})
 
             Dim sourceModule = DirectCast(c1.Assembly.Modules(0), SourceModuleSymbol)
             Dim methodDeclSymbol = DirectCast(sourceModule.GlobalNamespace.GetTypeMembers("C1").Single().GetMembers("MethodDecl").Single(), SourceMethodSymbol)
@@ -220,7 +221,7 @@ End Class
 </file>
             Dim dummyTree = VisualBasicSyntaxTree.ParseText(dummyCode.Value)
 
-            Dim c1 = VisualBasicCompilation.Create("Test", syntaxTrees:={dummyTree}, references:={Net40.mscorlib})
+            Dim c1 = VisualBasicCompilation.Create("Test", syntaxTrees:={dummyTree}, references:={Net40.References.mscorlib})
 
             Dim sourceModule = DirectCast(c1.Assembly.Modules(0), SourceModuleSymbol)
             Dim methodDeclSymbol = DirectCast(sourceModule.GlobalNamespace.GetTypeMembers("C1").Single().GetMembers("MethodDecl").Single(), SourceMethodSymbol)
@@ -1074,7 +1075,7 @@ End Class
 </file>
             Dim dummyTree = VisualBasicSyntaxTree.ParseText(dummyCode.Value)
 
-            Dim c1 = VisualBasicCompilation.Create("Test", syntaxTrees:={dummyTree}, references:={Net40.mscorlib},
+            Dim c1 = VisualBasicCompilation.Create("Test", syntaxTrees:={dummyTree}, references:={Net40.References.mscorlib},
                                         options:=TestOptions.ReleaseExe.WithOverflowChecks(False))
 
             Dim sourceModule = DirectCast(c1.Assembly.Modules(0), SourceModuleSymbol)
@@ -1445,7 +1446,7 @@ End Class
             Dim vbConversionsRef = TestReferences.SymbolsTests.VBConversions
             Dim modifiersRef = TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll
 
-            Dim c1 = VisualBasicCompilation.Create("Test", references:={Net40.mscorlib, vbConversionsRef, modifiersRef})
+            Dim c1 = VisualBasicCompilation.Create("Test", references:={Net40.References.mscorlib, vbConversionsRef, modifiersRef})
 
             Dim asmVBConversions = c1.GetReferencedAssemblySymbol(vbConversionsRef)
             Dim asmModifiers = c1.GetReferencedAssemblySymbol(modifiersRef)
@@ -2027,7 +2028,7 @@ End Class
         <Fact()>
         Public Sub BuiltIn()
 
-            Dim c1 = VisualBasicCompilation.Create("Test", references:={Net40.mscorlib})
+            Dim c1 = VisualBasicCompilation.Create("Test", references:={Net40.References.mscorlib})
 
             Dim nullable = c1.GetSpecialType(System_Nullable_T)
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
@@ -12,7 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.OverloadResolution
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -5764,7 +5764,7 @@ Module Program
     End Sub
 End Module
     ]]></file>
-</compilation>, {TestMetadata.Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
@@ -7395,7 +7395,7 @@ End Module
 
 
     ]]></file>
-</compilation>, {TestMetadata.Net40.SystemCore}, TestOptions.ReleaseExe)
+</compilation>, {Net40.References.SystemCore}, TestOptions.ReleaseExe)
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
@@ -7620,7 +7620,7 @@ End Module
 
 
     ]]></file>
-</compilation>, {TestMetadata.Net40.SystemCore}, TestOptions.ReleaseExe)
+</compilation>, {Net40.References.SystemCore}, TestOptions.ReleaseExe)
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of GenericNameSyntax)(compilation, "a.vb")
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetSemanticInfoTests.vb
@@ -15,8 +15,8 @@ Imports Microsoft.CodeAnalysis.VisualBasic.OverloadResolution
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities.TestMetadata
-
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
     Partial Public Class SemanticModelTests
@@ -4488,7 +4488,7 @@ Module Program
     End Function
 End Module
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             comp.VerifyDiagnostics()
 
             Dim tree = comp.SyntaxTrees.Single()
@@ -4550,7 +4550,7 @@ Module Program
     End Sub
 End Module
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             comp.AssertNoDiagnostics()
 
             Dim tree = comp.SyntaxTrees.Single()
@@ -5293,7 +5293,7 @@ End Namespace End Class
        apInitScenario("7. generic T_Method B ----------------------------
 
 }]]></file>
-    </compilation>, {Net40.SystemCore, Net40.System, Net40.SystemData}, TestOptions.ReleaseDll.WithOptionExplicit(False).WithOptionInfer(True))
+    </compilation>, {Net40.References.SystemCore, Net40.References.System, Net40.References.SystemData}, TestOptions.ReleaseDll.WithOptionExplicit(False).WithOptionInfer(True))
 
             compilation.GetDiagnostics()
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -26,7 +27,7 @@ Class Program
 End Class
 
     </file>
-</compilation>, {TestMetadata.Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
 
             compilation.AssertTheseDiagnostics(<errors>
 BC50001: Unused import statement.
@@ -89,7 +90,7 @@ Imports System.Reflection
 <Assembly: AssemblyKeyFile("]]><%= snkPath %><![CDATA[")>
 ]]>
     </file>
-</compilation>, references:={TestMetadata.Net40.SystemCore}, options:=TestOptions.ReleaseDll.WithStrongNameProvider(New DesktopStrongNameProvider()))
+</compilation>, references:={Net40.References.SystemCore}, options:=TestOptions.ReleaseDll.WithStrongNameProvider(New DesktopStrongNameProvider()))
 
             Dim libCompilation = CreateCompilationWithMscorlib40AndReferences(
 <compilation name="Lib">

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaSemanticInfoTests.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -1023,7 +1023,7 @@ Namespace ThenIncludeIntellisenseBug
     End Module
 End Namespace"
     ]]></file>
-</compilation>, references:={TestMetadata.Net40.SystemCore})
+</compilation>, references:={Net40.References.SystemCore})
 
             Dim tree = compilation.SyntaxTrees(0)
             Dim model = compilation.GetSemanticModel(tree)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Lambda_Relaxation.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Lambda_Relaxation.vb
@@ -5,7 +5,7 @@
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
@@ -2976,7 +2976,7 @@ End Module
     ]]></file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {TestMetadata.Net40.SystemCore}, TestOptions.ReleaseDll)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {Net40.References.SystemCore}, TestOptions.ReleaseDll)
 
             CompilationUtils.AssertTheseDiagnostics(compilation, <expected></expected>)
             Dim verifier = CompileAndVerify(compilation)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/MeMyBaseMyClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/MeMyBaseMyClassTests.vb
@@ -6,7 +6,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 Imports VB = Microsoft.CodeAnalysis.VisualBasic
 
@@ -515,7 +515,7 @@ Module MyExtensionModule
     End Function
 End Module
     </file>
-</compilation>, {TestMetadata.Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             Dim symbol = LookUpSymbolTest(comp, "Sum", expectedCount:=1, expectedString:="Function C1.Sum() As System.Int32")
             GetSymbolInfoTest(comp, "MyClass.Sum", symbol)
             GetTypeInfoTest(comp, "MyClass.Sum", "Integer")

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/MethodCalls.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/MethodCalls.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -4869,7 +4870,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {TestMetadata.Net40.SystemCore}, TestOptions.ReleaseExe)
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, TestOptions.ReleaseExe)
 
             Dim compilationVerifier = CompileAndVerify(compilation,
                          expectedOutput:=
@@ -4909,7 +4910,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {TestMetadata.Net40.SystemCore}, TestOptions.ReleaseExe)
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, TestOptions.ReleaseExe)
 
             Dim compilationVerifier = CompileAndVerify(compilation,
                          expectedOutput:=
@@ -5238,7 +5239,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {TestMetadata.Net40.SystemCore}, TestOptions.ReleaseExe)
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(source, {Net40.References.SystemCore}, TestOptions.ReleaseExe)
 
             Dim compilationVerifier = CompileAndVerify(compilation,
                          expectedOutput:=

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -2339,7 +2340,7 @@ End Class
     ]]></file>
 </compilation>
 
-            Dim comp = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {TestMetadata.Net40.SystemCore}, TestOptions.DebugExe)
+            Dim comp = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {Net40.References.SystemCore}, TestOptions.DebugExe)
 
             CompileAndVerify(comp, expectedOutput:=
             <![CDATA[
@@ -2416,7 +2417,7 @@ End Class
     ]]></file>
 </compilation>
 
-            Dim comp = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {TestMetadata.Net40.SystemCore}, TestOptions.DebugExe)
+            Dim comp = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {Net40.References.SystemCore}, TestOptions.DebugExe)
 
             AssertTheseDiagnostics(comp,
 <expected>
@@ -3224,7 +3225,7 @@ End Class
     ]]></file>
 </compilation>
 
-            Dim comp = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {TestMetadata.Net40.SystemCore}, TestOptions.DebugExe)
+            Dim comp = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {Net40.References.SystemCore}, TestOptions.DebugExe)
 
             CompileAndVerify(comp, expectedOutput:=
             <![CDATA[

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
@@ -14,7 +14,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics.OverloadResolutionTestHelpers
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
@@ -3054,7 +3054,7 @@ End Class
 
             Dim c1 = VisualBasicCompilation.Create("Test1",
                 syntaxTrees:={Parse(SemanticResourceUtil.OverloadResolutionTestSource), optionStrictOffTree},
-                references:={TestMetadata.Net40.mscorlib},
+                references:={Net40.References.mscorlib},
                 options:=TestOptions.ReleaseExe.WithOverflowChecks(False))
 
             Dim sourceModule = DirectCast(c1.Assembly.Modules(0), SourceModuleSymbol)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -3486,7 +3487,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {Net40.SystemCore})
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -5318,7 +5319,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -5419,7 +5420,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -6070,7 +6071,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -6735,7 +6736,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -7876,7 +7877,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -9530,7 +9531,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -10710,7 +10711,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -12534,7 +12535,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -12829,7 +12830,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation, <expected></expected>)
         End Sub
@@ -12874,7 +12875,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation, <expected></expected>)
         End Sub
@@ -12919,7 +12920,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation, <expected></expected>)
         End Sub
@@ -12955,7 +12956,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -13960,7 +13961,7 @@ End Class
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -14009,7 +14010,7 @@ Imports System.Linq
             End Sub
         End Module
     </file>
-    </compilation>, additionalRefs:={Net40.SystemCore})
+    </compilation>, additionalRefs:={Net40.References.SystemCore})
 
             AssertTheseEmitDiagnostics(compilation,
 <expected>
@@ -14125,7 +14126,7 @@ End Class
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore,
+                                                                                         additionalRefs:={Net40.References.SystemCore,
                                                                                                           SystemXmlRef,
                                                                                                           SystemXmlLinqRef})
 
@@ -14232,7 +14233,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -14323,7 +14324,7 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(compilationDef,
-                                                                                         additionalRefs:={Net40.SystemCore})
+                                                                                         additionalRefs:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -14351,7 +14352,7 @@ Module M
     End Sub
 End Module
     </file>
-    </compilation>, references:={Net40.SystemCore}).AssertTheseDiagnostics(
+    </compilation>, references:={Net40.References.SystemCore}).AssertTheseDiagnostics(
     <expected>
 BC31396: 'ArgIterator' cannot be made nullable, and cannot be used as the data type of an array element, field, anonymous type member, type argument, 'ByRef' parameter, or return statement.
         Dim c1 As System.ArgIterator()() = Nothing
@@ -14438,7 +14439,7 @@ End Module
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(compilationDef, references:={Net40.SystemCore},
+            Dim verifier = CompileAndVerify(compilationDef, references:={Net40.References.SystemCore},
                              expectedOutput:=
             <![CDATA[
 0
@@ -14505,7 +14506,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.SystemCore})
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -14531,7 +14532,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.SystemCore}, options:=TestOptions.ReleaseExe)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.References.SystemCore}, options:=TestOptions.ReleaseExe)
 
             CompileAndVerify(compilation,
                                 expectedOutput:=
@@ -14559,7 +14560,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.SystemCore}, options:=TestOptions.ReleaseExe)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.References.SystemCore}, options:=TestOptions.ReleaseExe)
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -14591,7 +14592,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.SystemCore})
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -14895,7 +14896,7 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.SystemCore}, options:=TestOptions.ReleaseExe)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.References.SystemCore}, options:=TestOptions.ReleaseExe)
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
@@ -14961,7 +14962,7 @@ End Module
     ]]></file>
 </compilation>
 
-            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.SystemCore}, options:=TestOptions.ReleaseExe)
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.References.SystemCore}, options:=TestOptions.ReleaseExe)
 
             CompileAndVerify(compilation,
                              expectedOutput:=
@@ -14998,7 +14999,7 @@ End Module
     </file>
 </compilation>
 
-            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.SystemCore}, options:=TestOptions.ReleaseDll).AssertNoDiagnostics()
+            CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.References.SystemCore}, options:=TestOptions.ReleaseDll).AssertNoDiagnostics()
 
         End Sub
 
@@ -15051,7 +15052,7 @@ Class C
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.SystemCore}, options:=TestOptions.ReleaseDll)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, references:={Net40.References.SystemCore}, options:=TestOptions.ReleaseDll)
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
 BC30451: 'Whi' is not declared. It may be inaccessible due to its protection level.

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_SemanticModel.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -3807,7 +3807,7 @@ Module AggrArgsInvalidmod
     End Sub
 End Module
     ]]></file>
-</compilation>, references:={TestMetadata.Net40.SystemCore})
+</compilation>, references:={Net40.References.SystemCore})
 
             compilation.VerifyDiagnostics(Diagnostic(ERRID.ERR_QueryOperatorNotFound, "aggr4").WithArguments("aggr4"))
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/VarianceConversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/VarianceConversions.vb
@@ -12,7 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.OverloadResolution
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
@@ -888,7 +888,7 @@ End Module
 </compilation>
 
             Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef,
-                                                                                     {TestMetadata.Net40.SystemCore},
+                                                                                     {Net40.References.SystemCore},
                                                                                      TestOptions.ReleaseExe.WithOptionStrict(OptionStrict.Custom))
 
             CompilationUtils.AssertTheseDiagnostics(compilation,

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/WithBlockSemanticModelTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/WithBlockSemanticModelTests.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -258,7 +259,7 @@ Module Program
     End Class
 End Module
     ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
 
             compilation.AssertNoDiagnostics()
 
@@ -399,7 +400,7 @@ Module Ext
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:={Net40.SystemCore})
+</compilation>, additionalRefs:={Net40.References.SystemCore})
 
             compilation.AssertTheseDiagnostics()
 
@@ -451,7 +452,7 @@ Module Ext
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:={Net40.SystemCore})
+</compilation>, additionalRefs:={Net40.References.SystemCore})
 
             compilation.AssertTheseDiagnostics()
 
@@ -508,7 +509,7 @@ Module Ext
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:={Net40.SystemCore})
+</compilation>, additionalRefs:={Net40.References.SystemCore})
 
             compilation.AssertTheseDiagnostics()
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
@@ -13,6 +13,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -4976,7 +4977,7 @@ Class C
     Private f As (Integer, String)
 End Class
                     </file>
-                </compilation>, references:={TestMetadata.Net40.SystemCore})
+                </compilation>, references:={Net40.References.SystemCore})
 
             Dim format = New SymbolDisplayFormat(memberOptions:=SymbolDisplayMemberOptions.IncludeType, miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.CollapseTupleTypes)
 
@@ -6053,7 +6054,7 @@ end class"
             expectedText As String,
             ParamArray kinds As SymbolDisplayPartKind())
 
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(text, references:={TestMetadata.Net40.SystemCore})
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(text, references:={Net40.References.SystemCore})
 
             ' symbol:
             Dim symbol = findSymbol(comp.GlobalNamespace)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesSemanticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesSemanticsTests.vb
@@ -11,9 +11,9 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.ExtensionMethods
 
@@ -1968,7 +1968,7 @@ End Module
             Dim spans As New List(Of TextSpan)
             ExtractTextIntervals(text, spans)
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndReferences(text, {TestMetadata.Net40.System, TestMetadata.Net40.SystemCore, TestMetadata.Net40.MicrosoftVisualBasic})
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndReferences(text, {Net40.References.System, Net40.References.SystemCore, Net40.References.MicrosoftVisualBasic})
             If errors Is Nothing Then
                 CompilationUtils.AssertNoErrors(compilation)
             Else

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CompilationCreationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CompilationCreationTests.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace CompilationCreationTestHelpers
     Friend Module Helpers
@@ -261,7 +262,7 @@ End Namespace
             Dim varV1MTTestLib2Path = TestReferences.SymbolsTests.V1.MTTestLib2.dll
             Dim asm1 = GetSymbolsForReferences(
             {
-            Net40.mscorlib,
+                Net40.References.mscorlib,
                 varV1MTTestLib2Path
             })
 
@@ -274,9 +275,9 @@ End Namespace
 
             Dim asm2 = GetSymbolsForReferences(
             {
-            Net40.mscorlib,
+                Net40.References.mscorlib,
                 varV1MTTestLib2Path,
-            TestReferences.SymbolsTests.V1.MTTestLib1.dll
+                TestReferences.SymbolsTests.V1.MTTestLib1.dll
             })
 
             Assert.Same(asm2(0), asm1(0))
@@ -298,9 +299,9 @@ End Namespace
             Dim varV2MTTestLib3Path = TestReferences.SymbolsTests.V2.MTTestLib3.dll
             Dim asm3 = GetSymbolsForReferences(
             {
-            Net40.mscorlib,
+                Net40.References.mscorlib,
                 varV1MTTestLib2Path,
-            TestReferences.SymbolsTests.V2.MTTestLib1.dll,
+                TestReferences.SymbolsTests.V2.MTTestLib1.dll,
                 varV2MTTestLib3Path
             })
 
@@ -341,7 +342,7 @@ End Namespace
             Dim varV3MTTestLib4Path = TestReferences.SymbolsTests.V3.MTTestLib4.dll
             Dim asm4 = GetSymbolsForReferences(
             {
-            Net40.mscorlib,
+            Net40.References.mscorlib,
                 varV1MTTestLib2Path,
             TestReferences.SymbolsTests.V3.MTTestLib1.dll,
                 varV2MTTestLib3Path,
@@ -409,7 +410,7 @@ End Namespace
             Assert.Same(retval14, asm4(3).GlobalNamespace.GetMembers("Class5").Single())
             Dim asm5 = GetSymbolsForReferences(
             {
-                Net40.mscorlib,
+                Net40.References.mscorlib,
                 TestReferences.SymbolsTests.V2.MTTestLib3.dll
             })
 
@@ -417,7 +418,7 @@ End Namespace
             Assert.True(asm5(1).RepresentsTheSameAssemblyButHasUnresolvedReferencesByComparisonTo(asm3(3)))
             Dim asm6 = GetSymbolsForReferences(
             {
-                Net40.mscorlib,
+                Net40.References.mscorlib,
                 TestReferences.SymbolsTests.V1.MTTestLib2.dll
             })
 
@@ -425,7 +426,7 @@ End Namespace
             Assert.Same(asm6(1), asm1(1))
             Dim asm7 = GetSymbolsForReferences(
             {
-            Net40.mscorlib,
+            Net40.References.mscorlib,
             TestReferences.SymbolsTests.V1.MTTestLib2.dll,
             TestReferences.SymbolsTests.V2.MTTestLib3.dll,
             TestReferences.SymbolsTests.V3.MTTestLib4.dll
@@ -472,7 +473,7 @@ End Namespace
             ' This test shows that simple reordering of references doesn't pick different set of assemblies
             Dim asm8 = GetSymbolsForReferences(
             {
-            Net40.mscorlib,
+            Net40.References.mscorlib,
             TestReferences.SymbolsTests.V3.MTTestLib4.dll,
             TestReferences.SymbolsTests.V1.MTTestLib2.dll,
             TestReferences.SymbolsTests.V2.MTTestLib3.dll
@@ -487,7 +488,7 @@ End Namespace
             Assert.Same(asm8(1), asm7(3))
             Dim asm9 = GetSymbolsForReferences(
             {
-                Net40.mscorlib,
+                Net40.References.mscorlib,
                 TestReferences.SymbolsTests.V3.MTTestLib4.dll
             })
 
@@ -495,7 +496,7 @@ End Namespace
             Assert.True(asm9(1).RepresentsTheSameAssemblyButHasUnresolvedReferencesByComparisonTo(asm4(4)))
             Dim asm10 = GetSymbolsForReferences(
             {
-            Net40.mscorlib,
+            Net40.References.mscorlib,
             TestReferences.SymbolsTests.V1.MTTestLib2.dll,
             TestReferences.SymbolsTests.V3.MTTestLib1.dll,
             TestReferences.SymbolsTests.V2.MTTestLib3.dll,

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/Choosing.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/Choosing.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 Imports VBReferenceManager = Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.ReferenceManager
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
@@ -25,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                              {
                                 TestResources.SymbolsTests.CorLibrary.GuidTest2,
-                                TestMetadata.ResourcesNet40.mscorlib
+                                Net40.Resources.mscorlib
                              })
 
             Assert.Same(assemblies(1), DirectCast(assemblies(0).Modules(0), PEModuleSymbol).CorLibrary)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
@@ -224,7 +224,7 @@ End Namespace
 
             Dim c1 = VisualBasicCompilation.Create("Test1",
                 syntaxTrees:={VisualBasicSyntaxTree.ParseText(source1.Value)},
-                references:={TestMetadata.Net40.mscorlib})
+                references:={Net40.References.mscorlib})
 
             Assert.Null(c1.GetTypeByMetadataName("DoesntExist"))
             Assert.Null(c1.GetTypeByMetadataName("DoesntExist`1"))
@@ -239,14 +239,14 @@ End Namespace
             Dim c2 = VisualBasicCompilation.Create("Test2",
                         syntaxTrees:={VisualBasicSyntaxTree.ParseText(source2.Value)},
                         references:={New VisualBasicCompilationReference(c1),
-                                        TestMetadata.Net40.mscorlib})
+                                        Net40.References.mscorlib})
 
             Dim c2TestClass As NamedTypeSymbol = c2.GetTypeByMetadataName("System.TestClass")
             Assert.Same(c2.Assembly, c2TestClass.ContainingAssembly)
 
             Dim c3 = VisualBasicCompilation.Create("Test3",
                         references:={New VisualBasicCompilationReference(c2),
-                                    TestMetadata.Net40.mscorlib})
+                                    Net40.References.mscorlib})
 
             Dim c3TestClass As NamedTypeSymbol = c3.GetTypeByMetadataName("System.TestClass")
             Assert.NotSame(c2TestClass, c3TestClass)
@@ -256,7 +256,7 @@ End Namespace
 
             Dim c4 = VisualBasicCompilation.Create("Test4",
                         references:={New VisualBasicCompilationReference(c1), New VisualBasicCompilationReference(c2),
-                                    TestMetadata.Net40.mscorlib})
+                                    Net40.References.mscorlib})
 
             Dim c4TestClass As NamedTypeSymbol = c4.GetTypeByMetadataName("System.TestClass")
             Assert.Null(c4TestClass)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.ExtensionMethods
 
@@ -27,7 +28,7 @@ Module Module1
 
 End Module
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             Dim enumerable As NamedTypeSymbol = compilation1.GetTypeByMetadataName("System.Linq.Enumerable")
 
@@ -1115,7 +1116,7 @@ Module Module1
     End Sub
 End Module
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             Dim module1 As NamedTypeSymbol = compilation1.GetTypeByMetadataName("Module1")
 
@@ -1205,7 +1206,7 @@ Class Module2
     End Sub
 End Class
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             Dim module2 As NamedTypeSymbol = compilation2.GetTypeByMetadataName("Module2")
 
@@ -1274,7 +1275,7 @@ End Module
 &lt;System.Runtime.CompilerServices.Extension()&gt; 'D
 Delegate Sub D()
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             For Each type As NamedTypeSymbol In compilation2.SourceModule.GlobalNamespace.GetTypeMembers()
                 Assert.False(type.MightContainExtensionMethods)
@@ -1353,7 +1354,7 @@ Module Module1
 End Module
 End Module
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             Dim module1 As NamedTypeSymbol = compilation1.GetTypeByMetadataName("Module2+Module1")
 
@@ -1447,7 +1448,7 @@ Module Module2
 End Module
 End Module
         </file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             Dim module1 As NamedTypeSymbol = compilation1.GetTypeByMetadataName("Module1")
 
@@ -1491,7 +1492,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(1, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1522,7 +1523,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(1, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1555,7 +1556,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(1, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1587,7 +1588,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(1, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1617,7 +1618,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(0, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1646,7 +1647,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             references:={Net40.SystemCore},
+                             references:={Net40.References.SystemCore},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(0, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1706,7 +1707,7 @@ End Module
     </compilation>
 
             Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilation1Def,
-                                                                                                       {Net40.SystemCore,
+                                                                                                       {Net40.References.SystemCore,
                                                                                                         New VisualBasicCompilationReference(compilation2),
                                                                                                         New VisualBasicCompilationReference(compilation3)},
                                                                                                        TestOptions.ReleaseExe)
@@ -1725,7 +1726,7 @@ End Namespace
     </compilation>)
 
             Dim compilation1_1 = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilation1Def,
-                                                                                                        {Net40.SystemCore,
+                                                                                                        {Net40.References.SystemCore,
                                                                                                          New VisualBasicCompilationReference(compilation3_1)},
                                                                                                          TestOptions.ReleaseExe)
 
@@ -1762,7 +1763,7 @@ End Namespace
     </compilation>)
 
             Dim compilation1_2 = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilation1Def,
-                                                                                                        {Net40.SystemCore,
+                                                                                                        {Net40.References.SystemCore,
                                                                                                          New VisualBasicCompilationReference(compilation3_2)},
                                                                                                          TestOptions.ReleaseExe)
 
@@ -1786,7 +1787,7 @@ End Module
     </compilation>
 
             Dim compilation1_3 = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilation1_3_Def,
-                                                                                                        {Net40.SystemCore,
+                                                                                                        {Net40.References.SystemCore,
                                                                                                          New VisualBasicCompilationReference(compilation3_1)},
                                                                                                         TestOptions.ReleaseExe)
 
@@ -1831,7 +1832,7 @@ End Namespace
     </compilation>
 
             Dim compilation1_4 = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilation1_4_Def,
-                                                                                                        {Net40.SystemCore,
+                                                                                                        {Net40.References.SystemCore,
                                                                                                          New VisualBasicCompilationReference(compilation3_1)},
                                                                                                         TestOptions.ReleaseExe)
 
@@ -1883,7 +1884,7 @@ Module Module1
 
 End Module
         </file>
-    </compilation>, {Net40.SystemCore,
+    </compilation>, {Net40.References.SystemCore,
                      New VisualBasicCompilationReference(compilation2),
                      New VisualBasicCompilationReference(compilation3)})
 
@@ -1915,7 +1916,7 @@ Module Module1
 
 End Module
         </file>
-    </compilation>, {Net40.SystemCore,
+    </compilation>, {Net40.References.SystemCore,
                      New VisualBasicCompilationReference(compilation2),
                      New VisualBasicCompilationReference(compilation3)})
 
@@ -1945,7 +1946,7 @@ End Module
         </file>
     </compilation>
 
-            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {Net40.SystemCore})
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {Net40.References.SystemCore})
             Dim assembly = compilation.SourceModule.ContainingAssembly
             Dim securityAttributes = assembly.GetAttributes()
             Debug.Assert(securityAttributes.Length = 1)
@@ -2264,7 +2265,7 @@ End Module
 Class C
         End Class
         ]]></file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             CompilationUtils.AssertTheseDiagnostics(compilation2,
 <expected><![CDATA[
@@ -2391,7 +2392,7 @@ Module M
 
 End Module
         ]]></file>
-    </compilation>, references:={Net40.SystemCore})
+    </compilation>, references:={Net40.References.SystemCore})
 
             Dim tree = comp.SyntaxTrees(0)
             Dim model = comp.GetSemanticModel(tree)
@@ -2441,7 +2442,7 @@ o.F()]]>
 
         <Fact>
         Public Sub InteractiveExtensionMethods()
-            Dim references = {Net40.mscorlib, Net40.SystemCore}
+            Dim references = {Net40.References.mscorlib, Net40.References.SystemCore}
 
             Dim source0 = "
 Imports System.Runtime.CompilerServices
@@ -2487,7 +2488,7 @@ public static class Extensions
     {
         System.Console.Write(p);
     }
-}", referencedAssemblies:={Net40.mscorlib, Net40.SystemCore}, parseOptions:=options).EmitToImageReference()
+}", referencedAssemblies:={Net40.References.mscorlib, Net40.References.SystemCore}, parseOptions:=options).EmitToImageReference()
 
             Dim vb = CreateCompilationWithMscorlib40AndVBRuntime(
 <compilation name="AssemblyName">
@@ -2516,7 +2517,7 @@ public static class Extensions
     {
         System.Console.Write(p);
     }
-}", referencedAssemblies:={Net40.mscorlib, Net40.SystemCore}, parseOptions:=options).EmitToImageReference()
+}", referencedAssemblies:={Net40.References.mscorlib, Net40.References.SystemCore}, parseOptions:=options).EmitToImageReference()
 
             Dim vb = CreateCompilationWithMscorlib40AndVBRuntime(
 <compilation name="AssemblyName">
@@ -2551,7 +2552,7 @@ Module E
     End Sub
 End Module
 ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
 
             Dim extensionMethod = DirectCast(compilation.GetSymbolsWithName("ExtMethod", SymbolFilter.Member).Single(), IMethodSymbol)
             Assert.NotNull(extensionMethod)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/GenericConstraintTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/GenericConstraintTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -2033,7 +2034,7 @@ Module M
     End Sub
 End Module
 ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             ' Note: Dev10 reports several errors, although it seems those are incorrect.
             ' BC30456: 'M_Object' is not a member of 'U1'.
             '         x.M_Object()
@@ -2135,7 +2136,7 @@ Module E
     End Sub
 End Module
 ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             compilation.AssertTheseDiagnostics(<expected>
 BC30456: 'M2' is not a member of 'T1'.
         _1.M2()
@@ -2268,7 +2269,7 @@ Module E
     End Sub
 End Module
 ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             compilation.AssertNoErrors()
         End Sub
 
@@ -2295,7 +2296,7 @@ Module E
     End Sub
 End Module
 ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             compilation.AssertTheseDiagnostics(<expected>
 BC30456: 'M2' is not a member of 'T'.
         x.M2(y)
@@ -2330,7 +2331,7 @@ Module E
     End Sub
 End Module
 ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             compilation.AssertTheseDiagnostics(<expected>
 BC30456: 'M' is not a member of 'I(Of B, A)'.
         y.M(z)
@@ -2433,7 +2434,7 @@ Module M
 End Module
 ]]>
     </file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             compilation.AssertTheseDiagnostics(<expected>
 BC36593: Expression of type 'T2' is not queryable. Make sure you are not missing an assembly reference and/or namespace import for the LINQ provider.
         result = From o In _2 Where o IsNot Nothing
@@ -2504,7 +2505,7 @@ Module E
     End Sub
 End Module
 ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             compilation.AssertTheseDiagnostics(<expected>
 BC32105: Type argument 'T' does not satisfy the 'Structure' constraint for type parameter 'T'.
         _1 = AddressOf arg.F1(Of T)
@@ -5381,7 +5382,7 @@ Module M
     End Function
 End Module
    ]]></file>
-</compilation>, references:={Net40.SystemCore})
+</compilation>, references:={Net40.References.SystemCore})
             compilation.AssertNoErrors()
         End Sub
 
@@ -5402,7 +5403,7 @@ Module M
     End Sub
 End Module
    ]]></file>
-</compilation>, references:={Net40.SystemCore})
+</compilation>, references:={Net40.References.SystemCore})
             compilation.AssertNoErrors()
             compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(
 <compilation>
@@ -5416,7 +5417,7 @@ Module M
     End Sub
 End Module
    ]]></file>
-</compilation>, references:={Net40.SystemCore})
+</compilation>, references:={Net40.References.SystemCore})
             compilation.AssertNoErrors()
         End Sub
 
@@ -5455,7 +5456,7 @@ Class C
     End Sub
 End Class
    ]]></file>
-</compilation>, references:={Net40.SystemCore})
+</compilation>, references:={Net40.References.SystemCore})
             compilation.AssertNoErrors()
             compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(
 <compilation>
@@ -5493,7 +5494,7 @@ Class E
     End Sub
 End Class
    ]]></file>
-</compilation>, references:={Net40.SystemCore})
+</compilation>, references:={Net40.References.SystemCore})
             compilation.AssertNoErrors()
             compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(
 <compilation>
@@ -5535,7 +5536,7 @@ Class D2
     End Sub
 End Class
    ]]></file>
-</compilation>, references:={Net40.SystemCore})
+</compilation>, references:={Net40.References.SystemCore})
             compilation.AssertTheseDiagnostics(
 <expected>
 BC30456: 'E1' is not a member of 'X'.

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/BaseTypeResolution.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/BaseTypeResolution.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -16,14 +17,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
         <Fact()>
         Public Sub Test1()
 
-            Dim assembly = MetadataTestHelpers.LoadFromBytes(TestMetadata.ResourcesNet40.mscorlib)
+            Dim assembly = MetadataTestHelpers.LoadFromBytes(Net40.Resources.mscorlib)
 
             TestBaseTypeResolutionHelper1(assembly)
 
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                                     {TestResources.General.MDTestLib1,
                                      TestResources.General.MDTestLib2,
-                                     TestMetadata.ResourcesNet40.mscorlib})
+                                     Net40.Resources.mscorlib})
 
             TestBaseTypeResolutionHelper2(assemblies)
 
@@ -288,7 +289,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
         <Fact()>
         Public Sub Test3()
 
-            Dim mscorlibRef = TestMetadata.Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
 
             Dim c1 = VisualBasicCompilation.Create("Test", references:={mscorlibRef})
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadCustomModifiers.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadCustomModifiers.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Microsoft.CodeAnalysis.CSharp
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -23,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                              {
                                 TestResources.SymbolsTests.CustomModifiers.Modifiers,
-                                TestMetadata.ResourcesNet40.mscorlib
+                                Net40.Resources.mscorlib
                              })
 
             Dim modifiersModule = assemblies(0).Modules(0)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingAttributes.vb
@@ -67,7 +67,7 @@ End Class]]>
                                     {
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                                        ResourcesNet40.mscorlib
+                                        Net40.Resources.mscorlib
                                     })
 
             Dim assembly0 = assemblies(0)
@@ -139,7 +139,7 @@ End Class]]>
                 {
                     TestResources.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                     TestResources.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                    ResourcesNet40.mscorlib
+                    Net40.Resources.mscorlib
                 })
 
             Dim assembly1 = assemblies(1)
@@ -212,7 +212,7 @@ End Class]]>
                                     {
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                                        ResourcesNet40.mscorlib
+                                        Net40.Resources.mscorlib
                                     })
 
             '<AString("C1")>
@@ -283,7 +283,7 @@ End Class]]>
                                     {
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                                        ResourcesNet40.mscorlib
+                                        Net40.Resources.mscorlib
                                     })
 
             Dim aBoolClass = TryCast(assemblies(1).Modules(0).GlobalNamespace.GetMember("ABooleanAttribute"), NamedTypeSymbol)
@@ -369,7 +369,7 @@ End Class]]>
             {
                 TestResources.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                 TestResources.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                ResourcesNet40.mscorlib
+                Net40.Resources.mscorlib
             })
 
             Dim aBoolClass = TryCast(assemblies(1).Modules(0).GlobalNamespace.GetMember("ABooleanAttribute"), NamedTypeSymbol)
@@ -419,7 +419,7 @@ End Class]]>
                                     {
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                                        ResourcesNet40.mscorlib
+                                        Net40.Resources.mscorlib
                                     })
 
             '<AString("C1")>
@@ -470,7 +470,7 @@ End Class]]>
                                     {
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeApplicationLib,
                                         TestResources.SymbolsTests.Metadata.MDTestAttributeDefLib,
-                                        ResourcesNet40.mscorlib
+                                        Net40.Resources.mscorlib
                                     })
 
             'Public Class C2(Of T1)
@@ -659,7 +659,7 @@ End Class]]>
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                                     {
                                         TestResources.SymbolsTests.Metadata.AttributeInterop01,
-                                        ResourcesNet40.mscorlib
+                                        Net40.Resources.mscorlib
                                     })
 
             '[assembly: ImportedFromTypeLib("InteropAttributes")]
@@ -751,7 +751,7 @@ End Class]]>
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                                    {
                                        TestResources.SymbolsTests.Metadata.AttributeInterop01,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             '[ComImport, Guid("ABCDEF5D-2448-447A-B786-64682CBEF123")]
@@ -818,7 +818,7 @@ End Class]]>
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                                    {
                                        TestResources.SymbolsTests.Metadata.AttributeInterop01,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             ' [Serializable, ComVisible(false)]
@@ -861,7 +861,7 @@ End Class]]>
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                                    {
                                        TestResources.SymbolsTests.Metadata.AttributeInterop02,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             ' [Guid("31230DD5-2448-447A-B786-64682CBEFEEE"), Flags]
@@ -901,7 +901,7 @@ End Class]]>
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                                    {
                                        TestResources.SymbolsTests.Metadata.AttributeInterop01,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             '[ComImport, TypeLibType(TypeLibTypeFlags.FAggregatable)]
@@ -1002,7 +1002,7 @@ End Class]]>
                                    {
                                        TestResources.SymbolsTests.Metadata.AttributeTestLib01,
                                        TestResources.SymbolsTests.Metadata.AttributeTestDef01,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             Dim caNS = DirectCast(assemblies(1).GlobalNamespace.GetMember("CustomAttribute"), NamespaceSymbol)
@@ -1043,7 +1043,7 @@ End Class]]>
                                    {
                                        TestResources.SymbolsTests.Metadata.AttributeTestLib01,
                                        TestResources.SymbolsTests.Metadata.AttributeTestDef01,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             Dim caNS = DirectCast(assemblies(1).GlobalNamespace.GetMember("CustomAttribute"), NamespaceSymbol)
@@ -1140,7 +1140,7 @@ End Class]]>
                                    {
                                        TestResources.SymbolsTests.Metadata.AttributeTestLib01,
                                        TestResources.SymbolsTests.Metadata.AttributeTestDef01,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             Dim caNS = DirectCast(assemblies(1).GlobalNamespace.GetMember("CustomAttribute"), NamespaceSymbol)
@@ -1251,7 +1251,7 @@ End Class]]>
                                    {
                                        Net461.Resources.SystemCore,
                                        Net461.Resources.System,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             Dim sysNS = DirectCast(assemblies(2).GlobalNamespace.GetMember("System"), NamespaceSymbol)
@@ -1275,7 +1275,7 @@ End Class]]>
                                    {
                                        Net461.Resources.SystemCore,
                                        Net461.Resources.System,
-                                       ResourcesNet40.mscorlib
+                                       Net40.Resources.mscorlib
                                    })
 
             Dim corsysNS = TryCast(assemblies(2).GlobalNamespace.GetMembers("System").Single, NamespaceSymbol)
@@ -1306,7 +1306,7 @@ End Class]]>
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                 {
                     Net461.Resources.System,
-                    ResourcesNet40.mscorlib,
+                    Net40.Resources.mscorlib,
                     Net461.Resources.SystemConfiguration
                 })
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingFields.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingFields.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -17,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                              {
                                 TestResources.SymbolsTests.Fields.CSFields,
                                 TestResources.SymbolsTests.Fields.VBFields,
-                                TestMetadata.ResourcesNet40.mscorlib
+                                Net40.Resources.mscorlib
                              }, importInternals:=True)
 
             Dim module1 = assemblies(0).Modules(0)
@@ -98,7 +99,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                              {
                                 TestResources.SymbolsTests.Fields.ConstantFields,
-                                TestMetadata.ResourcesNet40.mscorlib
+                                Net40.Resources.mscorlib
                              })
 
             Dim module1 = assemblies(0).Modules(0)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingGenericTypeParameters.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingGenericTypeParameters.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -18,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
         <Fact>
         Public Sub Test1()
-            Dim assembly = MetadataTestHelpers.LoadFromBytes(TestMetadata.ResourcesNet40.mscorlib)
+            Dim assembly = MetadataTestHelpers.LoadFromBytes(Net40.Resources.mscorlib)
             Dim module0 = assembly.Modules(0)
 
             Dim objectType = module0.GlobalNamespace.GetMembers("System").

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingMethods.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingMethods.vb
@@ -13,6 +13,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -28,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestResources.General.MDTestLib2,
                     TestResources.SymbolsTests.Methods.CSMethods,
                     TestResources.SymbolsTests.Methods.VBMethods,
-                    ResourcesNet40.mscorlib,
+                    Net40.Resources.mscorlib,
                     TestResources.SymbolsTests.Methods.ByRefReturn
                 }, importInternals:=True)
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingNamespacesAndTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingNamespacesAndTypes.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -17,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
         <Fact>
         Public Sub Test1()
-            Dim assembly = LoadFromBytes(ResourcesNet40.mscorlib)
+            Dim assembly = LoadFromBytes(Net40.Resources.mscorlib)
             Dim dumpXML As XElement = LoadChildNamespace1(assembly.Modules(0).GlobalNamespace)
 
             Dim baseLine = XElement.Load(New MemoryStream(TestResources.SymbolsTests.Metadata.MscorlibNamespacesAndTypes))
@@ -30,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
         <Fact>
         Public Sub Test2()
-            Dim assembly = LoadFromBytes(ResourcesNet40.mscorlib)
+            Dim assembly = LoadFromBytes(Net40.Resources.mscorlib)
             Dim dumpXML As XElement = LoadChildNamespace2(assembly.Modules(0).GlobalNamespace)
 
             Dim baseLine = XElement.Load(New MemoryStream(TestResources.SymbolsTests.Metadata.MscorlibNamespacesAndTypes))
@@ -105,7 +106,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
         <Fact>
         Public Sub Test3()
-            Dim assembly = LoadFromBytes(ResourcesNet40.mscorlib)
+            Dim assembly = LoadFromBytes(Net40.Resources.mscorlib)
             Dim module0 = assembly.Modules(0)
             Dim globalNS = module0.GlobalNamespace
 
@@ -149,7 +150,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
         <Fact()>
         Public Sub Test4()
-            Dim assembly = LoadFromBytes(ResourcesNet40.mscorlib)
+            Dim assembly = LoadFromBytes(Net40.Resources.mscorlib)
             TestGetMembersOfName(assembly.Modules(0))
 
             Dim assembly2 = LoadFromBytes(TestResources.SymbolsTests.DifferByCase.TypeAndNamespaceDifferByCase)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/MissingTypeReferences.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/MissingTypeReferences.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -26,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(
                                     {TestReferences.SymbolsTests.MissingTypes.MDMissingType,
                                      TestReferences.SymbolsTests.MissingTypes.MDMissingTypeLib,
-                                     TestMetadata.Net40.mscorlib})
+                                     Net40.References.mscorlib})
 
             TestMissingTypeReferencesHelper2(assemblies)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/NoPia.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/NoPia.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
     Public Class NoPia
@@ -33,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestReferences.SymbolsTests.NoPia.LocalTypes1,
                     TestReferences.SymbolsTests.NoPia.LocalTypes2,
                     TestReferences.SymbolsTests.NoPia.Pia1,
-                    Net40.mscorlib,
+                    Net40.References.mscorlib,
                     TestReferences.SymbolsTests.MDTestLib1
                 })
             Dim localTypes1_1 = assemblies1(0)
@@ -64,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                         TestReferences.SymbolsTests.NoPia.LocalTypes1,
                         TestReferences.SymbolsTests.NoPia.LocalTypes2,
                         TestReferences.SymbolsTests.NoPia.Pia1,
-                        Net40.mscorlib
+                        Net40.References.mscorlib
                     })
             Dim localTypes1_2 = assemblies2(0)
             Dim localTypes2_2 = assemblies2(1)
@@ -118,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestReferences.SymbolsTests.NoPia.LocalTypes1,
                     TestReferences.SymbolsTests.NoPia.LocalTypes2,
                     TestReferences.SymbolsTests.NoPia.Pia1,
-                    Net40.mscorlib,
+                    Net40.References.mscorlib,
                     TestReferences.SymbolsTests.MDTestLib1
                 })
 
@@ -131,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestReferences.SymbolsTests.NoPia.LocalTypes1,
                     TestReferences.SymbolsTests.NoPia.LocalTypes2,
                     TestReferences.SymbolsTests.NoPia.Pia2,
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 })
             Dim localTypes1_5 = assemblies5(0)
             Dim localTypes2_5 = assemblies5(1)
@@ -159,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestReferences.SymbolsTests.NoPia.LocalTypes1,
                     TestReferences.SymbolsTests.NoPia.LocalTypes2,
                     TestReferences.SymbolsTests.NoPia.Pia3,
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 })
             Dim localTypes1_6 = assemblies6(0)
             Dim localTypes2_6 = assemblies6(1)
@@ -182,7 +183,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestReferences.SymbolsTests.NoPia.LocalTypes1,
                     TestReferences.SymbolsTests.NoPia.LocalTypes2,
                     TestReferences.SymbolsTests.NoPia.Pia4,
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 })
             Dim localTypes1_7 = assemblies7(0)
             Dim localTypes2_7 = assemblies7(1)
@@ -206,7 +207,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestReferences.SymbolsTests.NoPia.LocalTypes2,
                     TestReferences.SymbolsTests.NoPia.Pia4,
                     TestReferences.SymbolsTests.NoPia.Pia1,
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 })
 
             Dim localTypes1_8 = assemblies8(0)
@@ -232,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestReferences.SymbolsTests.NoPia.Library1,
                     TestReferences.SymbolsTests.NoPia.LocalTypes1,
                     TestReferences.SymbolsTests.NoPia.Pia4,
-                    Net40.mscorlib
+                    Net40.References.mscorlib
                 })
             Dim library1_9 = assemblies9(0)
             Dim localTypes1_9 = assemblies9(1)
@@ -241,7 +242,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                     TestReferences.SymbolsTests.NoPia.Library1,
                     TestReferences.SymbolsTests.NoPia.LocalTypes1,
                     TestReferences.SymbolsTests.NoPia.Pia4,
-                    Net40.mscorlib,
+                    Net40.References.mscorlib,
                     TestReferences.SymbolsTests.MDTestLib1
                 })
             Dim library1_10 = assemblies10(0)
@@ -272,7 +273,7 @@ public class LocalTypes2
     End Sub
 End Class
             </text>.Value
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim pia1CopyLink = TestReferences.SymbolsTests.NoPia.Pia1Copy.WithEmbedInteropTypes(True)
             Dim pia1CopyRef = TestReferences.SymbolsTests.NoPia.Pia1Copy.WithEmbedInteropTypes(False)
 
@@ -286,7 +287,7 @@ End Class
             Dim assemblies1 = MetadataTestHelpers.GetSymbolsForReferences(
                     {
                         TestReferences.SymbolsTests.NoPia.Pia1,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         TestReferences.SymbolsTests.MDTestLib1,
                         TestReferences.SymbolsTests.MDTestLib2,
                         localTypes1,
@@ -330,7 +331,7 @@ End Class
             Dim assemblies2 = MetadataTestHelpers.GetSymbolsForReferences(
                     {
                         TestReferences.SymbolsTests.NoPia.Pia1,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         TestReferences.SymbolsTests.MDTestLib1,
                         localTypes1,
                         localTypes2
@@ -353,7 +354,7 @@ End Class
             Dim assemblies3 = MetadataTestHelpers.GetSymbolsForReferences(
                     {
                         TestReferences.SymbolsTests.NoPia.Pia1,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         localTypes1,
                         localTypes2
                     })
@@ -378,7 +379,7 @@ End Class
             Dim assemblies4 = MetadataTestHelpers.GetSymbolsForReferences(
                     {
                         TestReferences.SymbolsTests.NoPia.Pia1,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         TestReferences.SymbolsTests.MDTestLib1,
                         TestReferences.SymbolsTests.MDTestLib2,
                         localTypes1,
@@ -392,7 +393,7 @@ End Class
             Dim assemblies5 = MetadataTestHelpers.GetSymbolsForReferences(
                     {
                         TestReferences.SymbolsTests.NoPia.Pia2,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         localTypes1,
                         localTypes2
                     })
@@ -427,7 +428,7 @@ End Class
             Dim assemblies6 = MetadataTestHelpers.GetSymbolsForReferences(
                     {
                          TestReferences.SymbolsTests.NoPia.Pia3,
-                         Net40.mscorlib,
+                         Net40.References.mscorlib,
                          localTypes1,
                          localTypes2
                     })
@@ -452,7 +453,7 @@ End Class
             Dim assemblies7 = MetadataTestHelpers.GetSymbolsForReferences(
                     {
                         TestReferences.SymbolsTests.NoPia.Pia4,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         localTypes1,
                         localTypes2
                     })
@@ -481,7 +482,7 @@ End Class
                     {
                         TestReferences.SymbolsTests.NoPia.Pia4,
                         TestReferences.SymbolsTests.NoPia.Pia1,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         localTypes1,
                         localTypes2
                     })
@@ -507,7 +508,7 @@ End Class
                     {
                         TestReferences.SymbolsTests.NoPia.Library1,
                         TestReferences.SymbolsTests.NoPia.Pia4,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         localTypes1
                     })
 
@@ -518,7 +519,7 @@ End Class
                     {
                         TestReferences.SymbolsTests.NoPia.Library1,
                         TestReferences.SymbolsTests.NoPia.Pia4,
-                        Net40.mscorlib,
+                        Net40.References.mscorlib,
                         TestReferences.SymbolsTests.MDTestLib1,
                         localTypes1
                     })
@@ -562,7 +563,7 @@ End Class
             Assert.Equal("C31(Of I1).I31(Of C33)", illegal.UnderlyingSymbol.ToTestDisplayString())
             Assert.NotEqual(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test4").ReturnType.Kind)
             Assert.IsType(Of NoPiaIllegalGenericInstantiationSymbol)(localTypes3.GetMember(Of MethodSymbol)("Test5").ReturnType)
-            assemblies = MetadataTestHelpers.GetSymbolsForReferences({TestReferences.SymbolsTests.NoPia.LocalTypes3, TestReferences.SymbolsTests.NoPia.Pia1, Net40.mscorlib})
+            assemblies = MetadataTestHelpers.GetSymbolsForReferences({TestReferences.SymbolsTests.NoPia.LocalTypes3, TestReferences.SymbolsTests.NoPia.Pia1, Net40.References.mscorlib})
             localTypes3 = assemblies(0).GlobalNamespace.GetTypeMembers("LocalTypes3").Single()
             Assert.NotEqual(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test1").ReturnType.Kind)
             Assert.NotEqual(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test2").ReturnType.Kind)
@@ -574,7 +575,7 @@ End Class
 
         <Fact()>
         Public Sub GenericsClosedOverLocalTypes2()
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim pia5Link = TestReferences.SymbolsTests.NoPia.Pia5.WithEmbedInteropTypes(True)
             Dim pia5Ref = TestReferences.SymbolsTests.NoPia.Pia5.WithEmbedInteropTypes(False)
             Dim library2Ref = TestReferences.SymbolsTests.NoPia.Library2.WithEmbedInteropTypes(False)
@@ -663,7 +664,7 @@ End Class
 
         <Fact()>
         Public Sub GenericsClosedOverLocalTypes3()
-            Dim varmscorlibRef = Net40.mscorlib
+            Dim varmscorlibRef = Net40.References.mscorlib
             Dim varALink = TestReferences.SymbolsTests.NoPia.A.WithEmbedInteropTypes(True)
             Dim varARef = TestReferences.SymbolsTests.NoPia.A.WithEmbedInteropTypes(False)
             Dim varBLink = TestReferences.SymbolsTests.NoPia.B.WithEmbedInteropTypes(True)
@@ -764,7 +765,7 @@ End Interface
 public class C33
 End Class
             </text>.Value
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim pia1CopyLink = TestReferences.SymbolsTests.NoPia.Pia1Copy.WithEmbedInteropTypes(True)
             Dim pia1CopyRef = TestReferences.SymbolsTests.NoPia.Pia1Copy.WithEmbedInteropTypes(False)
             ' vbc /t:library /vbruntime- LocalTypes3.vb /l:Pia1.dll
@@ -780,7 +781,7 @@ End Class
             Assert.Equal("C31(Of I1).I31(Of C33)", illegal.UnderlyingSymbol.ToTestDisplayString())
             Assert.NotEqual(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test4").ReturnType.Kind)
             Assert.IsType(Of NoPiaIllegalGenericInstantiationSymbol)(localTypes3.GetMember(Of MethodSymbol)("Test5").ReturnType)
-            assemblies = MetadataTestHelpers.GetSymbolsForReferences({TestReferences.SymbolsTests.NoPia.Pia1, Net40.mscorlib, varC_LocalTypes3})
+            assemblies = MetadataTestHelpers.GetSymbolsForReferences({TestReferences.SymbolsTests.NoPia.Pia1, Net40.References.mscorlib, varC_LocalTypes3})
             localTypes3 = assemblies(2).GlobalNamespace.GetTypeMembers("LocalTypes3").Single()
             Assert.NotEqual(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test1").ReturnType.Kind)
             Assert.NotEqual(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test2").ReturnType.Kind)
@@ -841,7 +842,7 @@ public interface I7
     Function Bar() As List(Of I1)
 End interface
             </text>.Value
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             ' vbc /t:library /vbruntime- Pia5.vb
             Dim varC_Pia5 = VisualBasicCompilation.Create("Pia5", {Parse(pia5Source)}, {mscorlibRef})
             Dim pia5Link = New VisualBasicCompilationReference(varC_Pia5, embedInteropTypes:=True)
@@ -961,7 +962,7 @@ End interface
 
         <Fact()>
         Public Sub GenericsClosedOverLocalTypes6()
-            Dim mscorlibRef = Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim varC_A = VisualBasicCompilation.Create("A", references:={mscorlibRef})
             Dim varALink = New VisualBasicCompilationReference(varC_A, embedInteropTypes:=True)
             Dim varARef = New VisualBasicCompilationReference(varC_A, embedInteropTypes:=False)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeAccessibility.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeAccessibility.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -17,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
         <Fact>
         Public Sub Test1()
-            Dim assembly = MetadataTestHelpers.LoadFromBytes(TestMetadata.ResourcesNet40.mscorlib)
+            Dim assembly = MetadataTestHelpers.LoadFromBytes(Net40.Resources.mscorlib)
 
             TestTypeAccessibilityHelper(assembly.Modules(0))
         End Sub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeForwarders.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeForwarders.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -20,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
                                     {TestResources.SymbolsTests.TypeForwarders.TypeForwarder,
                                      TestResources.SymbolsTests.TypeForwarders.TypeForwarderLib,
                                      TestResources.SymbolsTests.TypeForwarders.TypeForwarderBase,
-                                     TestMetadata.ResourcesNet40.mscorlib})
+                                     Net40.Resources.mscorlib})
 
             TestTypeForwarderHelper(assemblies)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeKindTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeKindTests.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -17,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
         <Fact>
         Public Sub Test1()
-            Dim assembly = MetadataTestHelpers.LoadFromBytes(TestMetadata.ResourcesNet40.mscorlib)
+            Dim assembly = MetadataTestHelpers.LoadFromBytes(Net40.Resources.mscorlib)
 
             TestTypeKindHelper(assembly)
         End Sub
@@ -85,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
         <Fact>
         <WorkItem(546314, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546314")>
         Public Sub Bug15562()
-            Dim assembly = MetadataTestHelpers.LoadFromBytes(TestMetadata.ResourcesNet40.mscorlib)
+            Dim assembly = MetadataTestHelpers.LoadFromBytes(Net40.Resources.mscorlib)
             Dim module0 = assembly.Modules(0)
             Dim system = (From n In module0.GlobalNamespace.GetMembers()
                           Where n.Name.Equals("System")).Cast(Of NamespaceSymbol)().Single()

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/WinMdEventTest.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/WinMdEventTest.vb
@@ -12,7 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
+Imports Basic.Reference.Assemblies
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
@@ -1308,7 +1308,7 @@ End Class
         </file>
 </compilation>
 
-            Dim comp = CreateEmptyCompilationWithReferences(source, {TestMetadata.Net40.mscorlib}, TestOptions.ReleaseWinMD)
+            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.References.mscorlib}, TestOptions.ReleaseWinMD)
 
             ' This diagnostic is from binding the return type of the AddHandler, not from checking the parameter type
             ' of the ReturnHandler.  The key point is that a cascading ERR_RemoveParamWrongForWinRT is not reported.
@@ -1388,7 +1388,7 @@ End Class
         </file>
 </compilation>
 
-            Dim comp = CreateEmptyCompilationWithReferences(source, {TestMetadata.Net40.mscorlib}, TestOptions.ReleaseWinMD)
+            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.References.mscorlib}, TestOptions.ReleaseWinMD)
 
             ' This diagnostic is from binding the return type of the AddHandler, not from checking the parameter type
             ' of the ReturnHandler.  The key point is that a cascading ERR_RemoveParamWrongForWinRT is not reported.
@@ -1421,7 +1421,7 @@ End Namespace
         </file>
 </compilation>
 
-            Dim comp = CreateEmptyCompilationWithReferences(source, {TestMetadata.Net40.mscorlib}, TestOptions.ReleaseWinMD)
+            Dim comp = CreateEmptyCompilationWithReferences(source, {Net40.References.mscorlib}, TestOptions.ReleaseWinMD)
             AssertTheseDeclarationDiagnostics(comp, <errors><![CDATA[
 BC31091: Import of type 'EventRegistrationTokenTable(Of )' from assembly or module 'test.winmdobj' failed.
     Event E As System.Action    

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 Imports System.Xml.Linq
 Imports Xunit
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
     Public Class NoPia
@@ -226,7 +227,7 @@ End Class
             Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences(New Object() {
                     compilation1,
                     compilation2,
-                    TestMetadata.Net40.mscorlib
+                    Net40.References.mscorlib
                 })
             Dim localTypes1 = assemblies(0).Modules(0)
             Dim localTypes2 = assemblies(1).Modules(0)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetCustomModifiers.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetCustomModifiers.vb
@@ -17,6 +17,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols
 Imports Roslyn.Test.Utilities
 Imports Xunit
 Imports Roslyn.Test.Utilities.TestMetadata
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
 #If Not Retargeting Then
@@ -25,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
 
         <Fact>
         Public Sub Test1()
-            Dim oldMsCorLib = Net40.mscorlib
+            Dim oldMsCorLib = Net40.References.mscorlib
             Dim c1 = VisualBasicCompilation.Create("C1", references:={oldMsCorLib, TestReferences.SymbolsTests.CustomModifiers.Modifiers.netmodule})
 
             Dim c1Assembly = c1.Assembly
@@ -90,7 +91,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
 
         <Fact>
         Public Sub Test2()
-            Dim oldMsCorLib = Net40.mscorlib
+            Dim oldMsCorLib = Net40.References.mscorlib
             Dim source = "
 public class Modifiers
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetingCustomAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetingCustomAttributes.vb
@@ -17,6 +17,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols
 Imports Roslyn.Test.Utilities
 Imports Xunit
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
 #If Not Retargeting Then
@@ -151,7 +152,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
 
         Private Shared ReadOnly Property OldMsCorLib As MetadataReference
             Get
-                Return TestMetadata.Net40.mscorlib
+                Return Net40.References.mscorlib
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MeMyBaseMyClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MeMyBaseMyClassTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class MeMyBaseMyClassTests
@@ -1438,7 +1439,7 @@ Module MyExtensionModule
     End Function
 End Module
     </file>
-</compilation>, references:={TestMetadata.Net40.SystemCore}).VerifyIL("C1.Goo", <![CDATA[
+</compilation>, references:={Net40.References.SystemCore}).VerifyIL("C1.Goo", <![CDATA[
 {
   // Code size       12 (0xc)
   .maxstack  1

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MethodTests.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -1589,7 +1590,7 @@ Module M2
 
 End Module
 ]]></file>
-</compilation>, references:={TestMetadata.Net40.SystemCore, TestMetadata.Net40.System}, options:=TestOptions.ReleaseDll.WithGlobalImports(GlobalImport.Parse("AnExt=System.Runtime.CompilerServices.ExtensionAttribute")))
+</compilation>, references:={Net40.References.SystemCore, Net40.References.System}, options:=TestOptions.ReleaseDll.WithGlobalImports(GlobalImport.Parse("AnExt=System.Runtime.CompilerServices.ExtensionAttribute")))
 
             Dim globalNS = compilation.SourceModule.GlobalNamespace
             Dim sourceMod = DirectCast(compilation.SourceModule, SourceModuleSymbol)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
@@ -673,7 +674,7 @@ End Namespace
         <WorkItem(537199, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537199")>
         <Fact>
         Public Sub UseTypeInNetModule()
-            Dim mscorlibRef = TestMetadata.Net40.mscorlib
+            Dim mscorlibRef = Net40.References.mscorlib
             Dim module1Ref = TestReferences.SymbolsTests.netModule.netModule1
             Dim text = <literal>
 Class Test

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -6906,7 +6906,7 @@ BC30002: Type 'C1' is not defined.
         Public Sub BC30656ERR_UnsupportedField1()
             Dim csharpComp = CSharp.CSharpCompilation.Create("Test", options:=New CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             Dim text = "public class A  {      public static volatile int X;  }"
-            Dim ref = Net40.mscorlib
+            Dim ref = Net40.References.mscorlib
             csharpComp = csharpComp.AddSyntaxTrees(CSharp.SyntaxFactory.ParseSyntaxTree(text))
             csharpComp = csharpComp.AddReferences(ref)
             Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(
@@ -17302,7 +17302,7 @@ BC36015: 'Private Sub DisposeI(Of T As base)(ByRef Instance As T)' has the same 
                 End Sub
             End Class
         ]]></file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
 
             Dim expectedErrors1 = <errors><![CDATA[
 BC36551: Extension methods can be defined only in modules.
@@ -17324,7 +17324,7 @@ BC36551: Extension methods can be defined only in modules.
                 End Sub
             End Module
         ]]></file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             Dim expectedErrors1 = <errors><![CDATA[
 BC36552: Extension methods must declare at least one parameter. The first parameter specifies which type to extend.
                 Public Sub Print()
@@ -17345,7 +17345,7 @@ BC36552: Extension methods must declare at least one parameter. The first parame
                 End Sub
             End Module
         ]]></file>
-   </compilation>, {Net40.SystemCore})
+   </compilation>, {Net40.References.SystemCore})
             Dim expectedErrors1 = <errors><![CDATA[
 BC36553: 'Optional' cannot be applied to the first parameter of an extension method. The first parameter specifies which type to extend.
                 Public Sub Print(Optional ByVal str As String = "hello")
@@ -17366,7 +17366,7 @@ BC36553: 'Optional' cannot be applied to the first parameter of an extension met
                 End Sub
             End Module
         ]]></file>
-    </compilation>, {Net40.SystemCore})
+    </compilation>, {Net40.References.SystemCore})
             Dim expectedErrors1 = <errors><![CDATA[
 BC36554: 'ParamArray' cannot be applied to the first parameter of an extension method. The first parameter specifies which type to extend.
                 Public Sub Print(ByVal ParamArray str() As String)
@@ -17398,7 +17398,7 @@ Module M
     End Sub
 End Module
 ]]></file>
-</compilation>, {Net40.SystemCore})
+</compilation>, {Net40.References.SystemCore})
             Dim expectedErrors1 = <errors><![CDATA[
 BC36561: Extension method 'M2' has type constraints that can never be satisfied.
     Sub M2(Of T As I(Of U), U)(o As T)

--- a/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyMetadataVsSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyMetadataVsSourceTests.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId;
 
@@ -231,7 +231,7 @@ public partial class SymbolKeyTest : SymbolKeyTestBase
                 }
             }
             """;
-        var comp20 = (Compilation)CreateEmptyCompilation(src1, new[] { Net40.mscorlib });
+        var comp20 = (Compilation)CreateEmptyCompilation(src1, new[] { Net40.References.mscorlib });
 
         // "Compilation 2 Assembly"
         var comp40 = (Compilation)CreateCompilation(src2, new MetadataReference[] { comp20.EmitToImageReference() });
@@ -331,7 +331,7 @@ public partial class SymbolKeyTest : SymbolKeyTestBase
                 public void MyEveHandler(object o) { }
             }
             """;
-        var comp20 = CreateEmptyCompilation(src1, new[] { Net40.mscorlib });
+        var comp20 = CreateEmptyCompilation(src1, new[] { Net40.References.mscorlib });
 
         // "Compilation ref Compilation"
         var comp40 = CreateCompilation(src2, new[] { new CSharpCompilationReference(comp20) });
@@ -415,7 +415,7 @@ public partial class SymbolKeyTest : SymbolKeyTestBase
                 }
             }
             """;
-        var comp20 = CreateEmptyCompilation(src1, new[] { Net40.mscorlib });
+        var comp20 = CreateEmptyCompilation(src1, new[] { Net40.References.mscorlib });
 
         // "Compilation ref Compilation"
         var comp40 = CreateCompilation(src2, new[] { new CSharpCompilationReference(comp20) });

--- a/src/EditorFeatures/VisualBasicTest/SymbolId/SymbolKeyMetadataVsSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SymbolId/SymbolKeyMetadataVsSourceTests.vb
@@ -4,6 +4,7 @@
 
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SymbolId
 
@@ -232,7 +233,7 @@ End Class
                            </file>
                        </compilation>
 
-            Dim comp20 = CreateEmptyCompilationWithReferences(src1, {TestMetadata.Net40.mscorlib}, TestOptions.ReleaseDll)
+            Dim comp20 = CreateEmptyCompilationWithReferences(src1, {Net40.References.mscorlib}, TestOptions.ReleaseDll)
             ' "Compilation 2 Assembly"
             Dim comp40 = CreateCompilationWithMscorlib40AndReferences(src2, {comp20.ToMetadataReference()})
 
@@ -306,7 +307,7 @@ End Class
                            </file>
                        </compilation>
 
-            Dim comp20 = CreateEmptyCompilationWithReferences(src1, {TestMetadata.Net40.mscorlib}, TestOptions.ReleaseDll)
+            Dim comp20 = CreateEmptyCompilationWithReferences(src1, {Net40.References.mscorlib}, TestOptions.ReleaseDll)
             '
             Dim comp40 = CreateCompilationWithMscorlib40AndReferences(src2, {comp20.ToMetadataReference()})
 
@@ -382,7 +383,7 @@ End Class
                            </file>
                        </compilation>
 
-            Dim comp20 = CreateEmptyCompilationWithReferences(src1, {TestMetadata.Net40.mscorlib}, TestOptions.ReleaseDll)
+            Dim comp20 = CreateEmptyCompilationWithReferences(src1, {Net40.References.mscorlib}, TestOptions.ReleaseDll)
             Dim comp40 = CreateCompilationWithMscorlib40AndReferences(src2, {comp20.ToMetadataReference()})
 
             Dim ver20Symbols = GetSourceSymbols(comp20, SymbolCategory.NonTypeMember).Where(Function(s) Not s.IsAccessor() And s.Kind <> SymbolKind.Parameter).OrderBy(Function(s) s.Name).ToList()

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
@@ -506,7 +507,7 @@ class C
             // Test with CompileExpression rather than CompileExpressions
             // so field references in IL are named.
             // Debug build.
-            var comp = CreateCompilationWithMscorlib461(source, options: TestOptions.DebugDll, references: new[] { TestMetadata.Net40.SystemCore });
+            var comp = CreateCompilationWithMscorlib461(source, options: TestOptions.DebugDll, references: new[] { Net40.References.SystemCore });
             WithRuntimeInstance(
                 comp,
                 references: null,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -14,6 +14,7 @@ Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Test.Utilities
 Imports Xunit
+Imports Basic.Reference.Assemblies
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class LocalsTests
@@ -2015,7 +2016,7 @@ End Module
 }
 "
 
-            Dim comp = CreateCompilationWithMscorlib40({source}, {TestMetadata.Net40.SystemCore, TestMetadata.Net40.MicrosoftVisualBasic}, TestOptions.DebugDll)
+            Dim comp = CreateCompilationWithMscorlib40({source}, {Net40.References.SystemCore, Net40.References.MicrosoftVisualBasic}, TestOptions.DebugDll)
             WithRuntimeInstance(comp,
                 Sub(runtime)
                     Dim context = CreateMethodContext(runtime, "M.VB$StateMachine_0_F.MoveNext")

--- a/src/Workspaces/CoreTest/SemanticModelReuse/SemanticModelReuseTests.cs
+++ b/src/Workspaces/CoreTest/SemanticModelReuse/SemanticModelReuseTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.UnitTests.SemanticModelReuse
 {
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.SemanticModelReuse
             var projectId = ProjectId.CreateNewId();
             var project = solution.AddProject(projectId, "Project", "Project.dll", language).GetProject(projectId);
 
-            return project.AddMetadataReference(TestMetadata.Net40.mscorlib)
+            return project.AddMetadataReference(Net40.References.mscorlib)
                           .AddDocument("Document", SourceText.From(code));
         }
 


### PR DESCRIPTION
This moves us to use `Basic.Reference.Assemblies` for our `net40` test
assets. This saves ~200MB of I/O on CI restore.

This is a purely mechanical change. The bulk of the changes is

- Rename `Net40.mscorlib` to `Net40.Resources.mscorlib`
- Add an `Import` or `using` for `Basic.Reference.Assemblies`

Functionally there should be no change here.

**Note** there is one test change in `RefStructInterfacesTests` (see second commit). Adding `Basic.Reference.Assembiles.Net40` also updated to the newer version of `Basic.Reference.Assemblies.Net90`. That effectively moved us from Preview3 to Preview6 and that has the updated version of `Activator.CreateInstance`. Needed to update a baseline to account for that. 
