### PR TITLE
Prioritize original user symbol in FAR results above cascaded symbols.

### DIFF
--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService_FindReferences.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService_FindReferences.cs
@@ -161,7 +161,8 @@ internal abstract partial class AbstractFindUsagesService
         OptionsProvider<ClassificationOptions> classificationOptions,
         CancellationToken cancellationToken)
     {
-        var progress = new FindReferencesProgressAdapter(project.Solution, context, searchOptions, classificationOptions);
+        var progress = new FindReferencesProgressAdapter(
+            project.Solution, symbol, context, searchOptions, classificationOptions);
         return SymbolFinder.FindReferencesAsync(
             symbol, project.Solution, progress, documents: null, searchOptions, cancellationToken);
     }

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -609,6 +609,9 @@ internal partial class StreamingFindUsagesPresenter
 
         private static ImmutableArray<Entry> ToImmutableArray((List<Entry> primary, List<Entry> nonPrimary) entries)
         {
+            // When returning the final list of entries to the UI layer, we want primary entries to come first, followed
+            // by non-primary ones.
+
             var result = new FixedSizeArrayBuilder<Entry>(entries.nonPrimary.Count + entries.primary.Count);
             foreach (var entry in entries.primary)
                 result.Add(entry);

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/WithReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/WithReferencesFindUsagesContext.cs
@@ -28,20 +28,23 @@ internal partial class StreamingFindUsagesPresenter
     /// This context supports showing reference items, and will display appropriate messages
     /// about no-references being found for a definition at the end of the search.
     /// </summary>
-    private sealed class WithReferencesFindUsagesContext : AbstractTableDataSourceFindUsagesContext
+    private sealed class WithReferencesFindUsagesContext(
+        StreamingFindUsagesPresenter presenter,
+        IFindAllReferencesWindow findReferencesWindow,
+        ImmutableArray<ITableColumnDefinition> customColumns,
+        IGlobalOptionService globalOptions,
+        bool includeContainingTypeAndMemberColumns,
+        bool includeKindColumn,
+        IThreadingContext threadingContext)
+        : AbstractTableDataSourceFindUsagesContext(
+            presenter,
+            findReferencesWindow,
+            customColumns,
+            globalOptions,
+            includeContainingTypeAndMemberColumns,
+            includeKindColumn,
+            threadingContext)
     {
-        public WithReferencesFindUsagesContext(
-            StreamingFindUsagesPresenter presenter,
-            IFindAllReferencesWindow findReferencesWindow,
-            ImmutableArray<ITableColumnDefinition> customColumns,
-            IGlobalOptionService globalOptions,
-            bool includeContainingTypeAndMemberColumns,
-            bool includeKindColumn,
-            IThreadingContext threadingContext)
-            : base(presenter, findReferencesWindow, customColumns, globalOptions, includeContainingTypeAndMemberColumns, includeKindColumn, threadingContext)
-        {
-        }
-
         protected override async ValueTask OnDefinitionFoundWorkerAsync(DefinitionItem definition, CancellationToken cancellationToken)
         {
             // If this is a definition we always want to show, then create entries for all the declaration locations
@@ -83,7 +86,7 @@ internal partial class StreamingFindUsagesPresenter
                 {
                     // We only include declaration entries in the entries we show when 
                     // not grouping by definition.
-                    AddRange(PrimaryEntriesWhenNotGroupingByDefinition, NonPrimaryEntriesWhenNotGroupingByDefinition, entries, isPrimary);
+                    AddRange(EntriesWhenNotGroupingByDefinition, entries, isPrimary);
                     CurrentVersionNumber++;
                     changed = true;
                 }
@@ -100,13 +103,13 @@ internal partial class StreamingFindUsagesPresenter
         {
             lock (Gate)
             {
-                foreach (var entry in PrimaryEntriesWhenNotGroupingByDefinition)
+                foreach (var entry in EntriesWhenNotGroupingByDefinition.primary)
                 {
                     if (entry.DefinitionBucket.DefinitionItem == definition)
                         return true;
                 }
 
-                foreach (var entry in NonPrimaryEntriesWhenNotGroupingByDefinition)
+                foreach (var entry in EntriesWhenNotGroupingByDefinition.nonPrimary)
                 {
                     if (entry.DefinitionBucket.DefinitionItem == definition)
                         return true;
@@ -165,10 +168,10 @@ internal partial class StreamingFindUsagesPresenter
                 {
                     // Once we can make the new entry, add it to the appropriate list.
                     if (addToEntriesWhenGroupingByDefinition)
-                        Add(PrimaryEntriesWhenGroupingByDefinition, NonPrimaryEntriesWhenGroupingByDefinition, entry, isPrimary);
+                        Add(EntriesWhenGroupingByDefinition, entry, isPrimary);
 
                     if (addToEntriesWhenNotGroupingByDefinition)
-                        Add(PrimaryEntriesWhenNotGroupingByDefinition, NonPrimaryEntriesWhenNotGroupingByDefinition, entry, isPrimary);
+                        Add(EntriesWhenNotGroupingByDefinition, entry, isPrimary);
                 }
 
                 CurrentVersionNumber++;
@@ -236,7 +239,7 @@ internal partial class StreamingFindUsagesPresenter
         {
             lock (Gate)
             {
-                var entries = whenGroupingByDefinition
+                var (primary, nonPrimary) = whenGroupingByDefinition
                     ? EntriesWhenGroupingByDefinition
                     : EntriesWhenNotGroupingByDefinition;
 
@@ -244,7 +247,9 @@ internal partial class StreamingFindUsagesPresenter
                 // them if they want to be displayed without any references.  This will 
                 // ensure that we still see things like overrides and whatnot, but we
                 // won't show property-accessors.
-                var seenDefinitions = entries.Select(r => r.DefinitionBucket.DefinitionItem).ToSet();
+                var seenDefinitions = primary.Concat(nonPrimary)
+                    .Select(r => r.DefinitionBucket.DefinitionItem)
+                    .ToSet();
                 var q = from definition in Definitions
                         where !seenDefinitions.Contains(definition) &&
                               definition.DisplayIfNoReferences
@@ -253,19 +258,15 @@ internal partial class StreamingFindUsagesPresenter
                 // If we find at least one of these types of definitions, then just return those.
                 var result = ImmutableArray.CreateRange(q);
                 if (result.Length > 0)
-                {
                     return result;
-                }
 
-                // We found no definitions that *want* to be displayed.  However, we still 
-                // want to show something.  So, if necessary, show at lest the first definition
-                // even if we found no references and even if it would prefer to not be seen.
-                if (entries.Count == 0 && Definitions.Count > 0)
-                {
+                // We found no definitions that *want* to be displayed.  However, we still want to show something.  So,
+                // if necessary, show at lest the first definition even if we found no references and even if it would
+                // prefer to not be seen.
+                if (primary.Count == 0 && nonPrimary.Count == 0 && Definitions.Count > 0)
                     return [Definitions.First()];
-                }
 
-                return ImmutableArray<DefinitionItem>.Empty;
+                return [];
             }
         }
 

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
@@ -60,10 +60,13 @@ internal partial class StreamingFindUsagesPresenter
             var definitionBucket = GetOrCreateDefinitionBucket(CreateNoResultsDefinitionItem(message), expandedByDefault: true);
             var entry = await SimpleMessageEntry.CreateAsync(definitionBucket, navigationBucket: null, message).ConfigureAwait(false);
 
+            var isPrimary = IsPrimary(definitionBucket.DefinitionItem);
+
             lock (Gate)
             {
-                EntriesWhenGroupingByDefinition.Add(entry);
-                EntriesWhenNotGroupingByDefinition.Add(entry);
+                Add(PrimaryEntriesWhenGroupingByDefinition, NonPrimaryEntriesWhenGroupingByDefinition, entry, isPrimary);
+                Add(PrimaryEntriesWhenNotGroupingByDefinition, NonPrimaryEntriesWhenNotGroupingByDefinition, entry, isPrimary);
+
                 CurrentVersionNumber++;
             }
 
@@ -105,10 +108,12 @@ internal partial class StreamingFindUsagesPresenter
 
             if (entries.Count > 0)
             {
+                var isPrimary = IsPrimary(definition);
+
                 lock (Gate)
                 {
-                    AddRange(EntriesWhenGroupingByDefinition, entries);
-                    AddRange(EntriesWhenNotGroupingByDefinition, entries);
+                    AddRange(EntriesWhenGroupingByDefinition, entries, isPrimary);
+                    AddRange(EntriesWhenNotGroupingByDefinition, entries, isPrimary);
                     CurrentVersionNumber++;
                 }
 

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
@@ -23,19 +23,23 @@ internal partial class StreamingFindUsagesPresenter
     /// This context will not group entries by definition, and will instead just create
     /// entries for the definitions themselves.
     /// </summary>
-    private sealed class WithoutReferencesFindUsagesContext : AbstractTableDataSourceFindUsagesContext
+    private sealed class WithoutReferencesFindUsagesContext(
+        StreamingFindUsagesPresenter presenter,
+        IFindAllReferencesWindow findReferencesWindow,
+        ImmutableArray<ITableColumnDefinition> customColumns,
+        IGlobalOptionService globalOptions,
+        bool includeContainingTypeAndMemberColumns,
+        bool includeKindColumn,
+        IThreadingContext threadingContext)
+        : AbstractTableDataSourceFindUsagesContext(
+            presenter,
+            findReferencesWindow,
+            customColumns,
+            globalOptions,
+            includeContainingTypeAndMemberColumns,
+            includeKindColumn,
+            threadingContext)
     {
-        public WithoutReferencesFindUsagesContext(
-            StreamingFindUsagesPresenter presenter,
-            IFindAllReferencesWindow findReferencesWindow,
-            ImmutableArray<ITableColumnDefinition> customColumns,
-            IGlobalOptionService globalOptions,
-            bool includeContainingTypeAndMemberColumns,
-            bool includeKindColumn,
-            IThreadingContext threadingContext)
-            : base(presenter, findReferencesWindow, customColumns, globalOptions, includeContainingTypeAndMemberColumns, includeKindColumn, threadingContext)
-        {
-        }
 
         // We should never be called in a context where we get references.
         protected override ValueTask OnReferenceFoundWorkerAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
@@ -64,8 +68,8 @@ internal partial class StreamingFindUsagesPresenter
 
             lock (Gate)
             {
-                Add(PrimaryEntriesWhenGroupingByDefinition, NonPrimaryEntriesWhenGroupingByDefinition, entry, isPrimary);
-                Add(PrimaryEntriesWhenNotGroupingByDefinition, NonPrimaryEntriesWhenNotGroupingByDefinition, entry, isPrimary);
+                Add(EntriesWhenGroupingByDefinition, entry, isPrimary);
+                Add(EntriesWhenNotGroupingByDefinition, entry, isPrimary);
 
                 CurrentVersionNumber++;
             }

--- a/src/VisualStudio/Core/Def/FindReferences/StreamingFindUsagesPresenter.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/StreamingFindUsagesPresenter.cs
@@ -134,6 +134,9 @@ internal sealed partial class StreamingFindUsagesPresenter : IStreamingFindUsage
     public IClassificationFormatMap ClassificationFormatMap
         => _lazyClassificationFormatMap.Value;
 
+    private static bool IsPrimary(DefinitionItem definition)
+        => definition.Properties.ContainsKey(DefinitionItem.Primary);
+
     private static IEnumerable<ITableColumnDefinition> GetCustomColumns(IEnumerable<Lazy<ITableColumnDefinition, NameMetadata>> columns)
     {
         foreach (var column in columns)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2201415

Ensure that the initial symbol a user performs 'find all references' on is prioritized at the top of the FAR window (above all cascaded symbols):

![image](https://github.com/user-attachments/assets/64bc00e8-62e0-41da-9986-ccd72abbc8f4)
