### PR TITLE
Only copy devkit assemblies for unit tests when doing a real build

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Microsoft.CodeAnalysis.LanguageServer.UnitTests.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Microsoft.CodeAnalysis.LanguageServer.UnitTests.csproj
@@ -38,3 +38,4 @@
     </ItemGroup>
   </Target>
 </Project>
+

--- a/src/VisualStudio/DevKit/Impl/Microsoft.VisualStudio.LanguageServices.DevKit.csproj
+++ b/src/VisualStudio/DevKit/Impl/Microsoft.VisualStudio.LanguageServices.DevKit.csproj
@@ -55,8 +55,11 @@
     <Content Include="$(TargetPath)" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <!-- Used by LanguageServer.UnitTests project to be able to copy all the content to its own directory -->
-  <Target Name="GetPackInputs" DependsOnTargets="Build" Returns="@(_Content)">
+  <!--
+    Used by LanguageServer.UnitTests project to be able to copy all the content to its own directory.
+    Only needs to run as part of a real build, so skip it in design time builds to prevent issues.
+  -->
+  <Target Name="GetPackInputs" DependsOnTargets="Build" Returns="@(_Content)" Condition="'$(DesignTimeBuild)' != 'true'">
     <ItemGroup>
       <_Content Include="@(Content)" Condition="'%(Content.Pack)'=='true'"/>
     </ItemGroup>


### PR DESCRIPTION
I noticed that the design time build was actually failing when it tried to copy these.  We only need to copy them when running tests (whcih requires a real build) so skip it for design time builds.  We do this in other places too (e.g. semantic search, build host, etc).

This doesn't seem to be related to the current missing project references failures however.

Resolves https://github.com/dotnet/roslyn/issues/74801