### PR TITLE
Optimize usage of `Stack<T>` in SyntaxNavigator

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
@@ -101,7 +101,9 @@ namespace Microsoft.CodeAnalysis
 
                 while (stack.Count > 0)
                 {
-                    var en = stack.Pop();
+                    // only pop enumerator off the stack if it is actually done
+                    var en = stack.Peek();
+
                     if (en.MoveNext())
                     {
                         var child = en.Current;
@@ -111,12 +113,11 @@ namespace Microsoft.CodeAnalysis
                             var token = GetFirstToken(child.AsToken(), predicate, stepInto);
                             if (token.RawKind != None)
                             {
+                                // done, pop enumerator off stack
+                                stack.Pop();
                                 return token;
                             }
                         }
-
-                        // push this enumerator back, not done yet
-                        stack.Push(en);
 
                         if (child.IsNode)
                         {
@@ -147,7 +148,8 @@ namespace Microsoft.CodeAnalysis
 
                 while (stack.Count > 0)
                 {
-                    var en = stack.Pop();
+                    // only pop enumerator off the stack if it is actually done
+                    var en = stack.Peek();
 
                     if (en.MoveNext())
                     {
@@ -158,12 +160,11 @@ namespace Microsoft.CodeAnalysis
                             var token = GetLastToken(child.AsToken(), predicate, stepInto);
                             if (token.RawKind != None)
                             {
+                                // done, pop enumerator off stack
+                                stack.Pop();
                                 return token;
                             }
                         }
-
-                        // push this enumerator back, not done yet
-                        stack.Push(en);
 
                         if (child.IsNode)
                         {


### PR DESCRIPTION
I was looking through the control flow of some methods in SyntaxNavigator and I came across some inefficient pops and pushes on the allocated stacks. This PR fixes a couple of those incidents.

The problem here is that we are popping the enumerator off the stack, only to push it back if we're not done with the enumerator.
To fix this, we simply peek the value off the stack, operate on it, and pop it off if we're done with the enumerator.

The fixed method is faster. Below are the results of basic benchmarks that follow the above control flows:

| Method               | Mean     | Error     | StdDev    | Median   |
|--------------------- |---------:|----------:|----------:|---------:|
| PeekAndPopIfSuccess | 4.970 ns | 0.1276 ns | 0.1193 ns | 4.939 ns |
| PopAndPushIfFail    | 8.919 ns | 1.0096 ns | 2.8968 ns | 7.272 ns |