### PR TITLE
Remove dependency on deprecated ref package

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -260,7 +260,6 @@
     <PackageVersion Include="Microsoft.DiaSymReader.Converter.Xml" Version="1.1.0-beta2-22302-02" />
     <PackageVersion Include="Microsoft.Metadata.Visualizer" Version="1.0.0-beta3.21075.2" />
     <PackageVersion Include="Microsoft.ILVerification" Version="8.0.0-rtm.23523.3" />
-    <PackageVersion Include="Microsoft.NET.Build.Extensions" Version="2.2.101" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="5.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Cache" Version="17.3.26-alpha" />
     <PackageVersion Include="Microsoft.VisualStudio.Diagnostics.Measurement" Version="17.9.36343-preview.3" />

--- a/src/Compilers/Test/Core/Generate.ps1
+++ b/src/Compilers/Test/Core/Generate.ps1
@@ -130,10 +130,6 @@ Add-TargetFramework "SystemThreadingTasksExtensions" '$(PkgSystem_Threading_Task
   'NetStandard20Lib#\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll'
 )
 
-Add-TargetFramework "BuildExtensions" '$(PkgMicrosoft_NET_Build_Extensions)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions' @(
-  'NetStandardToNet461#net461\lib\netstandard.dll'
-)
-
 $targetsContent += @"
   </ItemGroup>
 </Project>

--- a/src/Compilers/Test/Core/Generated.cs
+++ b/src/Compilers/Test/Core/Generated.cs
@@ -69,18 +69,5 @@ namespace Roslyn.Test.Utilities
             public static PortableExecutableReference PortableLib { get; } = AssemblyMetadata.CreateFromImage(ResourcesSystemThreadingTasksExtensions.PortableLib).GetReference(display: "System.Threading.Tasks.Extensions.dll (systemthreadingtasksextensions)", filePath: "PortableLib.dll");
             public static PortableExecutableReference NetStandard20Lib { get; } = AssemblyMetadata.CreateFromImage(ResourcesSystemThreadingTasksExtensions.NetStandard20Lib).GetReference(display: "System.Threading.Tasks.Extensions.dll (systemthreadingtasksextensions)", filePath: "NetStandard20Lib.dll");
         }
-        public static class ResourcesBuildExtensions
-        {
-            private static byte[] _NetStandardToNet461;
-            public static byte[] NetStandardToNet461 => ResourceLoader.GetOrCreateResource(ref _NetStandardToNet461, "netstandardtonet461.buildextensions.netstandard.dll");
-            public static ReferenceInfo[] All => new[]
-            {
-                new ReferenceInfo("NetStandardToNet461.dll", NetStandardToNet461),
-            };
-        }
-        public static class BuildExtensions
-        {
-            public static PortableExecutableReference NetStandardToNet461 { get; } = AssemblyMetadata.CreateFromImage(ResourcesBuildExtensions.NetStandardToNet461).GetReference(display: "netstandard.dll (buildextensions)", filePath: "NetStandardToNet461.dll");
-        }
     }
 }

--- a/src/Compilers/Test/Core/Generated.targets
+++ b/src/Compilers/Test/Core/Generated.targets
@@ -20,9 +20,5 @@
           <LogicalName>netstandard20lib.systemthreadingtasksextensions.System.Threading.Tasks.Extensions.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\systemthreadingtasksextensions\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NET_Build_Extensions)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\net461\lib\netstandard.dll">
-          <LogicalName>netstandardtonet461.buildextensions.netstandard.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\buildextensions\netstandard.dll</Link>
-        </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -106,7 +106,6 @@
 
     <!-- Needed to find the Unsafe.dll binary to lay out at runtime for the compiler when testing analyzers. -->
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-    <PackageReference Include="Microsoft.NET.Build.Extensions" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.Threading.Tasks.Extensions" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CSharp" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualBasic" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />

--- a/src/Compilers/Test/Core/TestBase.cs
+++ b/src/Compilers/Test/Core/TestBase.cs
@@ -255,12 +255,6 @@ namespace Roslyn.Test.Utilities
 
         public static MetadataReference NetStandard20Ref => s_std20Ref.Value;
 
-        private static readonly Lazy<MetadataReference> s_46NetStandardFacade = new Lazy<MetadataReference>(
-            () => AssemblyMetadata.CreateFromImage(ResourcesBuildExtensions.NetStandardToNet461).GetReference(display: "netstandard20.netstandard.dll"),
-            LazyThreadSafetyMode.PublicationOnly);
-
-        public static MetadataReference Net46StandardFacade => s_46NetStandardFacade.Value;
-
         private static readonly Lazy<MetadataReference> s_systemRef = new Lazy<MetadataReference>(
             () => AssemblyMetadata.CreateFromImage(Net461.Resources.System).GetReference(display: "System.v4_0_30319.dll"),
             LazyThreadSafetyMode.PublicationOnly);

--- a/src/Workspaces/CoreTest/FindReferencesTests.cs
+++ b/src/Workspaces/CoreTest/FindReferencesTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -22,6 +23,22 @@ namespace Microsoft.CodeAnalysis.UnitTests
     {
         private static Workspace CreateWorkspace(Type[] additionalParts = null)
             => new AdhocWorkspace(FeaturesTestCompositions.Features.AddParts(additionalParts).GetHostServices());
+
+        private static Solution AddProjectWithMetadataReferences(Solution solution, string projectName, string languageName, string code, IEnumerable<MetadataReference> metadataReference, params ProjectId[] projectReferences)
+        {
+            var suffix = languageName == LanguageNames.CSharp ? "cs" : "vb";
+            var pid = ProjectId.CreateNewId();
+            var did = DocumentId.CreateNewId(pid);
+            var pi = ProjectInfo.Create(
+                pid,
+                VersionStamp.Default,
+                projectName,
+                projectName,
+                languageName,
+                metadataReferences: metadataReference,
+                projectReferences: projectReferences.Select(p => new ProjectReference(p)));
+            return solution.AddProject(pi).AddDocument(did, $"{projectName}.{suffix}", SourceText.From(code));
+        }
 
         private static Solution AddProjectWithMetadataReferences(Solution solution, string projectName, string languageName, string code, MetadataReference metadataReference, params ProjectId[] projectReferences)
         {
@@ -352,9 +369,9 @@ namespace N
     {
         System.Uri Get();
     }
-}", NetStandard20Ref);
+}", NetStandard20.References.All);
 
-            solution = AddProjectWithMetadataReferences(solution, "DesktopProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "NetCoreProject", LanguageNames.CSharp, @"
 using N;
 
 namespace N2 
@@ -366,12 +383,9 @@ namespace N2
             return null;
         }
     }
-}", SystemRef_v46, solution.Projects.Single(pid => pid.Name == "NetStandardProject").Id);
+}", NetCoreApp.References, solution.Projects.Single(pid => pid.Name == "NetStandardProject").Id);
 
-            var desktopProject = solution.Projects.First(p => p.Name == "DesktopProject");
-            solution = solution.AddMetadataReferences(desktopProject.Id, [MscorlibRef_v46, Net46StandardFacade]);
-
-            desktopProject = solution.GetProject(desktopProject.Id);
+            var netCoreProject = solution.Projects.First(p => p.Name == "NetCoreProject");
             var netStandardProject = solution.Projects.First(p => p.Name == "NetStandardProject");
 
             var interfaceMethod = (IMethodSymbol)(await netStandardProject.GetCompilationAsync()).GetTypeByMetadataName("N.I").GetMembers("Get").First();
@@ -383,7 +397,7 @@ namespace N2
             foreach (var r in references)
                 projectIds.Add(solution.GetOriginatingProjectId(r.Definition));
 
-            Assert.True(projectIds.Contains(desktopProject.Id));
+            Assert.True(projectIds.Contains(netCoreProject.Id));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35786")]
@@ -416,7 +430,7 @@ namespace N2
 
             using var workspace = CreateWorkspace();
             var solution = GetMultipleDocumentSolution(workspace, [implText, interface1Text, interface2Text]);
-            solution = solution.AddMetadataReferences(solution.ProjectIds.Single(), [MscorlibRef_v46, Net46StandardFacade, SystemRef_v46, NetStandard20Ref]);
+            solution = solution.AddMetadataReferences(solution.ProjectIds.Single(), NetFramework.References);
 
             var project = solution.Projects.Single();
             var compilation = await project.GetCompilationAsync();


### PR DESCRIPTION
This removes our dependency on the deprecated Microsoft.NET.Build.Extensions package. This is used under the hood when building a `net461` (or earlier) desktop TFM against `netstandard2.0` references. It contains a number of facade assemblies that bridge the gaps in a few places.

There is only one test that dependend on this. I migrated it to a .NET core scenario that should cover the same area.