### PR TITLE
Clean inline rename session

### DIFF
--- a/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -88,7 +88,7 @@ internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMetho
         // wait indicator for Extract Method
         if (_renameService.ActiveSession != null)
         {
-            _threadingContext.JoinableTaskFactory.Run(() => _renameService.ActiveSession.CommitAsync(previewChanges: false, CancellationToken.None));
+            _threadingContext.JoinableTaskFactory.Run(() => _renameService.ActiveSession.CommitAsync(previewChanges: false));
         }
 
         if (!args.SubjectBuffer.SupportsRefactorings())

--- a/src/EditorFeatures/Core/IInlineRenameSession.cs
+++ b/src/EditorFeatures/Core/IInlineRenameSession.cs
@@ -50,5 +50,5 @@ internal interface IInlineRenameSession
     /// <summary>
     /// Dismisses the rename session, completing the rename operation across all files.
     /// </summary>
-    Task CommitAsync(bool previewChanges, CancellationToken cancellationToken);
+    Task CommitAsync(bool previewChanges);
 }

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -735,17 +735,17 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         // which at least will allow the user to cancel the rename if they want.
         //
         // In the future we should remove this entrypoint and have all callers use CommitAsync instead.
-        return _threadingContext.JoinableTaskFactory.Run(() => CommitWorkerAsync(previewChanges, canUseBackgroundWorkIndicator: false, CancellationToken.None));
+        return _threadingContext.JoinableTaskFactory.Run(() => CommitWorkerAsync(previewChanges, canUseBackgroundWorkIndicator: false));
     }
 
-    public Task CommitAsync(bool previewChanges, CancellationToken cancellationToken)
-       => CommitWorkerAsync(previewChanges, canUseBackgroundWorkIndicator: true, cancellationToken);
+    public Task CommitAsync(bool previewChanges)
+       => CommitWorkerAsync(previewChanges, canUseBackgroundWorkIndicator: true);
 
     /// <returns><see langword="true"/> if the rename operation was commited, <see
     /// langword="false"/> otherwise</returns>
-    private async Task<bool> CommitWorkerAsync(bool previewChanges, bool canUseBackgroundWorkIndicator, CancellationToken cancellationToken)
+    private async Task<bool> CommitWorkerAsync(bool previewChanges, bool canUseBackgroundWorkIndicator)
     {
-        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
         VerifyNotDismissed();
 
         // If the identifier was deleted (or didn't change at all) then cancel the operation.

--- a/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                     session.Cancel()
                     VerifyBufferContentsInWorkspace(actualWorkspace, actualWorkspace)
                 ElseIf sessionCommit Then
-                    Await session.CommitAsync(previewChanges:=False, CancellationToken.None)
+                    Await session.CommitAsync(previewChanges:=False)
                     VerifyBufferContentsInWorkspace(actualWorkspace, resolvedConflictWorkspace)
                 End If
             End If

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                     Throw New NotImplementedException()
                 End Sub
 
-                Public Function CommitAsync(previewChanges As Boolean, cancellationToken As CancellationToken) As Task Implements IInlineRenameSession.CommitAsync
+                Public Function CommitAsync(previewChanges As Boolean) As Task Implements IInlineRenameSession.CommitAsync
                     Throw New NotImplementedException()
                 End Function
             End Class


### PR DESCRIPTION
A few clean PRs before moving the commit operation to async.
This PR has no-effect on existing product behaviors..

Might be easier to review based on commit.

**1. Remove the `CancellationToken` from `IInlineRenameSession.CommitAsync`.**
`IInlineRenameSession` already contains `void Cancel();` to control all the cancellations. All the existing callers are call that method to cancel rename.
In fact, `IInlineRenameSession.CommitAsync ` never accepts real cancellationToken from the caller.

**2. Let `InlineRenameSessionOptionsStorage.RenameAsynchronously` to control `CommitAsync`. (And it's on by default!!)**
This option exists for a long time, but things are never async. Only `ExtractMethodCommandHandler` is calling `CommitAsync` (And it's calling JTF.Run)
