### PR TITLE
Skip vsix crossgen targets when running design time build

### DIFF
--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -137,7 +137,7 @@
     <Error Text="Crossgen2 failed with exit code $(_Crossgen2ErrorCode)." Condition="'$(_Crossgen2ErrorCode)' != '0'" />
   </Target>
 
-  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)">
+  <Target Name="PublishedProjectOutputGroup" DependsOnTargets="CalculateCrossgenInputs" Returns="@(_VsixItem)" Condition="'$(DesignTimeBuild)' != 'true'">
     <PropertyGroup>
       <!-- 
         For BCL, we want to use the version provided by the runtime in VS, not the ones from the NuGet packages. 


### PR DESCRIPTION
This should fix the issue where project references would go missing in the IDE when opening Roslyn.sln.

Essentially this target was causing a design time build target called `_SplitProjectReferencesByFileExistence` to run for all child projects, but not running a pre-requisite target (`AssignProjectConfiguration`).  This resulted in project references being dropped for child projects.

The solution is to not run this target in the design time build - it is only necessary for setup authoring.