### PR TITLE
Semantic snippets: don't provide snippets when dotting of a type name

### DIFF
--- a/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopSnippetProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpDoWhileLoopStatementProvider()
+internal sealed class CSharpDoWhileLoopSnippetProvider()
     : AbstractConditionalBlockSnippetProvider<DoStatementSyntax, ExpressionSyntax>
 {
     public override string Identifier => CSharpSnippetIdentifiers.Do;

--- a/src/Features/CSharpTest/Snippets/AbstractCSharpConditionalBlockSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/AbstractCSharpConditionalBlockSnippetProviderTests.cs
@@ -538,4 +538,32 @@ public abstract class AbstractCSharpConditionalBlockSnippetProviderTests : Abstr
             }
             """);
     }
+
+    [Fact]
+    public async Task NoInlineSnippetForTypeItselfTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            class C
+            {
+                void M()
+                {
+                    bool.$$
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineSnippetForTypeItselfTest_Parenthesized()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            class C
+            {
+                void M()
+                {
+                    (bool).$$
+                }
+            }
+            """);
+    }
 }

--- a/src/Features/CSharpTest/Snippets/CSharpDoSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpDoSnippetProviderTests.cs
@@ -554,4 +554,32 @@ public sealed class CSharpDoSnippetProviderTests : AbstractCSharpSnippetProvider
             }
             """);
     }
+
+    [Fact]
+    public async Task NoInlineDoSnippetForTypeItselfTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            class C
+            {
+                void M()
+                {
+                    bool.$$
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineDoSnippetForTypeItselfTest_Parenthesized()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            class C
+            {
+                void M()
+                {
+                    (bool).$$
+                }
+            }
+            """);
+    }
 }

--- a/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
@@ -730,4 +730,52 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
             }
             """);
     }
+
+    [Theory]
+    [InlineData("ArrayList")]
+    [InlineData("IEnumerable")]
+    [InlineData("MyCollection")]
+    public async Task InsertInlineForEachSnippetForVariableNamedLikeTypeTest(string typeAndVariableName)
+    {
+        await VerifySnippetAsync($$"""
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    {{typeAndVariableName}} {{typeAndVariableName}} = default;
+                    {{typeAndVariableName}}.$$
+                }
+            }
+
+            class MyCollection : IEnumerable<int>
+            {
+                public IEnumerator<int> GetEnumerator() => null;
+                IEnumerator IEnumerable.GetEnumerator() = null;
+            }
+            """, $$"""
+            using System.Collections;
+            using System.Collections.Generic;
+            
+            class C
+            {
+                void M()
+                {
+                    {{typeAndVariableName}} {{typeAndVariableName}} = default;
+                    foreach (var {|0:item|} in {{typeAndVariableName}})
+                    {
+                        $$
+                    }
+                }
+            }
+            
+            class MyCollection : IEnumerable<int>
+            {
+                public IEnumerator<int> GetEnumerator() => null;
+                IEnumerator IEnumerable.GetEnumerator() = null;
+            }
+            """);
+    }
 }

--- a/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
@@ -224,17 +224,10 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
     }
 
     [Theory]
-    [InlineData("List<int>")]
-    [InlineData("int[]")]
-    [InlineData("IEnumerable<int>")]
-    [InlineData("ArrayList")]
-    [InlineData("IEnumerable")]
+    [MemberData(nameof(CommonSnippetTestData.CommonEnumerableTypes), MemberType = typeof(CommonSnippetTestData))]
     public async Task InsertInlineForEachSnippetForCorrectTypeTest(string collectionType)
     {
         await VerifySnippetAsync($$"""
-            using System.Collections;
-            using System.Collections.Generic;
-
             class C
             {
                 void M({{collectionType}} enumerable)
@@ -243,9 +236,6 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
                 }
             }
             """, $$"""
-            using System.Collections;
-            using System.Collections.Generic;
-            
             class C
             {
                 void M({{collectionType}} enumerable)
@@ -709,5 +699,35 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
             }
             """,
             referenceAssemblies: ReferenceAssemblies.Net.Net70);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.CommonEnumerableTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineForEachSnippetForTypeItselfTest(string collectionType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M()
+                {
+                    {{collectionType}}.$$
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.CommonEnumerableTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineForEachSnippetForTypeItselfTest_Parenthesized(string collectionType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M()
+                {
+                    ({{collectionType}}).$$
+                }
+            }
+            """);
     }
 }

--- a/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
@@ -875,4 +875,34 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
             }
             """);
     }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineForSnippetForTypeItselfTest(string integerType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M()
+                {
+                    {{integerType}}.$$
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineForSnippetForTypeItselfTest_Parenthesized(string integerType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M()
+                {
+                    ({{integerType}}).$$
+                }
+            }
+            """);
+    }
 }

--- a/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
@@ -905,4 +905,41 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
             }
             """);
     }
+
+    [Fact]
+    public async Task InsertInlineForSnippetForVariableNamedLikeTypeTest()
+    {
+        await VerifySnippetAsync("""
+            class C
+            {
+                void M()
+                {
+                    MyType MyType = default;
+                    MyType.$$
+                }
+            }
+
+            class MyType
+            {
+                public int Length => 0;
+            }
+            """, """
+            class C
+            {
+                void M()
+                {
+                    MyType MyType = default;
+                    for (int {|0:i|} = 0; {|0:i|} < MyType.Length; {|0:i|}++)
+                    {
+                        $$
+                    }
+                }
+            }
+
+            class MyType
+            {
+                public int Length => 0;
+            }
+            """);
+    }
 }

--- a/src/Features/CSharpTest/Snippets/CSharpReversedForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpReversedForSnippetProviderTests.cs
@@ -877,4 +877,71 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
             }
             """);
     }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineReversedForSnippetForTypeItselfTest(string integerType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M()
+                {
+                    {{integerType}}.$$
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineReversedForSnippetForTypeItselfTest_Parenthesized(string integerType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M()
+                {
+                    ({{integerType}}).$$
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task InsertInlineReversedForSnippetForVariableNamedLikeTypeTest()
+    {
+        await VerifySnippetAsync("""
+            class C
+            {
+                void M()
+                {
+                    MyType MyType = default;
+                    MyType.$$
+                }
+            }
+
+            class MyType
+            {
+                public int Length => 0;
+            }
+            """, """
+            class C
+            {
+                void M()
+                {
+                    MyType MyType = default;
+                    for (int {|0:i|} = MyType.Length - 1; {|0:i|} >= 0; {|0:i|}--)
+                    {
+                        $$
+                    }
+                }
+            }
+
+            class MyType
+            {
+                public int Length => 0;
+            }
+            """);
+    }
 }

--- a/src/Features/CSharpTest/Snippets/CommonSnippetTestData.cs
+++ b/src/Features/CSharpTest/Snippets/CommonSnippetTestData.cs
@@ -38,4 +38,14 @@ public static class CommonSnippetTestData
         "private protected",
         "protected internal",
     };
+
+    public static TheoryData<string> CommonEnumerableTypes => new()
+    {
+        "string",
+        "System.Collections.Generic.List<int>",
+        "int[]",
+        "System.Collections.Generic.IEnumerable<int>",
+        "System.Collections.ArrayList",
+        "System.Collections.IEnumerable",
+    };
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -83,19 +83,17 @@ internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax>
             syntaxFacts.IsExpressionStatement(parentNode?.Parent))
         {
             var expression = syntaxFacts.GetExpressionOfMemberAccessExpression(parentNode)!;
-
-            var typeInfo = semanticModel.GetTypeInfo(expression, cancellationToken);
             var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
 
-            // If we get the same symbol from symbol info as expression's type
-            // then we are dotting from a type name itself, e.g. `string.$$`.
+            // Forbid a case when we are dotting of a type, e.g. `string.$$`.
             // Inline statement snippets are not valid in this context
-            if (SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, typeInfo.Type))
+            if (symbolInfo.Symbol is ITypeSymbol)
             {
                 expressionInfo = null;
                 return false;
             }
 
+            var typeInfo = semanticModel.GetTypeInfo(expression, cancellationToken);
             expressionInfo = new(expression, typeInfo);
             return true;
         }


### PR DESCRIPTION
Fixes: https://youtu.be/V_eRvgl5sVg?t=2190