### PR TITLE
Standardize on NET pre-proc symbol

### DIFF
--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderHelper.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderHelper.cs
@@ -71,7 +71,7 @@ internal abstract class AbstractFileHeaderHelper
                 fileHeaderStart = Math.Min(trivia.FullSpan.Start, fileHeaderStart);
                 fileHeaderEnd = trivia.FullSpan.End;
 
-#if NETCOREAPP
+#if NET
                 sb.Append(commentText).AppendLine();
 #else
                 sb.AppendLine(commentText.ToString());

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var builder = new NodeMapBuilder(additionMap, tree, node);
                 builder.Visit(root);
 
-#if NETCOREAPP
+#if NET
                 // Ensure map is large enough to hold found nodes.
                 map.EnsureCapacity(map.Count + additionMap.Keys.Count);
 #endif

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
 
             var slice = text[start..currentIndex];
-#if NETCOREAPP
+#if NET
             content.Append(slice);
 #else
             unsafe

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_RawStringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_RawStringLiteral.cs
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             // Skip the leading whitespace that matches the terminator line and add any whitespace past that to the
             // string value.  Note: if the current line is shorter than the indentation whitespace, this will
             // intentionally copy nothing.
-#if NETCOREAPP
+#if NET
             _builder.Append(currentLineWhitespace, startIndex: indentationWhitespace.Length, count: Math.Max(0, currentLineWhitespace.Length - indentationWhitespace.Length));
 #else
             for (var i = indentationWhitespace.Length; i < currentLineWhitespace.Length; i++)

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
 {
     public class CommandLineTests : CommandLineTestBase
     {
-#if NETCOREAPP
+#if NET
         private static readonly string s_CSharpCompilerExecutable;
         private static readonly string s_DotnetCscRun;
 #else
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
 
         static CommandLineTests()
         {
-#if NETCOREAPP
+#if NET
             var cscDllPath = Path.Combine(
                 Path.GetDirectoryName(typeof(CommandLineTests).GetTypeInfo().Assembly.Location),
                 Path.Combine("dependency", "csc.dll"));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -1131,7 +1131,7 @@ class Program {
         }
 
         [WorkItem(57750, "https://github.com/dotnet/roslyn/issues/57750")]
-#if NETCOREAPP
+#if NET
         [InlineData(TargetFramework.Net60)]
         [InlineData(TargetFramework.Net50)]
 #endif
@@ -1238,7 +1238,7 @@ class App{
         }
 
         [WorkItem(57750, "https://github.com/dotnet/roslyn/issues/57750")]
-#if NETCOREAPP
+#if NET
         [InlineData(TargetFramework.Net60)]
         [InlineData(TargetFramework.Net50)]
 #endif
@@ -1341,7 +1341,7 @@ class App{
         }
 
         [WorkItem(57750, "https://github.com/dotnet/roslyn/issues/57750")]
-#if NETCOREAPP
+#if NET
         [InlineData(TargetFramework.Net60)]
         [InlineData(TargetFramework.Net50)]
 #endif
@@ -1397,7 +1397,7 @@ class App{
         }
 
         [WorkItem(57750, "https://github.com/dotnet/roslyn/issues/57750")]
-#if NETCOREAPP
+#if NET
         [InlineData(TargetFramework.Net60)]
         [InlineData(TargetFramework.Net50)]
 #endif

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -4075,7 +4075,7 @@ class C { }
             bool initialization = false)
         {
             var expectedMessage =
-#if NETCOREAPP
+#if NET
                 $"{message} (Parameter '{parameterName}')";
 #else
                 $"{message}{Environment.NewLine}Parameter name: {parameterName}";

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Microsoft.CodeAnalysis.VisualBasic;
 
-#if NETCOREAPP
+#if NET
 using Roslyn.Test.Utilities.CoreClr;
 using System.Runtime.Loader;
 #else
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
     {
         LoadDirect,
         ShadowLoad,
-#if NETCOREAPP
+#if NET
         LoadStream,
 #endif
     }
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestFixture = testFixture;
         }
 
-#if NETCOREAPP
+#if NET
 
         private void Run(AnalyzerTestKind kind, Action<AnalyzerAssemblyLoader, AssemblyLoadTestFixture> testAction, IAnalyzerAssemblyResolver[]? externalResolvers = null, [CallerMemberName] string? memberName = null) =>
             Run(
@@ -359,7 +359,7 @@ Delta: Gamma: Beta: Test B
 
             string getExpectedLoadPath(string path)
             {
-#if NETCOREAPP
+#if NET
                 if (loader is AnalyzerAssemblyLoader { AnalyzerLoadOption: AnalyzerLoadOption.LoadFromStream })
                 {
                     return "";
@@ -418,7 +418,7 @@ Delta: Gamma: Beta: Test B
         {
             IEnumerable<Assembly> loadedAssemblies;
 
-#if NETCOREAPP
+#if NET
             // This verify only works where there is a single load context.
             var alcs = loader.GetDirectoryLoadContextsSnapshot();
             Assert.Equal(1, alcs.Length);
@@ -740,7 +740,7 @@ Delta: Gamma: Beta: Test B
                 e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
                 var actual = sb.ToString();
 
-#if NETCOREAPP
+#if NET
                 var alcs = loader.GetDirectoryLoadContextsSnapshot();
                 Assert.Equal(2, alcs.Length);
 
@@ -900,7 +900,7 @@ Delta: Epsilon: Test E
 
                 // 2B or not 2B? That is the question...that depends on whether we're on .NET Core or not.
 
-#if NETCOREAPP
+#if NET
 
                 // On Core, we're able to load both of these into separate AssemblyLoadContexts.
                 if (loader.AnalyzerLoadOption == AnalyzerLoadOption.LoadFromDisk)
@@ -1055,7 +1055,7 @@ Delta: Epsilon: Test E
                 var e = epsilon.CreateInstance("Epsilon.E")!;
                 e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
 
-#if NETCOREAPP
+#if NET
                 var alcs1 = loader1.GetDirectoryLoadContextsSnapshot();
                 Assert.Equal(1, alcs1.Length);
 
@@ -1468,7 +1468,7 @@ Delta.2: Test D2
             });
         }
 
-#if NETCOREAPP
+#if NET
 
         [Theory]
         [CombinatorialData]

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedListTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedListTest.cs
@@ -788,7 +788,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
 
-#if NETCOREAPP
+#if NET
         [Fact]
         public void UsableWithCollectibleAssemblies()
         {

--- a/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
@@ -21,7 +21,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 using Microsoft.CodeAnalysis.VisualBasic;
-#if NETCOREAPP
+#if NET
 using Roslyn.Test.Utilities.CoreClr;
 using System.Runtime.Loader;
 #else
@@ -31,7 +31,7 @@ using Roslyn.Test.Utilities.Desktop;
 namespace Microsoft.CodeAnalysis.UnitTests
 {
 
-#if NETCOREAPP
+#if NET
 
     public sealed class InvokeUtil
     {

--- a/src/Compilers/Core/MSBuildTask/RCWForCurrentContext.cs
+++ b/src/Compilers/Core/MSBuildTask/RCWForCurrentContext.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     _shouldReleaseRCW &&
                     Marshal.IsComObject(_rcwForCurrentCtx))
                 {
-#if NETCOREAPP
+#if NET
                     Debug.Assert(OperatingSystem.IsWindows());
 #endif
                     Marshal.ReleaseComObject(_rcwForCurrentCtx);

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
@@ -25,7 +25,7 @@ internal static class TaskTestUtil
         Assert.Equal(line, rsp);
         Assert.Equal(expected, task.GenerateCommandLineArgsTaskItems(rsp).Select(x => x.ItemSpec));
 
-#if NETCOREAPP
+#if NET
         Assert.Equal($"exec \"{task.PathToManagedTool}\"", task.GenerateCommandLineContents().Trim());
 
         // Can only run the Execute path on .NET Core presently. The internal workings of ToolTask 

--- a/src/Compilers/Core/Portable/Collections/TemporaryArray`1.cs
+++ b/src/Compilers/Core/Portable/Collections/TemporaryArray`1.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             {
                 builder.Add(this[i]);
 
-#if NETCOREAPP
+#if NET
                 if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 #endif
                 {

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis
         // Matches EditorConfig property such as "indent_style = space", see https://editorconfig.org for details
         private const string s_propertyMatcherPattern = @"^\s*([\w\.\-_]+)\s*[=:]\s*(.*?)\s*([#;].*)?$";
 
-#if NETCOREAPP
+#if NET
 
         [GeneratedRegex(s_sectionMatcherPattern)]
         private static partial Regex GetSectionMatcherRegex();

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.Collections.Generic;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-#if NETCOREAPP
+#if NET
 
         internal DefaultAnalyzerAssemblyLoader(System.Runtime.Loader.AssemblyLoadContext? compilerLoadContext = null, AnalyzerLoadOption loadOption = AnalyzerLoadOption.LoadFromDisk, ImmutableArray<IAnalyzerAssemblyResolver>? externalResolvers = null)
             : base(compilerLoadContext, loadOption, externalResolvers ?? [])
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis
         /// will be the base directory where shadow copy assemblies are stored. </param>
         internal static IAnalyzerAssemblyLoaderInternal CreateNonLockingLoader(string windowsShadowPath, ImmutableArray<IAnalyzerAssemblyResolver>? externalResolvers = null)
         {
-#if NETCOREAPP
+#if NET
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return new DefaultAnalyzerAssemblyLoader(loadOption: AnalyzerLoadOption.LoadFromStream, externalResolvers: externalResolvers);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -12,7 +12,7 @@ using Roslyn.Utilities;
 using System.Collections.Immutable;
 using System.Reflection;
 
-#if NETCOREAPP
+#if NET
 using System.Runtime.Loader;
 #endif
 
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis
 
         internal int CopyCount => _mvidPathMap.Count;
 
-#if NETCOREAPP
+#if NET
         public ShadowCopyAnalyzerAssemblyLoader(string baseDirectory, ImmutableArray<IAnalyzerAssemblyResolver>? externalResolvers = null)
             : this(null, baseDirectory, externalResolvers)
         {

--- a/src/Compilers/Core/Portable/Hashing/NonCryptographicHashAlgorithm.cs
+++ b/src/Compilers/Core/Portable/Hashing/NonCryptographicHashAlgorithm.cs
@@ -161,7 +161,7 @@ namespace System.IO.Hashing
 
             while (true)
             {
-#if NETCOREAPP
+#if NET
                 int read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
 #else
                 int read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentDictionaryExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentDictionaryExtensions.cs
@@ -28,7 +28,7 @@ namespace Roslyn.Utilities
         public static TValue GetOrAdd<TKey, TArg, TValue>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
             where TKey : notnull
         {
-#if NETCOREAPP
+#if NET
             return dictionary.GetOrAdd(key, valueFactory, factoryArgument);
 #else
             if (dictionary.TryGetValue(key, out var value))
@@ -49,7 +49,7 @@ namespace Roslyn.Utilities
             TArg factoryArgument)
             where TKey : notnull
         {
-#if NETCOREAPP
+#if NET
             return dictionary.AddOrUpdate(key, addValueFactory, updateValueFactory, factoryArgument);
 #else
             using var _a = PooledDelegates.GetPooledFunction(addValueFactory, factoryArgument, out var pooledAddValueFactory);

--- a/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
@@ -238,7 +238,7 @@ namespace Roslyn.Utilities
 
         public void EnsureCapacity(int capacity)
         {
-#if NETCOREAPP
+#if NET
             _dictionary.EnsureCapacity(capacity);
 #endif
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
             // create a mutable hashset of the new items we can check against
             var itemsSet = (_inputComparer == EqualityComparer<T>.Default) ? PooledHashSet<T>.GetInstance() : new HashSet<T>(_inputComparer);
 
-#if NETCOREAPP
+#if NET
             itemsSet.EnsureCapacity(inputItems.Length);
 #endif
 

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// </remarks>
         internal static bool IsBinary(ReadOnlySpan<char> text)
         {
-#if NETCOREAPP
+#if NET
             // On .NET Core, Contains has an optimized vectorized implementation, much faster than a custom loop.
             return text.Contains("\0\0", StringComparison.Ordinal);
 #else

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal static (string processFilePath, string commandLineArguments, string toolFilePath) GetProcessInfo(string toolFilePathWithoutExtension, string commandLineArguments)
         {
-#if NETCOREAPP
+#if NET
             // First check for an app host file and return that if it's available.
             var appHostSuffix = PlatformInformation.IsWindows ? ".exe" : "";
             var appFilePath = $"{toolFilePathWithoutExtension}{appHostSuffix}";
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis
 #endif
         }
 
-#if NETCOREAPP
+#if NET
 
         internal static bool IsCoreClrRuntime => true;
 

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             try
             {
                 testEnvironment.Verify(peVerify);
-#if NETCOREAPP
+#if NET
                 ILVerify(peVerify);
 #endif
             }

--- a/src/Compilers/Test/Core/EncodingTestHelpers.cs
+++ b/src/Compilers/Test/Core/EncodingTestHelpers.cs
@@ -16,7 +16,7 @@ public static class EncodingTestHelpers
 {
     public static IEnumerable<Encoding?> GetEncodings()
     {
-#if NETCOREAPP
+#if NET
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
         yield return null;
@@ -26,7 +26,7 @@ public static class EncodingTestHelpers
         yield return new UTF32Encoding(bigEndian: false, byteOrderMark: false);
         yield return new UnicodeEncoding(bigEndian: true, byteOrderMark: false);
         yield return new UnicodeEncoding(bigEndian: false, byteOrderMark: false);
-#if NETCOREAPP
+#if NET
         foreach (var info in CodePagesEncodingProvider.Instance.GetEncodings())
         {
             yield return info.GetEncoding();

--- a/src/Compilers/Test/Core/Platform/CoreClr/AssemblyLoadContextUtils.cs
+++ b/src/Compilers/Test/Core/Platform/CoreClr/AssemblyLoadContextUtils.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.IO;

--- a/src/Compilers/Test/Core/Platform/CoreClr/CoreCLRRuntimeEnvironment.cs
+++ b/src/Compilers/Test/Core/Platform/CoreClr/CoreCLRRuntimeEnvironment.cs
@@ -4,7 +4,7 @@
 
 #nullable disable
 
-#if NETCOREAPP
+#if NET
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Compilers/Test/Core/Platform/CoreClr/CoreCLRRuntimeEnvironmentFactory.cs
+++ b/src/Compilers/Test/Core/Platform/CoreClr/CoreCLRRuntimeEnvironmentFactory.cs
@@ -4,7 +4,7 @@
 
 #nullable disable
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.Collections.Generic;

--- a/src/Compilers/Test/Core/Platform/CoreClr/SharedConsoleOutWriter.cs
+++ b/src/Compilers/Test/Core/Platform/CoreClr/SharedConsoleOutWriter.cs
@@ -4,7 +4,7 @@
 
 #nullable disable
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.IO;

--- a/src/Compilers/Test/Core/Platform/CoreClr/TestExecutionLoadContext.cs
+++ b/src/Compilers/Test/Core/Platform/CoreClr/TestExecutionLoadContext.cs
@@ -4,7 +4,7 @@
 
 #nullable disable
 
-#if NETCOREAPP
+#if NET
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
@@ -721,7 +721,7 @@ End Class
         End Sub
 
         Shared Sub VerifyArgumentExceptionDiagnostic(diagnostic As Diagnostic, generatorName As String, message As String, parameterName As String, Optional initialization As Boolean = False)
-#If NETCOREAPP Then
+#if NET Then
             Dim expectedMessage = $"{message} (Parameter '{parameterName}')"
 #Else
             Dim expectedMessage = $"{message}{Environment.NewLine}Parameter name: {parameterName}"

--- a/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
@@ -721,7 +721,7 @@ End Class
         End Sub
 
         Shared Sub VerifyArgumentExceptionDiagnostic(diagnostic As Diagnostic, generatorName As String, message As String, parameterName As String, Optional initialization As Boolean = False)
-#if NET Then
+#If NET Then
             Dim expectedMessage = $"{message} (Parameter '{parameterName}')"
 #Else
             Dim expectedMessage = $"{message}{Environment.NewLine}Parameter name: {parameterName}"

--- a/src/Dependencies/Collections/Internal/ArraySortHelper.cs
+++ b/src/Dependencies/Collections/Internal/ArraySortHelper.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-#if NETCOREAPP
+#if NET
 using System.Numerics;
 #else
 using System.Runtime.InteropServices;
@@ -1263,7 +1263,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
         public static int Log2(uint value)
         {
-#if NETCOREAPP
+#if NET
             return BitOperations.Log2(value);
 #else
             // Fallback contract is 0->0

--- a/src/Dependencies/Collections/SegmentedArray`1.cs
+++ b/src/Dependencies/Collections/SegmentedArray`1.cs
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.Collections
             var ret = 0;
             for (var i = Length >= 8 ? Length - 8 : 0; i < Length; i++)
             {
-#if NETCOREAPP
+#if NET
                 ret = HashCode.Combine(comparer.GetHashCode(this[i]!), ret);
 #else
                 ret = unchecked((ret * (int)0xA5555529) + comparer.GetHashCode(this[i]!));

--- a/src/Dependencies/Collections/SegmentedDictionary`2.cs
+++ b/src/Dependencies/Collections/SegmentedDictionary`2.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Collections
         where TKey : notnull
     {
         private const bool SupportsComparerDevirtualization
-#if NETCOREAPP
+#if NET
             = true;
 #else
             = false;
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Collections
         private int _freeList;
         private int _freeCount;
         private int _version;
-#if NETCOREAPP
+#if NET
         private readonly IEqualityComparer<TKey>? _comparer;
 #else
         /// <summary>
@@ -710,14 +710,14 @@ ReturnNotFound:
                         Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
                         entry._next = StartOfFreeList - _freeList;
 
-#if NETCOREAPP
+#if NET
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
 #endif
                         {
                             entry._key = default!;
                         }
 
-#if NETCOREAPP
+#if NET
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
 #endif
                         {
@@ -789,14 +789,14 @@ ReturnNotFound:
                         Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
                         entry._next = StartOfFreeList - _freeList;
 
-#if NETCOREAPP
+#if NET
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
 #endif
                         {
                             entry._key = default!;
                         }
 
-#if NETCOREAPP
+#if NET
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
 #endif
                         {

--- a/src/Dependencies/Collections/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/SegmentedHashSet`1.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Collections
 #endif
     {
         private const bool SupportsComparerDevirtualization
-#if NETCOREAPP
+#if NET
             = true;
 #else
             = false;
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Collections
         private int _freeList;
         private int _freeCount;
         private int _version;
-#if NETCOREAPP
+#if NET
         private readonly IEqualityComparer<T>? _comparer;
 #else
         /// <summary>
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.Collections
                         Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
                         entry._next = StartOfFreeList - _freeList;
 
-#if NETCOREAPP
+#if NET
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 #endif
                         {

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -359,7 +359,7 @@ namespace Microsoft.CodeAnalysis.Collections
         public void Clear()
         {
             _version++;
-#if NETCOREAPP
+#if NET
             if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 _size = 0;
@@ -1049,7 +1049,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 }
             }
 
-#if NETCOREAPP
+#if NET
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 #endif
             {
@@ -1075,7 +1075,7 @@ namespace Microsoft.CodeAnalysis.Collections
             {
                 SegmentedArray.Copy(_items, index + 1, _items, index, _size - index);
             }
-#if NETCOREAPP
+#if NET
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 #endif
             {
@@ -1109,7 +1109,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 }
 
                 _version++;
-#if NETCOREAPP
+#if NET
                 if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 #endif
                 {

--- a/src/Features/Core/Portable/Debugging/DebugInformationReaderProvider.cs
+++ b/src/Features/Core/Portable/Debugging/DebugInformationReaderProvider.cs
@@ -92,7 +92,7 @@ internal abstract class DebugInformationReaderProvider : IDisposable
             var symReader = Interlocked.Exchange(ref _symReader, null);
             if (symReader != null && Marshal.IsComObject(symReader))
             {
-#if NETCOREAPP
+#if NET
                 Debug.Assert(OperatingSystem.IsWindows());
 #endif
                 Marshal.ReleaseComObject(symReader);

--- a/src/Features/Core/Portable/EmbeddedLanguages/EmbeddedLanguageCommentDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/EmbeddedLanguageCommentDetector.cs
@@ -43,7 +43,7 @@ internal readonly struct EmbeddedLanguageCommentDetector
         identifier = match.Groups["identifier"].Value;
 
         var optionGroup = match.Groups["option"];
-#if NETCOREAPP
+#if NET
         options = optionGroup.Captures.Select(c => c.Value);
 #else
         options = optionGroup.Captures.OfType<Capture>().Select(c => c.Value);

--- a/src/Features/Core/Portable/PdbSourceDocument/SourceLinkMap.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/SourceLinkMap.cs
@@ -10,7 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 
-#if NETCOREAPP
+#if NET
 using System.Diagnostics.CodeAnalysis;
 #endif
 
@@ -167,7 +167,7 @@ internal readonly struct SourceLinkMap
     /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
     public bool TryGetUri(
         string path,
-#if NETCOREAPP
+#if NET
         [NotNullWhen(true)]
 #endif
         out string? uri)

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
@@ -653,7 +653,7 @@ internal partial class SymbolSearchUpdateEngine
             using (var inStream = new MemoryStream(compressedBytes))
             using (var deflateStream = new DeflateStream(inStream, CompressionMode.Decompress))
             {
-#if NETCOREAPP
+#if NET
                 await deflateStream.CopyToAsync(outStream, cancellationToken).ConfigureAwait(false);
 #else
                 await deflateStream.CopyToAsync(outStream).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Host
         /// <summary>
         /// Cached compile-time solution corresponding to an existing design-time solution.
         /// </summary>
-#if NETCOREAPP
+#if NET
         private readonly ConditionalWeakTable<Solution, Solution> _designTimeToCompileTimeSolution = [];
 #else
         private ConditionalWeakTable<Solution, Solution> _designTimeToCompileTimeSolution = new();
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Host
                 {
                     lock (_gate)
                     {
-#if NETCOREAPP
+#if NET
                         _designTimeToCompileTimeSolution.Clear();
 #else
                         _designTimeToCompileTimeSolution = new();

--- a/src/LanguageServer/Protocol/Protocol/Diagnostic.cs
+++ b/src/LanguageServer/Protocol/Protocol/Diagnostic.cs
@@ -170,7 +170,7 @@ namespace Roslyn.LanguageServer.Protocol
 
         /// <inheritdoc/>
         public override int GetHashCode() =>
-#if NETCOREAPP
+#if NET
             HashCode.Combine(Range, Severity, Code, Source, Message, Hash.CombineValues(Tags), CodeDescription, Data);
 #else
             Hash.Combine(Range,

--- a/src/LanguageServer/Protocol/Protocol/LocationLink.cs
+++ b/src/LanguageServer/Protocol/Protocol/LocationLink.cs
@@ -69,7 +69,7 @@ internal class LocationLink : IEquatable<LocationLink>
 
     /// <inheritdoc/>
     public override int GetHashCode() =>
-#if NETCOREAPP
+#if NET
         HashCode.Combine(OriginSelectionRange, TargetUri, TargetRange, TargetSelectionRange);
 #else
         Hash.Combine(OriginSelectionRange,

--- a/src/LanguageServer/Protocol/Protocol/SymbolInformation.cs
+++ b/src/LanguageServer/Protocol/Protocol/SymbolInformation.cs
@@ -127,7 +127,7 @@ namespace Roslyn.LanguageServer.Protocol
         /// <inheritdoc/>
         public override int GetHashCode() =>
 #pragma warning disable CS0618 // Type or member is obsolete
-#if NETCOREAPP
+#if NET
             HashCode.Combine(Name, Kind, Hash.CombineValues(Tags), Deprecated, Location, ContainerName);
 #else
             Hash.Combine(Name,

--- a/src/Tools/AnalyzerRunner/PerformanceTracker.cs
+++ b/src/Tools/AnalyzerRunner/PerformanceTracker.cs
@@ -12,13 +12,13 @@ namespace AnalyzerRunner
     internal sealed class PerformanceTracker
     {
         private readonly Stopwatch _stopwatch;
-#if NETCOREAPP
+#if NET
         private readonly long _initialTotalAllocatedBytes;
 #endif
 
         public PerformanceTracker(Stopwatch stopwatch, long initialTotalAllocatedBytes)
         {
-#if NETCOREAPP
+#if NET
             _initialTotalAllocatedBytes = initialTotalAllocatedBytes;
 #endif
             _stopwatch = stopwatch;
@@ -26,7 +26,7 @@ namespace AnalyzerRunner
 
         public static PerformanceTracker StartNew(bool preciseMemory = true)
         {
-#if NETCOREAPP
+#if NET
             var initialTotalAllocatedBytes = GC.GetTotalAllocatedBytes(preciseMemory);
 #else
             var initialTotalAllocatedBytes = 0L;
@@ -37,7 +37,7 @@ namespace AnalyzerRunner
 
         public TimeSpan Elapsed => _stopwatch.Elapsed;
 
-#if NETCOREAPP
+#if NET
         public long AllocatedBytes => GC.GetTotalAllocatedBytes(true) - _initialTotalAllocatedBytes;
 #else
         public long AllocatedBytes => 0;
@@ -45,7 +45,7 @@ namespace AnalyzerRunner
 
         public string GetSummary(bool preciseMemory = true)
         {
-#if NETCOREAPP
+#if NET
             var elapsedTime = Elapsed;
             var allocatedBytes = GC.GetTotalAllocatedBytes(preciseMemory) - _initialTotalAllocatedBytes;
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/Grammar/GrammarGenerator.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/Grammar/GrammarGenerator.cs
@@ -5,7 +5,7 @@
 #nullable disable
 
 // We only support grammar generation in the command line version for now which is the netcoreapp target
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/Program.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/Program.cs
@@ -5,7 +5,7 @@
 #nullable disable
 
 // We only include this file in the command line version for now which is the netcoreapp target
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.IO;

--- a/src/Workspaces/Core/MSBuild.BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Build/ProjectBuildManager.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             { PropertyNames.DesignTimeBuild, bool.TrueString },
 
             // this will force CoreCompile task to execute even if all inputs and outputs are up to date
-#if NETCOREAPP
+#if NET
             { PropertyNames.NonExistentFile, "__NonExistentSubDir__\\__NonExistentFile__" },
 #else
             // Setting `BuildingInsideVisualStudio` indirectly sets NonExistentFile:

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -20,7 +20,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Serialization;
 
-#if NETCOREAPP
+#if NET
 [SupportedOSPlatform("windows")]
 #endif
 internal partial class SerializerService : ISerializerService

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/Interop/SqlStatement.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/Interop/SqlStatement.cs
@@ -80,7 +80,7 @@ internal readonly struct SqlStatement(SqlConnection connection, SafeSqliteStatem
             if (utf8ByteCount <= OptimizedLengthThreshold)
             {
                 Span<byte> bytes = stackalloc byte[utf8ByteCount];
-#if NETCOREAPP
+#if NET
                 Contract.ThrowIfFalse(Encoding.UTF8.GetBytes(value.AsSpan(), bytes) == utf8ByteCount);
 #else
                 unsafe

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Host;
 /// <summary>
 /// Temporarily stores text and streams in memory mapped files.
 /// </summary>
-#if NETCOREAPP
+#if NET
 [SupportedOSPlatform("windows")]
 #endif
 internal sealed partial class TemporaryStorageService : ITemporaryStorageServiceInternal

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/LegacyTemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/LegacyTemporaryStorageService.cs
@@ -69,7 +69,7 @@ internal sealed class LegacyTemporaryStorageService : ITemporaryStorageService
         public async Task WriteStreamAsync(Stream stream, CancellationToken cancellationToken = default)
         {
             var newStream = new MemoryStream();
-#if NETCOREAPP
+#if NET
             await stream.CopyToAsync(newStream, cancellationToken).ConfigureAwait(false);
 # else
             await stream.CopyToAsync(newStream).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -60,7 +60,7 @@ internal readonly partial record struct Checksum(
 
     public string ToBase64String()
     {
-#if NETCOREAPP
+#if NET
         Span<byte> bytes = stackalloc byte[HashSize];
         this.WriteTo(bytes);
         return Convert.ToBase64String(bytes);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -148,7 +148,7 @@ internal sealed class TextDocumentStates<TState>
         {
             using var _ = PooledHashSet<DocumentId>.GetInstance(out var set);
 
-#if NETCOREAPP
+#if NET
             set.EnsureCapacity(ids.Length);
 #endif
 

--- a/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
     [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
     public class ReduceTokenTests
     {
-#if NETCOREAPP
+#if NET
         private static bool IsNetCoreApp => true;
 #else
         private static bool IsNetCoreApp => false;

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
     using static TemporaryStorageService;
 
     [UseExportProvider]
-#if NETCOREAPP
+#if NET
     [SupportedOSPlatform("windows")]
 #endif
     [Trait(Traits.Feature, Traits.Features.Workspace)]

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
                 public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => _stream.ReadAsync(buffer, offset, count, cancellationToken);
                 public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => _stream.WriteAsync(buffer, offset, count, cancellationToken);
 
-#if NETCOREAPP // nullability annotations differ
+#if NET // nullability annotations differ
                 public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) => _stream.BeginRead(buffer, offset, count, callback, state);
                 public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) => _stream.BeginWrite(buffer, offset, count, callback, state);
 #else

--- a/src/Workspaces/CoreTestUtilities/Remote/TestSerializerService.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/TestSerializerService.cs
@@ -22,7 +22,7 @@ using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Remote
 {
-#if NETCOREAPP
+#if NET
     [SupportedOSPlatform("windows")]
 #endif
     [method: Obsolete(MefConstruction.FactoryMethodMessage, error: true)]

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -289,7 +289,7 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
                     var missingChecksumsMemory = new ReadOnlyMemory<Checksum>(missingChecksums, 0, missingChecksumsCount);
                     Contract.ThrowIfTrue(missingChecksumsMemory.Length == 0);
 
-#if NETCOREAPP
+#if NET
                     Contract.ThrowIfTrue(missingChecksumsMemory.Span.Contains(Checksum.Null));
 #else
                     Contract.ThrowIfTrue(missingChecksumsMemory.Span.IndexOf(Checksum.Null) >= 0);

--- a/src/Workspaces/Remote/ServiceHubTest/RemoteAnalyzerAssemblyLoaderTests.cs
+++ b/src/Workspaces/Remote/ServiceHubTest/RemoteAnalyzerAssemblyLoaderTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP
+#if NET
 
 using System.IO;
 using System.Reflection;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectReader.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectReader.cs
@@ -73,7 +73,7 @@ internal sealed partial class ObjectReader : IDisposable
             // PipeReaderStream wraps any exception it throws in an AggregateException, which is not expected by
             // callers treating it as a normal stream. Unwrap and rethrow the inner exception for clarity.
             // https://github.com/dotnet/runtime/issues/70206
-#if NETCOREAPP
+#if NET
             ExceptionDispatchInfo.Throw(ex.InnerException);
 #else
             ExceptionDispatchInfo.Capture(ex.InnerException).Throw();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectWriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/ObjectWriter.cs
@@ -311,7 +311,7 @@ internal sealed partial class ObjectWriter : IDisposable
     {
         WriteArrayLength(span.Length);
 
-#if NETCOREAPP
+#if NET
         _writer.Write(span);
 #else
         // BinaryWriter in .NET Framework does not support ReadOnlySpan<byte>, so we use a temporary buffer to write

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/TextEncodingKind.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Serialization/TextEncodingKind.cs
@@ -90,7 +90,7 @@ internal static partial class EncodingExtensions
     }
 
     public static bool HasPreamble(this Encoding encoding)
-#if NETCOREAPP
+#if NET
         => !encoding.Preamble.IsEmpty;
 #else
         => !encoding.GetPreamble().IsEmpty();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/TextReaderWithLength.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/TextReaderWithLength.cs
@@ -12,7 +12,7 @@ internal abstract class TextReaderWithLength(int length) : TextReader
 
     public override string ReadToEnd()
     {
-#if NETCOREAPP
+#if NET
         return string.Create(Length, this, static (chars, state) => state.Read(chars));
 #else
         var chars = new char[Length];

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
@@ -271,7 +271,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             ' If the doc comment was parsed from a text fragment, there may not be
             ' an end-of-line at all. We need to trim the end before we check the
             ' number of line breaks in the text.
-#if NET Then
+#If NET Then
             Dim textWithoutFinalNewLine = text.TrimEnd()
 #Else
             Dim textWithoutFinalNewLine = text.TrimEnd(Nothing)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
@@ -271,7 +271,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             ' If the doc comment was parsed from a text fragment, there may not be
             ' an end-of-line at all. We need to trim the end before we check the
             ' number of line breaks in the text.
-#If NETCOREAPP Then
+#if NET Then
             Dim textWithoutFinalNewLine = text.TrimEnd()
 #Else
             Dim textWithoutFinalNewLine = text.TrimEnd(Nothing)


### PR DESCRIPTION
A good chunk of our code uses `#if NETCOREAPP` instead of `#if NET` for historical reasons. Did a quick replace so we can standardize on the more idiomatic approach