### PR TITLE
Fix error closing source link documents in VSCode

### DIFF
--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/AbstractPdbSourceDocumentTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/AbstractPdbSourceDocumentTests.cs
@@ -155,6 +155,14 @@ public abstract class AbstractPdbSourceDocumentTests
 
             var masWorkspace = service.TryGetWorkspace();
 
+            using var fileStream = File.OpenRead(file.FilePath);
+            var sourceText = SourceText.From(fileStream);
+            var text = SourceText.From(File.ReadAllText(file.FilePath));
+
+            var pdbService = (PdbSourceDocumentMetadataAsSourceFileProvider)workspace.ExportProvider.GetExportedValues<IMetadataAsSourceFileProvider>().Single(s => s is PdbSourceDocumentMetadataAsSourceFileProvider);
+
+            var documentInfo = pdbService.GetTestAccessor().Documents[file.FilePath];
+            masWorkspace!.OnDocumentAdded(documentInfo.DocumentInfo);
             var document = masWorkspace!.CurrentSolution.Projects.First().Documents.First(d => d.FilePath == file.FilePath);
 
             // Mapping the project from the generated document should map back to the original project
@@ -329,5 +337,16 @@ public abstract class AbstractPdbSourceDocumentTests
     protected static string GetPdbPath(string path)
     {
         return Path.Combine(path, "reference.pdb");
+    }
+
+    private class StaticSourceTextContainer(SourceText sourceText) : SourceTextContainer
+    {
+        public override SourceText CurrentText => sourceText;
+
+        public override event EventHandler<TextChangeEventArgs> TextChanged
+        {
+            add { }
+            remove { }
+        }
     }
 }

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -429,6 +429,23 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
         _sourceLinkEnabledProjects.Clear();
         _implementationAssemblyLookupService.Clear();
     }
+
+    internal TestAccessor GetTestAccessor()
+    {
+        return new TestAccessor(this);
+    }
+
+    internal readonly struct TestAccessor
+    {
+        private readonly PdbSourceDocumentMetadataAsSourceFileProvider _instance;
+
+        internal TestAccessor(PdbSourceDocumentMetadataAsSourceFileProvider instance)
+        {
+            _instance = instance;
+        }
+
+        public ImmutableDictionary<string, SourceDocumentInfo> Documents => _instance._fileToDocumentInfoMap.ToImmutableDictionary();
+    }
 }
 
 internal sealed record SourceDocument(string FilePath, SourceHashAlgorithm ChecksumAlgorithm, ImmutableArray<byte> Checksum, byte[]? EmbeddedTextBytes, string? SourceLinkUrl);

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -244,14 +244,18 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
             return null;
 
         var symbolId = SymbolKey.Create(symbol, cancellationToken);
-        var navigateProject = metadataWorkspace.CurrentSolution.GetRequiredProject(projectId);
 
-        var documentInfos = CreateDocumentInfos(sourceFileInfos, encoding, navigateProject.Id, sourceWorkspace, sourceProject);
+        // Get a view of the solution with the document added, but do not actually update the workspace.
+        // TryAddDocumentToWorkspace is responsible for actually updating the solution with the new document(s).
+        // We just need a view with the document added so we can find the right location in the generated source.
+        var pendingSolution = metadataWorkspace.CurrentSolution;
+        var documentInfos = CreateDocumentInfos(sourceFileInfos, encoding, projectId, sourceWorkspace, sourceProject);
         if (documentInfos.Length > 0)
         {
-            metadataWorkspace.OnDocumentsAdded(documentInfos);
-            navigateProject = metadataWorkspace.CurrentSolution.GetRequiredProject(projectId);
+            pendingSolution = pendingSolution.AddDocuments(documentInfos);
         }
+
+        var navigateProject = pendingSolution.GetRequiredProject(projectId);
 
         // If MetadataAsSourceHelpers.GetLocationInGeneratedSourceAsync can't find the actual document to navigate to, it will fall back
         // to the document passed in, which we just use the first document for.
@@ -319,20 +323,22 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
             }
 
             // If a document has multiple symbols then we might already know about it
-            if (_fileToDocumentInfoMap.ContainsKey(info.FilePath))
+            if (_fileToDocumentInfoMap.TryGetValue(info.FilePath, out var sourceDocumentInfo))
             {
+                documents.Add(sourceDocumentInfo.DocumentInfo);
                 continue;
             }
 
             var documentId = DocumentId.CreateNewId(projectId);
 
-            documents.Add(DocumentInfo.Create(
+            var documentInfo = DocumentInfo.Create(
                 documentId,
                 name: Path.GetFileName(info.FilePath),
                 loader: info.Loader,
                 filePath: info.FilePath,
                 isGenerated: true)
-                .WithDesignTimeOnly(true));
+                .WithDesignTimeOnly(true);
+            documents.Add(documentInfo);
 
             // If we successfully got something from SourceLink for this project then its nice to wait a bit longer
             // if the user performs subsequent navigation
@@ -342,7 +348,7 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
             }
 
             // In order to open documents in VS we need to understand the link from temp file to document and its encoding etc.
-            _fileToDocumentInfoMap[info.FilePath] = new(documentId, encoding, info.ChecksumAlgorithm, sourceProject.Id, sourceWorkspace);
+            _fileToDocumentInfoMap[info.FilePath] = new(documentId, encoding, info.ChecksumAlgorithm, sourceProject.Id, sourceWorkspace, documentInfo);
         }
 
         return documents.ToImmutableAndClear();
@@ -359,6 +365,7 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
         {
             if (_fileToDocumentInfoMap.TryGetValue(filePath, out var info))
             {
+                workspace.OnDocumentAdded(info.DocumentInfo);
                 workspace.OnDocumentOpened(info.DocumentId, sourceTextContainer);
                 documentId = info.DocumentId;
                 return true;
@@ -376,6 +383,7 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
             if (_fileToDocumentInfoMap.TryGetValue(filePath, out var info))
             {
                 workspace.OnDocumentClosed(info.DocumentId, new WorkspaceFileTextLoader(workspace.Services.SolutionServices, filePath, info.Encoding));
+                workspace.OnDocumentRemoved(info.DocumentId);
                 return true;
             }
 
@@ -425,4 +433,4 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
 
 internal sealed record SourceDocument(string FilePath, SourceHashAlgorithm ChecksumAlgorithm, ImmutableArray<byte> Checksum, byte[]? EmbeddedTextBytes, string? SourceLinkUrl);
 
-internal record struct SourceDocumentInfo(DocumentId DocumentId, Encoding Encoding, SourceHashAlgorithm ChecksumAlgorithm, ProjectId SourceProjectId, Workspace SourceWorkspace);
+internal record struct SourceDocumentInfo(DocumentId DocumentId, Encoding Encoding, SourceHashAlgorithm ChecksumAlgorithm, ProjectId SourceProjectId, Workspace SourceWorkspace, DocumentInfo DocumentInfo);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2222267/ where closing a sourcelink document would crash the server.

There were two changes that led to this issue
1.  When I implemented https://github.com/dotnet/roslyn/pull/74488, I implemented it on the assumption that `IMetadataAsSourceFileService.TryAddDocumentToWorkspace` and `IMetadataAsSourceFileService.TryRemoveDocumentFromWorkspace` actually added and removed documents from the workspace - which was true for metadata and decompilation.  This meant if the document was already found in a workspace, we **would skip calling `TryAddDocumentToWorkspace` in LSP**.
2.  When I implemented https://github.com/dotnet/roslyn/pull/74626, I failed to realize that `PdbSourceDocumentMetadataAsSourceFileProvider.TryAddDocumentToWorkspace` and `PdbSourceDocumentMetadataAsSourceFileProvider.TryRemoveDocumentFromWorkspace` did not actually add/remove from the workspace - that happened in `GetGeneratedFileAsync`.

So what happened was that `TryAddDocumentToWorkspace` was sometimes not called because the sourcelink document was already added to to the `MetadataAsSource` workspace when the original go to definition request was made.  So closing the document would throw because the document was never opened.

There were a couple ways to fix this.  I chose modifying `PdbSourceDocumentMetadataAsSourceFileProvider` to match the contract to add and remove the document from the WS in `TryAddDocumentToWorkspace` `TryRemoveDocumentFromWorkspace`.

