### PR TITLE
Adds MicrosoftIdentityModelJsonWebTokensVersion to Versions.prop

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,6 +57,7 @@
       So it's not affected by our central package management
     -->
     <MicrosoftDevDivOptimizationDataPowerShellVersion>1.0.803</MicrosoftDevDivOptimizationDataPowerShellVersion>
+    <MicrosoftIdentityModelJsonWebTokensVersion>6.34.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <!-- TODO: remove https://github.com/dotnet/roslyn/issues/71827 -->
     <MicrosoftDotNetXliffTasksVersion Condition="'$(DotnetBuildFromSource)' != 'true'">9.0.0-beta.24076.5</MicrosoftDotNetXliffTasksVersion>


### PR DESCRIPTION
Fixes CG alert -- seemed to not port correctly from 17.6