### PR TITLE
Switch to just using paths as keys for file watching

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
@@ -31,16 +31,7 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     /// are only created once we are actually applying a batch because we don't determine until the batch is applied if
     /// the file reference will actually be a file reference or it'll be a converted project reference.
     /// </summary>
-    private readonly Dictionary<TReference, (IWatchedFile Token, int RefCount)> _referenceFileWatchingTokens = [];
-
-    /// <summary>
-    /// Stores the caller for a previous disposal of a reference produced by this class, to track down a double-dispose
-    /// issue.
-    /// </summary>
-    /// <remarks>
-    /// This can be removed once https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1843611 is fixed.
-    /// </remarks>
-    private readonly ConditionalWeakTable<TReference, string> _previousDisposalLocations = new();
+    private readonly Dictionary<string, (IWatchedFile Token, int RefCount)> _referenceFileWatchingTokens = [];
 
     /// <summary>
     /// <see cref="CancellationTokenSource"/>s for in-flight refreshing of metadata references. When we see a file
@@ -113,17 +104,17 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     /// watched , the reference count will be incremented. This is *not* safe to attempt to call multiple times for the
     /// same project and reference (e.g. in applying workspace updates)
     /// </summary>
-    public void StartWatchingReference(TReference reference, string fullFilePath)
+    public void StartWatchingReference(string fullFilePath)
     {
         lock (_gate)
         {
-            var (token, count) = _referenceFileWatchingTokens.GetOrAdd(reference, _ =>
+            var (token, count) = _referenceFileWatchingTokens.GetOrAdd(fullFilePath, _ =>
             {
                 var fileToken = _fileReferenceChangeContext.Value.EnqueueWatchingFile(fullFilePath);
                 return (fileToken, RefCount: 0);
             });
 
-            _referenceFileWatchingTokens[reference] = (token, RefCount: count + 1);
+            _referenceFileWatchingTokens[fullFilePath] = (token, RefCount: count + 1);
         }
     }
 
@@ -132,16 +123,15 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     /// 0, the file watcher will be stopped. This is *not* safe to attempt to call multiple times for the same project
     /// and reference (e.g. in applying workspace updates)
     /// </summary>
-    public void StopWatchingReference(TReference reference, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+    public void StopWatchingReference(string fullFilePath, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
     {
         lock (_gate)
         {
             var disposalLocation = callerFilePath + ", line " + callerLineNumber;
-            if (!_referenceFileWatchingTokens.TryGetValue(reference, out var watchedFileReference))
+            if (!_referenceFileWatchingTokens.TryGetValue(fullFilePath, out var watchedFileReference))
             {
-                // We're attempting to stop watching a file that we never started watching. This is a bug.
-                var existingDisposalStackTrace = _previousDisposalLocations.TryGetValue(reference, out var previousDisposalLocation);
-                throw new ArgumentException("The reference was already disposed at " + previousDisposalLocation);
+                // We're Attempting to stop watching a file that we never started watching. This is a bug.
+                throw new ArgumentException("Attempting to stop watching a file that we never started watching. This is a bug.");
             }
 
             var newRefCount = watchedFileReference.RefCount - 1;
@@ -150,14 +140,11 @@ internal sealed class FileWatchedReferenceFactory<TReference>
             {
                 // No one else is watching this file, so stop watching it and remove from our map.
                 watchedFileReference.Token.Dispose();
-                _referenceFileWatchingTokens.Remove(reference);
-
-                _previousDisposalLocations.Remove(reference);
-                _previousDisposalLocations.Add(reference, disposalLocation);
+                _referenceFileWatchingTokens.Remove(fullFilePath);
             }
             else
             {
-                _referenceFileWatchingTokens[reference] = (watchedFileReference.Token, newRefCount);
+                _referenceFileWatchingTokens[fullFilePath] = (watchedFileReference.Token, newRefCount);
             }
 
             // Note we still potentially have an outstanding change that we haven't raised a notification for due to the

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1233,7 +1233,7 @@ internal sealed partial class ProjectSystemProject
         Contract.ThrowIfNull(remainingMetadataReferences);
 
         foreach (var reference in remainingMetadataReferences.OfType<PortableExecutableReference>())
-            _projectSystemProjectFactory.FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!);
+            _projectSystemProjectFactory.FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference, reference.FilePath!);
     }
 
     public void ReorderSourceFiles(ImmutableArray<string> filePaths)

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1233,7 +1233,7 @@ internal sealed partial class ProjectSystemProject
         Contract.ThrowIfNull(remainingMetadataReferences);
 
         foreach (var reference in remainingMetadataReferences.OfType<PortableExecutableReference>())
-            _projectSystemProjectFactory.FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference);
+            _projectSystemProjectFactory.FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!);
     }
 
     public void ReorderSourceFiles(ImmutableArray<string> filePaths)

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -418,7 +418,7 @@ internal sealed partial class ProjectSystemProjectFactory
 
         // Remove file watchers for any references we're no longer watching.
         foreach (var reference in projectUpdateState.RemovedMetadataReferences)
-            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!);
+            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference, reference.FilePath!);
 
         // Add file watchers for any references we are now watching.
         foreach (var reference in projectUpdateState.AddedMetadataReferences)
@@ -426,7 +426,7 @@ internal sealed partial class ProjectSystemProjectFactory
 
         // Remove file watchers for any references we're no longer watching.
         foreach (var reference in projectUpdateState.RemovedAnalyzerReferences)
-            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(reference.FullPath);
+            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(reference, reference.FullPath);
 
         // Add file watchers for any references we are now watching.
         foreach (var reference in projectUpdateState.AddedAnalyzerReferences)

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -418,19 +418,19 @@ internal sealed partial class ProjectSystemProjectFactory
 
         // Remove file watchers for any references we're no longer watching.
         foreach (var reference in projectUpdateState.RemovedMetadataReferences)
-            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference);
+            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!);
 
         // Add file watchers for any references we are now watching.
         foreach (var reference in projectUpdateState.AddedMetadataReferences)
-            FileWatchedPortableExecutableReferenceFactory.StartWatchingReference(reference, reference.FilePath!);
+            FileWatchedPortableExecutableReferenceFactory.StartWatchingReference(reference.FilePath!);
 
         // Remove file watchers for any references we're no longer watching.
         foreach (var reference in projectUpdateState.RemovedAnalyzerReferences)
-            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(reference);
+            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(reference.FullPath);
 
         // Add file watchers for any references we are now watching.
         foreach (var reference in projectUpdateState.AddedAnalyzerReferences)
-            FileWatchedAnalyzerReferenceFactory.StartWatchingReference(reference, reference.FullPath);
+            FileWatchedAnalyzerReferenceFactory.StartWatchingReference(reference.FullPath);
 
         // Clear the state from the this update in preparation for the next.
         projectUpdateState = projectUpdateState.ClearIncrementalState();


### PR DESCRIPTION
This simplifies work happening in https://github.com/dotnet/roslyn/pull/74780

In that PR we want to be able to make things like AnalyzerFileReferences temporarily, but switch out with IsolatedReferences to get dedicated ALCs.  If we use the analyzer ref *itself* as a key, this becomes much more complicated.  However, if all we're using is the path anyways (for both listening to notifications, and for reporting them externally), then it's simpler to just base the API on that.