### PR TITLE
Pass along services object to make multiple service retrieval easier

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetProviderTests.cs
@@ -53,7 +53,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var storage = new SolutionAssetCache();
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), new Dictionary<Checksum, object>() { { checksum, data } });
 
-            var provider = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
+            var provider = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.SolutionServices);
             var stored = await provider.GetAssetAsync<object>(AssetPath.FullLookupForTesting, checksum, CancellationToken.None);
             Assert.Equal(data, stored);
 
@@ -84,7 +84,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var storage = new SolutionAssetCache();
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
-            var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
+            var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.SolutionServices);
             await service.GetAssetsAsync<object>(AssetPath.FullLookupForTesting, new HashSet<Checksum>(map.Keys), CancellationToken.None);
 
             foreach (var kv in map)
@@ -112,7 +112,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var storage = new SolutionAssetCache();
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
-            var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
+            var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.SolutionServices);
             await service.SynchronizeSolutionAssetsAsync(await solution.CompilationState.GetChecksumAsync(CancellationToken.None), CancellationToken.None);
 
             TestUtils.VerifyAssetStorage(map, storage);
@@ -137,7 +137,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var storage = new SolutionAssetCache();
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
-            var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
+            var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.SolutionServices);
 
             using var _ = ArrayBuilder<ProjectStateChecksums>.GetInstance(out var allProjectChecksums);
             allProjectChecksums.Add(await project.State.GetStateChecksumsAsync(CancellationToken.None));
@@ -166,7 +166,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var storage = new SolutionAssetCache();
             var assetSource = new OrderedAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
-            var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
+            var service = new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.SolutionServices);
 
             using var _ = ArrayBuilder<ProjectStateChecksums>.GetInstance(out var allProjectChecksums);
             var stateChecksums = await project.State.GetStateChecksumsAsync(CancellationToken.None);

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -115,7 +115,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var storage = new SolutionAssetCache();
             var assetSource = new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map);
 
-            return new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetService<ISerializerService>());
+            return new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.SolutionServices);
         }
 
         [Fact]

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -548,7 +548,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // Do the initial full sync
         await solution.AppendAssetMapAsync(map, CancellationToken.None);
@@ -589,7 +589,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // Syncing project 1 should just since it over.
         await solution.AppendAssetMapAsync(map, project1.Id, CancellationToken.None);
@@ -631,7 +631,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         await solution.AppendAssetMapAsync(map, project2.Id, CancellationToken.None);
         var project2Checksum = await solution.CompilationState.GetChecksumAsync(project2.Id, CancellationToken.None);
@@ -664,7 +664,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // syncing P3 should since project P2 as well because of the p2p ref
         await solution.AppendAssetMapAsync(map, project3.Id, CancellationToken.None);
@@ -706,7 +706,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // syncing project3 should since project2 and project1 as well because of the p2p ref
         await solution.AppendAssetMapAsync(map, project3.Id, CancellationToken.None);
@@ -746,7 +746,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // syncing project3 should since project2 and project1 as well because of the p2p ref
         await solution.AppendAssetMapAsync(map, project3.Id, CancellationToken.None);
@@ -784,7 +784,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // Syncing over project1 should give us 1 set of options on the OOP side.
         await solution.AppendAssetMapAsync(map, project1.Id, CancellationToken.None);
@@ -817,7 +817,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // Do the initial full sync
         await solution.AppendAssetMapAsync(map, CancellationToken.None);
@@ -872,7 +872,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // Do the initial full sync
         await solution.AppendAssetMapAsync(map, CancellationToken.None);
@@ -941,7 +941,7 @@ public class SolutionServiceTests
 
         var map = new Dictionary<Checksum, object>();
         var assetProvider = new AssetProvider(
-            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.GetService<ISerializerService>());
+            Checksum.Create(ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray())), new SolutionAssetCache(), new SimpleAssetSource(workspace.Services.GetService<ISerializerService>(), map), remoteWorkspace.Services.SolutionServices);
 
         // Do the initial full sync
         await solution.AppendAssetMapAsync(map, CancellationToken.None);
@@ -1277,6 +1277,6 @@ public class SolutionServiceTests
         var storage = new SolutionAssetCache();
         var assetSource = new SimpleAssetSource(workspace.Services.GetRequiredService<ISerializerService>(), map);
 
-        return new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.GetRequiredService<ISerializerService>());
+        return new AssetProvider(sessionId, storage, assetSource, remoteWorkspace.Services.SolutionServices);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
@@ -18,16 +19,20 @@ namespace Microsoft.CodeAnalysis.Remote;
 /// <summary>
 /// This service provide a way to get roslyn objects from checksum
 /// </summary>
-internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionAssetCache assetCache, IAssetSource assetSource, ISerializerService serializerService)
+internal sealed partial class AssetProvider(
+    Checksum solutionChecksum,
+    SolutionAssetCache assetCache,
+    IAssetSource assetSource,
+    SolutionServices solutionServices)
     : AbstractAssetProvider
 {
     private const int PooledChecksumArraySize = 1024;
     private static readonly ObjectPool<Checksum[]> s_checksumPool = new(() => new Checksum[PooledChecksumArraySize], 16);
 
     private readonly Checksum _solutionChecksum = solutionChecksum;
-    private readonly ISerializerService _serializerService = serializerService;
     private readonly SolutionAssetCache _assetCache = assetCache;
     private readonly IAssetSource _assetSource = assetSource;
+    private readonly SolutionServices _solutionServices = solutionServices;
 
     public override async ValueTask<T> GetAssetAsync<T>(
         AssetPath assetPath, Checksum checksum, CancellationToken cancellationToken)
@@ -295,8 +300,9 @@ internal sealed partial class AssetProvider(Checksum solutionChecksum, SolutionA
                     Contract.ThrowIfTrue(missingChecksumsMemory.Span.IndexOf(Checksum.Null) >= 0);
 #endif
 
+                    var serializerService = _solutionServices.GetRequiredService<ISerializerService>();
                     await _assetSource.GetAssetsAsync(
-                        _solutionChecksum, assetPath, missingChecksumsMemory, _serializerService,
+                        _solutionChecksum, assetPath, missingChecksumsMemory, serializerService,
                         static (
                             Checksum missingChecksum,
                             T missingAsset,

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -28,7 +28,9 @@ internal partial class RemoteWorkspace
     /// </summary>
     private readonly struct SolutionCreator(RemoteWorkspace workspace, AssetProvider assetService, Solution baseSolution)
     {
+#pragma warning disable IDE0052 // used only in DEBUG builds
         private readonly RemoteWorkspace _workspace = workspace;
+#pragma warning restore
 
         private readonly AssetProvider _assetProvider = assetService;
         private readonly Solution _baseSolution = baseSolution;

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -26,11 +26,9 @@ internal partial class RemoteWorkspace
     /// <summary>
     /// Create solution for given checksum from base solution
     /// </summary>
-    private readonly struct SolutionCreator(HostServices hostServices, AssetProvider assetService, Solution baseSolution)
+    private readonly struct SolutionCreator(RemoteWorkspace workspace, AssetProvider assetService, Solution baseSolution)
     {
-#pragma warning disable IDE0052 // used only in DEBUG builds
-        private readonly HostServices _hostServices = hostServices;
-#pragma warning restore
+        private readonly RemoteWorkspace _workspace = workspace;
 
         private readonly AssetProvider _assetProvider = assetService;
         private readonly Solution _baseSolution = baseSolution;
@@ -607,7 +605,7 @@ internal partial class RemoteWorkspace
                 return;
 
             var solutionInfo = await _assetProvider.CreateSolutionInfoAsync(checksumFromRequest, cancellationToken).ConfigureAwait(false);
-            var workspace = new AdhocWorkspace(_hostServices);
+            var workspace = new AdhocWorkspace(_workspace.Services.HostServices);
             workspace.AddSolution(solutionInfo);
 
             await TestUtils.AssertChecksumsAsync(_assetProvider, checksumFromRequest, workspace.CurrentSolution, incrementalSolutionBuilt, projectConeId).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -34,10 +34,7 @@ internal sealed partial class RemoteWorkspace : Workspace
     }
 
     public AssetProvider CreateAssetProvider(Checksum solutionChecksum, SolutionAssetCache assetCache, IAssetSource assetSource)
-    {
-        var serializerService = Services.GetRequiredService<ISerializerService>();
-        return new AssetProvider(solutionChecksum, assetCache, assetSource, serializerService);
-    }
+        => new(solutionChecksum, assetCache, assetSource, this.Services.SolutionServices);
 
     protected internal override bool PartialSemanticsEnabled => true;
 
@@ -263,7 +260,7 @@ internal sealed partial class RemoteWorkspace : Workspace
                 assetProvider, newSolutionChecksum, cancellationToken).ConfigureAwait(false);
 
             // Now, bring that solution in line with the snapshot defined by solutionChecksum.
-            var updater = new SolutionCreator(Services.HostServices, assetProvider, solutionToUpdate);
+            var updater = new SolutionCreator(this, assetProvider, solutionToUpdate);
             return await updater.CreateSolutionAsync(newSolutionChecksum, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))


### PR DESCRIPTION
Extracted from https://github.com/dotnet/roslyn/pull/74780 to make that PR easier to review.