### PR TITLE
Switch to storing batched operations on AnalyzerReferences as just paths.  

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
@@ -132,16 +132,23 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     /// 0, the file watcher will be stopped. This is *not* safe to attempt to call multiple times for the same project
     /// and reference (e.g. in applying workspace updates)
     /// </summary>
-    public void StopWatchingReference(TReference reference, string fullFilePath, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+    public void StopWatchingReference(string fullFilePath, TReference? referenceToTrack, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
     {
         lock (_gate)
         {
             var disposalLocation = callerFilePath + ", line " + callerLineNumber;
             if (!_referenceFileWatchingTokens.TryGetValue(fullFilePath, out var watchedFileReference))
             {
-                // We're attempting to stop watching a file that we never started watching. This is a bug.
-                var existingDisposalStackTrace = _previousDisposalLocations.TryGetValue(reference, out var previousDisposalLocation);
-                throw new ArgumentException("The reference was already disposed at " + previousDisposalLocation);
+                if (referenceToTrack != null)
+                {
+                    // We're attempting to stop watching a file that we never started watching. This is a bug.
+                    var existingDisposalStackTrace = _previousDisposalLocations.TryGetValue(referenceToTrack, out var previousDisposalLocation);
+                    throw new ArgumentException("The reference was already disposed at " + previousDisposalLocation);
+                }
+                else
+                {
+                    throw new ArgumentException("Attempting to stop watching a file that we never started watching. This is a bug.");
+                }
             }
 
             var newRefCount = watchedFileReference.RefCount - 1;
@@ -152,8 +159,11 @@ internal sealed class FileWatchedReferenceFactory<TReference>
                 watchedFileReference.Token.Dispose();
                 _referenceFileWatchingTokens.Remove(fullFilePath);
 
-                _previousDisposalLocations.Remove(reference);
-                _previousDisposalLocations.Add(reference, disposalLocation);
+                if (referenceToTrack != null)
+                {
+                    _previousDisposalLocations.Remove(referenceToTrack);
+                    _previousDisposalLocations.Add(referenceToTrack, disposalLocation);
+                }
             }
             else
             {

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1022,8 +1022,8 @@ internal sealed partial class ProjectSystemProject
             {
                 _projectAnalyzerPaths.Remove(mappedFullPath);
 
-                // This analyzer may be one we've just added in the same batch; in that case, just don't add it in the
-                // first place.
+                // This analyzer may be one we've just added in the same batch; in that case, just don't add it in
+                // the first place.
                 if (!_analyzersAddedInBatch.Remove(mappedFullPath))
                     _analyzersRemovedInBatch.Add(mappedFullPath);
             }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.ProjectUpdateState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.ProjectUpdateState.cs
@@ -54,8 +54,8 @@ internal sealed partial class ProjectSystemProjectFactory
         ImmutableDictionary<ProjectId, ProjectReferenceInformation> ProjectReferenceInfos,
         ImmutableArray<PortableExecutableReference> RemovedMetadataReferences,
         ImmutableArray<PortableExecutableReference> AddedMetadataReferences,
-        ImmutableArray<AnalyzerFileReference> RemovedAnalyzerReferences,
-        ImmutableArray<AnalyzerFileReference> AddedAnalyzerReferences)
+        ImmutableArray<string> RemovedAnalyzerReferences,
+        ImmutableArray<string> AddedAnalyzerReferences)
     {
         public static ProjectUpdateState Empty = new(
             ImmutableDictionary<string, ImmutableArray<ProjectId>>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
@@ -121,16 +121,16 @@ internal sealed partial class ProjectSystemProjectFactory
         public ProjectUpdateState WithIncrementalMetadataReferenceAdded(PortableExecutableReference reference)
             => this with { AddedMetadataReferences = AddedMetadataReferences.Add(reference) };
 
-        public ProjectUpdateState WithIncrementalAnalyzerReferenceRemoved(AnalyzerFileReference reference)
+        public ProjectUpdateState WithIncrementalAnalyzerReferenceRemoved(string reference)
             => this with { RemovedAnalyzerReferences = RemovedAnalyzerReferences.Add(reference) };
 
-        public ProjectUpdateState WithIncrementalAnalyzerReferencesRemoved(List<AnalyzerFileReference> references)
+        public ProjectUpdateState WithIncrementalAnalyzerReferencesRemoved(List<string> references)
             => this with { RemovedAnalyzerReferences = RemovedAnalyzerReferences.AddRange(references) };
 
-        public ProjectUpdateState WithIncrementalAnalyzerReferenceAdded(AnalyzerFileReference reference)
+        public ProjectUpdateState WithIncrementalAnalyzerReferenceAdded(string reference)
             => this with { AddedAnalyzerReferences = AddedAnalyzerReferences.Add(reference) };
 
-        public ProjectUpdateState WithIncrementalAnalyzerReferencesAdded(List<AnalyzerFileReference> references)
+        public ProjectUpdateState WithIncrementalAnalyzerReferencesAdded(List<string> references)
             => this with { AddedAnalyzerReferences = AddedAnalyzerReferences.AddRange(references) };
 
         /// <summary>


### PR DESCRIPTION
This actually ends up simplifying things, and makes later work (like https://github.com/dotnet/roslyn/pull/74780) much simpler.  The problem there is htat if we use the analyzer reference itself as the 'identity', then things can easily get very confused when part of hte sytem is making AnalyzerFileReerences, and another is then making IsolatedAnalyzerReferences.  By just using strings here, we state taht at the tracking side we don't care what has happened. And only at the applicaiton side (the adding/removing of the references) do we actually go and figure out which ones to manipulate.