### PR TITLE
Always take ownership from UIThreadContext when rename commit

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
-        protected override void CommitAndSetFocus(InlineRenameSession activeSession, ITextView textView)
+        protected override void CommitAndSetFocus(InlineRenameSession activeSession, ITextView textView, IUIThreadOperationContext operationContext)
         {
             try
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             try
             {
-                base.CommitAndSetFocus(activeSession, textView);
+                base.CommitAndSetFocus(activeSession, textView, operationContext);
             }
             catch (NotSupportedException ex)
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
@@ -94,11 +94,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
-        protected override void Commit(InlineRenameSession activeSession, ITextView textView)
+        protected override void CommitAndSetFocus(InlineRenameSession activeSession, ITextView textView)
         {
             try
             {
-                base.Commit(activeSession, textView);
+                base.CommitAndSetFocus(activeSession, textView);
             }
             catch (NotSupportedException ex)
             {

--- a/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -88,7 +88,7 @@ internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMetho
         // wait indicator for Extract Method
         if (_renameService.ActiveSession != null)
         {
-            _threadingContext.JoinableTaskFactory.Run(() => _renameService.ActiveSession.CommitAsync(previewChanges: false));
+            _threadingContext.JoinableTaskFactory.Run(() => _renameService.ActiveSession.CommitAsync(previewChanges: false, context.OperationContext));
         }
 
         if (!args.SubjectBuffer.SupportsRefactorings())

--- a/src/EditorFeatures/Core/IInlineRenameSession.cs
+++ b/src/EditorFeatures/Core/IInlineRenameSession.cs
@@ -6,6 +6,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor;
 
@@ -50,5 +51,5 @@ internal interface IInlineRenameSession
     /// <summary>
     /// Dismisses the rename session, completing the rename operation across all files.
     /// </summary>
-    Task CommitAsync(bool previewChanges);
+    Task CommitAsync(bool previewChanges, IUIThreadOperationContext editorOperationContext = null);
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -119,8 +119,6 @@ internal abstract partial class AbstractRenameCommandHandler
     private void Commit(IUIThreadOperationContext operationContext)
     {
         RoslynDebug.AssertNotNull(_renameService.ActiveSession);
-        // Prevent Editor's typing responsiveness auto canceling the rename operation.
-        // InlineRenameSession will call IUIThreadOperationExecutor to sets up our own IUIThreadOperationContext
         operationContext.TakeOwnership();
         _renameService.ActiveSession.Commit();
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -119,7 +119,8 @@ internal abstract partial class AbstractRenameCommandHandler
     private void Commit(IUIThreadOperationContext operationContext)
     {
         RoslynDebug.AssertNotNull(_renameService.ActiveSession);
-        // Take ownership from editor to make sure it can rename commit could be controlled by its own IUIThreadOperationContext
+        // Prevent Editor's typing responsiveness auto canceling the rename operation.
+        // InlineRenameSession will call IUIThreadOperationExecutor to sets up our own IUIThreadOperationContext
         operationContext.TakeOwnership();
         _renameService.ActiveSession.Commit();
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -118,9 +118,9 @@ internal abstract partial class AbstractRenameCommandHandler
 
     private void Commit(IUIThreadOperationContext operationContext)
     {
+        RoslynDebug.AssertNotNull(_renameService.ActiveSession);
         // Take ownership from editor to make sure it can rename commit could be controlled by its own IUIThreadOperationContext
         operationContext.TakeOwnership();
-        RoslynDebug.AssertNotNull(_renameService.ActiveSession);
         _renameService.ActiveSession.Commit();
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -119,7 +119,6 @@ internal abstract partial class AbstractRenameCommandHandler
     private void Commit(IUIThreadOperationContext operationContext)
     {
         RoslynDebug.AssertNotNull(_renameService.ActiveSession);
-        operationContext.TakeOwnership();
-        _renameService.ActiveSession.Commit();
+        _renameService.ActiveSession.Commit(previewChanges: false, operationContext);
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_BackspaceDeleteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_BackspaceDeleteHandler.cs
@@ -21,7 +21,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
 
     public void ExecuteCommand(BackspaceKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
             {
                 var caretPoint = args.TextView.GetCaretPoint(args.SubjectBuffer);
                 if (!args.TextView.Selection.IsEmpty || caretPoint.Value != span.Start)
@@ -33,7 +33,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
 
     public void ExecuteCommand(DeleteKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
             {
                 var caretPoint = args.TextView.GetCaretPoint(args.SubjectBuffer);
                 if (!args.TextView.Selection.IsEmpty || caretPoint.Value != span.End)

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_BackspaceDeleteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_BackspaceDeleteHandler.cs
@@ -21,7 +21,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
 
     public void ExecuteCommand(BackspaceKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, _, span) =>
             {
                 var caretPoint = args.TextView.GetCaretPoint(args.SubjectBuffer);
                 if (!args.TextView.Selection.IsEmpty || caretPoint.Value != span.Start)
@@ -33,7 +33,7 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
 
     public void ExecuteCommand(DeleteKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, _, span) =>
             {
                 var caretPoint = args.TextView.GetCaretPoint(args.SubjectBuffer);
                 if (!args.TextView.Selection.IsEmpty || caretPoint.Value != span.End)

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_CutPasteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_CutPasteHandler.cs
@@ -16,7 +16,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public void ExecuteCommand(CutCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
         {
             nextHandler();
         });
@@ -27,7 +27,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public void ExecuteCommand(PasteCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
         {
             nextHandler();
         });

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_CutPasteHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_CutPasteHandler.cs
@@ -16,7 +16,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public void ExecuteCommand(CutCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, _, span) =>
         {
             nextHandler();
         });
@@ -27,7 +27,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public void ExecuteCommand(PasteCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, _, span) =>
         {
             nextHandler();
         });

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_MoveSelectedLinesHandler.cs
@@ -15,7 +15,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public bool ExecuteCommand(MoveSelectedLinesUpCommandArgs args, CommandExecutionContext context)
     {
-        CommitIfActive(args);
+        CommitIfActive(args, context.OperationContext);
         return false;
     }
 
@@ -24,7 +24,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public bool ExecuteCommand(MoveSelectedLinesDownCommandArgs args, CommandExecutionContext context)
     {
-        CommitIfActive(args);
+        CommitIfActive(args, context.OperationContext);
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
@@ -15,10 +15,9 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
 
     public void ExecuteCommand(OpenLineAboveCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
-            context.OperationContext.TakeOwnership();
-            activeSession.Commit();
+            Commit(operationContext);
             nextHandler();
         });
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineAboveHandler.cs
@@ -15,8 +15,9 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
 
     public void ExecuteCommand(OpenLineAboveCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
         {
+            context.OperationContext.TakeOwnership();
             activeSession.Commit();
             nextHandler();
         });

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
@@ -15,8 +15,9 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
 
     public void ExecuteCommand(OpenLineBelowCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
         {
+            context.OperationContext.TakeOwnership();
             activeSession.Commit();
             nextHandler();
         });

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_OpenLineBelowHandler.cs
@@ -15,10 +15,9 @@ internal abstract partial class AbstractRenameCommandHandler : IChainedCommandHa
 
     public void ExecuteCommand(OpenLineBelowCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, operationContext, span) =>
         {
-            context.OperationContext.TakeOwnership();
-            activeSession.Commit();
+            Commit(operationContext);
             nextHandler();
         });
     }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -18,7 +18,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public bool ExecuteCommand(ReorderParametersCommandArgs args, CommandExecutionContext context)
     {
-        CommitIfActive(args);
+        CommitIfActive(args, context.OperationContext);
         return false;
     }
 
@@ -27,7 +27,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public bool ExecuteCommand(RemoveParametersCommandArgs args, CommandExecutionContext context)
     {
-        CommitIfActive(args);
+        CommitIfActive(args, context.OperationContext);
         return false;
     }
 
@@ -36,7 +36,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public bool ExecuteCommand(ExtractInterfaceCommandArgs args, CommandExecutionContext context)
     {
-        CommitIfActive(args);
+        CommitIfActive(args, context.OperationContext);
         return false;
     }
 
@@ -45,7 +45,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public bool ExecuteCommand(EncapsulateFieldCommandArgs args, CommandExecutionContext context)
     {
-        CommitIfActive(args);
+        CommitIfActive(args, context.OperationContext);
         return false;
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
@@ -76,9 +76,8 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
             }
             else
             {
-                uIThreadOperationContext.TakeOwnership();
                 // Otherwise, commit the existing session and start a new one.
-                _renameService.ActiveSession.Commit();
+                Commit(uIThreadOperationContext);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_RenameHandler.cs
@@ -48,7 +48,7 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
         return true;
     }
 
-    private async Task ExecuteCommandAsync(RenameCommandArgs args, IUIThreadOperationContext uIThreadOperationContext)
+    private async Task ExecuteCommandAsync(RenameCommandArgs args, IUIThreadOperationContext editorOperationContext)
     {
         _threadingContext.ThrowIfNotOnUIThread();
 
@@ -77,7 +77,7 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
             else
             {
                 // Otherwise, commit the existing session and start a new one.
-                Commit(uIThreadOperationContext);
+                Commit(editorOperationContext);
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs
@@ -21,14 +21,14 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
             // InlineRenameSession will call IUIThreadOperationExecutor to sets up our own IUIThreadOperationContext
             context.OperationContext.TakeOwnership();
 
-            Commit(_renameService.ActiveSession, args.TextView);
+            CommitAndSetFocus(_renameService.ActiveSession, args.TextView);
             return true;
         }
 
         return false;
     }
 
-    protected virtual void Commit(InlineRenameSession activeSession, ITextView textView)
+    protected virtual void CommitAndSetFocus(InlineRenameSession activeSession, ITextView textView)
     {
         activeSession.Commit();
         SetFocusToTextView(textView);

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs
@@ -5,6 +5,7 @@
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
 
@@ -17,20 +18,16 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<R
     {
         if (_renameService.ActiveSession != null)
         {
-            // Prevent Editor's typing responsiveness auto canceling the rename operation.
-            // InlineRenameSession will call IUIThreadOperationExecutor to sets up our own IUIThreadOperationContext
-            context.OperationContext.TakeOwnership();
-
-            CommitAndSetFocus(_renameService.ActiveSession, args.TextView);
+            CommitAndSetFocus(_renameService.ActiveSession, args.TextView, context.OperationContext);
             return true;
         }
 
         return false;
     }
 
-    protected virtual void CommitAndSetFocus(InlineRenameSession activeSession, ITextView textView)
+    protected virtual void CommitAndSetFocus(InlineRenameSession activeSession, ITextView textView, IUIThreadOperationContext operationContext)
     {
-        activeSession.Commit();
+        Commit(operationContext);
         SetFocusToTextView(textView);
     }
 }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
@@ -16,6 +16,7 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<S
     {
         if (_renameService.ActiveSession != null)
         {
+            context.OperationContext.TakeOwnership();
             _renameService.ActiveSession.Commit();
             SetFocusToTextView(args.TextView);
         }

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_SaveHandler.cs
@@ -16,8 +16,7 @@ internal abstract partial class AbstractRenameCommandHandler : ICommandHandler<S
     {
         if (_renameService.ActiveSession != null)
         {
-            context.OperationContext.TakeOwnership();
-            _renameService.ActiveSession.Commit();
+            Commit(context.OperationContext);
             SetFocusToTextView(args.TextView);
         }
 

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_TabHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_TabHandler.cs
@@ -26,7 +26,7 @@ internal abstract partial class AbstractRenameCommandHandler :
             return;
         }
 
-        HandlePossibleTypingCommand(args, nextHandler, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
         {
             var spans = new NormalizedSnapshotSpanCollection(
                 activeSession.GetBufferManager(args.SubjectBuffer)

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_TabHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_TabHandler.cs
@@ -26,7 +26,7 @@ internal abstract partial class AbstractRenameCommandHandler :
             return;
         }
 
-        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, _, span) =>
         {
             var spans = new NormalizedSnapshotSpanCollection(
                 activeSession.GetBufferManager(args.SubjectBuffer)

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_TypeCharHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_TypeCharHandler.cs
@@ -19,7 +19,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, _, span) =>
         {
             var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)

--- a/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_TypeCharHandler.cs
+++ b/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_TypeCharHandler.cs
@@ -19,7 +19,7 @@ internal abstract partial class AbstractRenameCommandHandler :
 
     public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
     {
-        HandlePossibleTypingCommand(args, nextHandler, (activeSession, span) =>
+        HandlePossibleTypingCommand(args, nextHandler, context.OperationContext, (activeSession, span) =>
         {
             var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -761,13 +761,6 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
     private async Task<bool> CommitWorkerAsync(bool previewChanges, bool canUseBackgroundWorkIndicator, IUIThreadOperationContext editorUIOperationContext)
     {
         await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
-        if (editorUIOperationContext is not null)
-        {
-            // Prevent Editor's typing responsiveness auto canceling the rename operation.
-            // InlineRenameSession will call IUIThreadOperationExecutor to sets up our own IUIThreadOperationContext
-            editorUIOperationContext.TakeOwnership();
-        }
-
         VerifyNotDismissed();
 
         // If the identifier was deleted (or didn't change at all) then cancel the operation.
@@ -787,6 +780,13 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         }
 
         previewChanges = previewChanges || PreviewChanges;
+
+        if (editorUIOperationContext is not null)
+        {
+            // Prevent Editor's typing responsiveness auto canceling the rename operation.
+            // InlineRenameSession will call IUIThreadOperationExecutor to sets up our own IUIThreadOperationContext
+            editorUIOperationContext.TakeOwnership();
+        }
 
         try
         {

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -723,6 +723,10 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         }
     }
 
+    /// <remarks>
+    /// This method would create its own UIThreadOperationContext to handle cancellation.
+    /// Caller must make sure to call IUIThreadOperationContext.TakeOwnership() before calling this, otherwise it won't be able to cancel the rename operation.
+    /// </remarks>
     public void Commit(bool previewChanges = false)
         => CommitSynchronously(previewChanges);
 
@@ -738,6 +742,10 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         return _threadingContext.JoinableTaskFactory.Run(() => CommitWorkerAsync(previewChanges, canUseBackgroundWorkIndicator: false));
     }
 
+    /// <remarks>
+    /// This method would create its own UIThreadOperationContext to handle cancellation.
+    /// Caller must make sure to call IUIThreadOperationContext.TakeOwnership() before calling this, otherwise it won't be able to cancel the rename operation.
+    /// </remarks>
     public async Task CommitAsync(bool previewChanges)
     {
         if (this.RenameService.GlobalOptions.GetOption(InlineRenameSessionOptionsStorage.RenameAsynchronously))

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -16,6 +16,7 @@ Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
 Imports Microsoft.VisualStudio.Text.Operations
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
     Friend Class CommitTestData
@@ -111,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                     Throw New NotImplementedException()
                 End Sub
 
-                Public Function CommitAsync(previewChanges As Boolean) As Task Implements IInlineRenameSession.CommitAsync
+                Public Function CommitAsync(previewChanges As Boolean, Optional editorOperationContext As IUIThreadOperationContext = Nothing) As Task Implements IInlineRenameSession.CommitAsync
                     Throw New NotImplementedException()
                 End Function
             End Class


### PR DESCRIPTION
In the current build, if the rename commit takes long time, when the commit is not triggered by 'enter'.
Your won't be able to cancel the operation.

Before:
![CancelNoEffect](https://github.com/user-attachments/assets/d117ef41-7cee-4795-a391-f4f6d7645adf)

After:
![CancelEffect](https://github.com/user-attachments/assets/21e79e4b-eb51-4bd8-ad4f-a004d32f9fbf)

It happens when I type 'ctrl + s' to commit the rename.

Fix is always taking ownership from the UIContext when commit starts.
We already do this in enter command handler, https://github.com/dotnet/roslyn/blob/f91512531640df6f9b78f60aa6c1d2ebe9f086ac/src/EditorFeatures/Core/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs#L22

Later rename session would choose to use IUIThreadOperationContext or IBackgroundIndicator by itself.
