### PR TITLE
Semantic snippets: don't provide snippets when dotting of a type name (floow up)

### DIFF
--- a/src/Features/CSharpTest/Snippets/AbstractCSharpConditionalBlockSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/AbstractCSharpConditionalBlockSnippetProviderTests.cs
@@ -566,4 +566,21 @@ public abstract class AbstractCSharpConditionalBlockSnippetProviderTests : Abstr
             }
             """);
     }
+
+    [Fact]
+    public async Task NoInlineSnippetForTypeItselfTest_BeforeContextualKeyword()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async void M()
+                {
+                    bool.$$
+                    await Task.Delay(10);
+                }
+            }
+            """);
+    }
 }

--- a/src/Features/CSharpTest/Snippets/CSharpDoSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpDoSnippetProviderTests.cs
@@ -582,4 +582,21 @@ public sealed class CSharpDoSnippetProviderTests : AbstractCSharpSnippetProvider
             }
             """);
     }
+
+    [Fact]
+    public async Task NoInlineDoSnippetForTypeItselfTest_BeforeContextualKeyword()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async void M()
+                {
+                    bool.$$
+                    await Task.Delay(10);
+                }
+            }
+            """);
+    }
 }

--- a/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
@@ -732,6 +732,24 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
     }
 
     [Theory]
+    [MemberData(nameof(CommonSnippetTestData.CommonEnumerableTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineForEachSnippetForTypeItselfTest_BeforeContextualKeyword(string collectionType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async void M()
+                {
+                    {{collectionType}}.$$
+                    await Task.Delay(10);
+                }
+            }
+            """);
+    }
+
+    [Theory]
     [InlineData("ArrayList")]
     [InlineData("IEnumerable")]
     [InlineData("MyCollection")]

--- a/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
@@ -877,31 +877,67 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
     }
 
     [Theory]
+    [InlineData("MyType")]
     [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
-    public async Task NoInlineForSnippetForTypeItselfTest(string integerType)
+    public async Task NoInlineForSnippetForTypeItselfTest(string validTypes)
     {
         await VerifySnippetIsAbsentAsync($$"""
             class C
             {
                 void M()
                 {
-                    {{integerType}}.$$
+                    {{validTypes}}.$$
                 }
+            }
+
+            class MyType
+            {
+                public int Count => 0;
             }
             """);
     }
 
     [Theory]
+    [InlineData("MyType")]
     [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
-    public async Task NoInlineForSnippetForTypeItselfTest_Parenthesized(string integerType)
+    public async Task NoInlineForSnippetForTypeItselfTest_Parenthesized(string validTypes)
     {
         await VerifySnippetIsAbsentAsync($$"""
             class C
             {
                 void M()
                 {
-                    ({{integerType}}).$$
+                    ({{validTypes}}).$$
                 }
+            }
+
+            class MyType
+            {
+                public int Count => 0;
+            }
+            """);
+    }
+
+    [Theory]
+    [InlineData("MyType")]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineForSnippetForTypeItselfTest_BeforeContextualKeyword(string validTypes)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async void M()
+                {
+                    {{validTypes}}.$$
+                    await Task.Delay(10);
+                }
+            }
+
+            class MyType
+            {
+                public int Count => 0;
             }
             """);
     }

--- a/src/Features/CSharpTest/Snippets/CSharpReversedForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpReversedForSnippetProviderTests.cs
@@ -879,31 +879,67 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
     }
 
     [Theory]
+    [InlineData("MyType")]
     [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
-    public async Task NoInlineReversedForSnippetForTypeItselfTest(string integerType)
+    public async Task NoInlineReversedForSnippetForTypeItselfTest(string validTypes)
     {
         await VerifySnippetIsAbsentAsync($$"""
             class C
             {
                 void M()
                 {
-                    {{integerType}}.$$
+                    {{validTypes}}.$$
                 }
+            }
+
+            class MyType
+            {
+                public int Count => 0;
             }
             """);
     }
 
     [Theory]
+    [InlineData("MyType")]
     [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
-    public async Task NoInlineReversedForSnippetForTypeItselfTest_Parenthesized(string integerType)
+    public async Task NoInlineReversedForSnippetForTypeItselfTest_Parenthesized(string validTypes)
     {
         await VerifySnippetIsAbsentAsync($$"""
             class C
             {
                 void M()
                 {
-                    ({{integerType}}).$$
+                    ({{validTypes}}).$$
                 }
+            }
+
+            class MyType
+            {
+                public int Count => 0;
+            }
+            """);
+    }
+
+    [Theory]
+    [InlineData("MyType")]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineReversedForSnippetForTypeItselfTest_BeforeContextualKeyword(string validTypes)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async void M()
+                {
+                    {{validTypes}}.$$
+                    await Task.Delay(10);
+                }
+            }
+
+            class MyType
+            {
+                public int Count => 0;
             }
             """);
     }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -108,6 +108,16 @@ internal abstract class AbstractInlineStatementSnippetProvider<TStatementSyntax>
         if (syntaxFacts.IsQualifiedName(parentNode))
         {
             syntaxFacts.GetPartsOfQualifiedName(parentNode, out var expression, out _, out _);
+            var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+
+            // Forbid a case when we are dotting of a type, e.g. `string.$$`.
+            // Inline statement snippets are not valid in this context
+            if (symbolInfo.Symbol is ITypeSymbol)
+            {
+                expressionInfo = null;
+                return false;
+            }
+
             var typeInfo = semanticModel.GetSpeculativeTypeInfo(expression.SpanStart, expression, SpeculativeBindingOption.BindAsExpression);
             expressionInfo = new(expression, typeInfo);
             return true;


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/74841