### PR TITLE
Double check document changes when dismiss rename

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -386,12 +386,19 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
     {
         if (args.Kind != WorkspaceChangeKind.DocumentChanged)
         {
-            Logger.Log(FunctionId.Rename_InlineSession_Cancel_NonDocumentChangedWorkspaceChange, KeyValueLogMessage.Create(m =>
+            // Make sure only call Cancel() when there is real document changes.
+            // Sometimes, WorkspaceChangeKind.SolutionChanged might be triggered because of SourceGeneratorVersion get updated.
+            // We don't want to cancel rename when there is no changed documents.
+            var changedDocuments = args.NewSolution.GetChangedDocuments(args.OldSolution);
+            if (changedDocuments.Any())
             {
-                m["Kind"] = Enum.GetName(typeof(WorkspaceChangeKind), args.Kind);
-            }));
+                Logger.Log(FunctionId.Rename_InlineSession_Cancel_NonDocumentChangedWorkspaceChange, KeyValueLogMessage.Create(m =>
+                {
+                    m["Kind"] = Enum.GetName(typeof(WorkspaceChangeKind), args.Kind);
+                }));
 
-            Cancel();
+                Cancel();
+            }
         }
     }
 


### PR DESCRIPTION
Rename session listens to workspace change event, when there is document changed, it cancels the active rename session.

This is causing problem, sometimes `WorkspaceChangeKind.SolutionChanged` might be triggered, and there is no real document changes so user might see rename get dismissed randomly.
In background, it might just be source-generated version maps get udpated.
See the value when I hit the rename dismissed problem.
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/d8e4f477-fc29-4caf-a2c7-2f775c60bfd3">

So double-check if there is actual document changes.

It might be the fix to: https://github.com/dotnet/roslyn/issues/74347