### PR TITLE
Add a null check when replacement text changed in rename session.

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/AbstractInlineRenameUndoManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractInlineRenameUndoManager.cs
@@ -75,7 +75,7 @@ internal abstract class AbstractInlineRenameUndoManager<TBufferState>
 
     private void InlineRenameSession_ReplacementTextChanged(object sender, System.EventArgs e)
     {
-        if (currentState.ReplacementText != _trackedSession.ReplacementText)
+        if (currentState?.ReplacementText != _trackedSession.ReplacementText)
         {
             // No need to update anchor points here, just make sure the state in the undo stack
             // ends up with the correct replacement text. This can happen if the text buffer isn't


### PR DESCRIPTION
I don't know the exact repro steps, but I hit this NRE frequently when I debug rename session.

It happens when the ReplacementText gets changed, and flows to `InlineRenameSession_ReplacementTextChanged` from the UI. And at that moment `currentState` is null.

It might be a bigger problem under but It feels not bad to add a null check to stop the NRE.