### PR TITLE
Fix NRE in rename 

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/AbstractInlineRenameUndoManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractInlineRenameUndoManager.cs
@@ -44,7 +44,6 @@ internal abstract class AbstractInlineRenameUndoManager<TBufferState>
         this.InlineRenameService = inlineRenameService;
         _globalOptionService = globalOptionService;
 
-        InlineRenameService.ActiveSessionChanged += InlineRenameService_ActiveSessionChanged;
     }
 
     private void InlineRenameService_ActiveSessionChanged(object sender, InlineRenameService.ActiveSessionChangedEventArgs e)
@@ -96,6 +95,7 @@ internal abstract class AbstractInlineRenameUndoManager<TBufferState>
         this.RedoStack.Clear();
         this.initialState = null;
         this.currentState = null;
+        InlineRenameService.ActiveSessionChanged -= InlineRenameService_ActiveSessionChanged;
     }
 
     private void UpdateCurrentState(string replacementText, ITextSelection selection, SnapshotSpan activeSpan)
@@ -118,6 +118,7 @@ internal abstract class AbstractInlineRenameUndoManager<TBufferState>
     {
         UpdateCurrentState(replacementText, selection, startingSpan);
         this.initialState = this.currentState;
+        InlineRenameService.ActiveSessionChanged += InlineRenameService_ActiveSessionChanged;
     }
 
     public void OnTextChanged(ITextSelection selection, SnapshotSpan singleTrackingSpanTouched)


### PR DESCRIPTION
NRE might happen when typing using rename.

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/49fe9c77-869d-43f3-9558-630fc7781c7d">
(Note: NRE is going to happen on line 83, I use the debugger so it's easier to get repro)

I have experienced this most in cases when I open a solution first, use rename. Then open a second solution, use rename again and VS would crash in this case.

Look into the call stack:
![image](https://github.com/user-attachments/assets/dbe67a86-b36e-4414-9fd9-6c1411555166)
It shows that the `identifier` typed in UI propagates to `InlineRenameUndoManager` but `currentState` is null at that moment.

The sequence is:
`ActiveSession change` -> `InlineRenameService_ActiveSessionChanged` -> Register & Unregister `InlineRenameSession_ReplacementTextChanged event handler` (Where the NRE happens)

Moreover, the active `InlineRenameSevice` is referencing a different UndoManager (comparing to `this`)
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/cedd3d9b-fb78-4591-8d86-1dccaea6760b">

So the problem is:
`UndoManager` is registered in a [workspace factory ](https://github.com/dotnet/roslyn/blob/d4adac632d65a1b77dd1972175ea31d2732ce05a/src/EditorFeatures/Core/InlineRename/UndoManagerServiceFactory.cs#L29)

Later `InlineRenameService_ActiveSessionChanged` hooks to ActiveSession changed event in [ctor](https://github.com/dotnet/roslyn/blob/d4adac632d65a1b77dd1972175ea31d2732ce05a/src/EditorFeatures/Core/InlineRename/AbstractInlineRenameUndoManager.cs#L47) and it never gets unplug.

So in this case, when another solution is open, sometimes another `UndoManager` is created and two managers are hooked to the ActiveSession changed event. But one of them is clean after [Disconnect](https://github.com/dotnet/roslyn/blob/d4adac632d65a1b77dd1972175ea31d2732ce05a/src/EditorFeatures/Core/InlineRename/AbstractInlineRenameUndoManager.cs#L92) is called so NRE is thrown.

Solution:
Register `InlineRenameService_ActiveSessionChanged` in `CreateInitialState()` method. `CreateInitialState()` is only called when RenameSession get [created ](https://github.com/dotnet/roslyn/blob/d4adac632d65a1b77dd1972175ea31d2732ce05a/src/EditorFeatures/Core/InlineRename/InlineRenameService.cs#L105)
Then unregister when UndoManager gets disconnected. It will be called when [DismissUIAndRollbackEditsAndEndRenameSessionAsync](https://github.com/dotnet/roslyn/blob/d4adac632d65a1b77dd1972175ea31d2732ce05a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs#L660) is called (only happen when commit & cancel)



