### PR TITLE
Add required `--locale` option to BuildHost

### DIFF
--- a/src/Workspaces/Core/MSBuild.BuildHost/BuildHostLogger.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/BuildHostLogger.cs
@@ -2,15 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
 internal sealed class BuildHostLogger(TextWriter output)
 {
+    private const string InformationLevel = "info";
+    private const string WarningLevel = "warn";
+    private const string CriticalLevel = "crit";
+    private const string LogLevelPadding = ": ";
+
     public void LogInformation(string message)
-        => output.WriteLine(message);
+        => LogMessage(InformationLevel, message);
+
+    public void LogWarning(string message)
+        => LogMessage(WarningLevel, message);
 
     public void LogCritical(string message)
-        => output.WriteLine(message);
+        => LogMessage(CriticalLevel, message);
+
+    private void LogMessage(string level, string message)
+    {
+        output.Write(level);
+        output.Write(LogLevelPadding);
+        output.Write(message);
+        output.Write(Environment.NewLine);
+    }
 }

--- a/src/Workspaces/Core/MSBuild.BuildHost/Program.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Program.cs
@@ -41,7 +41,7 @@ internal static class Program
         catch (CultureNotFoundException)
         {
             // We couldn't find the culture, log a warning and fallback to the OS configured value.
-            logger.LogInformation($"Culture {locale} was not found, falling back to OS culture");
+            logger.LogWarning($"Culture {locale} was not found, falling back to OS culture");
         }
 
         logger.LogInformation($"BuildHost Runtime Version: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");

--- a/src/Workspaces/Core/MSBuild/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/BuildHostProcessManager.cs
@@ -240,6 +240,9 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
             AddArgument(processStartInfo, _binaryLogPath);
         }
 
+        AddArgument(processStartInfo, "--locale");
+        AddArgument(processStartInfo, System.Globalization.CultureInfo.CurrentUICulture.Name);
+
         // MSBUILD_EXE_PATH is read by MSBuild to find related tasks and targets. We don't want this to be inherited by our build process, or otherwise
         // it might try to load targets that aren't appropriate for the build host.
         processStartInfo.Environment.Remove("MSBUILD_EXE_PATH");

--- a/src/Workspaces/Core/MSBuild/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/BuildHostProcessManager.cs
@@ -83,13 +83,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         {
             if (!_processes.TryGetValue(buildHostKind, out var buildHostProcess))
             {
-                var processStartInfo = buildHostKind switch
-                {
-                    BuildHostProcessKind.NetCore => CreateDotNetCoreBuildHostStartInfo(),
-                    BuildHostProcessKind.NetFramework => CreateDotNetFrameworkBuildHostStartInfo(),
-                    BuildHostProcessKind.Mono => CreateMonoBuildHostStartInfo(),
-                    _ => throw ExceptionUtilities.UnexpectedValue(buildHostKind)
-                };
+                var processStartInfo = CreateBuildHostStartInfo(buildHostKind);
 
                 var process = Process.Start(processStartInfo);
                 Contract.ThrowIfNull(process, "Process.Start failed to launch a process.");
@@ -109,6 +103,17 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
 
             return buildHostProcess.BuildHost;
         }
+    }
+
+    internal ProcessStartInfo CreateBuildHostStartInfo(BuildHostProcessKind buildHostKind)
+    {
+        return buildHostKind switch
+        {
+            BuildHostProcessKind.NetCore => CreateDotNetCoreBuildHostStartInfo(),
+            BuildHostProcessKind.NetFramework => CreateDotNetFrameworkBuildHostStartInfo(),
+            BuildHostProcessKind.Mono => CreateMonoBuildHostStartInfo(),
+            _ => throw ExceptionUtilities.UnexpectedValue(buildHostKind)
+        };
     }
 
     private void BuildHostProcess_Disconnected(object? sender, EventArgs e)

--- a/src/Workspaces/MSBuildTest/BuildHostProcessManagerTests.cs
+++ b/src/Workspaces/MSBuildTest/BuildHostProcessManagerTests.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.MSBuild.UnitTests;
+
+using BuildHostProcessKind = BuildHostProcessManager.BuildHostProcessKind;
+
+public class BuildHostProcessManagerTests
+{
+    [Fact]
+    public void ProcessStartInfo_ForNetCore_RollsForwardToLatestPreview()
+    {
+        var processStartInfo = new BuildHostProcessManager()
+            .CreateBuildHostStartInfo(BuildHostProcessKind.NetCore);
+
+#if NET
+        var rollForwardIndex = processStartInfo.ArgumentList.IndexOf("--roll-forward");
+        var latestMajorIndex = processStartInfo.ArgumentList.IndexOf("LatestMajor");
+        Assert.True(rollForwardIndex >= 0);
+        Assert.True(latestMajorIndex >= 0);
+        Assert.Equal(latestMajorIndex, rollForwardIndex + 1);
+#else
+        Assert.Contains("--roll-forward LatestMajor", processStartInfo.Arguments);
+#endif
+    }
+
+    [Fact]
+    public void ProcessStartInfo_ForNetCore_LaunchesDotNetCLI()
+    {
+        var processStartInfo = new BuildHostProcessManager()
+            .CreateBuildHostStartInfo(BuildHostProcessKind.NetCore);
+
+        Assert.StartsWith("dotnet", processStartInfo.FileName);
+    }
+
+    [Fact]
+    public void ProcessStartInfo_ForMono_LaunchesMono()
+    {
+        var processStartInfo = new BuildHostProcessManager()
+            .CreateBuildHostStartInfo(BuildHostProcessKind.Mono);
+
+        Assert.Equal("mono", processStartInfo.FileName);
+    }
+
+    [Fact]
+    public void ProcessStartInfo_ForNetFramework_LaunchesBuildHost()
+    {
+        var processStartInfo = new BuildHostProcessManager()
+            .CreateBuildHostStartInfo(BuildHostProcessKind.NetFramework);
+
+        Assert.EndsWith("Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe", processStartInfo.FileName);
+    }
+
+    [Theory]
+    [InlineData(BuildHostProcessKind.NetFramework)]
+    [InlineData(BuildHostProcessKind.NetCore)]
+    [InlineData(BuildHostProcessKind.Mono)]
+    internal void ProcessStartInfo_PassesBinLogPath(BuildHostProcessKind buildHostKind)
+    {
+        const string BinaryLogPath = "test.binlog";
+
+        var processStartInfo = new BuildHostProcessManager(binaryLogPath: BinaryLogPath)
+            .CreateBuildHostStartInfo(buildHostKind);
+
+#if NET
+        var binlogIndex = processStartInfo.ArgumentList.IndexOf("--binlog");
+        Assert.True(binlogIndex >= 0);
+        Assert.Equal(BinaryLogPath, processStartInfo.ArgumentList[binlogIndex + 1]);
+#else
+        Assert.Contains($"--binlog {BinaryLogPath}", processStartInfo.Arguments);
+#endif
+    }
+
+    [Theory]
+    [InlineData(BuildHostProcessKind.NetFramework)]
+    [InlineData(BuildHostProcessKind.NetCore)]
+    [InlineData(BuildHostProcessKind.Mono)]
+    [UseCulture("de-DE", "de-DE")]
+    internal void ProcessStartInfo_PassesLocale(BuildHostProcessKind buildHostKind)
+    {
+        const string Locale = "de-DE";
+
+        var processStartInfo = new BuildHostProcessManager()
+            .CreateBuildHostStartInfo(buildHostKind);
+
+#if NET
+        var localeIndex = processStartInfo.ArgumentList.IndexOf("--locale");
+        Assert.True(localeIndex >= 0);
+        Assert.Equal(Locale, processStartInfo.ArgumentList[localeIndex + 1]);
+#else
+        Assert.Contains($"--locale {Locale}", processStartInfo.Arguments);
+#endif
+    }
+
+    [Theory]
+    [InlineData(BuildHostProcessKind.NetFramework)]
+    [InlineData(BuildHostProcessKind.NetCore)]
+    [InlineData(BuildHostProcessKind.Mono)]
+    internal void ProcessStartInfo_PassesProperties(BuildHostProcessKind buildHostKind)
+    {
+        var globalMSBuildProperties = new Dictionary<string, string>
+        {
+            ["TestKey1"] = "TestValue1",
+            ["TestKey2"] = "TestValue2",
+        }.ToImmutableDictionary();
+
+        var buildHostProcessManager = new BuildHostProcessManager(globalMSBuildProperties);
+
+        var processStartInfo = buildHostProcessManager.CreateBuildHostStartInfo(buildHostKind);
+
+#if NET
+        foreach (var kvp in globalMSBuildProperties)
+        {
+            var propertyArgument = GetPropertyArgument(kvp);
+            var argumentIndex = processStartInfo.ArgumentList.IndexOf(propertyArgument);
+            Assert.True(argumentIndex >= 0);
+            Assert.Equal("--property", processStartInfo.ArgumentList[argumentIndex - 1]);
+        }
+#else
+        foreach (var kvp in globalMSBuildProperties)
+        {
+            var propertyArgument = GetPropertyArgument(kvp);
+            Assert.Contains($"--property {propertyArgument}", processStartInfo.Arguments);
+        }
+#endif
+
+        static string GetPropertyArgument(KeyValuePair<string, string> property)
+        {
+            return $"{property.Key}={property.Value}";
+        }
+    }
+}

--- a/src/Workspaces/MSBuildTest/NetCoreTests.cs
+++ b/src/Workspaces/MSBuildTest/NetCoreTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.UnitTests;
 using Microsoft.CodeAnalysis.UnitTests.TestFiles;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Roslyn.Test.Utilities;
@@ -437,6 +438,40 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
 
             Assert.Contains(workspace.CurrentSolution.Projects, p => p.Name == "Library(net6)");
             Assert.Contains(workspace.CurrentSolution.Projects, p => p.Name == "Library(net5)");
+        }
+
+        [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]
+        [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [Trait(Traits.Feature, Traits.Features.NetCore)]
+        [UseCulture("en-EN", "en-EN")]
+        public async Task TestBuildHostLocale_EN()
+        {
+            await AssertInvalidTfmDiagnosticMessageContains("The TargetFramework value 'Invalid' was not recognized. It may be misspelled.");
+        }
+
+        [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]
+        [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [Trait(Traits.Feature, Traits.Features.NetCore)]
+        [UseCulture("de-DE", "de-DE")]
+        public async Task TestBuildHostLocale_DE()
+        {
+            await AssertInvalidTfmDiagnosticMessageContains("Der TargetFramework-Wert \"Invalid\" wurde nicht erkannt. Unter Umständen ist die Schreibweise nicht korrekt.");
+        }
+
+        private async Task AssertInvalidTfmDiagnosticMessageContains(string expected)
+        {
+            var projectPath = @"Project\Project.csproj";
+            var files = new FileSet((projectPath, Resources.ProjectFiles.CSharp.InvalidTFM));
+
+            CreateFiles(files);
+
+            var fullProjectPath = GetSolutionFileName(projectPath);
+
+            using var workspace = CreateMSBuildWorkspace(throwOnWorkspaceFailed: false);
+            var project = await workspace.OpenProjectAsync(fullProjectPath);
+
+            var diagnostic = Assert.Single(workspace.Diagnostics);
+            Assert.Contains(expected, diagnostic.Message);
         }
 
         [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/InvalidTFM.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/InvalidTFM.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>Invalid</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
@@ -132,6 +132,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string ExternAlias => GetText("ProjectFiles.CSharp.ExternAlias.csproj");
                 public static string ExternAlias2 => GetText("ProjectFiles.CSharp.ExternAlias2.csproj");
                 public static string ForEmittedOutput => GetText("ProjectFiles.CSharp.ForEmittedOutput.csproj");
+                public static string InvalidTFM => GetText("ProjectFiles.CSharp.InvalidTFM.csproj");
                 public static string Issue30174_InspectedLibrary => GetText("Issue30174.InspectedLibrary.InspectedLibrary.csproj");
                 public static string Issue30174_ReferencedLibrary => GetText("Issue30174.ReferencedLibrary.ReferencedLibrary.csproj");
                 public static string MSBuildExecutionError => GetText("ProjectFiles.CSharp.MSBuildExecutionError.csproj");


### PR DESCRIPTION
When invoking the BuildHost pass along the `CurrentUICulture.Name`. This will allow reported exceptions to match the language of the process which is using the MSBuildWorkspace.


Resolves #74902