### PR TITLE
Avoid synthesizing incorrect `allows ref struct` delegate type parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     // Add a type parameter
                     AnonymousTypeParameterSymbol typeParameter =
-                        new AnonymousTypeParameterSymbol(this, fieldIndex, GeneratedNames.MakeAnonymousTypeParameterName(field.Name));
+                        new AnonymousTypeParameterSymbol(this, fieldIndex, GeneratedNames.MakeAnonymousTypeParameterName(field.Name), allowsRefLikeType: false);
                     typeParametersBuilder.Add(typeParameter);
 
                     // Add a property

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
@@ -20,8 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private readonly AnonymousTypeOrDelegateTemplateSymbol _container;
             private readonly int _ordinal;
             private readonly string _name;
+            private readonly bool _allowsRefLikeType;
 
-            public AnonymousTypeParameterSymbol(AnonymousTypeOrDelegateTemplateSymbol container, int ordinal, string name)
+            public AnonymousTypeParameterSymbol(AnonymousTypeOrDelegateTemplateSymbol container, int ordinal, string name, bool allowsRefLikeType)
             {
                 Debug.Assert((object)container != null);
                 Debug.Assert(!string.IsNullOrEmpty(name));
@@ -29,6 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _container = container;
                 _ordinal = ordinal;
                 _name = name;
+                _allowsRefLikeType = allowsRefLikeType;
             }
 
             public override TypeParameterKind TypeParameterKind
@@ -91,13 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return false; }
             }
 
-            public override bool AllowsRefLikeType
-            {
-                get
-                {
-                    return _container.IsDelegateType() && ContainingAssembly.RuntimeSupportsByRefLikeGenerics;
-                }
-            }
+            public override bool AllowsRefLikeType => _allowsRefLikeType;
 
             public override bool IsValueTypeFromConstraintTypes
             {

--- a/src/Compilers/CSharp/Test/Emit3/RefStructInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/RefStructInterfacesTests.cs
@@ -22788,6 +22788,408 @@ namespace System
                 ).VerifyDiagnostics();
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_09_ParamsArray()
+        {
+            var source = """
+                var d = M;
+                System.Console.WriteLine(d.GetType());
+
+                void M(params int[] arr) { }
+                """;
+            var verifier = CompileAndVerify(source,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.Int32]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(params T1[] arg)", m.ToTestDisplayString());
+                Assert.False(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_10_ParamsArray()
+        {
+            var source = """
+                var d = M;
+                System.Console.WriteLine(d.GetType());
+
+                void M(string s, params int[] arr) { }
+                """;
+            var verifier = CompileAndVerify(source,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`2[System.String,System.Int32]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1, T2>.Invoke(T1 arg1, params T2[] arg2)", m.ToTestDisplayString());
+                Assert.Equal([true, false], m.ContainingType.TypeParameters.Select(t => t.AllowsRefLikeType));
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_11_ParamsArray()
+        {
+            var source = """
+                unsafe
+                {
+                    var d = M;
+                    System.Console.WriteLine(d.GetType());
+
+                    void M(int* p, params int[] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0.Invoke(System.Int32* arg1, params System.Int32[] arg2)", m.ToTestDisplayString());
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_12_ParamsArray()
+        {
+            var source = """
+                M<string>();
+                unsafe static void M<T>()
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T>
+                {
+                    public static void M(int* p, T x, params int[] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.String]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, T1 arg2, params System.Int32[] arg3)", m.ToTestDisplayString());
+                Assert.False(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_13_ParamsArray()
+        {
+            var source = """
+                M<string>();
+                unsafe static void M<T>() where T : allows ref struct
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T> where T : allows ref struct
+                {
+                    public static void M(int* p, T x, params int[] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.String]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, T1 arg2, params System.Int32[] arg3)", m.ToTestDisplayString());
+                Assert.True(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_14_ParamsArray()
+        {
+            var source = """
+                M<string>();
+                unsafe static void M<T>()
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T>
+                {
+                    public static void M(int* p, T x, params T[] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.String]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, T1 arg2, params T1[] arg3)", m.ToTestDisplayString());
+                Assert.False(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_15_ParamsArray()
+        {
+            var source = """
+                M<string>();
+                unsafe static void M<T>()
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T>
+                {
+                    public static void M(int* p, params T[] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.String]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, params T1[] arg2)", m.ToTestDisplayString());
+                Assert.False(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_16_ParamsArray()
+        {
+            var source = """
+                #nullable enable
+                M<string>();
+                unsafe static void M<T>()
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T>
+                {
+                    public static void M(int* p, params T?[] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.String]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, params T1?[] arg2)", m.ToTestDisplayString());
+                Assert.False(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_17_ParamsArray()
+        {
+            var source = """
+                M<short>();
+                unsafe static void M<T>() where T : struct
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T> where T : struct
+                {
+                    public static void M(int* p, params T?[] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.Int16]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, params T1?[] arg2)", m.ToTestDisplayString());
+                Assert.False(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_18_ParamsArray()
+        {
+            var source = """
+                M<short>();
+                unsafe static void M<T>()
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T>
+                {
+                    public static void M(int* p, params T[][] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.Int16]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, params T1[][] arg2)", m.ToTestDisplayString());
+                Assert.False(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_19_ParamsCollection()
+        {
+            var source = """
+                var d = M;
+                System.Console.WriteLine(d.GetType());
+
+                void M(params System.Collections.Generic.IEnumerable<int> e) { }
+                """;
+            var verifier = CompileAndVerify(source,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0.Invoke(params System.Collections.Generic.IEnumerable<System.Int32> arg)", m.ToTestDisplayString());
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_20()
+        {
+            var source = """
+                M<short>();
+                unsafe static void M<T>()
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T>
+                {
+                    public static void M(int* p, T[] arr) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.Int16]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, T1[] arg2)", m.ToTestDisplayString());
+                Assert.False(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_21()
+        {
+            var source = """
+                M<short>();
+                unsafe static void M<T>() where T : allows ref struct
+                {
+                    var d = C<T>.M;
+                    System.Console.WriteLine(d.GetType());
+                }
+                unsafe static class C<T> where T : allows ref struct
+                {
+                    public static void M(int* p, T t) { }
+                }
+                """;
+            var verifier = CompileAndVerify(source,
+                options: TestOptions.UnsafeReleaseExe,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>f__AnonymousDelegate0`1[System.Int16]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>f__AnonymousDelegate0.Invoke");
+                AssertEx.Equal("void <>f__AnonymousDelegate0<T1>.Invoke(System.Int32* arg1, T1 arg2)", m.ToTestDisplayString());
+                Assert.True(m.ContainingType.TypeParameters.Single().AllowsRefLikeType);
+            }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/74823")]
+        public void AnonymousDelegateType_22()
+        {
+            var source = """
+                var d = M;
+                System.Console.WriteLine(d.GetType());
+
+                void M(ref short p, int[] arr) { }
+                """;
+            var verifier = CompileAndVerify(source,
+                targetFramework: s_targetFrameworkSupportingByRefLikeGenerics,
+                symbolValidator: validate,
+                verify: Verification.FailsPEVerify,
+                expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "<>A{00000001}`2[System.Int16,System.Int32[]]" : null);
+            verifier.VerifyDiagnostics();
+
+            static void validate(ModuleSymbol module)
+            {
+                var m = module.GlobalNamespace.GetMember<MethodSymbol>("<>A{00000001}.Invoke");
+                AssertEx.Equal("void <>A{00000001}<T1, T2>.Invoke(ref T1 arg1, T2 arg2)", m.ToTestDisplayString());
+                Assert.Equal([true, true], m.ContainingType.TypeParameters.Select(t => t.AllowsRefLikeType));
+            }
+        }
+
         [Fact]
         public void ExpressionTree_01()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74823.