### PR TITLE
Field-backed properties: readonly backing field

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -193,6 +193,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
+                    // PROTOTYPE: We could treat the field as readonly if all manually implemented get and set
+                    // accessors are declared readonly. Although, to do so, we might need to bind the accessor
+                    // declarations before creating the backing field. See FieldKeywordTests.ReadOnly_05().
                     isReadOnly = false;
                 }
 

--- a/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
@@ -2666,8 +2666,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     Diagnostic(ErrorCode.ERR_DuplicatePropertyReadOnlyMods, "Q5").WithArguments("S.Q5").WithLocation(12, 12));
             }
             var actualMembers = comp.GetMember<NamedTypeSymbol>("S").GetMembers().OfType<FieldSymbol>().Select(f => $"{f.ToTestDisplayString()}: {f.IsReadOnly}");
-            // PROTOTYPE: When constructing the backing field in SourcePropertySymbolBase..ctor(),
-            // we're currently ignoring the readonly modifier on accessors.
+            // PROTOTYPE: When determining whether the backing field should be readonly in
+            // SourcePropertySymbolBase..ctor(), we're ignoring the readonly modifier on accessors.
             var expectedMembers = new[]
             {
                 $"System.Object S.<P1>k__BackingField: True",


### PR DESCRIPTION
From [proposal](https://github.com/dotnet/csharplang/blob/main/proposals/field-keyword.md#readonly-field):
> The synthesized backing field is *read-only* when the containing type is a `struct` and the property or containing type is declared `readonly`.