### PR TITLE
Fix broken url

### DIFF
--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -75,7 +75,7 @@ catch {
   Write-Host $_
   Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
-  Write-Host "##vso[task.logissue type=error]How to investigate bootstrap failures: https://github.com/dotnet/roslyn/blob/main/docs/compilers/Bootstrap%20Builds.md#Investigating"
+  Write-Host "##vso[task.logissue type=error]How to investigate bootstrap failures: https://github.com/dotnet/roslyn/blob/main/docs/contributing/Bootstrap%20Builds.md#Investigating"
   ExitWithExitCode 1
 }
 finally {


### PR DESCRIPTION
Looks like this doc file got moved.

Example log with a broken link: https://dev.azure.com/dnceng-public/public/_build/results?buildId=787723&view=logs&j=7cdae500-0ea5-58ba-9407-8d2db153220d&t=9f4a29f3-3fce-552d-95fd-b8c8a3e8295f&l=512