### PR TITLE
Update 'use collection expression' to support cases where switching to a collection expr will pick a ROS overload over an array one.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
@@ -71,6 +71,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
         var matches = UseCollectionExpressionHelpers.TryGetMatches(
             semanticModel,
             expression,
+            replacementExpression,
             expressionType,
             isSingletonInstance: false,
             allowSemanticsChange,

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
@@ -17,7 +17,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 
-using static SyntaxFactory;
+using static UseCollectionExpressionHelpers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer()
@@ -79,7 +79,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
         if (matches.IsDefault)
             return default;
 
-        if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
+        if (!CanReplaceWithCollectionExpression(
                 semanticModel, expression, expressionType, isSingletonInstance: false, allowSemanticsChange, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics))
         {
             return default;
@@ -101,7 +101,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
             if (ienumerableType is null)
                 return default;
 
-            if (!UseCollectionExpressionHelpers.IsConstructibleCollectionType(
+            if (!IsConstructibleCollectionType(
                     semanticModel.Compilation, ienumerableType.TypeArguments.Single()))
             {
                 return default;
@@ -122,7 +122,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
     {
         // if we have `new[] { ... }` we have no subsequent matches to add to the collection. All values come
         // from within the initializer.
-        if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
+        if (!CanReplaceWithCollectionExpression(
                 semanticModel, expression, replacementExpression, expressionType, isSingletonInstance: false, allowSemanticsChange, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics))
         {
             return default;
@@ -155,11 +155,10 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
 
         // Have to actually examine what would happen when we do the replacement, as the replaced value may interact
         // with inference based on the values within.
-        var replacementCollectionExpression = CollectionExpression(
-            [.. initializer.Expressions.Select(ExpressionElement)]);
+        var replacementCollectionExpression = CreateReplacementCollectionExpressionForAnalysis(initializer);
 
         var allowSemanticsChange = option.Value is CollectionExpressionPreference.WhenTypesLooselyMatch;
-        if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
+        if (!CanReplaceWithCollectionExpression(
                 semanticModel, arrayCreationExpression, replacementCollectionExpression,
                 expressionType, isSingletonInstance: false, allowSemanticsChange, skipVerificationForReplacedNode: true, cancellationToken,
                 out var changesSemantics))

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs
@@ -12,6 +12,8 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 
+using static UseCollectionExpressionHelpers;
+
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer
     : AbstractCSharpUseCollectionExpressionDiagnosticAnalyzer
@@ -127,6 +129,7 @@ internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnost
         return UseCollectionExpressionHelpers.TryGetMatches(
             semanticModel,
             expression,
+            CreateReplacementCollectionExpressionForAnalysis(expression.Initializer),
             expressionType,
             isSingletonInstance: false,
             allowSemanticsChange,

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -1235,6 +1235,6 @@ internal static class UseCollectionExpressionHelpers
                 nodeOrToken => nodeOrToken.IsToken ? nodeOrToken : Argument((ExpressionSyntax)nodeOrToken.AsNode()!)));
     }
 
-    public static CollectionExpressionSyntax CreateReplacementCollectionExpressionForAnalysis(InitializerExpressionSyntax initializer)
-        => CollectionExpression([.. initializer.Expressions.Select(ExpressionElement)]);
+    public static CollectionExpressionSyntax CreateReplacementCollectionExpressionForAnalysis(InitializerExpressionSyntax? initializer)
+        => initializer is null ? s_emptyCollectionExpression : CollectionExpression([.. initializer.Expressions.Select(ExpressionElement)]);
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -33,6 +33,8 @@ internal static class UseCollectionExpressionHelpers
         distinguishRefFromOut: true,
         // Not relevant.  We are not comparing method signatures.
         objectAndDynamicCompareEqually: false,
+        // Not relevant.  We are not comparing method signatures.
+        arrayAndReadOnlySpanCompareEqually: false,
         // The value we're tweaking.
         tupleNamesMustMatch: false,
         // We do not want to ignore this.  `ImmutableArray<string?>` should not be convertible to `ImmutableArray<string>`

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -1234,4 +1234,7 @@ internal static class UseCollectionExpressionHelpers
             : SeparatedList<ArgumentSyntax>(initializer.Expressions.GetWithSeparators().Select(
                 nodeOrToken => nodeOrToken.IsToken ? nodeOrToken : Argument((ExpressionSyntax)nodeOrToken.AsNode()!)));
     }
+
+    public static CollectionExpressionSyntax CreateReplacementCollectionExpressionForAnalysis(InitializerExpressionSyntax initializer)
+        => CollectionExpression([.. initializer.Expressions.Select(ExpressionElement)]);
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -817,6 +817,7 @@ internal static class UseCollectionExpressionHelpers
     public static ImmutableArray<CollectionExpressionMatch<StatementSyntax>> TryGetMatches<TArrayCreationExpressionSyntax>(
         SemanticModel semanticModel,
         TArrayCreationExpressionSyntax expression,
+        CollectionExpressionSyntax replacementExpression,
         INamedTypeSymbol? expressionType,
         bool isSingletonInstance,
         bool allowSemanticsChange,
@@ -926,7 +927,7 @@ internal static class UseCollectionExpressionHelpers
         }
 
         if (!CanReplaceWithCollectionExpression(
-                semanticModel, expression, expressionType, isSingletonInstance, allowSemanticsChange, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics))
+                semanticModel, expression, replacementExpression, expressionType, isSingletonInstance, allowSemanticsChange, skipVerificationForReplacedNode: true, cancellationToken, out changesSemantics))
         {
             return default;
         }

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
@@ -103,7 +103,7 @@ internal partial class CSharpUseCollectionExpressionForArrayCodeFixProvider()
             {
                 ImplicitArrayCreationExpressionSyntax arrayCreation
                     => CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.TryGetMatches(
-                        semanticModel, arrayCreation, expressionType, allowSemanticsChange: true, cancellationToken, out _),
+                        semanticModel, arrayCreation, CreateReplacementCollectionExpressionForAnalysis(arrayCreation.Initializer), expressionType, allowSemanticsChange: true, cancellationToken, out _),
 
                 ArrayCreationExpressionSyntax arrayCreation
                     => CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.TryGetMatches(

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
@@ -107,7 +107,7 @@ internal partial class CSharpUseCollectionExpressionForArrayCodeFixProvider()
 
                 ArrayCreationExpressionSyntax arrayCreation
                     => CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.TryGetMatches(
-                        semanticModel, arrayCreation, expressionType, allowSemanticsChange: true, cancellationToken, out _),
+                        semanticModel, arrayCreation, CreateReplacementCollectionExpressionForAnalysis(arrayCreation.Initializer), expressionType, allowSemanticsChange: true, cancellationToken, out _),
 
                 // We validated this is unreachable in the caller.
                 _ => throw ExceptionUtilities.Unreachable(),

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocCodeFixProvider.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -5701,18 +5701,18 @@ public class UseCollectionExpressionForArrayTests
     }
 
     [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/74931")]
-    public async Task AllowSwitchToReadOnlySpanCSharp12(bool whenTypesLooselyMatch)
+    public async Task AllowSwitchToReadOnlySpanCSharp12(bool implicitType, bool whenTypesLooselyMatch)
     {
         await new VerifyCS.Test
         {
-            TestCode = """
+            TestCode = $$"""
                 using System;
 
                 class C
                 {
                     void M(char c)
                     {
-                        Split([|[|new|][]|] { c });
+                        Split([|[|new|]{{(implicitType ? "" : " char")}}[]|] { c });
                     }
 
                     void Split(char[] p) { }
@@ -5743,18 +5743,18 @@ public class UseCollectionExpressionForArrayTests
     }
 
     [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/74931")]
-    public async Task AllowSwitchToReadOnlySpanCSharp13(bool whenTypesLooselyMatch)
+    public async Task AllowSwitchToReadOnlySpanCSharp13(bool implicitType, bool whenTypesLooselyMatch)
     {
         await new VerifyCS.Test
         {
-            TestCode = """
+            TestCode = $$"""
                 using System;
 
                 class C
                 {
                     void M(char c)
                     {
-                        Split([|[|new|][]|] { c });
+                        Split([|[|new|]{{(implicitType ? "" : " char")}}[]|] { c });
                     }
 
                     void Split(char[] p) { }
@@ -5785,60 +5785,18 @@ public class UseCollectionExpressionForArrayTests
     }
 
     [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/74931")]
-    public async Task AllowSwitchToReadOnlySpanGeneric1(bool whenTypesLooselyMatch)
+    public async Task AllowSwitchToReadOnlySpanGeneric1(bool implicitType, bool whenTypesLooselyMatch)
     {
         await new VerifyCS.Test
         {
-            TestCode = """
+            TestCode = $$"""
                 using System;
 
                 class C
                 {
                     void M(char c)
                     {
-                        Split([|[|new|][]|] { c });
-                    }
-
-                    void Split<T>(T[] p) { }
-                    void Split<T>(ReadOnlySpan<T> p) { }
-                }
-                """,
-            FixedCode = """
-                using System;
-                
-                class C
-                {
-                    void M(char c)
-                    {
-                        Split([c]);
-                    }
-                
-                    void Split<T>(T[] p) { }
-                    void Split<T>(ReadOnlySpan<T> p) { }
-                }
-                """,
-            EditorConfig = $$"""
-                [*]
-                dotnet_style_prefer_collection_expression={{(whenTypesLooselyMatch ? "when_types_loosely_match" : "when_types_exactly_match")}}
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
-        }.RunAsync();
-    }
-
-    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/74931")]
-    public async Task AllowSwitchToReadOnlySpanGeneric2(bool whenTypesLooselyMatch)
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(char c)
-                    {
-                        Split([|[|new|][]|] { c });
+                        Split([|[|new|]{{(implicitType ? "" : " char")}}[]|] { c });
                     }
 
                     void Split<T>(T[] p) { }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -5698,4 +5698,130 @@ public class UseCollectionExpressionForArrayTests
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/74931")]
+    public async Task AllowSwitchToReadOnlySpanCSharp12(bool whenTypesLooselyMatch)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(char c)
+                    {
+                        Split([|[|new|][]|] { c });
+                    }
+
+                    void Split(char[] p) { }
+                    void Split(ReadOnlySpan<char> p) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                class C
+                {
+                    void M(char c)
+                    {
+                        Split([c]);
+                    }
+                
+                    void Split(char[] p) { }
+                    void Split(ReadOnlySpan<char> p) { }
+                }
+                """,
+            EditorConfig = $$"""
+                [*]
+                dotnet_style_prefer_collection_expression={{(whenTypesLooselyMatch ? "when_types_loosely_match" : "when_types_exactly_match")}}
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/74931")]
+    public async Task AllowSwitchToReadOnlySpanCSharp13(bool whenTypesLooselyMatch)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(char c)
+                    {
+                        Split([|[|new|][]|] { c });
+                    }
+
+                    void Split(char[] p) { }
+                    void Split(ReadOnlySpan<char> p) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                class C
+                {
+                    void M(char c)
+                    {
+                        Split([c]);
+                    }
+                
+                    void Split(char[] p) { }
+                    void Split(ReadOnlySpan<char> p) { }
+                }
+                """,
+            EditorConfig = $$"""
+                [*]
+                dotnet_style_prefer_collection_expression={{(whenTypesLooselyMatch ? "when_types_loosely_match" : "when_types_exactly_match")}}
+                """,
+            LanguageVersion = LanguageVersion.CSharp13,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/74931")]
+    public async Task AllowSwitchToReadOnlySpanGeneric(bool whenTypesLooselyMatch)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(char c)
+                    {
+                        Split([|[|new|][]|] { c });
+                    }
+
+                    void Split<T>(T[] p) { }
+                    void Split<T>(ReadOnlySpan<T> p) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                
+                class C
+                {
+                    void M(char c)
+                    {
+                        Split([c]);
+                    }
+                
+                    void Split<T>(T[] p) { }
+                    void Split<T>(ReadOnlySpan<T> p) { }
+                }
+                """,
+            EditorConfig = $$"""
+                [*]
+                dotnet_style_prefer_collection_expression={{(whenTypesLooselyMatch ? "when_types_loosely_match" : "when_types_exactly_match")}}
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
 }

--- a/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
+++ b/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
@@ -1115,8 +1115,8 @@ class C
         var method_v1 = type1_v1.GetMembers("M").Single();
         var method_v2 = type1_v2.GetMembers("M").Single();
 
-        var trueComp = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true);
-        var falseComp = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: false, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true);
+        var trueComp = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
+        var falseComp = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: false, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
 
         Assert.False(trueComp.Equals(method_v1, method_v2));
         Assert.False(trueComp.Equals(method_v2, method_v1));
@@ -1355,8 +1355,8 @@ class T
         Assert.Equal(NullableAnnotation.Annotated, a1.NullableAnnotation);
         Assert.Equal(NullableAnnotation.NotAnnotated, a2.NullableAnnotation);
 
-        var ignoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true);
-        var notIgnoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true);
+        var ignoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
+        var notIgnoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
 
         Assert.True(ignoreComparer.Equals(a1, a2));
         Assert.True(ignoreComparer.Equals(b1, b2));
@@ -1419,8 +1419,8 @@ class T
         Assert.Equal(NullableAnnotation.None, a1.NullableAnnotation);
         Assert.Equal(NullableAnnotation.NotAnnotated, a2.NullableAnnotation);
 
-        var ignoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true);
-        var notIgnoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true);
+        var ignoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
+        var notIgnoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
 
         Assert.True(ignoreComparer.Equals(a1, a2));
         Assert.True(ignoreComparer.Equals(b1, b2));
@@ -1482,8 +1482,8 @@ class T
         Assert.Equal(NullableAnnotation.None, a1.NullableAnnotation);
         Assert.Equal(NullableAnnotation.Annotated, a2.NullableAnnotation);
 
-        var ignoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true);
-        var notIgnoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true);
+        var ignoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
+        var notIgnoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
 
         Assert.True(ignoreComparer.Equals(a1, a2));
         Assert.True(ignoreComparer.Equals(b1, b2));
@@ -1545,8 +1545,8 @@ class T
         Assert.Equal(NullableAnnotation.None, a1.NullableAnnotation);
         Assert.Equal(NullableAnnotation.Annotated, a2.NullableAnnotation);
 
-        var ignoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true);
-        var notIgnoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true);
+        var ignoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
+        var notIgnoreComparer = new SymbolEquivalenceComparer(assemblyComparer: null, distinguishRefFromOut: true, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
 
         Assert.True(ignoreComparer.Equals(a1, a2));
         Assert.True(ignoreComparer.Equals(b1, b2));
@@ -1749,7 +1749,7 @@ End Class
         var tb2 = (ITypeSymbol)b2.GlobalNamespace.GetMembers("T").Single();
         var tb3 = (ITypeSymbol)b3.GlobalNamespace.GetMembers("T").Single();
 
-        var identityComparer = new SymbolEquivalenceComparer(AssemblySymbolIdentityComparer.Instance, distinguishRefFromOut: false, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true);
+        var identityComparer = new SymbolEquivalenceComparer(AssemblySymbolIdentityComparer.Instance, distinguishRefFromOut: false, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
 
         // same name:
         Assert.True(SymbolEquivalenceComparer.IgnoreAssembliesInstance.Equals(ta1, ta2));
@@ -1835,7 +1835,7 @@ End Class
         var type1 = (ITypeSymbol)c1.GlobalNamespace.GetMembers("C").Single();
         var type2 = (ITypeSymbol)c2.GlobalNamespace.GetMembers("C").Single();
 
-        var identityComparer = new SymbolEquivalenceComparer(AssemblySymbolIdentityComparer.Instance, distinguishRefFromOut: false, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true);
+        var identityComparer = new SymbolEquivalenceComparer(AssemblySymbolIdentityComparer.Instance, distinguishRefFromOut: false, tupleNamesMustMatch: false, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
 
         var f1 = type1.GetMembers("F");
         var f2 = type2.GetMembers("F");

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2356,10 +2356,10 @@ internal abstract class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyz
     // They only affect custom attributes or metadata flags emitted on the members - all runtimes are expected to accept
     // these updates in metadata deltas, even if they do not have any observable effect.
     private static readonly SymbolEquivalenceComparer s_runtimeSymbolEqualityComparer = new(
-        AssemblyEqualityComparer.Instance, distinguishRefFromOut: false, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true);
+        AssemblyEqualityComparer.Instance, distinguishRefFromOut: false, tupleNamesMustMatch: false, ignoreNullableAnnotations: true, objectAndDynamicCompareEqually: true, arrayAndReadOnlySpanCompareEqually: false);
 
     private static readonly SymbolEquivalenceComparer s_exactSymbolEqualityComparer = new(
-        AssemblyEqualityComparer.Instance, distinguishRefFromOut: true, tupleNamesMustMatch: true, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: false);
+        AssemblyEqualityComparer.Instance, distinguishRefFromOut: true, tupleNamesMustMatch: true, ignoreNullableAnnotations: false, objectAndDynamicCompareEqually: false, arrayAndReadOnlySpanCompareEqually: false);
 
     protected static bool SymbolsEquivalent(ISymbol oldSymbol, ISymbol newSymbol)
         => s_exactSymbolEqualityComparer.Equals(oldSymbol, newSymbol);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -751,8 +751,8 @@ internal static partial class ITypeSymbolExtensions
             ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true }
         };
 
-    public static bool IsReadOnlySpan([NotNullWhen(true)] this ITypeSymbol? type)
-        => type is INamedTypeSymbol
+    public static bool IsReadOnlySpan([NotNullWhen(true)] this ISymbol? symbol)
+        => symbol is INamedTypeSymbol
         {
             Name: nameof(ReadOnlySpan<int>),
             TypeArguments.Length: 1,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -425,37 +425,37 @@ internal abstract class AbstractSpeculationAnalyzer<
             if (methodSymbol.MethodKind != newMethodSymbol.MethodKind)
                 return false;
 
-            if (!Equals(methodSymbol.ContainingType, newMethodSymbol.ContainingType))
-                return false;
-
             if (!Equals(methodSymbol.Name, newMethodSymbol.Name))
                 return false;
 
-            if (methodSymbol.Parameters.Length != newMethodSymbol.Parameters.Length)
+            //if (methodSymbol.Parameters.Length != newMethodSymbol.Parameters.Length)
+            //    return false;
+
+            //if (!methodSymbol.Parameters.Any(static p => p.Type is IArrayTypeSymbol))
+            //    return false;
+
+            //if (!newMethodSymbol.Parameters.Any(static p => p.Type.IsReadOnlySpan()))
+            //    return false;
+
+            if (!s_arrayAndReadOnlySpanCompareEqually.Equals(methodSymbol, newMethodSymbol))
                 return false;
 
-            if (!methodSymbol.Parameters.Any(static p => p.Type is IArrayTypeSymbol))
-                return false;
+            //for (int i = 0, n = methodSymbol.Parameters.Length; i < n; i++)
+            //{
+            //    var oldMethodParameter = methodSymbol.Parameters[i];
+            //    var newMethodParameter = newMethodSymbol.Parameters[i];
 
-            if (!newMethodSymbol.Parameters.Any(static p => p.Type.IsReadOnlySpan()))
-                return false;
-
-            for (int i = 0, n = methodSymbol.Parameters.Length; i < n; i++)
-            {
-                var oldMethodParameter = methodSymbol.Parameters[i];
-                var newMethodParameter = newMethodSymbol.Parameters[i];
-
-                if (oldMethodParameter.Type is IArrayTypeSymbol && newMethodParameter.Type.IsReadOnlySpan())
-                {
-                    if (!s_arrayAndReadOnlySpanCompareEqually.ParameterEquivalenceComparer.Equals(oldMethodParameter, newMethodParameter))
-                        return false;
-                }
-                else
-                {
-                    if (!CompareAcrossSemanticModels(oldMethodParameter, newMethodParameter))
-                        return false;
-                }
-            }
+            //    if (oldMethodParameter.Type is IArrayTypeSymbol && newMethodParameter.Type.IsReadOnlySpan())
+            //    {
+            //        if (!s_arrayAndReadOnlySpanCompareEqually.ParameterEquivalenceComparer.Equals(oldMethodParameter, newMethodParameter))
+            //            return false;
+            //    }
+            //    else
+            //    {
+            //        if (!CompareAcrossSemanticModels(oldMethodParameter, newMethodParameter))
+            //            return false;
+            //    }
+            //}
 
             return true;
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -406,59 +406,21 @@ internal abstract class AbstractSpeculationAnalyzer<
                 }
             }
 
-            if (IsCompatibleOverloadDifferingOnlyBetweenArrayAndReadOnlySpan(methodSymbol, newMethodSymbol))
-                return true;
-        }
-
-        return false;
-
-        static bool IsCompatibleOverloadDifferingOnlyBetweenArrayAndReadOnlySpan(
-            IMethodSymbol methodSymbol, IMethodSymbol newMethodSymbol)
-        {
             // We consider two method overloads compatible if one takes a T[] array for a particular parameter, and the
             // other takes a ReadOnlySpan<T> for the same parameter.  This is a considered a supported and desirable API
             // upgrade story for API authors.  Specifically, they start with an array-based method, and then add a
             // sibling ROS method.  In that case, the language will prefer the latter when both are applicable.  So if
             // we make a code change that makes the second compatible, then we are ok with that, as the expectation is
             // that the new method has the same semantics and it is desirable for code to now call that.
-
-            if (methodSymbol.MethodKind != newMethodSymbol.MethodKind)
-                return false;
-
-            if (!Equals(methodSymbol.Name, newMethodSymbol.Name))
-                return false;
-
-            //if (methodSymbol.Parameters.Length != newMethodSymbol.Parameters.Length)
-            //    return false;
-
-            //if (!methodSymbol.Parameters.Any(static p => p.Type is IArrayTypeSymbol))
-            //    return false;
-
-            //if (!newMethodSymbol.Parameters.Any(static p => p.Type.IsReadOnlySpan()))
-            //    return false;
-
-            if (!s_arrayAndReadOnlySpanCompareEqually.Equals(methodSymbol, newMethodSymbol))
-                return false;
-
-            //for (int i = 0, n = methodSymbol.Parameters.Length; i < n; i++)
-            //{
-            //    var oldMethodParameter = methodSymbol.Parameters[i];
-            //    var newMethodParameter = newMethodSymbol.Parameters[i];
-
-            //    if (oldMethodParameter.Type is IArrayTypeSymbol && newMethodParameter.Type.IsReadOnlySpan())
-            //    {
-            //        if (!s_arrayAndReadOnlySpanCompareEqually.ParameterEquivalenceComparer.Equals(oldMethodParameter, newMethodParameter))
-            //            return false;
-            //    }
-            //    else
-            //    {
-            //        if (!CompareAcrossSemanticModels(oldMethodParameter, newMethodParameter))
-            //            return false;
-            //    }
-            //}
-
-            return true;
+            if (methodSymbol.MethodKind == newMethodSymbol.MethodKind &&
+                Equals(methodSymbol.Name, newMethodSymbol.Name) &&
+                s_arrayAndReadOnlySpanCompareEqually.Equals(methodSymbol, newMethodSymbol))
+            {
+                return true;
+            }
         }
+
+        return false;
     }
 
     private static bool CompareAcrossSemanticModels(ISymbol symbol, ISymbol newSymbol)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -57,7 +57,6 @@ internal abstract class AbstractSpeculationAnalyzer<
 
     private static readonly SymbolEquivalenceComparer s_arrayAndReadOnlySpanCompareEqually = s_includeNullabilityComparer.With(arrayAndReadOnlySpanCompareEqually: true);
 
-
     /// <summary>
     /// Creates a semantic analyzer for speculative syntax replacement.
     /// </summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -455,10 +455,8 @@ internal abstract class AbstractSpeculationAnalyzer<
                    CompareAcrossSemanticModels(parameterSymbol.Type, newParameterSymbol.Type);
         }
 
-        if (symbol is IMethodSymbol methodSymbol &&
-            newSymbol is IMethodSymbol newMethodSymbol &&
-            methodSymbol.IsLocalFunction() &&
-            newMethodSymbol.IsLocalFunction())
+        if (symbol is IMethodSymbol { MethodKind: MethodKind.LocalFunction } methodSymbol &&
+            newSymbol is IMethodSymbol { MethodKind: MethodKind.LocalFunction } newMethodSymbol)
         {
             return symbol.Name == newSymbol.Name &&
                    methodSymbol.Parameters.Length == newMethodSymbol.Parameters.Length &&

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -406,23 +406,59 @@ internal abstract class AbstractSpeculationAnalyzer<
                 }
             }
 
-            if (methodSymbol.MethodKind == newMethodSymbol.MethodKind &&
-                Equals(methodSymbol.ContainingType, newMethodSymbol.ContainingType) &&
-                Equals(methodSymbol.Name, newMethodSymbol.Name))
-            {
-                // We consider two method overloads compatible if one takes a T[] array for a particular parameter, and
-                // the other takes a ReadOnlySpan<T> for the same parameter.  This is a considered a supported and
-                // desirable API upgrade story for API authors.  Specifically, they start with an array-based method,
-                // and then add a sibling ROS method.  In that case, the language will prefer the latter when both are
-                // applicable.  So if we make a code change that makes the second compatible, then we are ok with that,
-                // as the expectation is that the new method has the same semantics and it is desirable for code to now
-                // call that.
-                if (methodSymbol.Parameters.SequenceEqual(newMethodSymbol.Parameters, s_arrayAndReadOnlySpanCompareEqually.ParameterEquivalenceComparer))
-                    return true;
-            }
+            if (IsCompatibleOverloadDifferingOnlyBetweenArrayAndReadOnlySpan(methodSymbol, newMethodSymbol))
+                return true;
         }
 
         return false;
+
+        static bool IsCompatibleOverloadDifferingOnlyBetweenArrayAndReadOnlySpan(
+            IMethodSymbol methodSymbol, IMethodSymbol newMethodSymbol)
+        {
+            // We consider two method overloads compatible if one takes a T[] array for a particular parameter, and the
+            // other takes a ReadOnlySpan<T> for the same parameter.  This is a considered a supported and desirable API
+            // upgrade story for API authors.  Specifically, they start with an array-based method, and then add a
+            // sibling ROS method.  In that case, the language will prefer the latter when both are applicable.  So if
+            // we make a code change that makes the second compatible, then we are ok with that, as the expectation is
+            // that the new method has the same semantics and it is desirable for code to now call that.
+
+            if (methodSymbol.MethodKind != newMethodSymbol.MethodKind)
+                return false;
+
+            if (!Equals(methodSymbol.ContainingType, newMethodSymbol.ContainingType))
+                return false;
+
+            if (!Equals(methodSymbol.Name, newMethodSymbol.Name))
+                return false;
+
+            if (methodSymbol.Parameters.Length != newMethodSymbol.Parameters.Length)
+                return false;
+
+            if (!methodSymbol.Parameters.Any(static p => p.Type is IArrayTypeSymbol))
+                return false;
+
+            if (!newMethodSymbol.Parameters.Any(static p => p.Type.IsReadOnlySpan()))
+                return false;
+
+            for (int i = 0, n = methodSymbol.Parameters.Length; i < n; i++)
+            {
+                var oldMethodParameter = methodSymbol.Parameters[i];
+                var newMethodParameter = newMethodSymbol.Parameters[i];
+
+                if (oldMethodParameter.Type is IArrayTypeSymbol && newMethodParameter.Type.IsReadOnlySpan())
+                {
+                    if (!s_arrayAndReadOnlySpanCompareEqually.ParameterEquivalenceComparer.Equals(oldMethodParameter, newMethodParameter))
+                        return false;
+                }
+                else
+                {
+                    if (!CompareAcrossSemanticModels(oldMethodParameter, newMethodParameter))
+                        return false;
+                }
+            }
+
+            return true;
+        }
     }
 
     private static bool CompareAcrossSemanticModels(ISymbol symbol, ISymbol newSymbol)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -412,12 +412,12 @@ internal abstract class AbstractSpeculationAnalyzer<
             // sibling ROS method.  In that case, the language will prefer the latter when both are applicable.  So if
             // we make a code change that makes the second compatible, then we are ok with that, as the expectation is
             // that the new method has the same semantics and it is desirable for code to now call that.
-            if (methodSymbol.MethodKind == newMethodSymbol.MethodKind &&
-                Equals(methodSymbol.Name, newMethodSymbol.Name) &&
-                s_arrayAndReadOnlySpanCompareEqually.Equals(methodSymbol, newMethodSymbol))
-            {
+            //
+            // Note: this comparer will check the method kinds, name, containing type, arity, and virtually everything
+            // else about the methods.  The only difference it will allow between the methods is that parameter types
+            // can be different if they are an array vs a ReadOnlySpan.
+            if (s_arrayAndReadOnlySpanCompareEqually.Equals(methodSymbol, newMethodSymbol))
                 return true;
-            }
         }
 
         return false;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -49,11 +50,29 @@ internal partial class SymbolEquivalenceComparer
                 }
 
                 if (symbolEquivalenceComparer._arrayAndReadOnlySpanCompareEqually)
+                {
+                    if (xKind == SymbolKind.ArrayType && y.IsReadOnlySpan())
+                    {
+                        return AreArrayAndReadOnlySpanEquivalent((IArrayTypeSymbol)x, (INamedTypeSymbol)y, equivalentTypesWithDifferingAssemblies);
+                    }
+                    else if (x.IsReadOnlySpan() && yKind == SymbolKind.ArrayType)
+                    {
+                        return AreArrayAndReadOnlySpanEquivalent((IArrayTypeSymbol)y, (INamedTypeSymbol)x, equivalentTypesWithDifferingAssemblies);
+                    }
+                }
 
                 return false;
             }
 
             return AreEquivalentWorker(x, y, xKind, equivalentTypesWithDifferingAssemblies);
+        }
+
+        private bool AreArrayAndReadOnlySpanEquivalent(IArrayTypeSymbol array, INamedTypeSymbol readOnlySpanType, Dictionary<INamedTypeSymbol, INamedTypeSymbol>? equivalentTypesWithDifferingAssemblies)
+        {
+            if (array.Rank != 1)
+                return false;
+
+            return AreEquivalent(array.ElementType, readOnlySpanType.TypeArguments.Single(), equivalentTypesWithDifferingAssemblies);
         }
 
         internal bool AreEquivalent(CustomModifier x, CustomModifier y, Dictionary<INamedTypeSymbol, INamedTypeSymbol>? equivalentTypesWithDifferingAssemblies)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -13,12 +13,11 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities;
 
 internal partial class SymbolEquivalenceComparer
 {
-    private class EquivalenceVisitor(
+    private sealed class EquivalenceVisitor(
         SymbolEquivalenceComparer symbolEquivalenceComparer,
         bool compareMethodTypeParametersByIndex,
         bool objectAndDynamicCompareEqually)
     {
-
         public bool AreEquivalent(ISymbol? x, ISymbol? y, Dictionary<INamedTypeSymbol, INamedTypeSymbol>? equivalentTypesWithDifferingAssemblies)
         {
             if (ReferenceEquals(x, y))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -41,9 +41,14 @@ internal partial class SymbolEquivalenceComparer
                 // want to bail out using the above check.
                 if (objectAndDynamicCompareEqually)
                 {
-                    return (xKind == SymbolKind.DynamicType && IsObjectType(y)) ||
-                           (yKind == SymbolKind.DynamicType && IsObjectType(x));
+                    if ((xKind == SymbolKind.DynamicType && IsObjectType(y)) ||
+                        (yKind == SymbolKind.DynamicType && IsObjectType(x)))
+                    {
+                        return true;
+                    }
                 }
+
+                if (symbolEquivalenceComparer._arrayAndReadOnlySpanCompareEqually)
 
                 return false;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.SignatureTypeSymbolEquivalenceComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.SignatureTypeSymbolEquivalenceComparer.cs
@@ -14,13 +14,7 @@ internal partial class SymbolEquivalenceComparer
             => this.Equals(x, y, null);
 
         public bool Equals(ITypeSymbol? x, ITypeSymbol? y, Dictionary<INamedTypeSymbol, INamedTypeSymbol>? equivalentTypesWithDifferingAssemblies)
-        {
-            var visitor = symbolEquivalenceComparer.GetEquivalenceVisitor(
-                compareMethodTypeParametersByIndex: true,
-                symbolEquivalenceComparer._objectAndDynamicCompareEqually,
-                symbolEquivalenceComparer._arrayAndReadOnlySpanCompareEqually);
-            return visitor.AreEquivalent(x, y, equivalentTypesWithDifferingAssemblies);
-        }
+            => symbolEquivalenceComparer.GetEquivalenceVisitor(compareMethodTypeParametersByIndex: true, symbolEquivalenceComparer._objectAndDynamicCompareEqually).AreEquivalent(x, y, equivalentTypesWithDifferingAssemblies);
 
         public int GetHashCode(ITypeSymbol? x)
             => symbolEquivalenceComparer.GetGetHashCodeVisitor(compareMethodTypeParametersByIndex: true, symbolEquivalenceComparer._objectAndDynamicCompareEqually).GetHashCode(x, currentHash: 0);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.SignatureTypeSymbolEquivalenceComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.SignatureTypeSymbolEquivalenceComparer.cs
@@ -14,7 +14,13 @@ internal partial class SymbolEquivalenceComparer
             => this.Equals(x, y, null);
 
         public bool Equals(ITypeSymbol? x, ITypeSymbol? y, Dictionary<INamedTypeSymbol, INamedTypeSymbol>? equivalentTypesWithDifferingAssemblies)
-            => symbolEquivalenceComparer.GetEquivalenceVisitor(compareMethodTypeParametersByIndex: true, symbolEquivalenceComparer._objectAndDynamicCompareEqually).AreEquivalent(x, y, equivalentTypesWithDifferingAssemblies);
+        {
+            var visitor = symbolEquivalenceComparer.GetEquivalenceVisitor(
+                compareMethodTypeParametersByIndex: true,
+                symbolEquivalenceComparer._objectAndDynamicCompareEqually,
+                symbolEquivalenceComparer._arrayAndReadOnlySpanCompareEqually);
+            return visitor.AreEquivalent(x, y, equivalentTypesWithDifferingAssemblies);
+        }
 
         public int GetHashCode(ITypeSymbol? x)
             => symbolEquivalenceComparer.GetGetHashCodeVisitor(compareMethodTypeParametersByIndex: true, symbolEquivalenceComparer._objectAndDynamicCompareEqually).GetHashCode(x, currentHash: 0);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.cs
@@ -79,24 +79,20 @@ internal sealed partial class SymbolEquivalenceComparer : IEqualityComparer<ISym
         using var equivalenceVisitors = TemporaryArray<EquivalenceVisitor>.Empty;
         using var getHashCodeVisitors = TemporaryArray<GetHashCodeVisitor>.Empty;
 
-        foreach (var compareMethodTypeParametersByIndex in new[] { true, false })
-        {
-            foreach (var objectAndDynamicCompareEquallySwitch in new[] { true, false })
-            {
-                foreach (var arrayAndReadOnlySpanCompareEquallySwitch in new[] { true, false })
-                    AddVisitors(compareMethodTypeParametersByIndex, objectAndDynamicCompareEquallySwitch, arrayAndReadOnlySpanCompareEquallySwitch);
-            }
-        }
+        AddVisitors(compareMethodTypeParametersByIndex: true, objectAndDynamicCompareEqually: true);
+        AddVisitors(compareMethodTypeParametersByIndex: true, objectAndDynamicCompareEqually: false);
+        AddVisitors(compareMethodTypeParametersByIndex: false, objectAndDynamicCompareEqually: true);
+        AddVisitors(compareMethodTypeParametersByIndex: false, objectAndDynamicCompareEqually: false);
 
         _equivalenceVisitors = equivalenceVisitors.ToImmutableAndClear();
         _getHashCodeVisitors = getHashCodeVisitors.ToImmutableAndClear();
 
         return;
 
-        void AddVisitors(bool compareMethodTypeParametersByIndex, bool objectAndDynamicCompareEqually, bool arrayAndReadOnlySpanCompareEquallySwitch)
+        void AddVisitors(bool compareMethodTypeParametersByIndex, bool objectAndDynamicCompareEqually)
         {
-            equivalenceVisitors.Add(new(this, compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually, arrayAndReadOnlySpanCompareEquallySwitch));
-            getHashCodeVisitors.Add(new(this, compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually, arrayAndReadOnlySpanCompareEquallySwitch));
+            equivalenceVisitors.Add(new(this, compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually));
+            getHashCodeVisitors.Add(new(this, compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually));
         }
     }
 
@@ -134,21 +130,21 @@ internal sealed partial class SymbolEquivalenceComparer : IEqualityComparer<ISym
     // here.  So, instead, when asking if parameters are equal, we pass an appropriate flag so
     // that method type parameters are just compared by index and nothing else.
     private EquivalenceVisitor GetEquivalenceVisitor(
-        bool compareMethodTypeParametersByIndex = false, bool objectAndDynamicCompareEqually = false, bool arrayAndReadOnlySpanCompareEqually = false)
+        bool compareMethodTypeParametersByIndex = false, bool objectAndDynamicCompareEqually = false)
     {
-        var visitorIndex = GetVisitorIndex(compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually, arrayAndReadOnlySpanCompareEqually);
+        var visitorIndex = GetVisitorIndex(compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually);
         return _equivalenceVisitors[visitorIndex];
     }
 
     private GetHashCodeVisitor GetGetHashCodeVisitor(
-        bool compareMethodTypeParametersByIndex, bool objectAndDynamicCompareEqually, bool arrayAndReadOnlySpanCompareEqually)
+        bool compareMethodTypeParametersByIndex, bool objectAndDynamicCompareEqually)
     {
-        var visitorIndex = GetVisitorIndex(compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually, arrayAndReadOnlySpanCompareEqually);
+        var visitorIndex = GetVisitorIndex(compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually);
         return _getHashCodeVisitors[visitorIndex];
     }
 
     private static int GetVisitorIndex(bool compareMethodTypeParametersByIndex, bool objectAndDynamicCompareEqually)
-        => (compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually, arrayAndReadOnlySpanCompareEqually) switch
+        => (compareMethodTypeParametersByIndex, objectAndDynamicCompareEqually) switch
         {
             (true, true) => 0,
             (true, false) => 1,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/74931

LDM and runtime position is that if overloads are added that differ only in taking a ROS vs an array for a particular parameter, that the ROS version is the desirable one to call (we're even encoding that into overload resolution rules).  So, if existing code is manually constructing arrays, still offer to use a collection expression so that you actually move to teh better overload.