### PR TITLE
Change Cancel() to async in InlineRenameSession.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.PlatformUI.OleComponentSupport;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
@@ -223,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public void Cancel()
         {
             SmartRenameViewModel?.Cancel();
-            Session.Cancel();
+            _ = Session.CancelAsync();
         }
 
         public void Dispose()

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
@@ -320,7 +321,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
-            _model.Session.Cancel();
+            _ = CancelAsync();
+        }
+
+        private async Task CancelAsync()
+        {
+            //.ConfigureAwait(true) because we need to set focus later
+            await _model.Session.CancelAsync().ConfigureAwait(true);
             _textView.VisualElement.Focus();
         }
 

--- a/src/EditorFeatures/Core/IInlineRenameSession.cs
+++ b/src/EditorFeatures/Core/IInlineRenameSession.cs
@@ -46,7 +46,7 @@ internal interface IInlineRenameSession
     /// <summary>
     /// Cancels the rename session, and undoes any edits that had been performed by the session.
     /// </summary>
-    void Cancel();
+    Task CancelAsync();
 
     /// <summary>
     /// Dismisses the rename session, completing the rename operation across all files.

--- a/src/EditorFeatures/Core/InlineRename/AbstractInlineRenameUndoManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractInlineRenameUndoManager.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
 
@@ -154,7 +155,7 @@ internal abstract class AbstractInlineRenameUndoManager<TBufferState>
         }
         else
         {
-            this.InlineRenameService.ActiveSession.Cancel();
+            this.InlineRenameService.ActiveSession.CancelAsync().ReportNonFatalErrorAsync();
         }
     }
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -146,7 +146,7 @@ internal partial class InlineRenameSession
             var view = sender as ITextView;
             view.Closed -= OnTextViewClosed;
             _textViews.Remove(view);
-            _session.Cancel();
+            _ = _session.CancelAsync().ReportNonFatalErrorAsync();
         }
 
         internal void ConnectToView(ITextView textView)

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -397,7 +397,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
                     m["Kind"] = Enum.GetName(typeof(WorkspaceChangeKind), args.Kind);
                 }));
 
-                Cancel();
+                _ = CancelAsync().ReportNonFatalErrorAsync();
             }
         }
     }
@@ -647,15 +647,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         }
     }
 
-    public void Cancel()
-    {
-        _threadingContext.ThrowIfNotOnUIThread();
-
-        // This wait is safe.  We are not passing the async callback to DismissUIAndRollbackEditsAndEndRenameSessionAsync.
-        // So everything in that method will happen synchronously.
-        DismissUIAndRollbackEditsAndEndRenameSessionAsync(
-            RenameLogMessage.UserActionOutcome.Canceled, previewChanges: false).Wait();
-    }
+    public Task CancelAsync() => DismissUIAndRollbackEditsAndEndRenameSessionAsync(RenameLogMessage.UserActionOutcome.Canceled, previewChanges: false);
 
     private async Task DismissUIAndRollbackEditsAndEndRenameSessionAsync(
         RenameLogMessage.UserActionOutcome outcome,
@@ -782,7 +774,7 @@ internal partial class InlineRenameSession : IInlineRenameSession, IFeatureContr
         if (this.ReplacementText == string.Empty ||
             this.ReplacementText == _initialRenameText)
         {
-            Cancel();
+            await CancelAsync().ConfigureAwait(false);
             return false;
         }
 

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -725,7 +725,7 @@ End Class
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Sub SimpleEditAndCancel(host As RenameTestHost)
+        Public Async Function SimpleEditAndCancel(host As RenameTestHost) As Task
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
@@ -750,7 +750,7 @@ End Class
 
                 textBuffer.Insert(caretPosition, "Bar")
 
-                session.Cancel()
+                Await session.CancelAsync()
 
                 ' Assert the file is what it started as
                 Assert.Equal(initialTextSnapshot.GetText(), textBuffer.CurrentSnapshot.GetText())
@@ -758,7 +758,7 @@ End Class
                 ' Assert the file name didn't change
                 VerifyFileName(workspace, "Test1.cs")
             End Using
-        End Sub
+        End Function
 
         <WpfTheory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539513")>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
@@ -793,7 +793,7 @@ End Class
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Sub ReadOnlyRegionsCreated(host As RenameTestHost)
+        Public Async Function ReadOnlyRegionsCreated(host As RenameTestHost) As Task
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
@@ -820,17 +820,17 @@ End Class
                 Assert.True(buffer.IsReadOnly(0))
                 Assert.True(buffer.IsReadOnly(buffer.CurrentSnapshot.Length))
 
-                session.Cancel()
+                Await session.CancelAsync()
 
                 ' Assert the file name didn't change
                 VerifyFileName(workspace, "Test1.cs")
             End Using
-        End Sub
+        End Function
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543018")>
-        Public Sub ReadOnlyRegionsCreatedWhichHandleBeginningOfFileEdgeCase(host As RenameTestHost)
+        Public Async Function ReadOnlyRegionsCreatedWhichHandleBeginningOfFileEdgeCase(host As RenameTestHost) As Task
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
@@ -848,11 +848,11 @@ End Class
                 ' Replacing our span should work
                 Assert.False(buffer.IsReadOnly(New Span(workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value, length:=1)))
 
-                session.Cancel()
+                Await session.CancelAsync()
 
                 VerifyFileName(workspace, "Test1.cs")
             End Using
-        End Sub
+        End Function
 
         <Theory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
@@ -1027,7 +1027,7 @@ End Class
                 Await WaitForRename(workspace)
                 Await VerifyTagsAreCorrect(workspace)
 
-                session.Cancel()
+                Await session.CancelAsync()
                 Await VerifyNoRenameTrackingTags(renameTrackingTagger, workspace, document)
 
                 VerifyFileName(workspace, "Test1.cs")

--- a/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
@@ -191,7 +191,7 @@ End Class
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Sub TypingSpaceDuringRename(host As RenameTestHost)
+        Public Async Function TypingSpaceDuringRename(host As RenameTestHost) As Task
             Using workspace = CreateWorkspaceWithWaiter(
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -214,9 +214,9 @@ End Class
                                               Sub() AssertEx.Fail("Space should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
 
-                session.Cancel()
+                Await session.CancelAsync()
             End Using
-        End Sub
+        End Function
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
@@ -258,7 +258,7 @@ End Class
 
                 Assert.Equal(3, view.Caret.Position.BufferPosition.GetContainingLineNumber())
 
-                session.Cancel()
+                Await session.CancelAsync()
             End Using
         End Function
 
@@ -450,7 +450,7 @@ Goo f;
                                               Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(Span.FromBounds(startPosition + 1, lineEnd), view.Selection.SelectedSpans.Single().Span)
 #End Region
-                session.Cancel()
+                Await session.CancelAsync()
             End Using
         End Function
 
@@ -481,7 +481,7 @@ Goo f;
 
                 Await VerifyTagsAreCorrect(workspace)
 
-                session.Cancel()
+                Await session.CancelAsync()
             End Using
         End Function
 
@@ -568,7 +568,7 @@ Goo f;
                 Await VerifyTagsAreCorrect(workspace)
                 Assert.NotNull(workspace.GetService(Of IInlineRenameService).ActiveSession)
 
-                session.Cancel()
+                Await session.CancelAsync()
             End Using
         End Function
 
@@ -605,7 +605,7 @@ Goo f;
                 Await VerifyTagsAreCorrect(workspace)
                 Assert.NotNull(workspace.GetService(Of IInlineRenameService).ActiveSession)
 
-                session.Cancel()
+                Await session.CancelAsync()
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 Assert.True(Not sessionCommit Or Not sessionCancel)
 
                 If sessionCancel Then
-                    session.Cancel()
+                    Await session.CancelAsync()
                     VerifyBufferContentsInWorkspace(actualWorkspace, actualWorkspace)
                 ElseIf sessionCommit Then
                     Await session.CommitAsync(previewChanges:=False)
@@ -136,7 +136,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 Dim session = StartSession(workspace)
 
                 Await VerifyTaggedSpans(HighlightTags.RenameFieldBackgroundAndBorderTag.Instance, workspace, renameService)
-                session.Cancel()
+                Await session.CancelAsync()
             End Using
         End Function
 
@@ -1610,7 +1610,7 @@ static class E
                 Dim conflictTaggedSpans = Await GetTagsOfType(RenameConflictTag.Instance, workspace, renameService)
                 Dim conflictExpectedSpans = workspace.Documents.Single(Function(d) d.AnnotatedSpans.Count > 0).AnnotatedSpans("conflict").Select(Function(ts) ts.ToSpan())
 
-                session.Cancel()
+                Await session.CancelAsync()
 
                 AssertEx.Equal(validExpectedSpans, validTaggedSpans)
                 AssertEx.Equal(conflictExpectedSpans, conflictTaggedSpans)
@@ -1643,7 +1643,7 @@ static class E
                 Dim conflictTaggedSpans = Await GetTagsOfType(RenameConflictTag.Instance, workspace, renameService)
                 Dim conflictExpectedSpans = workspace.Documents.Single(Function(d) d.AnnotatedSpans.Count > 0).AnnotatedSpans("conflict").Select(Function(ts) ts.ToSpan())
 
-                session.Cancel()
+                Await session.CancelAsync()
 
                 AssertEx.Equal(validExpectedSpans, validTaggedSpans)
                 AssertEx.Equal(conflictExpectedSpans, conflictTaggedSpans)

--- a/src/EditorFeatures/Test2/Rename/RenameViewModelTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameViewModelTests.vb
@@ -653,7 +653,7 @@ class D : B
                     Assert.True(QuickInfoSession.Dismissed)
                 End Using
 
-                sessionInfo.Session.Cancel()
+                Await sessionInfo.Session.CancelAsync()
             End Using
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -108,11 +108,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
             Private Class MockInlineRenameSession
                 Implements IInlineRenameSession
 
-                Public Sub Cancel() Implements IInlineRenameSession.Cancel
-                    Throw New NotImplementedException()
-                End Sub
-
                 Public Function CommitAsync(previewChanges As Boolean, Optional editorOperationContext As IUIThreadOperationContext = Nothing) As Task Implements IInlineRenameSession.CommitAsync
+                    Throw New NotImplementedException()
+                End Function
+
+                Public Function CancelAsync() As Task Implements IInlineRenameSession.CancelAsync
                     Throw New NotImplementedException()
                 End Function
             End Class


### PR DESCRIPTION
There is a Task.Wait() in Cancel() method of inline rename session.
This PR removes it and make all other calls to be async