### PR TITLE
Use ignore case to fix analyzer reloading in devkit

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -879,7 +879,7 @@ internal sealed partial class ProjectSystemProjectFactory
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    if (getFilePath(oldReference) == fullFilePath)
+                    if (fullFilePath.Equals(getFilePath(oldReference), StringComparison.OrdinalIgnoreCase))
                     {
                         var newSolution = solutionChanges.Solution;
                         (newSolution, projectUpdateState) = update(


### PR DESCRIPTION
C# DevKit passes us references with capital drive letter, but VSCode tells us the file changed with lowercase.  This meant we'd never see the file changes.  We already do ordinal ignore comparisons in many many other locations as well, so this just matches that.

C# standalone uses lowercase in both cases (so it worked).