### PR TITLE
Semantic snippets: handle case with inline statement snippets before member access expression

### DIFF
--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -37,6 +38,9 @@ internal abstract class AbstractCSharpForLoopSnippetProvider : AbstractForLoopSn
     protected abstract ExpressionSyntax GenerateRightSideOfCondition(SyntaxGenerator generator, SyntaxNode? inlineExpression);
 
     protected abstract void AddSpecificPlaceholders(MultiDictionary<string, int> placeholderBuilder, ExpressionSyntax initializer, ExpressionSyntax rightOfCondition);
+
+    protected override bool CanInsertStatementAfterToken(SyntaxToken token)
+        => token.IsBeginningOfStatementContext() || token.IsBeginningOfGlobalStatementContext();
 
     protected override ForStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpDoWhileLoopSnippetProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -25,6 +26,9 @@ internal sealed class CSharpDoWhileLoopSnippetProvider()
     public override string Identifier => CSharpSnippetIdentifiers.Do;
 
     public override string Description => CSharpFeaturesResources.do_while_loop;
+
+    protected override bool CanInsertStatementAfterToken(SyntaxToken token)
+        => token.IsBeginningOfStatementContext() || token.IsBeginningOfGlobalStatementContext();
 
     protected override DoStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -8,6 +8,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -50,6 +51,9 @@ internal sealed class CSharpForEachLoopSnippetProvider() : AbstractForEachLoopSn
 
         return base.IsValidSnippetLocationCore(context, cancellationToken);
     }
+
+    protected override bool CanInsertStatementAfterToken(SyntaxToken token)
+        => token.IsBeginningOfStatementContext() || token.IsBeginningOfGlobalStatementContext();
 
     protected override ForEachStatementSyntax GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, InlineExpressionInfo? inlineExpressionInfo)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Snippets;
@@ -22,6 +23,9 @@ internal sealed class CSharpIfSnippetProvider() : AbstractIfSnippetProvider<IfSt
     public override string Identifier => CSharpSnippetIdentifiers.If;
 
     public override string Description => FeaturesResources.if_statement;
+
+    protected override bool CanInsertStatementAfterToken(SyntaxToken token)
+        => token.IsBeginningOfStatementContext() || token.IsBeginningOfGlobalStatementContext();
 
     protected override ExpressionSyntax GetCondition(IfStatementSyntax node)
         => node.Condition;

--- a/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Snippets;
@@ -22,6 +23,9 @@ internal sealed class CSharpWhileLoopSnippetProvider() : AbstractWhileLoopSnippe
     public override string Identifier => CSharpSnippetIdentifiers.While;
 
     public override string Description => FeaturesResources.while_loop;
+
+    protected override bool CanInsertStatementAfterToken(SyntaxToken token)
+        => token.IsBeginningOfStatementContext() || token.IsBeginningOfGlobalStatementContext();
 
     protected override ExpressionSyntax GetCondition(WhileStatementSyntax node)
         => node.Condition;

--- a/src/Features/CSharpTest/Snippets/AbstractCSharpConditionalBlockSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/AbstractCSharpConditionalBlockSnippetProviderTests.cs
@@ -540,6 +540,65 @@ public abstract class AbstractCSharpConditionalBlockSnippetProviderTests : Abstr
     }
 
     [Fact]
+    public async Task InsertInlineSnippetWhenDottingBeforeMemberAccessExpressionOnTheNextLineTest()
+    {
+        await VerifySnippetAsync("""
+            using System;
+
+            class C
+            {
+                void M(bool flag)
+                {
+                    flag.$$
+                    Console.WriteLine();
+                }
+            }
+            """, $$"""
+            using System;
+
+            class C
+            {
+                void M(bool flag)
+                {
+                    {{SnippetIdentifier}} (flag)
+                    {
+                        $$
+                    }
+                    Console.WriteLine();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineSnippetWhenDottingBeforeMemberAccessExpressionOnTheSameLineTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            class C
+            {
+                void M(bool flag)
+                {
+                    flag.$$ToString();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineSnippetWhenDottingBeforeContextualKeywordOnTheSameLineTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            class C
+            {
+                void M(bool flag)
+                {
+                    flag.$$var a = 0;
+                }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task NoInlineSnippetForTypeItselfTest()
     {
         await VerifySnippetIsAbsentAsync("""

--- a/src/Features/CSharpTest/Snippets/CSharpDoSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpDoSnippetProviderTests.cs
@@ -556,6 +556,66 @@ public sealed class CSharpDoSnippetProviderTests : AbstractCSharpSnippetProvider
     }
 
     [Fact]
+    public async Task InsertInlineDoSnippetWhenDottingBeforeMemberAccessExpressionOnTheNextLineTest()
+    {
+        await VerifySnippetAsync("""
+            using System;
+
+            class C
+            {
+                void M(bool flag)
+                {
+                    flag.$$
+                    Console.WriteLine();
+                }
+            }
+            """, """
+            using System;
+
+            class C
+            {
+                void M(bool flag)
+                {
+                    do
+                    {
+                        $$
+                    }
+                    while (flag);
+                    Console.WriteLine();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineDoSnippetWhenDottingBeforeMemberAccessExpressionOnTheSameLineTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            class C
+            {
+                void M(bool flag)
+                {
+                    flag.$$ToString();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineDoSnippetWhenDottingBeforeContextualKeywordOnTheSameLineTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            class C
+            {
+                void M(bool flag)
+                {
+                    flag.$$var a = 0;
+                }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task NoInlineDoSnippetForTypeItselfTest()
     {
         await VerifySnippetIsAbsentAsync("""

--- a/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
@@ -794,7 +794,8 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
                     Console.WriteLine();
                 }
             }
-            """);
+            """,
+            referenceAssemblies: ReferenceAssemblies.Net.Net80);
     }
 
     [Fact]
@@ -810,7 +811,8 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
                     ints.$$ToString();
                 }
             }
-            """);
+            """,
+            referenceAssemblies: ReferenceAssemblies.Net.Net80);
     }
 
     [Fact]
@@ -826,7 +828,8 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
                     ints.$$var a = 0;
                 }
             }
-            """);
+            """,
+            referenceAssemblies: ReferenceAssemblies.Net.Net80);
     }
 
     [Theory]

--- a/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForEachSnippetProviderTests.cs
@@ -598,6 +598,69 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
             """);
     }
 
+    [Fact]
+    public async Task InsertInlineForEachSnippetWhenDottingBeforeMemberAccessExpressionOnTheNextLineTest()
+    {
+        await VerifySnippetAsync("""
+            using System;
+
+            class C
+            {
+                void M(int[] ints)
+                {
+                    ints.$$
+                    Console.WriteLine();
+                }
+            }
+            """, """
+            using System;
+
+            class C
+            {
+                void M(int[] ints)
+                {
+                    foreach (var {|0:item|} in ints)
+                    {
+                        $$
+                    }
+                    Console.WriteLine();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineForEachSnippetWhenDottingBeforeMemberAccessExpressionOnTheSameLineTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            using System;
+
+            class C
+            {
+                void M(int[] ints)
+                {
+                    ints.$$ToString();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineForEachSnippetWhenDottingBeforeContextualKeywordOnTheSameLineTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            using System;
+
+            class C
+            {
+                void M(int[] ints)
+                {
+                    ints.$$var a = 0;
+                }
+            }
+            """);
+    }
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69598")]
     public async Task InsertInlineAwaitForEachSnippetWhenDottingBeforeContextualKeywordTest1()
     {
@@ -699,6 +762,71 @@ public sealed class CSharpForEachSnippetProviderTests : AbstractCSharpSnippetPro
             }
             """,
             referenceAssemblies: ReferenceAssemblies.Net.Net70);
+    }
+
+    [Fact]
+    public async Task InsertInlineAwaitForEachSnippetWhenDottingBeforeMemberAccessExpressionOnTheNextLineTest()
+    {
+        await VerifySnippetAsync("""
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(IAsyncEnumerable<int> ints)
+                {
+                    ints.$$
+                    Console.WriteLine();
+                }
+            }
+            """, """
+            using System;
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(IAsyncEnumerable<int> ints)
+                {
+                    await foreach (var {|0:item|} in ints)
+                    {
+                        $$
+                    }
+                    Console.WriteLine();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineAwaitForEachSnippetWhenDottingBeforeMemberAccessExpressionOnTheSameLineTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(IAsyncEnumerable<int> ints)
+                {
+                    ints.$$ToString();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NoInlineAwaitForEachSnippetWhenDottingBeforeContextualKeywordOnTheSameLineTest()
+    {
+        await VerifySnippetIsAbsentAsync("""
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(IAsyncEnumerable<int> ints)
+                {
+                    ints.$$var a = 0;
+                }
+            }
+            """);
     }
 
     [Theory]

--- a/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpForSnippetProviderTests.cs
@@ -569,6 +569,68 @@ public sealed class CSharpForSnippetProviderTests : AbstractCSharpSnippetProvide
     }
 
     [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task InsertInlineForSnippetWhenDottingBeforeMemberAccessExpressionOnTheNextLineTest(string intType)
+    {
+        await VerifySnippetAsync($$"""
+            using System;
+
+            class C
+            {
+                void M({{intType}} @int)
+                {
+                    @int.$$
+                    Console.WriteLine();
+                }
+            }
+            """, $$"""
+            using System;
+
+            class C
+            {
+                void M({{intType}} @int)
+                {
+                    for ({{intType}} {|0:i|} = 0; {|0:i|} < @int; {|0:i|}++)
+                    {
+                        $$
+                    }
+                    Console.WriteLine();
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineForSnippetWhenDottingBeforeMemberAccessExpressionOnTheSameLineTest(string intType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M({{intType}} @int)
+                {
+                    @int.$$ToString();
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineForSnippetWhenDottingBeforeContextualKeywordOnTheSameLineTest(string intType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M({{intType}} @int)
+                {
+                    @int.$$var a = 0;
+                }
+            }
+            """);
+    }
+
+    [Theory]
     [InlineData("int[]", "Length")]
     [InlineData("Span<byte>", "Length")]
     [InlineData("ReadOnlySpan<long>", "Length")]

--- a/src/Features/CSharpTest/Snippets/CSharpReversedForSnippetProviderTests.cs
+++ b/src/Features/CSharpTest/Snippets/CSharpReversedForSnippetProviderTests.cs
@@ -571,6 +571,68 @@ public sealed class CSharpReversedForSnippetProviderTests : AbstractCSharpSnippe
     }
 
     [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task InsertInlineReversedForSnippetWhenDottingBeforeMemberAccessExpressionOnTheNextLineTest(string intType)
+    {
+        await VerifySnippetAsync($$"""
+            using System;
+
+            class C
+            {
+                void M({{intType}} @int)
+                {
+                    @int.$$
+                    Console.WriteLine();
+                }
+            }
+            """, $$"""
+            using System;
+
+            class C
+            {
+                void M({{intType}} @int)
+                {
+                    for ({{intType}} {|0:i|} = @int - 1; {|0:i|} >= 0; {|0:i|}--)
+                    {
+                        $$
+                    }
+                    Console.WriteLine();
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineReversedForSnippetWhenDottingBeforeMemberAccessExpressionOnTheSameLineTest(string intType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M({{intType}} @int)
+                {
+                    @int.$$ToString();
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommonSnippetTestData.IntegerTypes), MemberType = typeof(CommonSnippetTestData))]
+    public async Task NoInlineReversedForSnippetWhenDottingBeforeContextualKeywordOnTheSameLineTest(string intType)
+    {
+        await VerifySnippetIsAbsentAsync($$"""
+            class C
+            {
+                void M({{intType}} @int)
+                {
+                    @int.$$var a = 0;
+                }
+            }
+            """);
+    }
+
+    [Theory]
     [InlineData("int[]", "Length")]
     [InlineData("Span<byte>", "Length")]
     [InlineData("ReadOnlySpan<long>", "Length")]


### PR DESCRIPTION
Previously inline statement snippets chacked, wherther they are part of a member access expression with parent being an expression statament. The second part of the check makes sure, that in cases like `Invocation(validType.$$)` the snippet isn't offered since we cannot insert a statement inside an invocation argument. That logic had ta flaw. It couldn't handle case like this:
```cs
validType.$$
Console.WriteLine();
```
Here syntractically we have the same thing as `validType.$$Console.WriteLine();`, therefore a snippet is executed in a hierarchy of expressions, thus by the previous rules is invalid there. But it is obvious, that this is just a state-of-the-world during typing and the snippet should be offered. Thus I changed how the core logic works. Instead of traversing a potentially complicated subtree I made a check, whether a position before the inline expression is suitable to insert statement into. This both guards us against `Invocation(validType.$$)`, but also suggests snippet in the primary case we want to fix. However, I didn't want snippets to appear inside a line as you edit it, e.g. I don't think `foreach` snippet will be useful if you are inside `enumerable.$$Select(...`, in such case you probably want to add a method to the call chain or something similar. Therefore I made an additional line checks, so now inline statement snippet can only be the last "member access" on the line. Yes, we usually compute completions based only on previous tokens, but snippets stand out quite a bit, so I think that such approach to them is ok