### PR TITLE
Emit generated inline array types without LayoutKind.Auto and with CompilerGeneratedAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeParameters = ImmutableArray.Create<TypeParameterSymbol>(typeParameter);
         }
 
+        public override bool IsImplicitlyDeclared => true;
+
         public override int Arity => 1;
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
@@ -192,6 +192,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var compilation = _containingModule.DeclaringCompilation;
             Debug.Assert(compilation is { });
 
+            AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
+
             AddSynthesizedAttribute(
                 ref attributes,
                 SynthesizedAttributeData.Create(

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInlineArrayTypeSymbol.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool ShouldAddWinRTMembers => false;
 
-        internal override TypeLayout Layout => default;
+        internal override TypeLayout Layout => new TypeLayout(LayoutKind.Sequential, size: 1, alignment: 0);
 
         internal override CharSet MarshallingCharSet => DefaultMarshallingCharSet;
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -14419,6 +14419,7 @@ partial class Program
                     foreach (var inlineArrayType in getInlineArrayTypes(module))
                     {
                         Assert.Equal(System.Runtime.InteropServices.LayoutKind.Sequential, inlineArrayType.Layout.Kind);
+                        Assert.Single(inlineArrayType.GetAttributes(), a => a.AttributeClass.Name == nameof(System.Runtime.CompilerServices.CompilerGeneratedAttribute));
                     }
                 },
                 verify: Verification.Skipped);

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -14415,6 +14415,11 @@ partial class Program
                 symbolValidator: module =>
                 {
                     AssertEx.Equal(new[] { "<>y__InlineArray2", "<>y__InlineArray3" }, getInlineArrayTypeNames(module));
+
+                    foreach (var inlineArrayType in getInlineArrayTypes(module))
+                    {
+                        Assert.Equal(System.Runtime.InteropServices.LayoutKind.Sequential, inlineArrayType.Layout.Kind);
+                    }
                 },
                 verify: Verification.Skipped);
             var refA = comp.EmitToImageReference();
@@ -14475,9 +14480,14 @@ partial class Program
                 verify: Verification.Skipped,
                 expectedOutput: IncludeExpectedOutput($"{n}"));
 
+            static ImmutableArray<NamedTypeSymbol> getInlineArrayTypes(ModuleSymbol module)
+            {
+                return module.GlobalNamespace.GetTypeMembers().WhereAsArray(t => t.Name.StartsWith("<>y__InlineArray", StringComparison.Ordinal));
+            }
+
             static ImmutableArray<string> getInlineArrayTypeNames(ModuleSymbol module)
             {
-                return module.GlobalNamespace.GetTypeMembers().WhereAsArray(t => t.Name.StartsWith("<>y__InlineArray", StringComparison.Ordinal)).SelectAsArray(t => t.Name);
+                return getInlineArrayTypes(module).SelectAsArray(t => t.Name);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -14477,7 +14477,7 @@ partial class Program
 
             static ImmutableArray<string> getInlineArrayTypeNames(ModuleSymbol module)
             {
-                return module.GlobalNamespace.GetTypeMembers().WhereAsArray(t => t.Name.StartsWith("<>y__InlineArray")).SelectAsArray(t => t.Name);
+                return module.GlobalNamespace.GetTypeMembers().WhereAsArray(t => t.Name.StartsWith("<>y__InlineArray", StringComparison.Ordinal)).SelectAsArray(t => t.Name);
             }
         }
 


### PR DESCRIPTION
Fixes #74957