### PR TITLE
Find first potential editorconfig when trying to synchronize

### DIFF
--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
@@ -82,7 +82,10 @@ internal partial class SettingsEditorControl : UserControl
 
         var solution = _workspace.CurrentSolution;
         var analyzerConfigDocument = solution.Projects
-            .Select(p => p.TryGetExistingAnalyzerConfigDocumentAtPath(_filepath)).FirstOrDefault();
+            .Select(p => p.TryGetExistingAnalyzerConfigDocumentAtPath(_filepath))
+            .WhereNotNull()
+            .FirstOrDefault();
+
         if (analyzerConfigDocument is null)
         {
             return;


### PR DESCRIPTION
Probably fixes a lot of reports of https://github.com/dotnet/roslyn/issues/54556

Saw on reddit people complaining but not helping, so I helped. Prior to this it would depend on which project was first in the list instead of searching all of them.