### PR TITLE
Remove toolset compiler workarounds

### DIFF
--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,2 +1,1 @@
-# Workaround for https://github.com/dotnet/sdk/issues/41791
--p:_IsDisjointMSBuildVersion=false
+# This file intentionally left blank to avoid accidental import during build.

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -61,12 +61,6 @@
     <!-- TODO --> 
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
 
-    <!--
-      Needed to avoid error NU1010: The PackageReference items Microsoft.Net.Compilers.Toolset.Framework do not have corresponding PackageVersion.
-      Related to https://github.com/dotnet/sdk/issues/41791.
-    -->
-    <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
-
     <!-- https://github.com/dotnet/msbuild/issues/10306 -->
     <CoreCompileDependsOn>$(CoreCompileDependsOn);ResolveKeySource</CoreCompileDependsOn> 
   </PropertyGroup>


### PR DESCRIPTION
These should not be needed with .NET SDK 9 preview 7 which is now in main.