### PR TITLE
Workaround for InvalidOperationException thrown from EmitSolutionUpdateResults.GetAllDiagnosticsAsync

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -60,6 +60,12 @@
 
     <!-- TODO --> 
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
+
+    <!--
+      Needed to avoid error NU1010: The PackageReference items Microsoft.Net.Compilers.Toolset.Framework do not have corresponding PackageVersion.
+      Related to https://github.com/dotnet/sdk/issues/41791.
+    -->
+    <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)TargetFrameworks.props" />

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -212,7 +212,12 @@ internal readonly struct EmitSolutionUpdateResults
         foreach (var (documentId, documentRudeEdits) in RudeEdits)
         {
             var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
-            Contract.ThrowIfNull(document);
+            if (document == null)
+            {
+                // Make sure the solution snapshot has all source-generated documents up-to-date.
+                solution = solution.WithUpToDateSourceGeneratorDocuments(solution.ProjectIds);
+                document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            }
 
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             foreach (var documentRudeEdit in documentRudeEdits)
@@ -262,7 +267,14 @@ internal readonly struct EmitSolutionUpdateResults
 
         foreach (var (documentId, diagnostics) in rudeEdits)
         {
-            var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            if (document == null)
+            {
+                // Make sure the solution snapshot has all source-generated documents up-to-date.
+                solution = solution.WithUpToDateSourceGeneratorDocuments(solution.ProjectIds);
+                document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            }
+
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var diagnostic in diagnostics)

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
@@ -414,7 +414,7 @@ public abstract class EditAndContinueWorkspaceTestBase : TestBase
         const string ClosingMarker = "*/";
 
         var index = markedSource.IndexOf(OpeningMarker);
-        if (index > 0)
+        if (index >= 0)
         {
             index += OpeningMarker.Length;
             var closing = markedSource.IndexOf(ClosingMarker, index);


### PR DESCRIPTION
We were missing call to `WithUpToDateSourceGeneratorDocuments` in code paths that post-processed rude edits reported by `EditAndContinueService`. The service itself did call `WithUpToDateSourceGeneratorDocuments` on the solution snapshot it analyzed but the rude edits were post-processed on the snapshot that has not been updated with the latest source generator outputs.  When the analysis found a rude edit in a document that has just been generated we did not find that document in the solution snapshot.

Following up with a better fix that removes the post-processing step, but for servicing this workaround is more appropriate: https://github.com/dotnet/roslyn/pull/75013

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2169491