### PR TITLE
Convert RudeEditDiagnostic to Diagnostic in EmitSolutionUpdateAsync

### DIFF
--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -329,7 +329,7 @@ internal sealed class EditAndContinueLanguageService(
 
         UpdateApplyChangesDiagnostics(diagnosticData);
 
-        var diagnostics = await EmitSolutionUpdateResults.GetAllDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, moduleUpdates.Status, cancellationToken).ConfigureAwait(false);
+        var diagnostics = EmitSolutionUpdateResults.GetAllDiagnostics(diagnosticData, rudeEdits, syntaxError, moduleUpdates.Status);
         return new ManagedHotReloadUpdates(moduleUpdates.Updates.FromContract(), diagnostics.FromContract());
     }
 }

--- a/src/EditorFeatures/ExternalAccess/Debugger/GlassTestsHotReloadService.cs
+++ b/src/EditorFeatures/ExternalAccess/Debugger/GlassTestsHotReloadService.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Debugger
         public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(Solution solution, CancellationToken cancellationToken)
         {
             var result = await _encService.EmitSolutionUpdateAsync(GetSessionId(), solution, s_noActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
-            var diagnostics = await EmitSolutionUpdateResults.GetAllDiagnosticsAsync(solution, result.Diagnostics.ToDiagnosticData(solution), result.RudeEdits, result.GetSyntaxErrorData(solution), result.ModuleUpdates.Status, cancellationToken).ConfigureAwait(false);
+            var diagnostics = EmitSolutionUpdateResults.GetAllDiagnostics(result.Diagnostics.ToDiagnosticData(solution), result.RudeEdits.ToDiagnosticData(solution), result.GetSyntaxErrorData(solution), result.ModuleUpdates.Status);
             return new ManagedHotReloadUpdates(result.ModuleUpdates.Updates.FromContract(), diagnostics.FromContract());
         }
     }

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -163,12 +163,13 @@ public class EditAndContinueLanguageServiceTests : EditAndContinueWorkspaceTestB
             var documentDiagnostic = CodeAnalysis.Diagnostic.Create(diagnosticDescriptor1, Location.Create(syntaxTree, TextSpan.FromBounds(1, 2)), ["doc", "error 1"]);
             var projectDiagnostic = CodeAnalysis.Diagnostic.Create(diagnosticDescriptor1, Location.None, ["proj", "error 2"]);
             var syntaxError = CodeAnalysis.Diagnostic.Create(diagnosticDescriptor1, Location.Create(syntaxTree, TextSpan.FromBounds(1, 2)), ["doc", "syntax error 3"]);
+            var rudeEditDiagnostic = new RudeEditDiagnostic(RudeEditKind.Delete, TextSpan.FromBounds(2, 3), arguments: ["x"]).ToDiagnostic(syntaxTree);
 
             return new()
             {
                 ModuleUpdates = new ModuleUpdates(ModuleUpdateStatus.Ready, []),
                 Diagnostics = [new ProjectDiagnostics(project.Id, [documentDiagnostic, projectDiagnostic])],
-                RudeEdits = [(documentId, [new RudeEditDiagnostic(RudeEditKind.Delete, TextSpan.FromBounds(2, 3), arguments: ["x"])])],
+                RudeEdits = [new ProjectDiagnostics(project.Id, [rudeEditDiagnostic])],
                 SyntaxError = syntaxError
             };
         };

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -212,7 +212,12 @@ internal readonly struct EmitSolutionUpdateResults
         foreach (var (documentId, documentRudeEdits) in RudeEdits)
         {
             var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
-            Contract.ThrowIfNull(document);
+            if (document == null)
+            {
+                // Make sure the solution snapshot has all source-generated documents up-to-date.
+                solution = solution.WithUpToDateSourceGeneratorDocuments(solution.ProjectIds);
+                document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            }
 
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             foreach (var documentRudeEdit in documentRudeEdits)
@@ -262,7 +267,14 @@ internal readonly struct EmitSolutionUpdateResults
 
         foreach (var (documentId, diagnostics) in rudeEdits)
         {
-            var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            if (document == null)
+            {
+                // Make sure the solution snapshot has all source-generated documents up-to-date.
+                solution = solution.WithUpToDateSourceGeneratorDocuments(solution.ProjectIds);
+                document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            }
+
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var diagnostic in diagnostics)

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
@@ -56,7 +56,7 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
     public async ValueTask<(
             ModuleUpdates updates,
             ImmutableArray<DiagnosticData> diagnostics,
-            ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> rudeEdits,
+            ImmutableArray<DiagnosticData> rudeEdits,
             DiagnosticData? syntaxError)> EmitSolutionUpdateAsync(
         Solution solution,
         ActiveStatementSpanProvider activeStatementSpanProvider,
@@ -64,7 +64,7 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
     {
         ModuleUpdates moduleUpdates;
         ImmutableArray<DiagnosticData> diagnosticData;
-        ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> rudeEdits;
+        ImmutableArray<DiagnosticData> rudeEdits;
         DiagnosticData? syntaxError;
 
         try
@@ -75,7 +75,7 @@ internal sealed class RemoteDebuggingSessionProxy(SolutionServices services, IDi
                 var results = await GetLocalService().EmitSolutionUpdateAsync(sessionId, solution, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
                 moduleUpdates = results.ModuleUpdates;
                 diagnosticData = results.Diagnostics.ToDiagnosticData(solution);
-                rudeEdits = results.RudeEdits;
+                rudeEdits = results.RudeEdits.ToDiagnosticData(solution);
                 syntaxError = results.GetSyntaxErrorData(solution);
             }
             else

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnostic.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnostic.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Text;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
@@ -51,6 +52,12 @@ internal static class RudeEditExtensions
 
     internal static bool IsBlocking(this RudeEditKind kind)
         => kind.GetSeverity() == DiagnosticSeverity.Error;
+
+    internal static bool IsBlockingRudeEdit(this Diagnostic diagnostic)
+        => diagnostic.Descriptor.DefaultSeverity == DiagnosticSeverity.Error;
+
+    public static bool HasBlockingRudeEdits(this ImmutableArray<Diagnostic> diagnostics)
+        => diagnostics.Any(IsBlockingRudeEdit);
 
     public static bool HasBlockingRudeEdits(this IEnumerable<RudeEditDiagnostic> diagnostics)
         => diagnostics.Any(static e => e.Kind.IsBlocking());

--- a/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Utilities/Extensions.cs
@@ -95,18 +95,25 @@ internal static partial class Extensions
         => filePath.EndsWith(".razor.g.cs", StringComparison.OrdinalIgnoreCase) ||
             filePath.EndsWith(".cshtml.g.cs", StringComparison.OrdinalIgnoreCase);
 
-    public static ManagedHotReloadDiagnostic ToHotReloadDiagnostic(this DiagnosticData data, ModuleUpdateStatus updateStatus)
+    public static ManagedHotReloadDiagnostic ToHotReloadDiagnostic(this DiagnosticData data, ModuleUpdateStatus updateStatus, bool isRudeEdit)
     {
         var fileSpan = data.DataLocation.MappedFileSpan;
 
         return new(
             data.Id,
             data.Message ?? FeaturesResources.Unknown_error_occurred,
-            updateStatus == ModuleUpdateStatus.RestartRequired
-                ? ManagedHotReloadDiagnosticSeverity.RestartRequired
-                : (data.Severity == DiagnosticSeverity.Error)
-                    ? ManagedHotReloadDiagnosticSeverity.Error
-                    : ManagedHotReloadDiagnosticSeverity.Warning,
+            isRudeEdit
+                ? data.DefaultSeverity switch
+                {
+                    DiagnosticSeverity.Error => ManagedHotReloadDiagnosticSeverity.RestartRequired,
+                    DiagnosticSeverity.Warning => ManagedHotReloadDiagnosticSeverity.Warning,
+                    _ => throw ExceptionUtilities.UnexpectedValue(data.DefaultSeverity)
+                }
+                : updateStatus == ModuleUpdateStatus.RestartRequired
+                    ? ManagedHotReloadDiagnosticSeverity.RestartRequired
+                    : (data.Severity == DiagnosticSeverity.Error)
+                        ? ManagedHotReloadDiagnosticSeverity.Error
+                        : ManagedHotReloadDiagnosticSeverity.Warning,
             fileSpan.Path ?? "",
             fileSpan.Span.ToSourceSpan());
     }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingHotReloadService.cs
@@ -126,7 +126,7 @@ internal sealed class UnitTestingHotReloadService(HostWorkspaceServices services
                 update.UpdatedMethods,
                 update.UpdatedTypes));
 
-        var diagnostics = await results.GetAllDiagnosticsAsync(solution, cancellationToken).ConfigureAwait(false);
+        var diagnostics = results.GetAllDiagnostics();
 
         return (updates, diagnostics);
     }

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -178,7 +178,7 @@ internal sealed class WatchHotReloadService(SolutionServices services, Func<Valu
             _encService.CommitSolutionUpdate(sessionId);
         }
 
-        var diagnostics = await results.GetAllDiagnosticsAsync(solution, cancellationToken).ConfigureAwait(false);
+        var diagnostics = results.GetAllDiagnostics();
 
         var projectsToRestart = new HashSet<Project>();
         var projectsToRebuild = new HashSet<Project>();

--- a/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -2617,12 +2617,12 @@ class C { int Y => 2; }
         var results = await debuggingSession.EmitSolutionUpdateAsync(solution, s_noActiveSpans, CancellationToken.None).ConfigureAwait(false);
         var updates = results.ModuleUpdates;
         var diagnosticData = results.Diagnostics.ToDiagnosticData(solution);
-        var rudeEdits = results.RudeEdits;
+        var rudeEdits = results.RudeEdits.ToDiagnosticData(solution);
         var syntaxError = results.GetSyntaxErrorData(solution);
         Assert.Empty(diagnosticData);
         Assert.Null(syntaxError);
 
-        var diagnostics = await EmitSolutionUpdateResults.GetAllDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, updates.Status, CancellationToken.None).ConfigureAwait(false);
+        var diagnostics = EmitSolutionUpdateResults.GetAllDiagnostics(diagnosticData, rudeEdits, syntaxError, updates.Status);
 
         AssertEx.Equal(
         [

--- a/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -200,14 +200,14 @@ public class RemoteEditAndContinueServiceTests
             var syntaxError = Diagnostic.Create(diagnosticDescriptor1, Location.Create(syntaxTree, TextSpan.FromBounds(1, 2)), new[] { "doc", "syntax error" });
 
             var updates = new ModuleUpdates(ModuleUpdateStatus.Ready, deltas);
-            var diagnostics = ImmutableArray.Create(new ProjectDiagnostics(project.Id, ImmutableArray.Create(documentDiagnostic, projectDiagnostic)));
-            var documentsWithRudeEdits = ImmutableArray.Create((documentId, ImmutableArray<RudeEditDiagnostic>.Empty));
+            var diagnostics = ImmutableArray.Create(new ProjectDiagnostics(project.Id, [documentDiagnostic, projectDiagnostic]));
+            var documentsWithRudeEdits = ImmutableArray.Create(new ProjectDiagnostics(project.Id, []));
 
             return new()
             {
                 ModuleUpdates = updates,
                 Diagnostics = diagnostics,
-                RudeEdits = documentsWithRudeEdits,
+                RudeEdits = [],
                 SyntaxError = syntaxError
             };
         };

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
@@ -414,7 +414,7 @@ public abstract class EditAndContinueWorkspaceTestBase : TestBase
         const string ClosingMarker = "*/";
 
         var index = markedSource.IndexOf(OpeningMarker);
-        if (index > 0)
+        if (index >= 0)
         {
             index += OpeningMarker.Length;
             var closing = markedSource.IndexOf(ClosingMarker, index);

--- a/src/Workspaces/Remote/Core/EditAndContinue/ManagedHotReloadLanguageService.cs
+++ b/src/Workspaces/Remote/Core/EditAndContinue/ManagedHotReloadLanguageService.cs
@@ -252,7 +252,7 @@ internal sealed partial class ManagedHotReloadLanguageService(
 
             ModuleUpdates moduleUpdates;
             ImmutableArray<DiagnosticData> diagnosticData;
-            ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> rudeEdits;
+            ImmutableArray<DiagnosticData> rudeEdits;
             DiagnosticData? syntaxError;
 
             try
@@ -261,7 +261,7 @@ internal sealed partial class ManagedHotReloadLanguageService(
 
                 moduleUpdates = results.ModuleUpdates;
                 diagnosticData = results.Diagnostics.ToDiagnosticData(solution);
-                rudeEdits = results.RudeEdits;
+                rudeEdits = results.RudeEdits.ToDiagnosticData(solution);
                 syntaxError = results.GetSyntaxErrorData(solution);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
@@ -285,7 +285,7 @@ internal sealed partial class ManagedHotReloadLanguageService(
                 _pendingUpdatedDesignTimeSolution = designTimeSolution;
             }
 
-            var diagnostics = await EmitSolutionUpdateResults.GetAllDiagnosticsAsync(solution, diagnosticData, rudeEdits, syntaxError, moduleUpdates.Status, cancellationToken).ConfigureAwait(false);
+            var diagnostics = EmitSolutionUpdateResults.GetAllDiagnostics(diagnosticData, rudeEdits, syntaxError, moduleUpdates.Status);
             return new ManagedHotReloadUpdates(moduleUpdates.Updates, diagnostics);
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))


### PR DESCRIPTION
Replaces workaround https://github.com/dotnet/roslyn/pull/75011