### PR TITLE
Fix typo in ProjectCodeModelFactory.ProcessNextDocumentBatchAsync

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
                 // Keep firing events for this doc, as long as we haven't exceeded the max amount
                 // of waiting time, and there's no user input that should take precedence.
-                if (stopwatch.Elapsed.Ticks > MaxTimeSlice || IsInputPending())
+                if (stopwatch.Elapsed.TotalMilliseconds > MaxTimeSlice || IsInputPending())
                 {
                     await this.Listener.Delay(delayBetweenProcessing, cancellationToken).ConfigureAwait(true);
                     stopwatch = SharedStopwatch.StartNew();


### PR DESCRIPTION
I was looking at this code when inspecting tasks remaining during shutdown. Using Ticks means this code pretty much calls Listener.Delay on every loop iteration.