### PR TITLE
Preserve trailing trivia when replacing method with property

### DIFF
--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Composition;
-using System.Reflection.Metadata;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
@@ -19,7 +18,6 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.ReplaceMethodWithProperty;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProperty;
 

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Reflection.Metadata;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
@@ -18,6 +19,7 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.ReplaceMethodWithProperty;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProperty;
 
@@ -185,6 +187,7 @@ internal class CSharpReplaceMethodWithPropertyService : AbstractReplaceMethodWit
                 return accessorDeclaration.WithBody(null)
                                           .WithExpressionBody(arrowExpression)
                                           .WithSemicolonToken(semicolonToken)
+                                          .WithTrailingTrivia(accessorDeclaration.Body.GetTrailingTrivia())
                                           .WithAdditionalAnnotations(Formatter.Annotation);
             }
         }

--- a/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -3021,4 +3021,46 @@ index: 1);
             }
             """);
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/61161")]
+    public async Task TestEndOfLineTrivia1()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                public int [||]Test1() { return 1; }
+                public void Test2() { }
+            }
+            """,
+            """
+            class C
+            {
+                public int Test1 => 1;
+                public void Test2() { }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/61161")]
+    public async Task TestEndOfLineTrivia2()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                public int [||]Test1() { return 1; }
+
+                public void Test2() { }
+            }
+            """,
+            """
+            class C
+            {
+                public int Test1 => 1;
+
+                public void Test2() { }
+            }
+            """);
+    }
 }


### PR DESCRIPTION
Fixes `CSharpReplaceMethodWithPropertyService` in some cases not preserving end of line trivia.

Closes #61161
