### PR TITLE
Use ordinal ignore case for opening pdb source documents

### DIFF
--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -68,7 +68,7 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
     /// generally run concurrently.  However, to be safe, we make this a concurrent dictionary to be safe to that
     /// potentially happening.
     /// </summary>
-    private readonly ConcurrentDictionary<string, SourceDocumentInfo> _fileToDocumentInfoMap = [];
+    private readonly ConcurrentDictionary<string, SourceDocumentInfo> _fileToDocumentInfoMap = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<MetadataAsSourceFile?> GetGeneratedFileAsync(
         MetadataAsSourceWorkspace metadataWorkspace,


### PR DESCRIPTION
Same thing is done in the decompilation provider

https://github.com/dotnet/roslyn/blob/main/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs#L54

Resolves https://github.com/dotnet/vscode-csharp/issues/7532