### PR TITLE
Cherry-pick sourcelink casing fix

### DIFF
--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -68,7 +68,7 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
     /// generally run concurrently.  However, to be safe, we make this a concurrent dictionary to be safe to that
     /// potentially happening.
     /// </summary>
-    private readonly ConcurrentDictionary<string, SourceDocumentInfo> _fileToDocumentInfoMap = [];
+    private readonly ConcurrentDictionary<string, SourceDocumentInfo> _fileToDocumentInfoMap = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<MetadataAsSourceFile?> GetGeneratedFileAsync(
         MetadataAsSourceWorkspace metadataWorkspace,


### PR DESCRIPTION
Cherry-picks https://github.com/dotnet/roslyn/pull/75030 to a release patch branch for vscode.