### PR TITLE
docs: Fix "Augment user code" example

### DIFF
--- a/docs/features/incremental-generators.cookbook.md
+++ b/docs/features/incremental-generators.cookbook.md
@@ -223,7 +223,7 @@ Provide that attribute in a `RegisterPostInitializationOutput` step. Register fo
 ```csharp
 public partial class UserClass
 {
-    [Generate]
+    [Generated]
     public partial void UserMethod();
 }
 ```
@@ -244,7 +244,7 @@ public class AugmentingGenerator : IIncrementalGenerator
                     {
                     }
                 }
-                """, Encoding.UTF8));
+                """, Encoding.UTF8)));
 
         var pipeline = context.SyntaxProvider.ForAttributeWithMetadataName(
             fullyQualifiedMetadataName: "GeneratedNamespace.GeneratedAttribute",

--- a/docs/features/incremental-generators.cookbook.md
+++ b/docs/features/incremental-generators.cookbook.md
@@ -223,7 +223,7 @@ Provide that attribute in a `RegisterPostInitializationOutput` step. Register fo
 ```csharp
 public partial class UserClass
 {
-    [Generated]
+    [GeneratedNamespace.Generated]
     public partial void UserMethod();
 }
 ```


### PR DESCRIPTION
The generator generates a `Generated` attribute. Not `Generate`. Also added missing a closing paren.