### PR TITLE
Fix issue where closing sourcelink document threw if not opened

### DIFF
--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -257,7 +257,14 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
         var documentInfos = CreateDocumentInfos(sourceFileInfos, encoding, projectId, sourceWorkspace, sourceProject);
         if (documentInfos.Length > 0)
         {
-            pendingSolution = pendingSolution.AddDocuments(documentInfos);
+            foreach (var documentInfo in documentInfos)
+            {
+                // The document might have already been added by a previous go to definition call.
+                if (!pendingSolution.ContainsDocument(documentInfo.Id))
+                {
+                    pendingSolution = pendingSolution.AddDocument(documentInfo);
+                }
+            }
         }
 
         var navigateProject = pendingSolution.GetRequiredProject(projectId);


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/7514

Essentially it is possible in LSP that `TryRemoveDocumentFromWorkspace` gets called without `TryAddDocumentToWorkspace` getting called first.  This commonly happens if a sourcelink document is opened, but immediately closed - LSP will not attempt to call `TryAddDocumentToWorkspace` until a feature requiring a `Solution` is requested.  If the document is immediately closed this never happens, but we would still attempt to close the document in the MAS workspace.

This matches what the decompilation provider does as well
https://github.com/dotnet/roslyn/blob/main/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs#L321