### PR TITLE
Enable NuGet audit

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -22,6 +22,10 @@
     <add key="vs-impl-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl-archived/nuget/v3/index.json" />
     <add key="vs-buildservices" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -16,6 +16,14 @@
     <!-- TODO: https://github.com/dotnet/roslyn/issues/71667 -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
 
+    <!--
+      Do not error on NuGet audit warnings. These are warnings that are introduced asynchronously as
+      new vulnerabilities are discovered. Having these as errors means that CI would pass on on job,
+      and then potentially fail on the next. This is meant to be an early warning system, not a 
+      random CI failure generator.
+    -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+
     <CommonExtensionInstallationRoot>CommonExtensions</CommonExtensionInstallationRoot>
     <LanguageServicesExtensionInstallationFolder>Microsoft\VBCSharp\LanguageServices</LanguageServicesExtensionInstallationFolder>
 

--- a/src/Compilers/Test/Core/Mocks/Silverlight.cs
+++ b/src/Compilers/Test/Core/Mocks/Silverlight.cs
@@ -37,9 +37,6 @@ public static class Silverlight
     private static (byte[], byte[]) BuildImages()
     {
         const string corlibExtraCode = """
-            using System;
-            using System.Reflection;
-
             namespace System.Reflection;
 
             [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]

--- a/src/Compilers/Test/Core/TestHelpers.cs
+++ b/src/Compilers/Test/Core/TestHelpers.cs
@@ -163,7 +163,7 @@ namespace Roslyn.Test.Utilities
 
             return ImmutableCollectionsMarshal.AsImmutableArray(bytes);
 
-            byte parseByte(ReadOnlySpan<char> input, NumberStyles numberStyle)
+            static byte parseByte(ReadOnlySpan<char> input, NumberStyles numberStyle)
             {
 #if NET
                 return byte.Parse(input, numberStyle);


### PR DESCRIPTION
This enables NuGet audit using the audit sources from nuget.org. This is the standard that is being pushed into all of our repositories. The end result is that we will get early warning on CVE and won't need to wait until CG scans on our scheduled builds reveal them.

I've set this up so that it warns not errors. That is deliberate because the audit warnings are asynchronous. Setting them up as errors would mean that builds, which were passing one minute, could start failing the next t. A warning here feels like the right balance but we can experiment and see how it goes.

Related https://github.com/dotnet/arcade/issues/15019